### PR TITLE
Bug: AzureSQLServer needs to gracefully handle error: InvalidResourceLocation

### DIFF
--- a/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
@@ -200,11 +200,13 @@ func (s *AzureSqlServerManager) Ensure(ctx context.Context, obj runtime.Object, 
 		case errhelp.LocationNotAvailableForResourceType,
 			errhelp.RequestDisallowedByPolicy,
 			errhelp.RegionDoesNotAllowProvisioning,
+			errhelp.InvalidResourceLocation,
 			errhelp.QuotaExceeded:
 
 			instance.Status.Message = "Unable to provision Azure SQL Server due to error: " + errhelp.StripErrorIDs(err)
 			instance.Status.Provisioning = false
 			instance.Status.Provisioned = false
+			instance.Status.FailedProvisioning = true
 			return true, nil
 		}
 


### PR DESCRIPTION
closes #784

**Describe the bug**

This error occurs when you attempt to create a SQL Server with a name that already exists for another server in a different location.

```
2020-03-18T10:56:59.587-0700	ERROR	controller-runtime.controller	Reconciler error	{"controller": "azuresqlserver", "request": "default/sqlserver-sample-7779999999911", "error": "1 error occurred:\n\t* sql.ServersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code=\"InvalidResourceLocation\" Message=\"The resource 'sqlserver-sample-7779999999911' already exists in location 'westus' in resource group 'helm'. A resource with the same name cannot be created in location 'eastus'. Please select a new resource name.\"\n\n"}
github.com/go-logr/zapr.(*zapLogger).Error
	/Users/administrador/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/Users/administrador/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:218
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/Users/administrador/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:192
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/Users/administrador/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:171
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
```

**To Reproduce**
Steps to reproduce the behavior:
<Fill in the steps>

**Expected behavior**
A clear and concise description of what you expected to happen.

**Screenshots**
If applicable, add screenshots to help explain your problem.

**Additional context**
Add any other context about the problem here.
