### PR TITLE
New pipeline update: Remove Helm chart packaging stage and use checked in Helm chart instead

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -244,8 +244,6 @@ steps:
         echo $(chosenclustername)
         az aks get-credentials -g $(AKS_CLUSTER_RG) -n $(chosenclustername)
         kubectl delete -f ./charts/azure-service-operator/crds/
-        helm list
-        helm delete aso
         # Set tags to available for the selected cluster to put it back into the free pool
         echo "Setting tags back to free"
         az resource tag --tags 'freeforpipeline=true' -g $(AKS_CLUSTER_RG) -n $(chosenclustername) --resource-type Microsoft.ContainerService/managedClusters

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,20 +207,20 @@ steps:
       echo $img
       sed -i -e 's@azure-service-operator:latest@azureserviceoperator:'${img}'@' charts/azure-service-operator/values.yaml
       # create directory for generated files
-      mkdir charts/azure-service-operator/templates/generated
+      # mkdir charts/azure-service-operator/templates/generated
       # generate files using kustomize
-      which kustomize
-      kustomize build ./config/default -o ./charts/azure-service-operator/templates/generated
+      # which kustomize
+      # kustomize build ./config/default -o ./charts/azure-service-operator/templates/generated
       # remove namespace, as we need to wrap it in a conditional since Helm 3 does not autocreate them
-      rm charts/azure-service-operator/templates/generated/~g_v1_namespace_azureoperator-system.yaml
+      # rm charts/azure-service-operator/templates/generated/~g_v1_namespace_azureoperator-system.yaml
       # replace hard coded ASO image with Helm templating
