### PR TITLE
Removed confusing resource group name

### DIFF
--- a/pkg/secrets/keyvault/client.go
+++ b/pkg/secrets/keyvault/client.go
@@ -23,7 +23,7 @@ type KeyvaultSecretClient struct {
 
 func getVaultsURL(ctx context.Context, vaultName string) string {
 	vaultURL := "https://" + vaultName + ".vault.azure.net" //default
-	vault, err := kvhelper.AzureKeyVaultManager.GetVault(ctx, config.GroupName(), vaultName)
+	vault, err := kvhelper.AzureKeyVaultManager.GetVault(ctx, "", vaultName)
 	if err == nil {
 		vaultURL = *vault.Properties.VaultURI
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

In the Keyvault secretclient code that was just merged, there is a confusing resource group name used (config.groupName()) to get the vault properties. This is wrong (the value is incorrrect) and is also a variable that is being looked at being removed in an upcoming PR.

As it turns out it looks like the resource group name can be empty in the call as keyvaults are globally identifiable in a subscription. so removed the config.GroupName() and replaces with empty string.

**Special notes for your reviewer**:

make install
Run "go test" from pkg/secrets/keyvault

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
