### PR TITLE
Vnet provision -> false

### DIFF
--- a/pkg/errhelp/errors.go
+++ b/pkg/errhelp/errors.go
@@ -60,6 +60,7 @@ const (
 	InternalServerError                            = "InternalServerError"
 	NetworkAclsValidationFailure                   = "NetworkAclsValidationFailure"
 	SubnetHasServiceEndpointWithInvalidServiceName = "SubnetHasServiceEndpointWithInvalidServiceName"
+	InvalidAddressPrefixFormat                     = "InvalidAddressPrefixFormat"
 )
 
 func NewAzureError(err error) error {

--- a/pkg/resourcemanager/vnet/reconcile.go
+++ b/pkg/resourcemanager/vnet/reconcile.go
@@ -6,6 +6,7 @@ package vnet
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
@@ -44,7 +45,7 @@ func (g *AzureVNetManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 	}
 
 	instance.Status.Provisioning = true
-	_, err = g.CreateVNet(
+	result, err := g.CreateVNet(
 		ctx,
 		location,
 		resourceGroup,
@@ -72,6 +73,7 @@ func (g *AzureVNetManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 			errhelp.NetcfgInvalidVirtualNetworkSite,
 			errhelp.InvalidCIDRNotation,
 			errhelp.InvalidRequestFormat,
+			errhelp.InvalidAddressPrefixFormat,
 		}
 
 		// everything ok - just requeue


### PR DESCRIPTION
closes #709

closes #997

Sets provisioning to false when the vnet creation process hasnt started and there's a requeue

Also implements the FailedProvisioning flag properly for when ending reconciliation due to failure

Gif is in honor of Max who continues to improve :-)

![EquatorialLivelyFulmar-size_restricted](https://user-images.githubusercontent.com/32373900/80030695-6952fe00-849d-11ea-9dd1-5e9ac06c5c40.gif)
