### PR TITLE
Adding Make Target for cert-manager dependencies 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,15 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 all: manager
 
+# Generate test certs for development
+generate-test-certs: 
+	echo "[req]" > config.txt
+	echo "distinguished_name = req_distinguished_name" >> config.txt
+	echo "[req_distinguished_name]" >> config.txt
+	echo "[SAN]" >> config.txt
+	echo "subjectAltName=DNS:azureoperator-webhook-service.azureoperator-system.svc.cluster.local" >> config.txt
+	openssl req -x509 -days 730 -out tls.crt -keyout tls.key -newkey rsa:4096 -subj "/CN=azureoperator-webhook-service.azureoperator-system" -config config.txt -nodes
+
 # Run tests
 test: generate fmt vet manifests
 	TEST_USE_EXISTING_CLUSTER=false go test -v -coverprofile=coverage.txt -covermode count ./api/... ./controllers/... ./pkg/resourcemanager/eventhubs/...  ./pkg/resourcemanager/resourcegroups/...  ./pkg/resourcemanager/storages/... 2>&1 | tee testlogs.txt


### PR DESCRIPTION
Addresses #45  

**What this PR does / why we need it**:
Adding generate-test-certs in makefile to automatically create cert manager dependencies to make testing/ life easier for the user.

**Special notes for your reviewer**:
Run `make generate-test-certs` to create a tls.crt, tls.key, config.txt, and test.sh

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
