### PR TITLE
updating provisioning flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ BUILD_ID ?= $(shell git rev-parse --short HEAD)
 # best to keep the prefix as short as possible to not exceed naming limits for things like keyvault (24 chars)
 TEST_RESOURCE_PREFIX ?= aso-$(BUILD_ID)
 
+# Some parts of the test suite use Go Build Tags to ignore certain tests. Default to all tests but allow the user to pass custom tags.
+BUILD_TAGS ?= all
+
 all: manager
 
 # Generate test certs for development
@@ -40,7 +43,7 @@ api-test: generate fmt vet manifests
 # Run tests
 test: generate fmt vet manifests 
 	TEST_USE_EXISTING_CLUSTER=false TEST_CONTROLLER_WITH_MOCKS=true REQUEUE_AFTER=20 \
-	go test -tags all -parallel 3 -v -coverprofile=coverage.txt -covermode count \
+	go test -tags "$(BUILD_TAGS)" -parallel 3 -v -coverprofile=coverage.txt -covermode count \
 	./api/... \
 	./controllers/... \
 	-timeout 10m 2>&1 | tee testlogs.txt
@@ -49,7 +52,7 @@ test: generate fmt vet manifests
 
 # Run tests with existing cluster
 test-existing-controllers: generate fmt vet manifests
-	TEST_RESOURCE_PREFIX=$(TEST_RESOURCE_PREFIX) TEST_USE_EXISTING_CLUSTER=true REQUEUE_AFTER=20 go test -tags all -parallel 4 -v ./controllers/... -timeout 45m
+	TEST_RESOURCE_PREFIX=$(TEST_RESOURCE_PREFIX) TEST_USE_EXISTING_CLUSTER=true REQUEUE_AFTER=20 go test -tags "$(BUILD_TAGS)" -parallel 4 -v ./controllers/... -timeout 45m
 
 unit-tests:
 	go test ./pkg/resourcemanager/keyvaults/unittest/

--- a/docs/test.md
+++ b/docs/test.md
@@ -5,6 +5,6 @@ Testing the full project can be done in two ways:
 - `make api-test` - Runs the Kubernetes API tests against the CRDs
 - `make test` - Test against the Kubernetes integration testing framework.
 - `make test-existing-managers` - Test the resource managers against an existing cluster. This is currently the easiest way to run tests against a kind cluster setup.
-- `make test-existing-controllers` - Test the controllers against an existing cluster. By default this will run every controller test, but you can edit the `tags` parameter in the makefile to specify individual test suites. Each controller test file declares its tags in the `// +build` comment at the top of the file.
+- `make test-existing-controllers` - Test the controllers against an existing cluster. 
 
-
+Some test suites (primarily the controller suite) have included Go Build Tags to allow selectively running tests. Users can specify individual test suites by setting the `BUILD_TAGS` parameter as an environment variable or before the make target: `make BUILD_TAGS=azuresqlservercombined test-existing-controllers`. Test files declare their tags in the `// +build` comment at the top of the file.


### PR DESCRIPTION
Closes #704 

**What this PR does / why we need it**:
This sets the provisioning flag to false when Azure SQL resources haven't started provisioning yet due to other errors. We need this so the provisioning metric is more accurate.

**Special notes for your reviewer**:
Test Cases:
1. Deploy a SQL Server database without a server and provisioning timer should not start until the server is created.
2. Deploy a SQL Server database with an unrecoverable CreateOrUpdate error.
3. Deploy a SQL Server VNet rule. 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/FA77mwaxV74SA/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
