### PR TITLE
wrong number of args

### DIFF
--- a/controllers/sqldatabase_controller.go
+++ b/controllers/sqldatabase_controller.go
@@ -66,7 +66,7 @@ func (r *SqlDatabaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	if helpers.IsBeingDeleted(&instance) {
 		if helpers.HasFinalizer(&instance, SQLDatabaseFinalizerName) {
 			if err := r.deleteExternal(&instance); err != nil {
-				log.Info("Delete SqlDatabase failed with ", err.Error())
+				log.Info("Delete SqlDatabase failed with ", "err", err.Error())
 				return ctrl.Result{}, err
 			}
 


### PR DESCRIPTION
the logger expects an even number of args after the initial message string