### PR TITLE
upgrade kube rbac proxy to 0.5.0

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -6,19 +6,18 @@ metadata:
   name: controller-manager
   namespace: system
 spec:
-  template:
-    spec:
-      containers:
-      - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
-      - name: manager
-        args:
-        - "--metrics-addr=127.0.0.1:8080"
+  containers:
+  - name: kube-rbac-proxy
+    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+    args:
+    - "--secure-listen-address=0.0.0.0:8443"
+    - "--upstream=http://127.0.0.1:8080/"
+    - "--logtostderr=true"
+    - "--v=10"
+    ports:
+    - containerPort: 8443
+      name: https
+  - name: manager
+    args:
+    - "--metrics-addr=127.0.0.1:8080"
+    - "--enable-leader-election


### PR DESCRIPTION
the older version of the proxy has security issues...this is the version being used by the kubebuilder folks

to test...

deploy to a cluster and ensure everything still works
