### PR TITLE
AzureSqlFailoverGroup: Persist server names into secrets

### DIFF
--- a/controllers/azuresqlfailovergroup_controller.go
+++ b/controllers/azuresqlfailovergroup_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Azure/azure-service-operator/pkg/helpers"
 	azuresqlfailovergroup "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlfailovergroup"
 	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 const azureSQLFailoverGroupFinalizerName = "AzureSqlFailoverGroup.finalizers.azure.com"
@@ -45,6 +46,7 @@ type AzureSqlFailoverGroupReconciler struct {
 	Recorder                     record.EventRecorder
 	Scheme                       *runtime.Scheme
 	AzureSqlFailoverGroupManager azuresqlfailovergroup.SqlFailoverGroupManager
+	SecretClient                 secrets.SecretClient
 }
 
 // +kubebuilder:rbac:groups=azure.microsoft.com,resources=azuresqlfailovergroups,verbs=get;list;watch;create;update;patch;delete
@@ -140,6 +142,24 @@ func (r *AzureSqlFailoverGroupReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 			log.Info("waiting for failovergroup to come up")
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
+		return ctrl.Result{}, err
+	}
+
+	// Check to see if secret already exists for server names and paths
+	r.Log.Info("retrieving or generating secret values")
+	secret, _ := r.GetOrPrepareSecret(ctx, &instance)
+
+	// create or update the secret
+	r.Log.Info("persisting failovergroup secrets")
+	key := types.NamespacedName{Name: instance.ObjectMeta.Name, Namespace: instance.Namespace}
+	err = r.SecretClient.Upsert(
+		ctx,
+		key,
+		secret,
+		secrets.WithOwner(&instance),
+		secrets.WithScheme(r.Scheme),
+	)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -259,4 +279,28 @@ func (r *AzureSqlFailoverGroupReconciler) addFinalizer(instance *azurev1alpha1.A
 	}
 	r.Recorder.Event(instance, v1.EventTypeNormal, "Updated", fmt.Sprintf("finalizer %s added", azureSQLFailoverGroupFinalizerName))
 	return nil
+}
+
+func (r *AzureSqlFailoverGroupReconciler) GetOrPrepareSecret(ctx context.Context, instance *azurev1alpha1.AzureSqlFailoverGroup) (map[string][]byte, error) {
+	failovergroupname := instance.ObjectMeta.Name
+	azuresqlprimaryservername := instance.Spec.Server
+	azuresqlsecondaryservername := instance.Spec.SecondaryServerName
+
+	secret := map[string][]byte{}
+
+	key := types.NamespacedName{Name: failovergroupname, Namespace: instance.Namespace}
+
+	if stored, err := r.SecretClient.Get(ctx, key); err == nil {
+		r.Log.Info("secret already exists, pulling stored values")
+		return stored, nil
+	}
+
+	r.Log.Info("secret not found, generating values for new secret")
+
+	secret["azureSqlPrimaryServerName"] = []byte(azuresqlprimaryservername)
+	secret["readWriteListenerEndpoint"] = []byte(failovergroupname + ".database.windows.net")
+	secret["azureSqlSecondaryServerName"] = []byte(azuresqlsecondaryservername)
+	secret["readOnlyListenerEndpoint"] = []byte(failovergroupname + ".secondary.database.windows.net")
+
+	return secret, nil
 }

--- a/controllers/azuresqlfailovergroup_controller_test.go
+++ b/controllers/azuresqlfailovergroup_controller_test.go
@@ -29,7 +29,7 @@ func TestAzureSqlFailoverGroupControllerNoResourceGroup(t *testing.T) {
 	var sqlServerTwoName string
 	var sqlDatabaseName string
 	var err error
-  
+
 	// Add any setup steps that needs to be executed before each test
 	rgName = tc.resourceGroupName
 	rgLocation1 = "westus2"
@@ -66,7 +66,7 @@ func TestAzureSqlFailoverGroupControllerNoResourceGroup(t *testing.T) {
 	assert.Eventually(func() bool {
 		err = tc.k8sClient.Get(ctx, sqlFailoverGroupNamespacedName, sqlFailoverGroupInstance)
 		return strings.Contains(sqlFailoverGroupInstance.Status.Message, errhelp.ResourceGroupNotFoundErrorCode)
-	}, tc.timeout, tc.retry, "wait for rg not found error")
+	}, tc.timeout, tc.retry, "wait for rg not found error to clear")
 
 	err = tc.k8sClient.Delete(ctx, sqlFailoverGroupInstance)
 	assert.Equal(nil, err, "delete failovergroup in k8s")

