### PR TITLE
Add pre-reqs to setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Curious to see how it all works? Check out our [control flow diagrams](/docs/how
 
 Ready to quickly deploy the latest version of Azure Service Operator on your Kubernetes cluster and start exploring? Follow these steps.
 
+0. Before starting, you must have a Kubernetes cluster (at least version 1.16) [created and running](https://kubernetes.io/docs/tutorials/kubernetes-basics/create-cluster/). Check your connection and version with:
+
+   ```console
+   $ kubectl version
+   Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.2", GitCommit:"f5743093fd1c663cb0cbc89748f730662345d44d", GitTreeState:"clean", BuildDate:"2020-09-16T13:41:02Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}
+   Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.2", GitCommit:"52c56ce7a8272c798dbc29846288d7cd9fbae032", GitTreeState:"clean", BuildDate:"2020-04-30T20:19:45Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}
+    ```
 
 1. Install [cert-manager](https://cert-manager.io/docs/installation/kubernetes/) on the cluster using the following command.
 


### PR DESCRIPTION
Minimum Kubernetes version (`cert-manager` requirement) was not noted.

[Link to rendered file.](https://github.com/Azure/azure-service-operator/blob/b3a3681f24d5777bcfc56b5f0e52074c9422c09a/README.md)

<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

There was no minimum version for Kubernetes specified, but `cert-manager` (at least) requires 1.16.

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3gnYmbMCvE3Hq/giphy.gif)
