### PR TITLE
Fix: removing params from GetServer

### DIFF
--- a/controllers/sqlserver_controller.go
+++ b/controllers/sqlserver_controller.go
@@ -210,7 +210,7 @@ func (r *SqlServerReconciler) verifyExternal(instance *azurev1.SqlServer) error 
 		Location:          location,
 	}
 
-	serv, err := sdkClient.GetServer(groupName, name)
+	serv, err := sdkClient.GetServer()
 	if err != nil {
 		azerr := errhelp.NewAzureError(err).(*errhelp.AzureError)
 		if azerr.Type != errhelp.ResourceNotFound {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing error `controllers/sqlserver_controller.go:58:15: undefined: instance
controllers/sqlserver_controller.go:109:55: too many arguments in call to sdkClient.CheckNameAvailability` 

Switching `(string)` to `()`

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
