### PR TITLE
Adding fields to SqlFirewallRule spec

### DIFF
--- a/api/v1/sqlfirewallrule_types.go
+++ b/api/v1/sqlfirewallrule_types.go
@@ -26,8 +26,10 @@ import (
 type SqlFirewallRuleSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Location      string `json:"location"`
-	ResourceGroup string `json:"resourcegroup,omitempty"`
+	Location       string `json:"location"`
+	ResourceGroup  string `json:"resourcegroup,omitempty"`
+	StartIPAddress string `json:"startipaddress,omitempty"`
+	EndIPAddress   string `json:"endipaddress,omitempty"`
 }
 
 // SqlFirewallRuleStatus defines the observed state of SqlFirewallRule


### PR DESCRIPTION
#147 

**What this PR does / why we need it**:
Adding StartIPAddress and EndIPAddress to SqlFireWallRule spec for future implementation 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