-      sed -i -e 's/controller:latest/{{ .Values.image.repository }}/' ./charts/azure-service-operator/templates/generated/*_deployment_*
+      # sed -i -e 's/controller:latest/{{ .Values.image.repository }}/' ./charts/azure-service-operator/templates/generated/*_deployment_*
       # replace hard coded namespace with Helm templating
-      find ./charts/azure-service-operator/templates/generated/ -type f -exec sed -i '' -e 's@namespace: azureoperator-system@namespace: {{ .Release.Namespace }}@' {} \;
+      # find ./charts/azure-service-operator/templates/generated/ -type f -exec sed -i '' -e 's@namespace: azureoperator-system@namespace: {{ .Release.Namespace }}@' {} \;
       # package the necessary files into a tar file
-      helm package ./charts/azure-service-operator -d ./charts
+      # helm package ./charts/azure-service-operator -d ./charts
       # update Chart.yaml for Helm Repository
-      helm repo index ./charts
+      # helm repo index ./charts
       # remove directory containing generated manifests for Helm Chart
       #rm -rf charts/azure-service-operator/templates/generated/
     displayName: Deploy to AKS - Helm generate and package charts
@@ -233,7 +233,8 @@ steps:
         kubectl delete namespace $(OPERATOR_NAMESPACE)
         imagename="$(PIPELINE_CONTAINER_REGISTRY_NAME)/$(IMAGE_NAME):$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)"
         echo $imagename
-        make install
+        kubectl apply -f ./charts/azure-service-operator/crds/
+        #make install
         helm upgrade --install aso charts/azure-service-operator-0.1.0.tgz -n azureoperator-system --create-namespace \
             --set azureSubscriptionID=$(AZURE_SUBSCRIPTION_ID) \
             --set azureTenantID=$(AZURE_TENANT_ID) \
@@ -256,6 +257,8 @@ steps:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        make delete
+        helm delete aso
         echo "Chosen AKS Cluster name"
         echo $(chosenclustername)
         # Set tags to available for the selected cluster to put it back into the free pool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,7 +218,7 @@ steps:
         imagename="$(PIPELINE_CONTAINER_REGISTRY_NAME)/$(IMAGE_NAME):$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)"
         echo $imagename
         kubectl apply -f ./charts/azure-service-operator/crds/
-        helm upgrade --install aso charts/azure-service-operator-0.1.0.tgz -n azureoperator-system --create-namespace \
+        helm upgrade --install aso charts/azure-service-operator-0.1.0.tgz -n $(OPERATOR_NAMESPACE) --create-namespace \
             --set azureSubscriptionID=$(AZURE_SUBSCRIPTION_ID) \
             --set azureTenantID=$(AZURE_TENANT_ID) \
             --set azureClientID=$(AZURE_CLIENT_ID) \
@@ -242,8 +242,9 @@ steps:
       inlineScript: |
         echo "Chosen AKS Cluster name"
         echo $(chosenclustername)
-        az aks get-credentials -g $(AKS_CLUSTER_RG) -n $(chosenclustername)
         kubectl delete -f ./charts/azure-service-operator/crds/
+        helm list -n $(OPERATOR_NAMESPACE)
+        helm delete aso -n $(OPERATOR_NAMESPACE)
         # Set tags to available for the selected cluster to put it back into the free pool
         echo "Setting tags back to free"
         az resource tag --tags 'freeforpipeline=true' -g $(AKS_CLUSTER_RG) -n $(chosenclustername) --resource-type Microsoft.ContainerService/managedClusters

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,8 +78,6 @@ steps:
         os=$(go env GOOS)
         arch=$(go env GOARCH)
         curl -sL https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C $(go env GOPATH)/bin
-        #mv $(go env GOPATH)/bin/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
-        #export PATH=$PATH:/usr/local/kubebuilder/bin
         export PATH=$PATH:$(go env path)/bin
         echo '##vso[task.prependpath]$(go env path)/bin'
         # download kustomize
@@ -106,7 +104,6 @@ steps:
       make install
       export TEST_APIM_RG=$(TEST_APIM_RG)
       export TEST_APIM_NAME=$(TEST_APIM_NAME)
-      export BUILD_TAGS=resourcegroup
       make test-integration-controllers
     displayName: Run tests on a Kind Cluster
     continueOnError: 'false'
@@ -185,7 +182,7 @@ steps:
         echo "##vso[task.setvariable variable=chosenclustername]$clustername"
         echo 'az aks get-credentials -g $(AKS_CLUSTER_RG) -n $clustername'
         az aks get-credentials -g $(AKS_CLUSTER_RG) -n $clustername
-        # Set tags to not available for the selected cluster so it doesn't get used
+        # Set tags to not available for the selected cluster so it doesn't get used in another run
         az resource tag --tags 'freeforpipeline=false' -g $(AKS_CLUSTER_RG) -n $clustername --resource-type Microsoft.ContainerService/managedClusters
       workingDirectory: '$(System.DefaultWorkingDirectory)'
       failOnStandardError: true
@@ -217,7 +214,9 @@ steps:
         kubectl delete namespace $(OPERATOR_NAMESPACE)
         imagename="$(PIPELINE_CONTAINER_REGISTRY_NAME)/$(IMAGE_NAME):$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)"
         echo $imagename
+        # Apply CRDs as Helm 3 does not install CRDs for Helm upgrade
         kubectl apply -f ./charts/azure-service-operator/crds/
+        # Deploy using Helm
         helm upgrade --install aso charts/azure-service-operator-0.1.0.tgz -n $(OPERATOR_NAMESPACE) --create-namespace \
             --set azureSubscriptionID=$(AZURE_SUBSCRIPTION_ID) \
             --set azureTenantID=$(AZURE_TENANT_ID) \
@@ -228,6 +227,7 @@ steps:
             --set aad-pod-identity.azureIdentity.resourceID="/subscriptions/$(AZURE_SUBSCRIPTION_ID)/resourcegroups/resourcegroup-azure-operators/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$(ASO-DEVOPS-MI)" \
             --set aad-pod-identity.azureIdentity.clientID=$(POD-IDENTITY-CLIENTID) \
             --set image.repository=$imagename 
+        # Verify namespace and pods
         kubectl get namespace
         kubectl get pods -n $(OPERATOR_NAMESPACE)
         kubectl describe pods -n $(OPERATOR_NAMESPACE)
@@ -242,7 +242,9 @@ steps:
       inlineScript: |
         echo "Chosen AKS Cluster name"
         echo $(chosenclustername)
+        # Delete CRDs to clean up cluster
         kubectl delete -f ./charts/azure-service-operator/crds/
+        # Remove Helm deployment
         helm list -n $(OPERATOR_NAMESPACE)
         helm delete aso -n $(OPERATOR_NAMESPACE)
         # Set tags to available for the selected cluster to put it back into the free pool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -258,7 +258,8 @@ steps:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
-        make delete
+        kubectl delete -f ./charts/azure-service-operator/crds/
+        helm list
         helm delete aso
         echo "Chosen AKS Cluster name"
         echo $(chosenclustername)
@@ -266,7 +267,7 @@ steps:
         echo "Setting tags back to free"
         az resource tag --tags 'freeforpipeline=true' -g $(AKS_CLUSTER_RG) -n $(chosenclustername) --resource-type Microsoft.ContainerService/managedClusters
       workingDirectory: '$(System.DefaultWorkingDirectory)'
-      failOnStandardError: true
+      failOnStandardError: false
     displayName: Deploy to AKS - Clean up deployment and release cluster back to free pool
 
   - task: Docker@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,7 @@ steps:
       make install
       export TEST_APIM_RG=$(TEST_APIM_RG)
       export TEST_APIM_NAME=$(TEST_APIM_NAME)
+      export BUILD_TAGS=resourcegroup
       make test-integration-controllers
     displayName: Run tests on a Kind Cluster
     continueOnError: 'false'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,24 +207,7 @@ steps:
       img="$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION"
       echo $img
       sed -i -e 's@azure-service-operator:latest@azureserviceoperator:'${img}'@' charts/azure-service-operator/values.yaml
-      # create directory for generated files
-      # mkdir charts/azure-service-operator/templates/generated
-      # generate files using kustomize
-      # which kustomize
-      # kustomize build ./config/default -o ./charts/azure-service-operator/templates/generated
-      # remove namespace, as we need to wrap it in a conditional since Helm 3 does not autocreate them
-      # rm charts/azure-service-operator/templates/generated/~g_v1_namespace_azureoperator-system.yaml
-      # replace hard coded ASO image with Helm templating
-      # sed -i -e 's/controller:latest/{{ .Values.image.repository }}/' ./charts/azure-service-operator/templates/generated/*_deployment_*
-      # replace hard coded namespace with Helm templating
-      # find ./charts/azure-service-operator/templates/generated/ -type f -exec sed -i '' -e 's@namespace: azureoperator-system@namespace: {{ .Release.Namespace }}@' {} \;
-      # package the necessary files into a tar file
-      # helm package ./charts/azure-service-operator -d ./charts
-      # update Chart.yaml for Helm Repository
-      # helm repo index ./charts
-      # remove directory containing generated manifests for Helm Chart
-      #rm -rf charts/azure-service-operator/templates/generated/
-    displayName: Deploy to AKS - Helm generate and package charts
+    displayName: Deploy to AKS - Replace image in values.yaml
 
   - task: Bash@3
     displayName: Deploy to AKS - Helm Deploy
@@ -235,7 +218,6 @@ steps:
         imagename="$(PIPELINE_CONTAINER_REGISTRY_NAME)/$(IMAGE_NAME):$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)"
         echo $imagename
         kubectl apply -f ./charts/azure-service-operator/crds/
-        #make install
         helm upgrade --install aso charts/azure-service-operator-0.1.0.tgz -n azureoperator-system --create-namespace \
             --set azureSubscriptionID=$(AZURE_SUBSCRIPTION_ID) \
             --set azureTenantID=$(AZURE_TENANT_ID) \
@@ -258,11 +240,12 @@ steps:
       scriptType: 'bash'
       scriptLocation: 'inlineScript'
       inlineScript: |
+        echo "Chosen AKS Cluster name"
+        echo $(chosenclustername)
+        az aks get-credentials -g $(AKS_CLUSTER_RG) -n $(chosenclustername)
         kubectl delete -f ./charts/azure-service-operator/crds/
         helm list
         helm delete aso
-        echo "Chosen AKS Cluster name"
-        echo $(chosenclustername)
         # Set tags to available for the selected cluster to put it back into the free pool
         echo "Setting tags back to free"
         az resource tag --tags 'freeforpipeline=true' -g $(AKS_CLUSTER_RG) -n $(chosenclustername) --resource-type Microsoft.ContainerService/managedClusters

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -251,7 +251,7 @@ steps:
         echo "Setting tags back to free"
         az resource tag --tags 'freeforpipeline=true' -g $(AKS_CLUSTER_RG) -n $(chosenclustername) --resource-type Microsoft.ContainerService/managedClusters
       workingDirectory: '$(System.DefaultWorkingDirectory)'
-      failOnStandardError: false
+      failOnStandardError: true
     displayName: Deploy to AKS - Clean up deployment and release cluster back to free pool
 
   - task: Docker@2


### PR DESCRIPTION
Closes #1132 

**What this PR does / why we need it**:
- We were building the helm chart in the pipeline, but that results in us not being able to validate the Helm chart thats checked in and makes it impossible for us to catch the Helm chart not being updated in the repo. So the pipeline now uses the checked in charts and pushes that to MCR/release. 
- Also cleans up the CRDs and deployment in the cluster at the end of the deploy test

Latest run of the pipeline - https://dev.azure.com/azure/azure-service-operator/_build/results?buildId=10817&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
