### PR TITLE
Add operator bundle artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ manager
 # terraform artifacts
 .terraform*
 terraform.tfstate*
+
+# operator bundle artifacts
+bundle.Dockerfile
+bundle/


### PR DESCRIPTION
**What this PR does / why we need it**:
This hides the dockerfile and bundle directory that the generate-operator-bundle target (#1285) generates so they don't get accidentally added to the repository.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/sI9zGC4bh9eCI/giphy.gif)
