### PR TITLE
Catches InvalidAddressPrefixFormat Err for VirtualNetwork

### DIFF
--- a/pkg/errhelp/errors.go
+++ b/pkg/errhelp/errors.go
@@ -26,6 +26,7 @@ const (
 	FailoverGroupBusy                   = "FailoverGroupBusy"
 	Forbidden                           = "Forbidden"
 	InvalidAccessPolicy                 = "InvalidAccessPolicy"
+	InvalidAddressPrefixFormat          = "InvalidAddressPrefixFormat"
 	InvalidCIDRNotation                 = "InvalidCIDRNotation"
 	InvalidFailoverGroupRegion          = "InvalidFailoverGroupRegion"
 	InvalidParameters                   = "InvalidParameters"

--- a/pkg/resourcemanager/vnet/reconcile.go
+++ b/pkg/resourcemanager/vnet/reconcile.go
@@ -66,6 +66,7 @@ func (g *AzureVNetManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 			errhelp.NetcfgInvalidVirtualNetworkSite,
 			errhelp.InvalidCIDRNotation,
 			errhelp.InvalidRequestFormat,
+			errhelp.InvalidAddressPrefixFormat,
 		}
 		if helpers.ContainsString(catch, azerr.Type) {
 			switch azerr.Type {


### PR DESCRIPTION
Closes #997 

**What this PR does / why we need it**:
Found a new err while testing Will's PR for VNET. If the user has an incorrect format subnet prefix, the operator begins to err out with this message:

```
2020-04-23T14:10:45.213-0600	DEBUG	controller-runtime.manager.events	Warning	{"object": {"kind":"VirtualNetwork","namespace":"default","name":"vnet122","uid":"249a94b3-a1f5-4e4d-8fe5-f69c1e48854d","apiVersion":"azure.microsoft.com/v1alpha1","resourceVersion":"1981839"}, "reason": "FailedReconcile", "message": "Failed to reconcile resource: 1 error occurred:\n\t* Error creating VNet: resourcegroup-azure-operators-mel, vnet122 - network.VirtualNetworksClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code=\"InvalidAddressPrefixFormat\" Message=\"Address prefix 10.1.0.0 of resource /subscriptions/7060bca0-7a3c-44bd-b54c-4bb1e9facfac/resourceGroups/resourcegroup-azure-operators-mel/providers/Microsoft.Network/virtualNetworks/vnet122/subnets/test1 is not formatted correctly. It should follow CIDR notation, for example 10.0.0.0/24.\" Details=[]\n\n"}
2020-04-23T14:10:45.213-0600	ERROR	controller-runtime.controller	Reconciler error	{"controller": "virtualnetwork", "request": "default/vnet122", "error": "1 error occurred:\n\t* Error creating VNet: resourcegroup-azure-operators-mel, vnet122 - network.VirtualNetworksClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code=\"InvalidAddressPrefixFormat\" Message=\"Address prefix 10.1.0.0 of resource /subscriptions/7060bca0-7a3c-44bd-b54c-4bb1e9facfac/resourceGroups/resourcegroup-azure-operators-mel/providers/Microsoft.Network/virtualNetworks/vnet122/subnets/test1 is not formatted correctly. It should follow CIDR notation, for example 10.0.0.0/24.\" Details=[]\n\n"}
github.com/go-logr/zapr.(*zapLogger).Error
	/Users/melanierush/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/melanierush/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:218
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/melanierush/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:192
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/Users/melanierush/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:171
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
	/Users/melanierush/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/Users/melanierush/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
	/Users/melanierush/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:88
```

**Special notes for your reviewer**:
Create a virtualnetwork with invalid subnetAddressPrefix value

Here is my sample YAML
```
apiVersion: azure.microsoft.com/v1alpha1
kind: VirtualNetwork
metadata:
  name: meltest
spec:
  location: westus
  resourceGroup: resourcegroup-azure-operators-mel
  addressSpace: "10.0.0.0/8"
  subnets:
    - subnetName: test1
      subnetAddressPrefix: "10.1.0.0"
    - subnetName: test2
      subnetAddressPrefix: "10.2.0.."
```

Will be caught in message and once PR #980 is merged, it will be set as a FailedProvisioningState. 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/fTnmUs24FN1ifdqciN/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
