### PR TITLE
update broken link in docs

### DIFF
--- a/docs/services/apimgmt/apimgmt.md
+++ b/docs/services/apimgmt/apimgmt.md
@@ -60,4 +60,4 @@ The spec consists of the following fields:
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/appinsights/appinsights.md
+++ b/docs/services/appinsights/appinsights.md
@@ -22,4 +22,4 @@ For more details on where the secrets are stored, look [here](/docs/secrets.md)
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/azuresql/azuresql.md
+++ b/docs/services/azuresql/azuresql.md
@@ -192,7 +192,7 @@ If you are using Kube for storing secrets, there will be one secret with name `<
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.
 
 ## Demo
 

--- a/docs/services/keyvault/keyvault.md
+++ b/docs/services/keyvault/keyvault.md
@@ -49,4 +49,4 @@ ALTER COLUMN ENCRYPTION KEY key_name
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/mysql/mysql.md
+++ b/docs/services/mysql/mysql.md
@@ -81,4 +81,4 @@ The username is defined by `username`. The MySQL server admin secret is stored i
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/postgresql/postgresql.md
+++ b/docs/services/postgresql/postgresql.md
@@ -59,4 +59,4 @@ The `server` indicates the PostgreSQL server on which you want to configure the 
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/rediscache/rediscache.md
+++ b/docs/services/rediscache/rediscache.md
@@ -83,4 +83,4 @@ The `shardID` field is used to specify a specific RedisCache shard to reboot. Th
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/resourcegroup/resourcegroup.md
+++ b/docs/services/resourcegroup/resourcegroup.md
@@ -15,4 +15,4 @@ A resource group needs the following fields to deploy
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/storage/blobcontainer.md
+++ b/docs/services/storage/blobcontainer.md
@@ -15,4 +15,4 @@ A Blob Container needs the following fields to deploy, along with a location and
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/storage/storageaccount.md
+++ b/docs/services/storage/storageaccount.md
@@ -32,7 +32,7 @@ A Storage Account needs the following fields to deploy, along with a location an
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.
 
 ## Secrets
 After creating a storage account, the operator stores a JSON formatted secret with the following fields. For more details on where the secrets are stored, look [here](/docs/secrets.md).

--- a/docs/services/virtualmachine/virtualmachine.md
+++ b/docs/services/virtualmachine/virtualmachine.md
@@ -32,4 +32,4 @@ Not available.
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/virtualnetwork/loadbalancer.md
+++ b/docs/services/virtualnetwork/loadbalancer.md
@@ -34,4 +34,4 @@ Not available.
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/virtualnetwork/networkinterface.md
+++ b/docs/services/virtualnetwork/networkinterface.md
@@ -28,4 +28,4 @@ Not available.
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/virtualnetwork/publicipaddress.md
+++ b/docs/services/virtualnetwork/publicipaddress.md
@@ -30,4 +30,4 @@ Not available.
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/virtualnetwork/virtualnetwork.md
+++ b/docs/services/virtualnetwork/virtualnetwork.md
@@ -30,4 +30,4 @@ You are able to specify a single or multiple subnets for your virtual network.
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/services/vmscaleset/vmscaleset.md
+++ b/docs/services/vmscaleset/vmscaleset.md
@@ -42,4 +42,4 @@ Not available.
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.

--- a/docs/virtualmachineextension/virtualmachineextension.md
+++ b/docs/virtualmachineextension/virtualmachineextension.md
@@ -37,4 +37,4 @@ A Virtual Machine Extension needs the following fields to deploy, along with a l
 
 ## Deploy, view and delete resources
 
-You can follow the steps [here](/docs/topics/resourceprovision.md) to deploy, view and delete resources.
+You can follow the steps [here](/docs/howto/resourceprovision.md) to deploy, view and delete resources.


### PR DESCRIPTION
**What this PR does / why we need it**:
- some of the documentation was moved around in https://github.com/Azure/azure-service-operator/commit/97bb1a23a314cfe6538559b6b9b4e898fd03c1d6#diff-d922fb40bc498ea697e996ac414f56cb
- not all links to the resourceprovision.md file appear to have been updated
- should hopefully make navigating the docs a little easier


**If applicable**:
- [x] this PR contains documentation
