### PR TITLE
fix(azure-vote-example): fix apiversion to RedisCache object

### DIFF
--- a/examples/demo/azure-vote-app-redis.yaml
+++ b/examples/demo/azure-vote-app-redis.yaml
@@ -1,4 +1,4 @@
-apiVersion: azure.microsoft.com/v1alpha1alpha1
+apiVersion: azure.microsoft.com/v1alpha1
 kind: RedisCache
 metadata:
   name: azure-redis


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

Looks like in the midst of switching from v1alpha1 to v1 and then back to v1alpha1, this example got messed up.

This fixes the version number of the azure-vote-redis app.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
