### PR TITLE
Handle SQL DB conflicts (and other errors)

### DIFF
--- a/api/v1alpha1/azuresqldatabase_types.go
+++ b/api/v1alpha1/azuresqldatabase_types.go
@@ -25,7 +25,6 @@ type AzureSqlDatabaseSpec struct {
 	DbName string `json:"dbName,omitempty"`
 }
 
-
 // AzureSqlDatabase is the Schema for the azuresqldatabases API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/pkg/errhelp/errors.go
+++ b/pkg/errhelp/errors.go
@@ -69,7 +69,7 @@ const (
 	OperationIdNotFound                            = "OperationIdNotFound"
 )
 
-func NewAzureError(err error) error {
+func NewAzureError(err error) *AzureError {
 	var kind, reason string
 	if err == nil {
 		return nil
@@ -146,13 +146,6 @@ func NewAzureError(err error) error {
 	ae.Type = kind
 
 	return &ae
-}
-
-func NewAzureErrorAzureError(err error) *AzureError {
-	if err == nil {
-		return nil
-	}
-	return NewAzureError(err).(*AzureError)
 }
 
 type AzureError struct {

--- a/pkg/errhelp/errors.go
+++ b/pkg/errhelp/errors.go
@@ -66,6 +66,7 @@ const (
 	FeatureNotSupportedForEdition                  = "FeatureNotSupportedForEdition"
 	VirtualNetworkRuleBadRequest                   = "VirtualNetworkRuleBadRequest"
 	LongTermRetentionPolicyInvalid                 = "LongTermRetentionPolicyInvalid"
+	OperationIdNotFound                            = "OperationIdNotFound"
 )
 
 func NewAzureError(err error) error {
@@ -148,6 +149,9 @@ func NewAzureError(err error) error {
 }
 
 func NewAzureErrorAzureError(err error) *AzureError {
+	if err == nil {
+		return nil
+	}
 	return NewAzureError(err).(*AzureError)
 }
 

--- a/pkg/resourcemanager/apim/apimgmt/apimgmt.go
+++ b/pkg/resourcemanager/apim/apimgmt/apimgmt.go
@@ -163,7 +163,7 @@ func (m *Manager) Ensure(ctx context.Context, obj runtime.Object, opts ...resour
 		catch := []string{
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			instance.Status.Message = err.Error()
 			return false, nil
@@ -199,7 +199,7 @@ func (m *Manager) Delete(ctx context.Context, obj runtime.Object, opts ...resour
 	if err != nil {
 		i.Status.Message = err.Error()
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		handle := []string{
 			errhelp.ResourceNotFound,
 			errhelp.ParentNotFoundErrorCode,

--- a/pkg/resourcemanager/apim/apimgmt/apimgmt_test.go
+++ b/pkg/resourcemanager/apim/apimgmt/apimgmt_test.go
@@ -73,7 +73,7 @@ var _ = Describe("API Management", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false
@@ -98,7 +98,7 @@ var _ = Describe("API Management", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false

--- a/pkg/resourcemanager/apim/apimservice/reconcile.go
+++ b/pkg/resourcemanager/apim/apimservice/reconcile.go
@@ -79,7 +79,7 @@ func (g *AzureAPIMgmtServiceManager) Ensure(ctx context.Context, obj runtime.Obj
 			_, err := g.CreateAPIMgmtSvc(ctx, tier, location, resourceGroupName, resourceName, publisherName, publisherEmail)
 			if err != nil {
 				instance.Status.Provisioning = false
-				azerr := errhelp.NewAzureErrorAzureError(err)
+				azerr := errhelp.NewAzureError(err)
 				if helpers.ContainsString(catch, azerr.Type) {
 					instance.Status.Message = "API Mgmt Svc encountered a caught error, requeueing..."
 					return false, nil
@@ -119,7 +119,7 @@ func (g *AzureAPIMgmtServiceManager) Ensure(ctx context.Context, obj runtime.Obj
 			appInsightsName,
 		)
 		if err != nil {
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 			if helpers.ContainsString(catch, azerr.Type) {
 				instance.Status.Message = "API Mgmt Svc encountered a caught error, requeueing..."
 				return false, nil
@@ -151,7 +151,7 @@ func (g *AzureAPIMgmtServiceManager) Ensure(ctx context.Context, obj runtime.Obj
 			subnetName,
 		)
 		if err != nil {
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 			if !helpers.ContainsString(catch, azerr.Type) {
 				instance.Status.Message = "API Mgmt Svc encountered a caught error, requeueing..."
 				return false, nil
@@ -194,7 +194,7 @@ func (g *AzureAPIMgmtServiceManager) Delete(ctx context.Context, obj runtime.Obj
 
 	_, err = g.DeleteAPIMgmtSvc(ctx, resourceGroupName, resourceName)
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		alreadyDeletedErrors := []string{
 			errhelp.ResourceGroupNotFoundErrorCode,

--- a/pkg/resourcemanager/appinsights/api_keys_reconcile.go
+++ b/pkg/resourcemanager/appinsights/api_keys_reconcile.go
@@ -65,7 +65,7 @@ func (c *InsightsAPIKeysClient) Ensure(ctx context.Context, obj runtime.Object, 
 	)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// handle errors
 		switch azerr.Code {
@@ -135,7 +135,7 @@ func (c *InsightsAPIKeysClient) Delete(ctx context.Context, obj runtime.Object, 
 			errhelp.ResourceGroupNotFoundErrorCode,
 			errhelp.AsyncOpIncompleteError,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}

--- a/pkg/resourcemanager/appinsights/appinsights.go
+++ b/pkg/resourcemanager/appinsights/appinsights.go
@@ -196,7 +196,7 @@ func (m *Manager) Ensure(ctx context.Context, obj runtime.Object, opts ...resour
 			errhelp.AsyncOpIncompleteError,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			instance.Status.Message = err.Error()
 			return false, nil
@@ -247,7 +247,7 @@ func (m *Manager) Delete(ctx context.Context, obj runtime.Object, opts ...resour
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/appinsights/appinsights_test.go
+++ b/pkg/resourcemanager/appinsights/appinsights_test.go
@@ -46,7 +46,7 @@ var _ = Describe("App Insights", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false
@@ -71,7 +71,7 @@ var _ = Describe("App Insights", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false

--- a/pkg/resourcemanager/appinsights/suite_test.go
+++ b/pkg/resourcemanager/appinsights/suite_test.go
@@ -80,7 +80,7 @@ var _ = AfterSuite(func() {
 	ignore := []string{
 		errhelp.AsyncOpIncompleteError,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if !helpers.ContainsString(ignore, azerr.Type) {
 		log.Println("Delete RG failed")
 		return
@@ -95,7 +95,7 @@ var _ = AfterSuite(func() {
 			catch := []string{
 				errhelp.ResourceGroupNotFoundErrorCode,
 			}
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 			if helpers.ContainsString(catch, azerr.Type) {
 				log.Println("Delete RG failed")
 				return

--- a/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
+++ b/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
@@ -123,7 +123,7 @@ func (s *AzureSqlActionManager) UpdateAdminPassword(ctx context.Context, groupNa
 	_, _, err = azuresqlserverManager.CreateOrUpdateSQLServer(ctx, groupName, *server.Location, serverName, server.Tags, azureSqlServerProperties, true)
 
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if !strings.Contains(azerr.Type, errhelp.AsyncOpIncompleteError) {
 			return err
 		}

--- a/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction_reconcile.go
@@ -63,7 +63,7 @@ func (s *AzureSqlActionManager) Ensure(ctx context.Context, obj runtime.Object, 
 					errhelp.ResourceGroupNotFoundErrorCode, // RG not present yet
 					errhelp.ResourceNotFound,               // server not present yet
 				}
-				azerr := errhelp.NewAzureErrorAzureError(err)
+				azerr := errhelp.NewAzureError(err)
 				if helpers.ContainsString(catch, azerr.Type) {
 					return false, nil //requeue until server/RG ready
 				}

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_reconcile.go
@@ -71,7 +71,7 @@ func (db *AzureSqlDbManager) Ensure(ctx context.Context, obj runtime.Object, opt
 		// TODO: There are other places which use PollClient which may or may not need this treatment as well...
 		pClient := pollclient.NewPollClient()
 		res, err := pClient.Get(ctx, instance.Status.PollingURL)
-		pollErr := errhelp.NewAzureErrorAzureError(err)
+		pollErr := errhelp.NewAzureError(err)
 		if pollErr != nil {
 			if pollErr.Type == errhelp.OperationIdNotFound {
 				// Something happened to our OperationId, just clear things out and try again
@@ -129,7 +129,7 @@ func (db *AzureSqlDbManager) Ensure(ctx context.Context, obj runtime.Object, opt
 					errhelp.LongTermRetentionPolicyInvalid,
 				}
 				instance.Status.Message = fmt.Sprintf("Azure DB long-term retention policy error: %s", errhelp.StripErrorIDs(err))
-				azerr := errhelp.NewAzureErrorAzureError(err)
+				azerr := errhelp.NewAzureError(err)
 				if helpers.ContainsString(failureErrors, azerr.Type) {
 					instance.Status.Provisioning = false
 					instance.Status.Provisioned = false
@@ -150,7 +150,7 @@ func (db *AzureSqlDbManager) Ensure(ctx context.Context, obj runtime.Object, opt
 			return true, nil
 		} else {
 			instance.Status.Message = fmt.Sprintf("AzureSqlDb Get error %s", err.Error())
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 			requeuErrors := []string{
 				errhelp.ParentNotFoundErrorCode,
 				errhelp.ResourceGroupNotFoundErrorCode,
@@ -165,7 +165,7 @@ func (db *AzureSqlDbManager) Ensure(ctx context.Context, obj runtime.Object, opt
 
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// handle errors
 		// resource request has been sent to ARM
@@ -238,7 +238,7 @@ func (db *AzureSqlDbManager) Delete(ctx context.Context, obj runtime.Object, opt
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/azuresql/azuresqlfailovergroup/azuresqlfailovergroup_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlfailovergroup/azuresqlfailovergroup_reconcile.go
@@ -64,7 +64,7 @@ func (fg *AzureSqlFailoverGroupManager) Ensure(ctx context.Context, obj runtime.
 		errhelp.ResourceGroupNotFoundErrorCode,
 		errhelp.ParentNotFoundErrorCode,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if helpers.ContainsString(requeuErrors, azerr.Type) {
 		instance.Status.Provisioning = false
 		return false, nil
@@ -85,7 +85,7 @@ func (fg *AzureSqlFailoverGroupManager) Ensure(ctx context.Context, obj runtime.
 		catchUnrecoverableErrors := []string{
 			errhelp.InvalidFailoverGroupRegion,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}
@@ -142,7 +142,7 @@ func (fg *AzureSqlFailoverGroupManager) Delete(ctx context.Context, obj runtime.
 	_, err = fg.DeleteFailoverGroup(ctx, groupName, serverName, failoverGroupName)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// these errors are expected
 		ignore := []string{

--- a/pkg/resourcemanager/azuresql/azuresqlfirewallrule/azuresqlfirewallrule_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlfirewallrule/azuresqlfirewallrule_reconcile.go
@@ -42,7 +42,7 @@ func (fw *AzureSqlFirewallRuleManager) Ensure(ctx context.Context, obj runtime.O
 		errhelp.ResourceGroupNotFoundErrorCode,
 		errhelp.ParentNotFoundErrorCode,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if helpers.ContainsString(requeuErrors, azerr.Type) {
 		instance.Status.Provisioning = false
 		return false, nil
@@ -58,7 +58,7 @@ func (fw *AzureSqlFirewallRuleManager) Ensure(ctx context.Context, obj runtime.O
 			errhelp.AlreadyExists,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}
@@ -89,7 +89,7 @@ func (fw *AzureSqlFirewallRuleManager) Delete(ctx context.Context, obj runtime.O
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser_reconcile.go
@@ -50,7 +50,7 @@ func (s *AzureSqlManagedUserManager) Ensure(ctx context.Context, obj runtime.Obj
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(requeuErrors, azerr.Type) {
 			return false, nil
 		}
@@ -156,7 +156,7 @@ func (s *AzureSqlManagedUserManager) Delete(ctx context.Context, obj runtime.Obj
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// Best case deletion of secrets
 			err2 := s.DeleteSecrets(ctx, instance, s.SecretClient)

--- a/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
@@ -124,7 +124,7 @@ func (s *AzureSqlServerManager) Ensure(ctx context.Context, obj runtime.Object, 
 
 		serv, err := s.GetServer(ctx, instance.Spec.ResourceGroup, instance.Name)
 		if err != nil {
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 
 			// handle failures in the async operation
 			if instance.Status.PollingURL != "" {
@@ -178,7 +178,7 @@ func (s *AzureSqlServerManager) Ensure(ctx context.Context, obj runtime.Object, 
 		instance.Status.Message = err.Error()
 
 		// check for our known errors
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		switch azerr.Type {
 		case errhelp.AsyncOpIncompleteError:
@@ -275,7 +275,7 @@ func (s *AzureSqlServerManager) Delete(ctx context.Context, obj runtime.Object, 
 	_, err = s.DeleteSQLServer(ctx, groupName, name)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// these errors are expected
 		ignore := []string{

--- a/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
@@ -86,7 +86,7 @@ func (s *AzureSqlUserManager) Ensure(ctx context.Context, obj runtime.Object, op
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(requeuErrors, azerr.Type) {
 			return false, nil
 		}
@@ -334,7 +334,7 @@ func (s *AzureSqlUserManager) Delete(ctx context.Context, obj runtime.Object, op
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}

--- a/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule_reconcile.go
@@ -48,7 +48,7 @@ func (vr *AzureSqlVNetRuleManager) Ensure(ctx context.Context, obj runtime.Objec
 		errhelp.ResourceGroupNotFoundErrorCode,
 		errhelp.ParentNotFoundErrorCode,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if helpers.ContainsString(requeuErrors, azerr.Type) {
 		instance.Status.Provisioning = false
 		return false, nil
@@ -58,7 +58,7 @@ func (vr *AzureSqlVNetRuleManager) Ensure(ctx context.Context, obj runtime.Objec
 	_, err = vr.CreateOrUpdateSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, ignoreendpoint)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		if azerr.Type == errhelp.AsyncOpIncompleteError {
 			instance.Status.Provisioning = true
@@ -104,7 +104,7 @@ func (vr *AzureSqlVNetRuleManager) Delete(ctx context.Context, obj runtime.Objec
 	if err != nil {
 		instance.Status.Message = err.Error()
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		// these errors are expected
 		ignore := []string{
 			errhelp.AsyncOpIncompleteError,

--- a/pkg/resourcemanager/cosmosdbs/cosmosdb_reconcile.go
+++ b/pkg/resourcemanager/cosmosdbs/cosmosdb_reconcile.go
@@ -68,7 +68,7 @@ func (m *AzureCosmosDBManager) Ensure(ctx context.Context, obj runtime.Object, o
 	// get the instance and update status
 	db, err := m.GetCosmosDB(ctx, instance.Spec.ResourceGroup, instance.Name)
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		instance.Status.Message = err.Error()
 
@@ -117,7 +117,7 @@ func (m *AzureCosmosDBManager) Ensure(ctx context.Context, obj runtime.Object, o
 	accountName := instance.ObjectMeta.Name
 	db, pollingUrl, err := m.CreateOrUpdateCosmosDB(ctx, accountName, instance.Spec, tags)
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		instance.Status.Message = err.Error()
 
 		switch azerr.Type {
@@ -184,7 +184,7 @@ func (m *AzureCosmosDBManager) Delete(ctx context.Context, obj runtime.Object, o
 	// try to delete the cosmosdb instance & secrets
 	_, err = m.DeleteCosmosDB(ctx, groupName, accountName)
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// request submitted or already in progress
 		if azerr.Type == errhelp.AsyncOpIncompleteError || (azerr.Type == errhelp.PreconditionFailed && strings.Contains(azerr.Reason, "operation in progress")) {

--- a/pkg/resourcemanager/eventhubs/consumergroup.go
+++ b/pkg/resourcemanager/eventhubs/consumergroup.go
@@ -124,7 +124,7 @@ func (cg *azureConsumerGroupManager) Ensure(ctx context.Context, obj runtime.Obj
 	newCg, err := cg.CreateConsumerGroup(ctx, resourcegroup, namespaceName, eventhubName, azureConsumerGroupName)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// this happens when op isnt complete, just requeue
 		if strings.Contains(azerr.Type, errhelp.AsyncOpIncompleteError) {
@@ -175,7 +175,7 @@ func (cg *azureConsumerGroupManager) Delete(ctx context.Context, obj runtime.Obj
 	// deletions to non existing groups lead to 'conflicting operation' errors so we GET it here
 	_, err = cg.GetConsumerGroup(ctx, resourcegroup, namespaceName, eventhubName, azureConsumerGroupName)
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		catch := []string{
 			errhelp.ResourceGroupNotFoundErrorCode,
 			errhelp.ParentNotFoundErrorCode,

--- a/pkg/resourcemanager/eventhubs/hub.go
+++ b/pkg/resourcemanager/eventhubs/hub.go
@@ -250,7 +250,7 @@ func (e *azureEventHubManager) Ensure(ctx context.Context, obj runtime.Object, o
 	hub, err := e.CreateHub(ctx, resourcegroup, eventhubNamespace, eventhubName, messageRetentionInDays, partitionCount, capturePtr)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// this happens when op isnt complete, just requeue
 		if azerr.Type == errhelp.AsyncOpIncompleteError {
@@ -349,7 +349,7 @@ func (e *azureEventHubManager) Delete(ctx context.Context, obj runtime.Object, o
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.NotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			instance.Status.Message = err.Error()
 			return false, nil

--- a/pkg/resourcemanager/eventhubs/namespace.go
+++ b/pkg/resourcemanager/eventhubs/namespace.go
@@ -318,7 +318,7 @@ func (ns *azureEventHubNamespaceManager) Ensure(ctx context.Context, obj runtime
 				_, err := ns.CreateNetworkRuleSet(ctx, resourcegroup, namespaceName, networkRuleSet)
 				if err != nil {
 					instance.Status.Message = errhelp.StripErrorIDs(err)
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 
 					ignorableErrors := []string{
 						errhelp.ResourceGroupNotFoundErrorCode,
@@ -359,7 +359,7 @@ func (ns *azureEventHubNamespaceManager) Ensure(ctx context.Context, obj runtime
 	newNs, err := ns.CreateNamespace(ctx, resourcegroup, namespaceName, namespaceLocation, eventHubNSSku, eventHubNSProperties)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		if strings.Contains(azerr.Type, errhelp.AsyncOpIncompleteError) {
 			// resource creation request sent to Azure
@@ -392,7 +392,7 @@ func (ns *azureEventHubNamespaceManager) Delete(ctx context.Context, obj runtime
 
 	resp, err := ns.DeleteNamespace(ctx, resourcegroup, namespaceName)
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// check if async op from previous delete was still happening
 		catch := []string{

--- a/pkg/resourcemanager/keyvaults/keyops.go
+++ b/pkg/resourcemanager/keyvaults/keyops.go
@@ -47,7 +47,7 @@ func (k *KeyvaultKeyClient) Ensure(ctx context.Context, obj runtime.Object, opts
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}
@@ -139,7 +139,7 @@ func (k *KeyvaultKeyClient) Delete(ctx context.Context, obj runtime.Object, opts
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}

--- a/pkg/resourcemanager/keyvaults/keyvault.go
+++ b/pkg/resourcemanager/keyvaults/keyvault.go
@@ -475,7 +475,7 @@ func HandleCreationError(instance *v1alpha1.KeyVault, err error) (bool, error) {
 		errhelp.LocationNotAvailableForResourceType,
 	}
 
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if helpers.ContainsString(catch, azerr.Type) {
 		// most of these error technically mean the resource is actually not provisioning
 		switch azerr.Type {
@@ -529,7 +529,7 @@ func (k *azureKeyVaultManager) Delete(ctx context.Context, obj runtime.Object, o
 				errhelp.NotFoundErrorCode,
 				errhelp.ResourceNotFound,
 			}
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 			if helpers.ContainsString(catch, azerr.Type) {
 				return true, nil
 			} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/keyvaults/keyvault_test.go
+++ b/pkg/resourcemanager/keyvaults/keyvault_test.go
@@ -78,7 +78,7 @@ var _ = Describe("KeyVault Resource Manager test", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false
@@ -105,7 +105,7 @@ var _ = Describe("KeyVault Resource Manager test", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false

--- a/pkg/resourcemanager/keyvaults/suite_test.go
+++ b/pkg/resourcemanager/keyvaults/suite_test.go
@@ -84,7 +84,7 @@ var _ = AfterSuite(func() {
 	ignore := []string{
 		errhelp.AsyncOpIncompleteError,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if !helpers.ContainsString(ignore, azerr.Type) {
 		log.Println("Delete RG failed")
 		return
@@ -101,7 +101,7 @@ var _ = AfterSuite(func() {
 		catch := []string{
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			log.Println("resource group deleted")
 			return true

--- a/pkg/resourcemanager/loadbalancer/reconcile.go
+++ b/pkg/resourcemanager/loadbalancer/reconcile.go
@@ -71,7 +71,7 @@ func (g *AzureLoadBalancerClient) Ensure(ctx context.Context, obj runtime.Object
 			errhelp.InvalidResourceReference,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -99,7 +99,7 @@ func (g *AzureLoadBalancerClient) Ensure(ctx context.Context, obj runtime.Object
 			errhelp.SubscriptionDoesNotHaveServer,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -150,7 +150,7 @@ func (g *AzureLoadBalancerClient) Delete(ctx context.Context, obj runtime.Object
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/mysql/database/reconcile.go
+++ b/pkg/resourcemanager/mysql/database/reconcile.go
@@ -57,7 +57,7 @@ func (m *MySQLDatabaseClient) Ensure(ctx context.Context, obj runtime.Object, op
 			errhelp.ResourceNotFound,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -85,7 +85,7 @@ func (m *MySQLDatabaseClient) Ensure(ctx context.Context, obj runtime.Object, op
 			errhelp.SubscriptionDoesNotHaveServer,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -131,7 +131,7 @@ func (m *MySQLDatabaseClient) Delete(ctx context.Context, obj runtime.Object, op
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/mysql/firewallrule/reconcile.go
+++ b/pkg/resourcemanager/mysql/firewallrule/reconcile.go
@@ -59,7 +59,7 @@ func (m *MySQLFirewallRuleClient) Ensure(ctx context.Context, obj runtime.Object
 			errhelp.ResourceNotFound,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -89,7 +89,7 @@ func (m *MySQLFirewallRuleClient) Ensure(ctx context.Context, obj runtime.Object
 			errhelp.AsyncOpIncompleteError,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -134,7 +134,7 @@ func (m *MySQLFirewallRuleClient) Delete(ctx context.Context, obj runtime.Object
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
@@ -83,7 +83,7 @@ func (s *MySqlUserManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(requeuErrors, azerr.Type) {
 			return false, nil
 		}
@@ -228,7 +228,7 @@ func (s *MySqlUserManager) Delete(ctx context.Context, obj runtime.Object, opts 
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}

--- a/pkg/resourcemanager/mysql/server/reconcile.go
+++ b/pkg/resourcemanager/mysql/server/reconcile.go
@@ -154,7 +154,7 @@ func (m *MySQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts
 			instance.Status.Message = errhelp.StripErrorIDs(err)
 			instance.Status.Provisioning = false
 
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 
 			catchInProgress := []string{
 				errhelp.AsyncOpIncompleteError,
@@ -223,7 +223,7 @@ func (m *MySQLServerClient) Delete(ctx context.Context, obj runtime.Object, opts
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/mysql/vnetrule/reconcile.go
+++ b/pkg/resourcemanager/mysql/vnetrule/reconcile.go
@@ -48,7 +48,7 @@ func (vr *MySQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Object, o
 		errhelp.ResourceGroupNotFoundErrorCode,
 		errhelp.ParentNotFoundErrorCode,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if helpers.ContainsString(requeuErrors, azerr.Type) {
 		instance.Status.Provisioning = false
 		return false, nil
@@ -58,7 +58,7 @@ func (vr *MySQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Object, o
 	_, err = vr.CreateOrUpdateSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, ignoreendpoint)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		if azerr.Type == errhelp.AsyncOpIncompleteError {
 			instance.Status.Provisioning = true
@@ -115,7 +115,7 @@ func (vr *MySQLVNetRuleClient) Delete(ctx context.Context, obj runtime.Object, o
 	if err != nil {
 		instance.Status.Message = err.Error()
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		// these errors are expected
 		ignore := []string{
 			errhelp.AsyncOpIncompleteError,

--- a/pkg/resourcemanager/nic/reconcile.go
+++ b/pkg/resourcemanager/nic/reconcile.go
@@ -65,7 +65,7 @@ func (g *AzureNetworkInterfaceClient) Ensure(ctx context.Context, obj runtime.Ob
 			errhelp.InvalidResourceReference,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -93,7 +93,7 @@ func (g *AzureNetworkInterfaceClient) Ensure(ctx context.Context, obj runtime.Ob
 			errhelp.SubscriptionDoesNotHaveServer,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -144,7 +144,7 @@ func (g *AzureNetworkInterfaceClient) Delete(ctx context.Context, obj runtime.Ob
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/pip/reconcile.go
+++ b/pkg/resourcemanager/pip/reconcile.go
@@ -68,7 +68,7 @@ func (g *AzurePublicIPAddressClient) Ensure(ctx context.Context, obj runtime.Obj
 			errhelp.PublicIPIdleTimeoutIsOutOfRange,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			isReconcilationDone := false
@@ -100,7 +100,7 @@ func (g *AzurePublicIPAddressClient) Ensure(ctx context.Context, obj runtime.Obj
 			errhelp.SubscriptionDoesNotHaveServer,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -151,7 +151,7 @@ func (g *AzurePublicIPAddressClient) Delete(ctx context.Context, obj runtime.Obj
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/psql/database/database_reconcile.go
+++ b/pkg/resourcemanager/psql/database/database_reconcile.go
@@ -49,7 +49,7 @@ func (p *PSQLDatabaseClient) Ensure(ctx context.Context, obj runtime.Object, opt
 		instance.Status.Message = errhelp.StripErrorIDs(err)
 		instance.Status.Provisioning = false
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		catchInProgress := []string{
 			errhelp.AsyncOpIncompleteError,
@@ -108,7 +108,7 @@ func (p *PSQLDatabaseClient) Delete(ctx context.Context, obj runtime.Object, opt
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/psql/firewallrule/firewallrule_reconcile.go
+++ b/pkg/resourcemanager/psql/firewallrule/firewallrule_reconcile.go
@@ -47,7 +47,7 @@ func (p *PSQLFirewallRuleClient) Ensure(ctx context.Context, obj runtime.Object,
 		instance.Status.Message = errhelp.StripErrorIDs(err)
 		instance.Status.Provisioning = false
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		catchInProgress := []string{
 			errhelp.AsyncOpIncompleteError,
@@ -105,7 +105,7 @@ func (p *PSQLFirewallRuleClient) Delete(ctx context.Context, obj runtime.Object,
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/psql/psqluser/psqluser_reconcile.go
+++ b/pkg/resourcemanager/psql/psqluser/psqluser_reconcile.go
@@ -86,7 +86,7 @@ func (s *PostgreSqlUserManager) Ensure(ctx context.Context, obj runtime.Object, 
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(requeuErrors, azerr.Type) {
 			return false, nil
 		}
@@ -230,7 +230,7 @@ func (s *PostgreSqlUserManager) Delete(ctx context.Context, obj runtime.Object, 
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return false, nil
 		}

--- a/pkg/resourcemanager/psql/server/server_reconcile.go
+++ b/pkg/resourcemanager/psql/server/server_reconcile.go
@@ -150,7 +150,7 @@ func (p *PSQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts 
 			instance.Status.Message = errhelp.StripErrorIDs(err)
 			instance.Status.Provisioning = false
 
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 
 			catchInProgress := []string{
 				errhelp.AsyncOpIncompleteError,
@@ -221,7 +221,7 @@ func (p *PSQLServerClient) Delete(ctx context.Context, obj runtime.Object, opts 
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/psql/vnetrule/reconcile.go
+++ b/pkg/resourcemanager/psql/vnetrule/reconcile.go
@@ -49,7 +49,7 @@ func (vr *PostgreSQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Obje
 		errhelp.ResourceGroupNotFoundErrorCode,
 		errhelp.ParentNotFoundErrorCode,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if helpers.ContainsString(requeuErrors, azerr.Type) {
 		instance.Status.Provisioning = false
 		return false, nil
@@ -59,7 +59,7 @@ func (vr *PostgreSQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Obje
 	_, err = vr.CreateOrUpdatePostgreSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, ignoreendpoint)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		if azerr.Type == errhelp.AsyncOpIncompleteError {
 			instance.Status.Provisioning = true
@@ -116,7 +116,7 @@ func (vr *PostgreSQLVNetRuleClient) Delete(ctx context.Context, obj runtime.Obje
 	if err != nil {
 		instance.Status.Message = err.Error()
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		// these errors are expected
 		ignore := []string{
 			errhelp.AsyncOpIncompleteError,

--- a/pkg/resourcemanager/rediscaches/firewallrule/rediscachefirewallrule_reconcile.go
+++ b/pkg/resourcemanager/rediscaches/firewallrule/rediscachefirewallrule_reconcile.go
@@ -40,7 +40,7 @@ func (fw *AzureRedisCacheFirewallRuleManager) Ensure(ctx context.Context, obj ru
 	if err != nil {
 		instance.Status.Message = err.Error()
 		instance.Status.Provisioning = false
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		inProgress := []string{
 			errhelp.RequestConflictError,
@@ -87,7 +87,7 @@ func (fw *AzureRedisCacheFirewallRuleManager) Delete(ctx context.Context, obj ru
 	_, err = fw.DeleteRedisCacheFirewallRule(ctx, instance.Spec.ResourceGroup, instance.Spec.CacheName, instance.ObjectMeta.Name)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		ignorableErr := []string{
 			errhelp.AsyncOpIncompleteError,

--- a/pkg/resourcemanager/rediscaches/redis/rediscache_reconcile.go
+++ b/pkg/resourcemanager/rediscaches/redis/rediscache_reconcile.go
@@ -72,7 +72,7 @@ func (rc *AzureRedisCacheManager) Ensure(ctx context.Context, obj runtime.Object
 	_, err = rc.CreateRedisCache(ctx, *instance)
 	if err != nil {
 		instance.Status.Message = errhelp.StripErrorIDs(err)
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		catchInProgress := []string{
 			errhelp.AsyncOpIncompleteError,
@@ -150,7 +150,7 @@ func (rc *AzureRedisCacheManager) Delete(ctx context.Context, obj runtime.Object
 	_, err = rc.DeleteRedisCache(ctx, groupName, name)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		ignorableErr := []string{
 			errhelp.AsyncOpIncompleteError,

--- a/pkg/resourcemanager/resourcegroups/reconcile.go
+++ b/pkg/resourcemanager/resourcegroups/reconcile.go
@@ -30,7 +30,7 @@ func (g *AzureResourceGroupManager) Ensure(ctx context.Context, obj runtime.Obje
 	group, err := g.CreateGroup(ctx, resourcegroupName, resourcegroupLocation)
 	if err != nil {
 		instance.Status.Message = err.Error()
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 
 		// this happens when op isnt complete, just requeue
 		if strings.Contains(azerr.Type, errhelp.AsyncOpIncompleteError) {
@@ -72,11 +72,9 @@ func (g *AzureResourceGroupManager) Delete(ctx context.Context, obj runtime.Obje
 			errhelp.ResourceGroupNotFoundErrorCode,
 			errhelp.AsyncOpIncompleteError,
 		}
-		err = errhelp.NewAzureError(err)
-		if azerr, ok := err.(*errhelp.AzureError); ok {
-			if helpers.ContainsString(catch, azerr.Type) {
-				return false, nil
-			}
+		azerr := errhelp.NewAzureError(err)
+		if helpers.ContainsString(catch, azerr.Type) {
+			return false, nil
 		}
 
 		return true, fmt.Errorf("ResourceGroup delete error %v", err)

--- a/pkg/resourcemanager/resourcegroups/resourcegroup_test.go
+++ b/pkg/resourcemanager/resourcegroups/resourcegroup_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ResourceGroups", func() {
 
 			_, err = resourceGroupManager.DeleteGroup(context.Background(), resourcegroupName)
 			if err != nil {
-				azerr := errhelp.NewAzureErrorAzureError(err)
+				azerr := errhelp.NewAzureError(err)
 				if azerr.Type == errhelp.AsyncOpIncompleteError {
 					err = nil
 				}

--- a/pkg/resourcemanager/storages/blobcontainer/blob_container_reconcile.go
+++ b/pkg/resourcemanager/storages/blobcontainer/blob_container_reconcile.go
@@ -45,7 +45,7 @@ func (bc *AzureBlobContainerManager) Ensure(ctx context.Context, obj runtime.Obj
 		}
 		// END WIP: Validation error handling investigation
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		catchIgnorable := []string{
 			errhelp.ParentNotFoundErrorCode,
 			errhelp.ResourceGroupNotFoundErrorCode,
@@ -98,7 +98,7 @@ func (bc *AzureBlobContainerManager) Delete(ctx context.Context, obj runtime.Obj
 	if err != nil {
 		instance.Status.Message = err.Error()
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		catch := []string{
 			errhelp.AsyncOpIncompleteError,
 		}

--- a/pkg/resourcemanager/vm/reconcile.go
+++ b/pkg/resourcemanager/vm/reconcile.go
@@ -98,7 +98,7 @@ func (g *AzureVirtualMachineClient) Ensure(ctx context.Context, obj runtime.Obje
 			errhelp.InvalidResourceReference,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -133,7 +133,7 @@ func (g *AzureVirtualMachineClient) Ensure(ctx context.Context, obj runtime.Obje
 			errhelp.SubscriptionDoesNotHaveServer,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -175,7 +175,7 @@ func (g *AzureVirtualMachineClient) Delete(ctx context.Context, obj runtime.Obje
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/vmext/reconcile.go
+++ b/pkg/resourcemanager/vmext/reconcile.go
@@ -92,7 +92,7 @@ func (g *AzureVirtualMachineExtensionClient) Ensure(ctx context.Context, obj run
 			errhelp.InvalidResourceReference,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -120,7 +120,7 @@ func (g *AzureVirtualMachineExtensionClient) Ensure(ctx context.Context, obj run
 			errhelp.SubscriptionDoesNotHaveServer,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -172,7 +172,7 @@ func (g *AzureVirtualMachineExtensionClient) Delete(ctx context.Context, obj run
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/vmss/reconcile.go
+++ b/pkg/resourcemanager/vmss/reconcile.go
@@ -96,7 +96,7 @@ func (g *AzureVMScaleSetClient) Ensure(ctx context.Context, obj runtime.Object, 
 			errhelp.InvalidResourceReference,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -124,7 +124,7 @@ func (g *AzureVMScaleSetClient) Ensure(ctx context.Context, obj runtime.Object, 
 			errhelp.SubscriptionDoesNotHaveServer,
 		}
 
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// most of these error technically mean the resource is actually not provisioning
 			switch azerr.Type {
@@ -174,7 +174,7 @@ func (g *AzureVMScaleSetClient) Delete(ctx context.Context, obj runtime.Object, 
 			errhelp.NotFoundErrorCode,
 			errhelp.ResourceNotFound,
 		}
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			return true, nil
 		} else if helpers.ContainsString(gone, azerr.Type) {

--- a/pkg/resourcemanager/vnet/reconcile.go
+++ b/pkg/resourcemanager/vnet/reconcile.go
@@ -57,7 +57,7 @@ func (g *AzureVNetManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 		subnets,
 	)
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		instance.Status.Message = err.Error()
 
 		if result.Response.Response != nil && result.Response.Response.StatusCode == http.StatusBadRequest {

--- a/pkg/resourcemanager/vnet/suite_test.go
+++ b/pkg/resourcemanager/vnet/suite_test.go
@@ -86,7 +86,7 @@ var _ = AfterSuite(func() {
 	ignore := []string{
 		errhelp.AsyncOpIncompleteError,
 	}
-	azerr := errhelp.NewAzureErrorAzureError(err)
+	azerr := errhelp.NewAzureError(err)
 	if !helpers.ContainsString(ignore, azerr.Type) {
 		log.Println("Delete RG failed")
 		return
@@ -101,7 +101,7 @@ var _ = AfterSuite(func() {
 			catch := []string{
 				errhelp.ResourceGroupNotFoundErrorCode,
 			}
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 			if helpers.ContainsString(catch, azerr.Type) {
 				log.Println("resource group deleted")
 				break

--- a/pkg/resourcemanager/vnet/vnet_test.go
+++ b/pkg/resourcemanager/vnet/vnet_test.go
@@ -57,7 +57,7 @@ var _ = Describe("VNet", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false
@@ -82,7 +82,7 @@ var _ = Describe("VNet", func() {
 					ignore := []string{
 						errhelp.AsyncOpIncompleteError,
 					}
-					azerr := errhelp.NewAzureErrorAzureError(err)
+					azerr := errhelp.NewAzureError(err)
 					if !helpers.ContainsString(ignore, azerr.Type) {
 						fmt.Println("error occured")
 						return false

--- a/pkg/secrets/keyvault/client.go
+++ b/pkg/secrets/keyvault/client.go
@@ -292,7 +292,7 @@ func (k *KeyvaultSecretClient) Delete(ctx context.Context, key types.NamespacedN
 	_, err := k.KeyVaultClient.DeleteSecret(ctx, vaultBaseURL, secretName)
 
 	if err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if azerr.Type != errhelp.SecretNotFound { // If not found still need to purge
 			return err
 		}
@@ -301,7 +301,7 @@ func (k *KeyvaultSecretClient) Delete(ctx context.Context, key types.NamespacedN
 	// If Keyvault has softdelete enabled, we will need to purge the secret in addition to deleting it
 	_, err = k.KeyVaultClient.PurgeDeletedSecret(ctx, vaultBaseURL, secretName)
 	for err != nil {
-		azerr := errhelp.NewAzureErrorAzureError(err)
+		azerr := errhelp.NewAzureError(err)
 		if azerr.Type == errhelp.NotSupported { // Keyvault not softdelete enabled; ignore error
 			return nil
 		}

--- a/pkg/secrets/keyvault/client_test.go
+++ b/pkg/secrets/keyvault/client_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Keyvault Secrets Client", func() {
 		// Delete the resource group
 		_, err = resourceGroupManager.DeleteGroup(context.Background(), resourcegroupName)
 		if err != nil {
-			azerr := errhelp.NewAzureErrorAzureError(err)
+			azerr := errhelp.NewAzureError(err)
 			if azerr.Type == errhelp.AsyncOpIncompleteError {
 				err = nil
 			}


### PR DESCRIPTION
Closes #1274

**What this PR does / why we need it**:
SQL Databases can sometimes hit an error when attempting to modify them in quick succession. This can happen for a variety of reasons but is common in situations where there are multiple managers reconciling against the same Azure resource. Before this fix when this happened the DB would just get stuck forever.

This PR fixes the above issues and allows the operator to retry when this problem occurs.

**Special notes for your reviewer**:
This issue is difficult to write a test for given the current test framework. We should spend some time improving the framework to allow for this sort of test (probably after generator lands?)
