### PR TITLE
Removing AdminUser from SqlServer

### DIFF
--- a/api/v1/sqlserver_types.go
+++ b/api/v1/sqlserver_types.go
@@ -28,7 +28,6 @@ type SqlServerSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 	Location                string `json:"location"`
 	ResourceGroup           string `json:"resourcegroup,omitempty"`
-	AdminUser               string `json:"adminuser,omitempty"`
 	AllowAzureServiceAccess bool   `json:"allowazureserviceaccess,omitempty"`
 }
 

--- a/config/crd/bases/azure.microsoft.com_sqlservers.yaml
+++ b/config/crd/bases/azure.microsoft.com_sqlservers.yaml
@@ -401,8 +401,6 @@ spec:
         spec:
           description: SqlServerSpec defines the desired state of SqlServer
           properties:
-            adminuser:
-              type: string
             allowazureserviceaccess:
               type: boolean
             location:


### PR DESCRIPTION
Solves #219 

**What this PR does / why we need it**:
- Removes AdminUser from spec (sqlserver_types.go)
- Removes AdminUser name from sample yaml (azure.microsoft.com_sqlservers.yaml)

**To Test**:
Test to see if SQL Server correctly provisions in Azure by running:

Terminal 1
`make install`
`make run`

Terminal 2
`kubectl create -f config/samples/azure_v1_resourcegroup.yaml`
`kubectl create -f config/samples/azure_v1_sqlserver.yaml`

Returns `sqlserver.azure.microsoft.com/sqlserver-sample-rush created`
and resources exist in Azure -> code works!

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
