### PR TITLE
Fix: cleaning sql interface

### DIFF
--- a/pkg/resourcemanager/sqlclient/resourceclient.go
+++ b/pkg/resourcemanager/sqlclient/resourceclient.go
@@ -18,6 +18,6 @@ type ResourceClient interface {
 	DeleteDB(databaseName string) (result autorest.Response, err error)
 	DeleteSQLServer() (result autorest.Response, err error)
 	DeleteSQLFirewallRule(ruleName string) (err error)
-	GetServer() (sql.Server, error)
+	GetServer() (result sql.Server, err error)
 	IsAsyncNotCompleted(err error) (result bool)
 }

--- a/pkg/resourcemanager/sqlclient/sqlclient_godsk.go
+++ b/pkg/resourcemanager/sqlclient/sqlclient_godsk.go
@@ -234,7 +234,7 @@ func (sdk GoSDKClient) IsAsyncNotCompleted(err error) (result bool) {
 }
 
 // GetServer returns a server
-func (sdk GoSDKClient) GetServer() (sql.Server, error) {
+func (sdk GoSDKClient) GetServer() (result sql.Server, err error) {
 	serversClient := getGoServersClient()
 
 	return serversClient.Get(


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleaning the ResourceClient interface in the SQL client
Specifically, fixing "GetServer()"'s return parameters to match the other functions

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
