### PR TITLE
initial pr template draft

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
+
+**What this PR does / why we need it**:
+
+**Special notes for your reviewer**:
+
+**If applicable**:
+- [ ] this PR contains documentation
+- [ ] this PR contains tests


### PR DESCRIPTION
This template will show up in the editing textbox when new PRs are opened.

I find it useful to help clean up issues when PRs finish the work from the issue. It can also be helpful to remind users about testing and describing the necessary steps to test.