### PR TITLE
Refactor Custom Secrets and AzureSQLUser

### DIFF
--- a/docs/azuresql/azuresql.md
+++ b/docs/azuresql/azuresql.md
@@ -148,7 +148,9 @@ Once you apply this, a secret with the same name as the SQL failovergroup is als
 
 The SQL user operator is used to create a user on the specified Azure SQL database. This user is more restrictive than the admin user created on the SQL server and is so recommended to use. The operator creates the user on the database by auto generating a strong password, and also stores the username and password as a secret (name can be specified in the YAML), so applications can use them.
 
-User credentials are persisted in the secret store that has been configured for the operator runtime. The default secret contains the following fields:
+User credentials are persisted in the secret store that has been configured for the operator runtime. You can explicitly set the SQL User key store by setting the `keyVaultToStoreSecrets` value in the User Spec.
+
+The default secret contains the following fields:
 
 - `azureSqlDatabaseName`
 - `azureSqlServerName`
@@ -157,13 +159,15 @@ User credentials are persisted in the secret store that has been configured for 
 - `username`
 - `password`
 
-When Key Vault is configured, each value is Base64 encoded and the set of secrets is persisted as a single JSON document in the Key Vault.
-The default secret name prefix in Key Vault is `azuresqluser-<serverName>-<azureSqlDatabaseName>`. Users can set the `keyVaultSecretPrefix` parameter to override this value.
+When using Kube secrets, the default secret will be stored under the namespace and name of the SQL User object,
 
-Additionally, some client libraries support connecting directly to Key Vault to retrieve secrets. Users can set the `keyVaultSecretFormats` parameter so that explicit connection strings for their desired formats are added to the Key Vault. Each secret will be named after the secret prefix followed by the format name, for example: `azuresqluser-<serverName>-<azureSqlDatabaseName>-adonet`.
-Here is a [sample YAML](/config/samples/azure_v1alpha1_azuresqluser.yaml) for creating a database user
+When Key Vault is configured, each secret value is Base64 encoded and the set of secrets is persisted as a single JSON document in the Key Vault.
+The default secret name for a SQL User in Key Vault is prefixed by `azuresqluser-<serverName>-<azureSqlDatabaseName>`. Users can set the `keyVaultSecretPrefix` parameter to override this value. Note that the SQL User name will always be appended to the secret name so the final name may be `azuresqluser-<serverName>-<azureSqlDatabaseName>-<azureSqlUserName>`
 
-The `name` is used to generate the username on the database. The exact name is not used but rather a UUID is appended to this to make it unique. `server` and `dbname` qualify the database on which you want to create the user on. `adminsecret` is the name of the secret where the username and password will be stored. `roles` specify the security roles that this user should have on the specified database.
+Some client libraries support connecting directly to Key Vault to retrieve secrets. Users can set the `keyVaultSecretFormats` parameter to request that connection strings for their desired formats are added to the Key Vault. Each secret will be named after the secret prefix followed by the format name, for example: `azuresqluser-<serverName>-<azureSqlDatabaseName>-<azureSqlUserName>-adonet`.
+The AzureSQLUser [sample YAML](/config/samples/azure_v1alpha1_azuresqluser.yaml) demonstrates the usage of these parameters.
+
+The `name` passed in the SQL User Spec is used to generate the username on the database. To ensure uniqueness on shared servers, a UUID is appended to the requested name to make the username in Azure SQL unique. `server` and `dbname` qualify the database on which you want to create the user on. `adminsecret` is the name of the secret where the username and password will be stored. `roles` specify the security roles that this user should have on the specified database.
 
 ## Deploy, view and delete resources
 

--- a/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
+++ b/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
@@ -71,12 +71,12 @@ func (s *AzureSqlActionManager) UpdateUserPassword(ctx context.Context, groupNam
 	password := helpers.NewPassword()
 	DBSecret["password"] = []byte(password)
 
-	err = azuresqluserManager.UpdateUser(ctx, DBSecret, db)
+	err = azuresqluserManager.RotateUserPassword(ctx, DBSecret, db)
 	if err != nil {
 		return fmt.Errorf("error updating user credentials: %v", err)
 	}
 
-	secretKey := azuresqluser.GetNamespacedName(instance, userSecretClient)
+	secretKey := azuresqluserManager.GetSecretNamespacedName(instance, userSecretClient)
 	key := types.NamespacedName{Namespace: secretKey.Namespace, Name: dbUser}
 	err = userSecretClient.Upsert(
 		ctx,

--- a/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_manager.go
+++ b/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_manager.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 
 	azuresql "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2015-05-01-preview/sql"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
@@ -23,6 +24,7 @@ type SqlUserManager interface {
 	DropUser(ctx context.Context, db *sql.DB, user string) error
 	DeleteSecrets(ctx context.Context, instance *v1alpha1.AzureSQLUser, secretClient secrets.SecretClient) (bool, error)
 	GetOrPrepareSecret(ctx context.Context, instance *v1alpha1.AzureSQLUser, secretClient secrets.SecretClient) map[string][]byte
+	GetSecretNamespacedName(instance *v1alpha1.AzureSQLUser, secretClient secrets.SecretClient) types.NamespacedName
 
 	// also embed methods from AsyncClient
 	resourcemanager.ARMClient

--- a/pkg/secrets/kube/client.go
+++ b/pkg/secrets/kube/client.go
@@ -31,6 +31,10 @@ func (k *KubeSecretClient) Create(ctx context.Context, key types.NamespacedName,
 		opt(options)
 	}
 
+	if options.Flatten {
+		return fmt.Errorf("kube secret client does not support flattened secrets")
+	}
+
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.Name,

--- a/pkg/secrets/kube/client_test.go
+++ b/pkg/secrets/kube/client_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -48,6 +49,11 @@ var _ = Describe("Kube Secrets Client", func() {
 			Context("creating secret with secret client", func() {
 				err = client.Create(ctx, key, data)
 				Expect(err).To(BeNil())
+			})
+
+			Context("creating secret with secret and flatten enabled", func() {
+				err = client.Create(ctx, key, data, secrets.Flatten(true))
+				Expect(err).ToNot(BeNil())
 			})
 
 			secret := &v1.Secret{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Secrets Pkg:
* Return error when trying to use flatten on kube client (+test)

AzureSqlUser:
* Refactor and move custom secret formatting and reconciliation into its own function (out of Ensure)
* Clean up and standardize NamespacedName generation
* Clean up overall azuresqluser variable naming for code clarity

The flatten option has been kept in the implementation because we need to have a way to ask the secrets package to create individual secrets rather than the default behavior of working with a map/json array. The kube client now returns an error when asked to flatten because that doesn't make sense in-context (Kube only works with map objects for secrets).

Closes #887

**Special notes for your reviewer**:


**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
