### PR TITLE
APIM: Update License & fix build tag

### DIFF
--- a/api/v1alpha1/apimgmt_types.go
+++ b/api/v1alpha1/apimgmt_types.go
@@ -1,17 +1,5 @@
-/*
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 package v1alpha1
 

--- a/api/v1alpha1/apimgmt_types_test.go
+++ b/api/v1alpha1/apimgmt_types_test.go
@@ -1,17 +1,5 @@
-/*
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 package v1alpha1
 

--- a/controllers/apimgmt_controller.go
+++ b/controllers/apimgmt_controller.go
@@ -1,17 +1,5 @@
-/*
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 package controllers
 

--- a/controllers/apimgmt_controller_test.go
+++ b/controllers/apimgmt_controller_test.go
@@ -1,19 +1,8 @@
-/*
-Copyright 2019 Microsoft.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 // +build all apimgmt
+
 package controllers
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
The APIM component was still in review when we migrated the project license to MIT and was not updated with the rest of the project.

This PR also adds spacing around the build tag, a blank line is required after the tag for it to be parsed properly.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3oKIPBe4bfkwO3On5e/giphy.gif)

