### PR TITLE
remove incorrect use of Update() to correctly remove finalizer

### DIFF
--- a/controllers/azuresqldatabase_controller.go
+++ b/controllers/azuresqldatabase_controller.go
@@ -73,7 +73,7 @@ func (r *AzureSqlDatabaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 			}
 
 			helpers.RemoveFinalizer(&instance, AzureSQLDatabaseFinalizerName)
-			if err := r.Status().Update(context.Background(), &instance); err != nil {
+			if err := r.Update(context.Background(), &instance); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/controllers/azuresqlserver_controller.go
+++ b/controllers/azuresqlserver_controller.go
@@ -99,7 +99,7 @@ func (r *AzureSqlServerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			}
 
 			helpers.RemoveFinalizer(&instance, AzureSQLServerFinalizerName)
-			if err := r.Status().Update(context.Background(), &instance); err != nil {
+			if err := r.Update(context.Background(), &instance); err != nil {
 				return ctrl.Result{}, err
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
to add or remove finalizer from Metadata section we need to call `Update()` not `Status().Update()`


**Special notes for your reviewer**:
make sure the operator removes finalizer from sql server and database when deleted
