### PR TITLE
Gopls no longer causes devcontainer to fail building

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
     && go get -x -d github.com/stamblerre/gocode 2>&1 \
     && go build -o gocode-gomod github.com/stamblerre/gocode \
     && mv gocode-gomod $GOPATH/bin/ \
+    && GO111MODULE=on go get -v golang.org/x/tools/gopls@latest 2>&1 \
     #
     # Install Go tools
     && go get -u -v \
@@ -44,7 +45,6 @@ RUN apt-get update \
         github.com/cweill/gotests/... \
         golang.org/x/tools/cmd/goimports \
         golang.org/x/lint/golint \
-        golang.org/x/tools/cmd/gopls \
         github.com/alecthomas/gometalinter \
         honnef.co/go/tools/... \
         github.com/golangci/golangci-lint/cmd/golangci-lint \


### PR DESCRIPTION
closes #583 

**What this PR does / why we need it**:
This PR addresses the issue of building the devcontainer from scratch.

**Special notes for your reviewer**:
To test, simply reopen the project in VSCode and build the devcontainer.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
