### PR TITLE
Explain better the spanning set of CRDs that need to be applied for SQL Server

### DIFF
--- a/docs/azuresql/azuresql.md
+++ b/docs/azuresql/azuresql.md
@@ -33,15 +33,20 @@ For instance, this is the sample YAML for the Azure SQL server.
      resourcegroup: resourceGroup1
   ```
 
-The value for kind, `AzureSqlServer` is the Custom Resource Definition (CRD) name.
-`sqlserver-sample` is the name of the SQL server resource that will be created.
+The value for kind, `AzureSqlServer` is the Custom Resource Definition (CRD) name and `sqlserver-sample` in this case is the name of the SQL server resource that will be created.
 
 The values under `spec` provide the values for the location where you want to create the Azure SQL server at and the Resource group in which you want to create it under.
 
-Once you've updated the YAML with the settings you need,  you have the operator running, and you have created the resource group you specified (as necessary), you can create a Custom SQL server resource with:
+Deploying a SQL Server instance requires that you deploy a ResourceGroup, an AzureSqlDatabase, and AzureSqlServer CRDs.
+
+The project maintains a [set of samples](https://github.com/Azure-Samples/azure-service-operator-samples) of how to utilize the Azure Service Operator.
+
+As part of this, there is a sample voting app that utilizes a SQL server. Clone this repo, adjust the names in the resource group and SQL Server CRDs such that they are unique and then deploy them with:
 
 ```bash
-$ kubectl apply -f config/samples/azure_v1alpha1_azuresqldatabase.yaml
+$ kubectl apply -f azure-votes-sql/manifests/azure_v1_resourcegroup.yaml
+$ kubectl apply -f azure-votes-sql/manifests/azure_v1_sqldatabase.yaml
+$ kubectl apply -f azure-votes-sql/manifests/azure_v1_sqlserver.yaml
 ```
 
 Along with creating the SQL server, this operator also generates the admin username and password for the SQL server and stores it in a kube secret with the same name as the SQL server.


### PR DESCRIPTION
Tweaks to SQL Server documentation to better explain the CRDs that need to be applied to provision a SQL Server with Azure Service Operator