### PR TITLE
Revert "Removing empty tests"

### DIFF
--- a/controllers/postgresqldatabase_controller_test.go
+++ b/controllers/postgresqldatabase_controller_test.go
@@ -1,0 +1,5 @@
+// +build all psql psqldatabase
+
+package controllers
+
+// add tests for unhappy paths here

--- a/controllers/postgresqlfirewallrule_controller_test.go
+++ b/controllers/postgresqlfirewallrule_controller_test.go
@@ -1,0 +1,5 @@
+// +build all psql psqlfirewallrule
+
+package controllers
+
+// add negative tests here

--- a/controllers/postgresqlserver_controller_test.go
+++ b/controllers/postgresqlserver_controller_test.go
@@ -1,0 +1,11 @@
+// +build all psql psqlserver
+
+package controllers
+
+// func TestPSQLServerController(t *testing.T) {
+// 	t.Parallel()
+// 	defer PanicRecover()
+// 	ctx := context.Background()
+// }
+
+// Add non happy path tests here


### PR DESCRIPTION
Reverts Azure/azure-service-operator#682

These tests should be added instead of removing the files.