### PR TITLE
Corret the MySQL username format to <username>@%, and use SQL injection for MySQL CreateUser and DropUser

### DIFF
--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
@@ -89,7 +89,7 @@ func (s *MySqlUserManager) GrantUserRoles(ctx context.Context, user string, data
 		if err := helpers.FindBadChars(role); err != nil {
 			return fmt.Errorf("Problem found with role: %v", err)
 		}
-		//TODO: how to use SQL injection for grant command, like CreateUser and DropUser
+		//TODO: how to use SQL parameters for grant command, like CreateUser and DropUser
 		tsql := fmt.Sprintf("GRANT %s ON `%s`.* TO '%s'", role, database, user)
 		_, err := db.ExecContext(ctx, tsql)
 		if err != nil {

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
@@ -18,7 +18,7 @@ import (
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	_ "github.com/go-sql-driver/mysql" //sql drive link
+	_ "github.com/go-sql-driver/mysql" //mysql drive link
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -62,7 +62,7 @@ func (s *MySqlUserManager) GetDB(ctx context.Context, resourceGroupName string, 
 // ConnectToSqlDb connects to the SQL db using the given credentials
 func (s *MySqlUserManager) ConnectToSqlDb(ctx context.Context, drivername string, fullserver string, database string, port int, user string, password string) (*sql.DB, error) {
 
-	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=skip-verify", user, password, fullserver, port, database)
+	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=skip-verify&interpolateParams=true", user, password, fullserver, port, database)
 
 	db, err := sql.Open(drivername, connString)
 	if err != nil {
@@ -78,19 +78,19 @@ func (s *MySqlUserManager) ConnectToSqlDb(ctx context.Context, drivername string
 }
 
 // GrantUserRoles grants roles to a user for a given database
-func (s *MySqlUserManager) GrantUserRoles(ctx context.Context, user string, server string, database string, roles []string, db *sql.DB) error {
+func (s *MySqlUserManager) GrantUserRoles(ctx context.Context, user string, database string, roles []string, db *sql.DB) error {
 	var errorStrings []string
 	if err := helpers.FindBadChars(user); err != nil {
 		return fmt.Errorf("Problem found with username: %v", err)
 	}
 
 	for _, role := range roles {
-		tsql := fmt.Sprintf("GRANT %s ON `%s`.* TO '%s'@'%s'", role, database, user, server)
 
 		if err := helpers.FindBadChars(role); err != nil {
 			return fmt.Errorf("Problem found with role: %v", err)
 		}
-
+		//TODO: how to use SQL injection for grant command, like CreateUser and DropUser
+		tsql := fmt.Sprintf("GRANT %s ON `%s`.* TO '%s'", role, database, user)
 		_, err := db.ExecContext(ctx, tsql)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -104,11 +104,10 @@ func (s *MySqlUserManager) GrantUserRoles(ctx context.Context, user string, serv
 }
 
 // CreateUser creates user with secret credentials
-func (s *MySqlUserManager) CreateUser(ctx context.Context, server string, secret map[string][]byte, db *sql.DB) (string, error) {
+func (s *MySqlUserManager) CreateUser(ctx context.Context, secret map[string][]byte, db *sql.DB) (string, error) {
 	newUser := string(secret[MSecretUsernameKey])
 	newPassword := string(secret[MSecretPasswordKey])
 
-	// make an effort to prevent sql injection
 	if err := helpers.FindBadChars(newUser); err != nil {
 		return "", fmt.Errorf("Problem found with username: %v", err)
 	}
@@ -116,8 +115,8 @@ func (s *MySqlUserManager) CreateUser(ctx context.Context, server string, secret
 		return "", fmt.Errorf("Problem found with password: %v", err)
 	}
 
-	tsql := fmt.Sprintf("CREATE USER IF NOT EXISTS '%s'@'%s' IDENTIFIED BY '%s'", newUser, server, newPassword)
-	_, err := db.ExecContext(ctx, tsql)
+	tsql := "CREATE USER IF NOT EXISTS ? IDENTIFIED BY ? "
+	_, err := db.ExecContext(ctx, tsql, newUser, newPassword)
 
 	if err != nil {
 		return newUser, err
@@ -126,11 +125,9 @@ func (s *MySqlUserManager) CreateUser(ctx context.Context, server string, secret
 }
 
 // UserExists checks if db contains user
-func (s *MySqlUserManager) UserExists(ctx context.Context, db *sql.DB, username string, server string) (bool, error) {
+func (s *MySqlUserManager) UserExists(ctx context.Context, db *sql.DB, username string) (bool, error) {
 
-	//tsql := fmt.Sprintf("SELECT * FROM mysql.user WHERE (Host = '%s') and (User = '%s')", server, username)
-
-	err := db.QueryRowContext(ctx, "SELECT * FROM mysql.user WHERE (Host = $1) and (User = $2)", server, username)
+	err := db.QueryRowContext(ctx, "SELECT * FROM mysql.user WHERE User = $1", username)
 	//err := db.ExecContext(ctx, tsql)
 
 	if err != nil {
@@ -138,18 +135,16 @@ func (s *MySqlUserManager) UserExists(ctx context.Context, db *sql.DB, username 
 	}
 	return true, nil
 
-	//rows, err := res.RowsAffected()
-	//return rows > 0, err
-
 }
 
 // DropUser drops a user from db
-func (s *MySqlUserManager) DropUser(ctx context.Context, db *sql.DB, user string, server string) error {
-	tsql := fmt.Sprintf("DROP USER IF EXISTS '%s'@'%s'", user, server)
+func (s *MySqlUserManager) DropUser(ctx context.Context, db *sql.DB, user string) error {
+
 	if err := helpers.FindBadChars(user); err != nil {
 		return fmt.Errorf("Problem found with username: %v", err)
 	}
-	_, err := db.ExecContext(ctx, tsql)
+	tsql := "DROP USER IF EXISTS ?"
+	_, err := db.ExecContext(ctx, tsql, user)
 	return err
 }
 
@@ -183,7 +178,6 @@ func (s *MySqlUserManager) GetOrPrepareSecret(ctx context.Context, instance *v1a
 
 	secret, err := secretClient.Get(ctx, key)
 	if err != nil {
-		// @todo: find out whether this is an error due to non existing key or failed conn
 		pw := helpers.NewPassword()
 		return map[string][]byte{
 			"username":                 []byte(""),

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
@@ -143,8 +143,7 @@ func (s *MySqlUserManager) DropUser(ctx context.Context, db *sql.DB, user string
 	if err := helpers.FindBadChars(user); err != nil {
 		return fmt.Errorf("Problem found with username: %v", err)
 	}
-	tsql := "DROP USER IF EXISTS ?"
-	_, err := db.ExecContext(ctx, tsql, user)
+	_, err := db.ExecContext(ctx, "DROP USER IF EXISTS ?", user)
 	return err
 }
 

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser_manager.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser_manager.go
@@ -14,13 +14,14 @@ import (
 	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
+//MySQLUser interface provides the functions of mySQLUser
 type MySQLUser interface {
 	GetDB(ctx context.Context, resourceGroupName string, serverName string, databaseName string) (mysql.Database, error)
 	ConnectToMySqlDb(ctx context.Context, drivername string, server string, dbname string, port int, username string, password string) (*sql.DB, error)
-	GrantUserRoles(ctx context.Context, user string, server string, database string, roles []string, db *sql.DB) error
+	GrantUserRoles(ctx context.Context, user string, database string, roles []string, db *sql.DB) error
 	CreateUser(ctx context.Context, server string, secret map[string][]byte, db *sql.DB) (string, error)
-	UserExists(ctx context.Context, db *sql.DB, username string, sevrer string) (bool, error)
-	DropUser(ctx context.Context, db *sql.DB, user string, server string) error
+	UserExists(ctx context.Context, db *sql.DB, username string) (bool, error)
+	DropUser(ctx context.Context, db *sql.DB, user string) error
 	DeleteSecrets(ctx context.Context, instance *v1alpha1.MySQLUser, secretClient secrets.SecretClient) (bool, error)
 	GetOrPrepareSecret(ctx context.Context, instance *v1alpha1.MySQLUser, secretClient secrets.SecretClient) map[string][]byte
 

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
@@ -150,7 +150,7 @@ func (s *MySqlUserManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 		return false, err
 	}
 
-	user, err = s.CreateUser(ctx, string(instance.Spec.Server), DBSecret, db)
+	user, err = s.CreateUser(ctx, DBSecret, db)
 	if err != nil {
 		instance.Status.Message = "failed creating user, err: " + err.Error()
 		return false, err
@@ -162,7 +162,7 @@ func (s *MySqlUserManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 		return false, fmt.Errorf("No roles specified for database user")
 	}
 
-	err = s.GrantUserRoles(ctx, user, string(instance.Spec.Server), string(instance.Spec.DbName), instance.Spec.Roles, db)
+	err = s.GrantUserRoles(ctx, user, string(instance.Spec.DbName), instance.Spec.Roles, db)
 	if err != nil {
 		instance.Status.Message = "GrantUserRoles failed"
 		return false, fmt.Errorf("GrantUserRoles failed")
@@ -271,7 +271,7 @@ func (s *MySqlUserManager) Delete(ctx context.Context, obj runtime.Object, opts 
 
 	user := string(userSecret[MSecretUsernameKey])
 
-	err = s.DropUser(ctx, db, user, string(instance.Spec.Server))
+	err = s.DropUser(ctx, db, user)
 	if err != nil {
 		instance.Status.Message = fmt.Sprintf("Delete MySqlUser failed with %s", err.Error())
 		return false, err


### PR DESCRIPTION
This PR is part of  #1147, also fix the username bug found during customer test in engagement3. 

**What this PR does / why we need it**:
The PR has fixes: 
-- As customer requested,  MySQL Username should be created using the default format: ```<username>@%```, but not ```<username>@<servername>```.The '%' is the hostname and is different than the mysql login name that should be with the ```<username>@<servername> ``` format. 
https://dev.mysql.com/doc/refman/5.7/en/create-user.html
https://dev.mysql.com/doc/refman/5.7/en/account-names.html

If the user was created without specify the '@' part, it will be created using the default format.  
-- By specify the 'interpolateParams' parameter and MySQL CreateUser and DropUser now use the SQL injection to create SQL query command.  

**Special notes for your reviewer**:
Before the PR: 
Use the sample yaml file to create a MySQL user (should create a MySQL server and MySQL database first). Then from the connect tool like MySQL Workbench you will see the MySQL User name format is like below: 

![image](https://user-images.githubusercontent.com/37413937/84031715-c4e33780-a9c8-11ea-80ae-a8075ac5809e.png)

After the change: 
The create user is using the default format <username>@%.  

![image](https://user-images.githubusercontent.com/37413937/84617464-96ea7f80-af01-11ea-9a25-37dec12e8c3e.png)

To further verify the user has been created correctly, use the created username and password to login to MySQL (using mysql workbench as an example). 
Please note that when login, the username should be entered with the format <username>@<mysqlserver> which is required by MySQL. 


![image](https://user-images.githubusercontent.com/37413937/84617631-34de4a00-af02-11ea-9a32-d7d6aa934fe3.png)

You can successfully login with the newly create mysql user and if you have granted privilege to the user, you can execute corresponding actions. e.g. Select operation. 

Delete the user and you will get the mysql user removed from both cli and the MySQL workbench. 

The introduce of 'interpolateParams' won't impact the MySQL create and delete strategy but will make it safe. 





**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
