### PR TITLE
add mkdir for kustomize bin dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ endif
 install-kustomize:
 ifeq (,$(shell which kustomize))
 	@echo "installing kustomize"
+	mkdir -p /usr/local/kubebuilder/bin
 	# download kustomize
 	curl -o /usr/local/kubebuilder/bin/kustomize -sL "https://go.kubebuilder.io/kustomize/$(shell go env GOOS)/$(shell go env GOARCH)"
 	# set permission


### PR DESCRIPTION
What this PR does / why we need it:
This PR enables make install-kustomize to work independently of kubebuilder having been installed through make install-kubebuilder

closes #262