### PR TITLE
Changed VSC Go extension name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,7 @@
     ],
     
     "extensions": [
-      "ms-vscode.go",
+      "golang.go",		
       "ms-vscode.azurecli",
       "ms-azuretools.vscode-docker",
       "ms-kubernetes-tools.vscode-kubernetes-tools"


### PR DESCRIPTION
VSC Go extension is hosted by Google now. This PR points to the new extension name.
This should fix #1230

