### PR TITLE
save the app insights instrumentation key in a secret so apps don't have to guess

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -182,7 +182,11 @@ func setup() error {
 	var consumerGroupClient resourcemanagereventhub.ConsumerGroupManager
 
 	if os.Getenv("TEST_CONTROLLER_WITH_MOCKS") == "false" {
-		appInsightsManager = resourcemanagerappinsights.NewManager(ctrl.Log.WithName("appinsightsmanager").WithName("AppInsights"))
+		appInsightsManager = resourcemanagerappinsights.NewManager(
+			ctrl.Log.WithName("appinsightsmanager").WithName("AppInsights"),
+			secretClient,
+			scheme.Scheme,
+		)
 		resourceGroupManager = resourcegroupsresourcemanager.NewAzureResourceGroupManager()
 		eventHubManagers = resourcemanagereventhub.AzureEventHubManagers
 		storageManagers = resourcemanagerstorages.AzureStorageManagers

--- a/main.go
+++ b/main.go
@@ -114,7 +114,11 @@ func main() {
 
 	vnetManager := vnet.NewAzureVNetManager(ctrl.Log.WithName("controllers").WithName("VirtualNetwork"))
 	resourceGroupManager := resourcemanagerresourcegroup.NewAzureResourceGroupManager()
-	appInsightsManager := resourcemanagerappinsights.NewManager(ctrl.Log.WithName("appinsightsmanager").WithName("AppInsights"))
+	appInsightsManager := resourcemanagerappinsights.NewManager(
+		ctrl.Log.WithName("appinsightsmanager").WithName("AppInsights"),
+		secretClient,
+		scheme,
+	)
 	eventhubNamespaceClient := resourcemanagereventhub.NewEventHubNamespaceClient(ctrl.Log.WithName("controllers").WithName("EventhubNamespace"))
 	consumerGroupClient := resourcemanagereventhub.NewConsumerGroupClient(ctrl.Log.WithName("controllers").WithName("ConsumerGroup"))
 	storageManagers := resourcemanagerstorage.AzureStorageManagers

--- a/pkg/resourcemanager/appinsights/appinsights.go
+++ b/pkg/resourcemanager/appinsights/appinsights.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/Azure/azure-service-operator/pkg/secrets"
+
 	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
@@ -36,13 +38,17 @@ import (
 
 // Manager manages Azure Application Insights services
 type Manager struct {
-	Log logr.Logger
+	Log          logr.Logger
+	SecretClient secrets.SecretClient
+	Scheme       *runtime.Scheme
 }
 
 // NewManager creates a new AppInsights Manager
-func NewManager(log logr.Logger) *Manager {
+func NewManager(log logr.Logger, secretClient secrets.SecretClient, scheme *runtime.Scheme) *Manager {
 	return &Manager{
-		Log: log,
+		Log:          log,
+		SecretClient: secretClient,
+		Scheme:       scheme,
 	}
 }
 
@@ -150,6 +156,21 @@ func (m *Manager) Ensure(ctx context.Context, obj runtime.Object) (bool, error) 
 	}
 
 	instance.Status.State = *appcomp.ProvisioningState
+
+	instKey := *appcomp.ApplicationInsightsComponentProperties.InstrumentationKey
+
+	key := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
+	err = m.SecretClient.Upsert(
+		ctx,
+		key,
+		map[string][]byte{"instrumentationKey": []byte(instKey)},
+		secrets.WithOwner(instance),
+		secrets.WithScheme(m.Scheme),
+	)
+	if err != nil {
+		instance.Status.Message = "failed to update secret, err: " + err.Error()
+		return false, err
+	}
 
 	if instance.Status.Provisioning {
 		instance.Status.Provisioned = true


### PR DESCRIPTION
Need to make the instrumentation key accessible to apps being deployed declaratively alongside the insights account.

This PR saves it to a secret on successful account creation.