### PR TITLE
KeyVault multiple policies ObjectID fix

### DIFF
--- a/pkg/resourcemanager/keyvaults/keyvault.go
+++ b/pkg/resourcemanager/keyvaults/keyvault.go
@@ -270,6 +270,7 @@ func (k *azureKeyVaultManager) CreateVault(ctx context.Context, instance *v1alph
 	var accessPolicies []keyvault.AccessPolicyEntry
 	if instance.Spec.AccessPolicies != nil {
 		for _, policy := range *instance.Spec.AccessPolicies {
+			policy := policy // Make a copy of the variable and redeclare it
 			newEntry, err := ParseAccessPolicy(&policy, ctx)
 			if err != nil {
 				return keyvault.Vault{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:

The range variable is overwritten at each iteration, and &policy is the same. It's end up appending a newEntry containing the same ObjectID multiple times. Simple workaround is to use a local copy of that variable.
