### PR TITLE
Bug: Fix missing CRD in release setup_yaml

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
 - bases/azure.microsoft.com_postgresqldatabases.yaml
 - bases/azure.microsoft.com_postgresqlfirewallrules.yaml
 - bases/azure.microsoft.com_apimservices.yaml
+- bases/azure.microsoft.com_apimgmtapis.yaml
 - bases/azure.microsoft.com_virtualnetworks.yaml
 
 - bases/azure.microsoft.com_keyvaultkeys.yaml
@@ -49,6 +50,7 @@ resources:
 #- patches/webhook_in_postgresqldatabases.yaml
 #- patches/webhook_in_postgresqlfirewallrules.yaml
 #- patches/webhook_in_apimservices.yaml
+#- patches/webhook_in_apimgmtapis.yaml
 #- patches/webhook_in_virtualnetworks.yaml
 #- patches/webhook_in_keyvaultkeys.yaml
 #- patches/webhook_in_azuresqlvnetrules.yaml
@@ -73,6 +75,7 @@ resources:
 #- patches/cainjection_in_postgresqldatabases.yaml
 #- patches/cainjection_in_postgresqlfirewallrules.yaml
 #- patches/cainjection_in_apimservices.yaml
+#- patches/cainjection_in_apimgmtapis.yaml
 #- patches/cainjection_in_virtualnetworks.yaml
 #- patches/cainjection_in_keyvaultkeys.yaml
 #- patches/cainjection_in_azuresqlvnetrules.yaml

--- a/config/crd/patches/cainjection_in_apimgmtapis.yaml
+++ b/config/crd/patches/cainjection_in_apimgmtapis.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: apimgmtapis.azure.microsoft.com

--- a/config/crd/patches/webhook_in_apimgmtapis.yaml
+++ b/config/crd/patches/webhook_in_apimgmtapis.yaml
@@ -1,0 +1,17 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apimgmtapis.azure.microsoft.com
+spec:
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+      caBundle: Cg==
+      service:
+        namespace: system
+        name: webhook-service
+        path: /convert


### PR DESCRIPTION
The customer reported that the apimgmgtapi CRD is missing in the setup yaml. This is because the cainjection files for that CRD were not checked in. Kubebuilder seems to use these to generate the CRD in the setup.yaml for release.

Followed the same process as we did for sqluser CRD for the same problem in PR https://github.com/Azure/azure-service-operator/pull/585

Verification:

You'll see in the output of make deploy (I use the "Set kind cluster" stage in pipeline to verify) that you will have this CRD now 

Before the fix:

```
namespace/azureoperator-system configured
customresourcedefinition.apiextensions.k8s.io/apimservices.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/appinsights.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuredatalakegen2filesystems.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlactions.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqldatabases.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlfailovergroups.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlfirewallrules.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlservers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlusers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlvnetrules.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/blobcontainers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/consumergroups.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/cosmosdbs.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/eventhubnamespaces.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/eventhubs.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/keyvaultkeys.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/keyvaults.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/postgresqldatabases.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/postgresqlfirewallrules.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/postgresqlservers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/rediscaches.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/resourcegroups.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/storages.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/virtualnetworks.azure.microsoft.com configured

```

After the fix

```
namespace/azureoperator-system configured
customresourcedefinition.apiextensions.k8s.io/apimgmtapis.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/apimservices.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/appinsights.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuredatalakegen2filesystems.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlactions.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqldatabases.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlfailovergroups.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlfirewallrules.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlservers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlusers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/azuresqlvnetrules.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/blobcontainers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/consumergroups.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/cosmosdbs.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/eventhubnamespaces.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/eventhubs.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/keyvaultkeys.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/keyvaults.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/postgresqldatabases.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/postgresqlfirewallrules.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/postgresqlservers.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/rediscaches.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/resourcegroups.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/storages.azure.microsoft.com configured
customresourcedefinition.apiextensions.k8s.io/virtualnetworks.azure.microsoft.com configured
```