### PR TITLE
add code owners for default reviewer list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @frodopwns @WilliamMortlMicrosoft @jananivMS


### PR DESCRIPTION
This should allow us to require PR approval from a list of maintainers in addition to the current requirement.