### PR TITLE
fix asserting in app insights test

### DIFF
--- a/controllers/appinsights_controller_test.go
+++ b/controllers/appinsights_controller_test.go
@@ -62,7 +62,7 @@ func TestAppInsightsController(t *testing.T) {
 	// Wait for the AppInsights instance to be provisioned
 	assert.Eventually(func() bool {
 		_ = tc.k8sClient.Get(ctx, appInsightsNamespacedName, appInsightsInstance)
-		return strings.Contains(appInsightsInstance.Status.Message, "Succeeded")
+		return strings.Contains(appInsightsInstance.Status.Message, successMsg)
 	}, tc.timeout, tc.retry, "awaiting appinsights instance creation")
 
 	// Delete the service


### PR DESCRIPTION
the test is checking for the wrong string which causes the test to take 6 times longer than it should....need to figure out why timeouts to assert.Eventually don't result in test failures