### PR TITLE
Test update

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -108,6 +108,7 @@ var _ = BeforeSuite(func(done Done) {
 		Client:   k8sManager.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("EventHub"),
 		Recorder: k8sManager.GetEventRecorderFor("Eventhub-controller"),
+		Scheme:   scheme.Scheme,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
The eventhub operator is now using controllerutil.createorupdate for creating secrets. This requires that the reconciler have access to the scheme in main.go. To manage this, I added the Scheme to the Reconciler struct. The test was not updated to add this. 


`invalid memory address or nil pointer dereference`