### PR TITLE
CANCELLED: Bug: SQL User error on GetDB in transitional state

### DIFF
--- a/pkg/errhelp/errors.go
+++ b/pkg/errhelp/errors.go
@@ -55,6 +55,7 @@ const (
 	ServiceBusy                         = "ServiceBusy"
 	NameNotAvailable                    = "NameNotAvailable"
 	PublicIPIdleTimeoutIsOutOfRange     = "PublicIPIdleTimeoutIsOutOfRange"
+	Failed                              = "Failed"
 )
 
 func NewAzureError(err error) error {


### PR DESCRIPTION
Closes #905

**Describe the bug**
If you deploy a RG, SQLServer, SQLDatabase, SQLFirewall, SQLUser at the same time you will see uncaught errors in the SQL User (and SQL Db) operator.

```
2020-04-08T18:30:21.485-0600	ERROR	controller-runtime.controller	Reconciler error	{"controller": "azuresqluser", "request": "default/sqluser1", "error": "1 error occurred:\n\t* sql.DatabasesClient#Get: Failure responding to request: StatusCode=404 -- Original Error: json: cannot unmarshal array into Go struct field serviceError2.details of type map[string]interface {}\n\n"}
```

**To Reproduce**
put the manifests in a directory and run `kubectl create -f <directory>`...you won't see the errors until just before everything finishes...

everything comes up eventually but these errors should still be caught

**Expected behavior**
no stack traces in logs

**Fix**
Updated Azure SQL

![giphy-downsized-large](https://user-images.githubusercontent.com/32373900/79006020-0e202380-7b0d-11ea-8ed4-6481f3c02f56.gif)