--- a/controllers/azuresqlserver_combined_test.go
+++ b/controllers/azuresqlserver_combined_test.go
@@ -1,4 +1,4 @@
-// +build all azuresqlserver
+// +build all azuresqlserver azuresqlservercombined
 
 package controllers
 
@@ -293,6 +293,12 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 		_ = tc.k8sClient.Get(ctx, sqlFailoverGroupNamespacedName, sqlFailoverGroupInstance)
 		return strings.Contains(sqlFailoverGroupInstance.Status.Message, successMsg)
 	}, tc.timeout, tc.retry, "wait for failovergroup to provision")
+
+	assert.Eventually(func() bool {
+		var secrets, _ = tc.secretClient.Get(ctx, sqlFailoverGroupNamespacedName)
+
+		return strings.Contains(string(secrets["azureSqlPrimaryServerName"]), sqlServerName)
+	}, tc.timeout, tc.retry, "wait for secret store to show failovergroup server names  ")
 
 	err = tc.k8sClient.Delete(ctx, sqlFailoverGroupInstance)
 	assert.Equal(nil, err, "delete sqlFailoverGroupInstance in k8s")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -373,6 +373,7 @@ func setup() error {
 		Recorder:                     k8sManager.GetEventRecorderFor("AzureSqlFailoverGroup-controller"),
 		Scheme:                       scheme.Scheme,
 		AzureSqlFailoverGroupManager: sqlFailoverGroupManager,
+		SecretClient:                 secretClient,
 	}).SetupWithManager(k8sManager)
 	if err != nil {
 		return err

--- a/docs/azuresql/azuresql.md
+++ b/docs/azuresql/azuresql.md
@@ -158,7 +158,7 @@ Once you apply this, the kube secret with the same name as the SQL server is upd
 
 ### SQL failover group
 
-The SQL failover group operator is used to create a failover group on a specified primary Azure SQL server, given the secondary Azure SQL server (should be in a different location from the primary server) and the databases on the primary server that should failover.
+The SQL failover group operator is used to create a failover group across two Azure SQL servers (one primary, one secondary). The servers should already be provisioned and deployed different regions. The specified databases will be replicated from the primary server and created on the secondary.
 
 Below is a sample YAML for creating a failover group
 
@@ -182,7 +182,7 @@ spec:
 
 The `name` is a name for the failover group that we want to create. `server` is the primary SQL server on which the failover group is created, `location` and `resourcegroup` are the location and the resource group of the primary SQL server. `failoverpolicy` can be "automatic" or "manual". `failovergraceperiod` is the time in minutes. `secondaryserver` is the secondary SQL server to failover to and `secondaryserverresourcegroup` is the resource group that the server is in. `databaselist` is the list of databased on the primary SQL server that should replicate to the secondary SQL server, when there is a failover action.
 
-Once you apply this, a secret with the same name as the SQL failovergroup is also stored. This secret contains the fields for primary/secondary failovergroup listener endpoints (`readwritelistenerendpoint` and `readonlylistenerendpoint`) and the primary/secondary SQL server names (`azuresqlprimaryservername` and `azuresqlsecondaryservername`)
+Once you apply this, a secret with the same name as the SQL failovergroup is also stored. This secret contains the fields for primary/secondary failovergroup listener endpoints (`readWriteListenerEndpoint` and `readOnlyListenerEndpoint`) and the primary/secondary SQL server names (`azureSqlPrimaryServerName` and `azureSqlSecondaryServerName`)
 
 ### SQL database user
 

--- a/main.go
+++ b/main.go
@@ -312,6 +312,7 @@ func main() {
 		Recorder:                     mgr.GetEventRecorderFor("AzureSqlFailoverGroup-controller"),
 		Scheme:                       mgr.GetScheme(),
 		AzureSqlFailoverGroupManager: sqlFailoverGroupManager,
+		SecretClient:                 secretClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AzureSqlFailoverGroup")
 		os.Exit(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:
Persists SQL Server names and domains into the secret store so that downstream apps can connect directly to the associated servers.

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3NtY188QaxDdC/giphy.gif)

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains tests

Closes #453 