### PR TITLE
Bug#802#HandleValidataionErrorStorageAccount

### DIFF
--- a/pkg/resourcemanager/storages/storageaccount/storage_reconcile.go
+++ b/pkg/resourcemanager/storages/storageaccount/storage_reconcile.go
@@ -133,6 +133,15 @@ func (sa *azureStorageManager) Delete(ctx context.Context, obj runtime.Object, o
 	groupName := instance.Spec.ResourceGroup
 	_, err = sa.DeleteStorage(ctx, groupName, name)
 	if err != nil {
+		catch := []string{
+			errhelp.ValidationError,
+		}
+		err = errhelp.NewAzureError(err)
+		if azerr, ok := err.(*errhelp.AzureError); ok {
+			if helpers.ContainsString(catch, azerr.Type) {
+				return false, nil
+			}
+		}
 		return true, err
 	}
 


### PR DESCRIPTION


Closes #[802]

**What this PR does / why we need it**:
The PR is to handle the 'ValidationError' during the delete of a storage account with invalid name. 

**Special notes for your reviewer**:
**Before the change,** 
the issue could be easily reproduced by: 
1. Create a storage account with invalid name, e.g.  storagesample1908ayzkj1234567890111213141516, which would result to a failed provisioning as the name length exceeds the 24 limits for storage account name. 
```
Metadata:
  Creation Timestamp:  2020-04-02T03:12:01Z
  Finalizers:
    azure.microsoft.com/finalizer
  Generation:        2
  Resource Version:  7739
  Self Link:         /apis/azure.microsoft.com/v1alpha1/namespaces/default/storages/storagesample1908ayzkj1234567890111213141516
  UID:               517bdb3e-e0e3-40ee-ba8a-46bc135328bd
Output:
Spec:
  Access Tier:     Hot
  Kind:            StorageV2
  Location:        chinanorth
  Resource Group:  resourcegroup-azure-operators
  Sku:
    Name:                       Standard_RAGRS
  Supports Https Traffic Only:  true
Status:
  Failed Provisioning:  true
  Message:              AccountNameInvalid
  Requested:            2020-04-02T03:12:01Z
  State:                NotReady
Events:
  Type    Reason      Age                From                Message
  ----    ------      ----               ----                -------
  Normal  Added       50s                Storage-controller  Object finalizer is added
  Normal  Reconciled  48s (x2 over 49s)  Storage-controller  Successfully reconciled
```
2. Delete this storage account: 
```
kubectl delete Storage storagesample1908ayzkj1234567890111213141516
```
Then there will be error output and the delete process is hanging there forever. 
```
020-04-02T10:47:28.322+0800	DEBUG	controller-runtime.manager.events	Warning	{"object": {"kind":"Storage","namespace":"default","name":"storagesample1234567890abcefghijklmn","uid":"f97a23b0-370f-4f38-b4e4-e5c958454c52","apiVersion":"azure.microsoft.com/v1alpha1","resourceVersion":"1000"}, "reason": "FailedDelete", "message": "Failed to delete resource: 1 error occurred:\n\t* storage.AccountsClient#Delete: Invalid input: autorest/validation: validation failed: parameter=accountName constraint=MaxLength value=\"storagesample1234567890abcefghijklmn\" details: value length must be less than or equal to 24\n\n"}
2020-04-02T10:47:28.322+0800	ERROR	controller-runtime.controller	Reconciler error	{"controller": "storage", "request": "default/storagesample1234567890abcefghijklmn", "error": "1 error occurred:\n\t* storage.AccountsClient#Delete: Invalid input: autorest/validation: validation failed: parameter=accountName constraint=MaxLength value=\"storagesample1234567890abcefghijklmn\" details: value length must be less than or equal to 24\n\n"}
github.com/go-logr/zapr.(*zapLogger).Error
	/Users/hongbu/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/hongbu/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:218
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/hongbu/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:192
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/Users/hongbu/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:171
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
	/Users/hongbu/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/Users/hongbu/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
	/Users/hongbu/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:88
```
This is because the SDK send back and validation error on the storage name and cause the reconcile into an infinite loop. 

**After the change,** 
Use the same way to create a storage account with invalid name and delete it. The storage account could be deleted without error output nor hanging. 

```
 kubectl delete Storage storagesample1908ayzkj1234567890111213141516
storage.azure.microsoft.com "storagesample1908ayzkj1234567890111213141516" deleted
```
The code change does not impact the normal storage account create/delete. Tested and verified. 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/jnskQIduiEHks/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
