### PR TITLE
Fix typos in the cosmosdb yaml file

### DIFF
--- a/config/samples/azure_v1alpha1_cosmosdb.yaml
+++ b/config/samples/azure_v1alpha1_cosmosdb.yaml
@@ -3,44 +3,48 @@ kind: CosmosDB
 metadata:
   name: cosmosdb-sample-1
 spec:
-  # possible values are 'GlobalDocumentDB', 'MongoDB'. 
+  # #possible values are 'GlobalDocumentDB', 'MongoDB'. 
   kind: GlobalDocumentDB
   location: westus
   resourceGroup: resourcegroup-azure-operators
-  # Start of properties
+  # #Start of properties
   properties:
     databaseAccountOfferType: Standard
 
-    # optionally turn on multi-region writes
+    # #optionally turn on multi-region writes
     # enableMultipleWriteLocations: true
 
-    # Optionally set the capabilities name to the following options: (the default is SQL)
-    # "EnableCassandra", "EnableTable", "EnableGremlin", "EnableMongo"
-    # NOTE: If using "EnableMongo" kind must be set to MongoDB for this to take effect
+    # #Optionally set the capabilities name to the following options: (the default is SQL)
+    # #"EnableCassandra", "EnableTable", "EnableGremlin", "EnableMongo"
+    # #NOTE: If using "EnableMongo" kind must be set to MongoDB for this to take effect
     #capabilities: 
     # - name: "EnableCassandra"
 
-    # optionally set the mongoDBVersion to "3.2" or "3.6", if omitted the default is "3.2"
-    # NOTE: kind must be set to MongoDB for this to take effect
+    # #optionally set the mongoDBVersion to "3.2" or "3.6", if omitted the default is "3.2"
+    # #NOTE: kind must be set to MongoDB for this to take effect
     # mongoDBVersion: "3.6"
 
-    # enable virtual network rules if configured below
+    # #enable virtual network rules if configured below
     isVirtualNetworkFilterEnabled: true
-  # End of properties
+  # #End of properties
 
-  # optionally restrict access to specific virtual networks
-  virtualNetworkRules:
-    - subnetID: /subscriptions/{subscription_id}/resourceGroups/{resourcegroup}/providers/Microsoft.Network/virtualNetworks/{vnet_name}/subnets/{subnet_name}
-      ignoreMissingVNetServiceEndpoint: true
+  #   #optionally restrict access to specific virtual networks
+  # virtualNetworkRules:
+  #  - subnetID: /subscriptions/{subscription_id}/resourceGroups/{resourcegroup}/providers/Microsoft.Network/virtualNetworks/{vnet_name}/subnets/{subnet_name}
+  #    ignoreMissingVNetServiceEndpoint: true
 
-  # optionally configure different CIDR IP ranges for allowed-list, omitting allows all or falls back to vNetRules
-  ipRules:
-  #   # the ips in this rule are needed to access your db from the portal
-    - 104.42.195.92
-  #   # add additional ips you would like to grant access
-    - 1.2.3.4
+  # #optionally configure different CIDR IP ranges for allowed-list, omitting allows all or falls back to vNetRules
+  # ipRules:
+  #  #the ips in this rule are needed to access your db from the portal
+  #  - 104.42.195.92
+  #  - 40.76.54.131
+  #  - 52.176.6.30
+  #  - 52.169.50.45
+  #  - 52.187.184.26
+  #  #add additional ips you would like to grant access
+  #  - 1.2.3.4
 
-  # optionally configure multiple regions and availability zone redundancy
+  # #optionally configure multiple regions and availability zone redundancy
   # locations:
   #   - locationName: eastus
   #     failoverPriority: 0


### PR DESCRIPTION

Closes #1030 
Correct the sample cosmosDB yaml file. 

**What this PR does / why we need it**:
To correct the typos and format issues of the sample cosmosDB yaml file. 

**Special notes for your reviewer**:
--Use the current cosmosDB sample yaml file to enable virtual network and iprules (firewall). The cosmosDB would be created with no vnet/firewall settings. 
-- Apply the modified yaml file and the vnet/firewall shall be configured. 
![image](https://user-images.githubusercontent.com/37413937/81252525-b962c080-9058-11ea-95cf-05b8dca38903.png)


To quickly check the yaml file settings have been submitted from kubectl. Be able to see the ip rules, virtual network rules have all been set with the correct values. 

```
 kubectl describe cosmosdb                   
Name:         cosmosdb-sample-1
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"azure.microsoft.com/v1alpha1","kind":"CosmosDB","metadata":{"annotations":{},"name":"cosmosdb-sample-1","namespace":"defaul...
API Version:  azure.microsoft.com/v1alpha1
Kind:         CosmosDB
Metadata:
  Creation Timestamp:  2020-05-06T10:58:52Z
  Finalizers:
    azure.microsoft.com/finalizer
  Generation:  2
  Owner References:
    API Version:           azure.microsoft.com/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  ResourceGroup
    Name:                  resourcegroup-azure-operators
    UID:                   79217d7a-7f0b-4ce4-8e3f-d423e7fb1f68
  Resource Version:        57355
  Self Link:               /apis/azure.microsoft.com/v1alpha1/namespaces/default/cosmosdbs/cosmosdb-sample-1
  UID:                     33ccd8cc-256f-4077-ba16-289a4b295c86
Spec:
  Ip Rules:
    104.42.195.92
    1.2.3.4
  Kind:      GlobalDocumentDB
  Location:  westus
  Properties:
    Database Account Offer Type:        Standard
    Is Virtual Network Filter Enabled:  true
  Resource Group:                       resourcegroup-azure-operators
  Virtual Network Rules:
    Ignore Missing V Net Service Endpoint:  true
    Subnet ID:                              /subscriptions/***/resourceGroups/resourcegroup-azure-operators/providers/Microsoft.Network/virtualNetworks/vnet-sample-01/subnets/test1
```

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
