### PR TITLE
Current pipeline: Fix Go workspace issue

### DIFF
--- a/devops/azure-pipelines.yaml
+++ b/devops/azure-pipelines.yaml
@@ -10,7 +10,7 @@ variables:
   MAJOR_VERSION: 0
   MINOR_VERSION: 0
   PATCH_VERSION: $(Build.BuildId)
-  GOROOT: '/usr/local/go1.13' # Go installation path
+  GOROOT: '/usr/local/go1.13.10' # Go installation path
   GOPATH: '$(System.DefaultWorkingDirectory)/gopath' # Go workspace path
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
   MODULE_PATH: '$(GOPATH)/src/$(Build.Repository.Name)' # Path to the module's code


### PR DESCRIPTION
Looks like the Go versions in the image changed on us.

Made a small change and the pipeline seems to be passing beyond this stage - https://dev.azure.com/epicstuff/azure-service-operator/_build/results?buildId=22542&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=f8ed7bd8-2a7f-56f6-9385-7fc29a8b5b7b