### PR TITLE
 Mysql firewall test random failure in pipeline - setting SuccessMsg in all successful paths

### DIFF
--- a/pkg/resourcemanager/mysql/firewallrule/reconcile.go
+++ b/pkg/resourcemanager/mysql/firewallrule/reconcile.go
@@ -33,6 +33,7 @@ func (m *MySQLFirewallRuleClient) Ensure(ctx context.Context, obj runtime.Object
 		instance.Status.Provisioned = true
 		instance.Status.Provisioning = false
 		instance.Status.State = firewallrule.Status
+		instance.Status.Message = resourcemanager.SuccessMsg
 		return true, nil
 	}
 


### PR DESCRIPTION
The mysql test seems to be failing on the firewall test randomly in the pipeline. It looks like the status.message for SuccessMsg is not set in one of the path in the reconcile. Trying to set this to see if this helps with the failures.