### PR TITLE
Move secret deletion to best effort again

### DIFF
--- a/api/v1alpha2/mysqlserver_types.go
+++ b/api/v1alpha2/mysqlserver_types.go
@@ -69,7 +69,7 @@ func NewDefaultMySQLServer(name, resourceGroup, location string) *MySQLServer {
 				Name:     "GP_Gen5_4",
 				Tier:     SkuTier("GeneralPurpose"),
 				Family:   "Gen5",
-				Size:     "51200",
+				Size:     "107374182400",
 				Capacity: 4,
 			},
 			ServerVersion:  ServerVersion("8.0"),
@@ -78,7 +78,7 @@ func NewDefaultMySQLServer(name, resourceGroup, location string) *MySQLServer {
 			StorageProfile: &MySQLStorageProfile{
 				BackupRetentionDays: to.Int32Ptr(10),
 				GeoRedundantBackup:  "Disabled",
-				StorageMB:           to.Int32Ptr(5120),
+				StorageMB:           to.Int32Ptr(100 * 1024),
 				StorageAutogrow:     "Disabled",
 			},
 		},

--- a/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser_reconcile.go
@@ -159,11 +159,7 @@ func (s *AzureSqlManagedUserManager) Delete(ctx context.Context, obj runtime.Obj
 		azerr := errhelp.NewAzureError(err)
 		if helpers.ContainsString(catch, azerr.Type) {
 			// Best case deletion of secrets
-			err2 := s.DeleteSecrets(ctx, instance, s.SecretClient)
-			if err2 != nil {
-				instance.Status.Message = "failed to delete secrets for managed identity user, err: " + err2.Error()
-				return false, err2
-			}
+			s.DeleteSecrets(ctx, instance, s.SecretClient)
 
 			return false, nil
 		}
@@ -204,11 +200,7 @@ func (s *AzureSqlManagedUserManager) Delete(ctx context.Context, obj runtime.Obj
 	}
 
 	// Best case deletion of secrets
-	err = s.DeleteSecrets(ctx, instance, s.SecretClient)
-	if err != nil {
-		instance.Status.Message = "failed to delete secrets for managed identity user, err: " + err.Error()
-		return false, err
-	}
+	s.DeleteSecrets(ctx, instance, s.SecretClient)
 
 	instance.Status.Message = fmt.Sprintf("Delete AzureSqlManagedUser succeeded")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves secret deletion to best effort.

**Special notes for your reviewer**: It was like this before and was changed as it looked like a bug. Turns out some customers liked the old behavior so we're reverting for now.

I've filed #1280 tracking a feature that should allow us to do both best effort and required deletions.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
