### PR TITLE
Fixing broken link of 'Testing' content

### DIFF
--- a/docs/howto/contents.md
+++ b/docs/howto/contents.md
@@ -8,7 +8,7 @@
 2. [Developing](development.md)
     Find useful information for running the operator locally.
 
-3. [Testing](test.md)
+3. [Testing](testing.md)
    Find information about how to run and author tests.
 
 4. [Deploying](deploy.md)


### PR DESCRIPTION
Azure Service Operator Documentation has a link to the Testing page. But that link is broken and it is giving a 404 error. This PR is fixing that broken link.

- [ ]  this PR contains documentation

