### PR TITLE
Add missing fields and quotes in deployment yaml

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -6,18 +6,20 @@ metadata:
   name: controller-manager
   namespace: system
 spec:
-  containers:
-  - name: kube-rbac-proxy
-    image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-    args:
-    - "--secure-listen-address=0.0.0.0:8443"
-    - "--upstream=http://127.0.0.1:8080/"
-    - "--logtostderr=true"
-    - "--v=10"
-    ports:
-    - containerPort: 8443
-      name: https
-  - name: manager
-    args:
-    - "--metrics-addr=127.0.0.1:8080"
-    - "--enable-leader-election
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"


### PR DESCRIPTION
This adds back a couple fields that were removed by mistake and adds a quote to the deploy yaml. Once added I was able to successfully build helm manifests and deploy