### PR TITLE
pulling updated ignore file from master to address merge conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ coverage.xml
 testlogs.txt
 .DS_Store
 
+# Generated CRDS
+config/crd/bases/*
+config/rbac/role.yaml
+api/v1/zz_generated.*
+
 # Kubernetes Generated files - skip generated files, except for vendored files
 
 !vendor/**/zz_generated.*


### PR DESCRIPTION
Master branch now ignores generated files to reduce merge conflicts from generated files. This is due to reordering of generated files. These files will now be generated during the build process.