### PR TITLE
[WIP] Construct clients/managers inside AsyncReconciler.Reconcile

### DIFF
--- a/controllers/async_controller.go
+++ b/controllers/async_controller.go
@@ -60,10 +60,10 @@ func (r *AsyncReconciler) Reconcile(req ctrl.Request, obj runtime.Object) (resul
 	var secretClient secrets.SecretClient
 	if keyvaultName == "" {
 		r.Telemetry.LogInfoByInstance("status", "keyvault name is empty", req.String())
-		secretClient = kubesecrets.New(r.Client)
+		secretClient = kubesecrets.New(r.Client, config.SecretNamingVersion())
 	} else {
 		r.Telemetry.LogInfoByInstance("status", "Instantiating secrets client for keyvault "+keyvaultName, req.String())
-		secretClient = keyvaultsecrets.New(keyvaultName, creds)
+		secretClient = keyvaultsecrets.New(keyvaultName, creds, config.SecretNamingVersion())
 	}
 
 	armClient := r.ARMFactory(creds, secretClient, r.Scheme)

--- a/controllers/azuresql_combined_test.go
+++ b/controllers/azuresql_combined_test.go
@@ -17,15 +17,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/api/v1beta1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
-	"github.com/Azure/azure-service-operator/pkg/helpers"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
-	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqluser"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	kvsecrets "github.com/Azure/azure-service-operator/pkg/secrets/keyvault"
 )
 
 func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
@@ -54,16 +50,6 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 	// create and wait
 	RequireInstance(ctx, t, tc, sqlServerInstance)
 	RequireInstance(ctx, t, tc, sqlServerInstance2)
-
-	//verify secret exists in secret client for server 1 ---------------------------------
-	assert.Eventually(func() bool {
-		_, err := tc.secretClient.Get(ctx, types.NamespacedName{Name: sqlServerName, Namespace: sqlServerInstance.Namespace})
-
-		if err == nil {
-			return true
-		}
-		return false
-	}, tc.timeoutFast, tc.retry, "wait for server to have secret")
 
 	sqlDatabaseName1 := GenerateTestResourceNameWithRandom("sqldatabase", 10)
 	sqlDatabaseName2 := GenerateTestResourceNameWithRandom("sqldatabase", 10)
@@ -257,176 +243,6 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 			RunAzureSqlVNetRuleHappyPath(t, sqlServerName, rgLocation)
 		})
 
-	})
-
-	var sqlUser *azurev1alpha1.AzureSQLUser
-	var kvSqlUser1 *azurev1alpha1.AzureSQLUser
-	var kvSqlUser2 *azurev1alpha1.AzureSQLUser
-
-	// run sub tests that require 2 servers or have to be run after rolladmincreds test ------------------
-	t.Run("group2", func(t *testing.T) {
-
-		t.Run("set up user in first db", func(t *testing.T) {
-			t.Parallel()
-
-			// create a sql user and verify it provisions
-			username := "sql-test-user" + helpers.RandomString(10)
-			roles := []string{"db_owner"}
-			keyVaultSecretFormats := []string{"adonet"}
-
-			sqlUser = &azurev1alpha1.AzureSQLUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      username,
-					Namespace: "default",
-				},
-				Spec: azurev1alpha1.AzureSQLUserSpec{
-					Server:                sqlServerName,
-					DbName:                sqlDatabaseName1,
-					ResourceGroup:         rgName,
-					Roles:                 roles,
-					KeyVaultSecretFormats: keyVaultSecretFormats,
-				},
-			}
-
-			EnsureInstance(ctx, t, tc, sqlUser)
-
-			// Verify user's secret has been created. This controller
-			// generates different key name/namespace combinations
-			// depending on the secret client implementation (but
-			// without it being part of the SecretClient interface).
-			// TODO(creds-refactor): we should make this more sane.
-			assert.Eventually(func() bool {
-				key := azuresqluser.GetNamespacedName(sqlUser, tc.secretClient)
-				secrets, _ := tc.secretClient.Get(ctx, key)
-
-				return strings.Contains(string(secrets["azureSqlDatabaseName"]), sqlDatabaseName1)
-			}, tc.timeoutFast, tc.retry, "wait for secret store to show azure sql user credentials")
-
-			t.Log(sqlUser.Status)
-		})
-
-		t.Run("set up user in first db with custom keyvault", func(t *testing.T) {
-			t.Parallel()
-
-			// create a sql user and verify it provisions
-			username := "sql-test-user" + helpers.RandomString(10)
-			roles := []string{"db_owner"}
-
-			// This test will attempt to persist secrets to the KV that was instantiated as part of the test suite
-			keyVaultName := tc.keyvaultName
-
-			kvSqlUser1 = &azurev1alpha1.AzureSQLUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      username,
-					Namespace: "default",
-				},
-				Spec: azurev1alpha1.AzureSQLUserSpec{
-					Server:                 sqlServerName,
-					DbName:                 sqlDatabaseName1,
-					ResourceGroup:          rgName,
-					Roles:                  roles,
-					KeyVaultToStoreSecrets: keyVaultName,
-				},
-			}
-
-			EnsureInstance(ctx, t, tc, kvSqlUser1)
-
-			// Check that the user's secret is in the keyvault
-			keyVaultSecretClient := kvsecrets.New(keyVaultName, config.GlobalCredentials())
-
-			assert.Eventually(func() bool {
-				keyNamespace := "azuresqluser-" + sqlServerName + "-" + sqlDatabaseName1
-				key := types.NamespacedName{Name: kvSqlUser1.ObjectMeta.Name, Namespace: keyNamespace}
-				var secrets, _ = keyVaultSecretClient.Get(ctx, key)
-
-				return strings.Contains(string(secrets["azureSqlDatabaseName"]), sqlDatabaseName1)
-			}, tc.timeoutFast, tc.retry, "wait for keyvault to show azure sql user credentials")
-
-			t.Log(kvSqlUser1.Status)
-		})
-
-		t.Run("set up user in first db with custom keyvault and custom formatting", func(t *testing.T) {
-			t.Parallel()
-
-			// create a sql user and verify it provisions
-			username := "sql-test-user" + helpers.RandomString(10)
-			roles := []string{"db_owner"}
-			formats := []string{"adonet"}
-
-			// This test will attempt to persist secrets to the KV that was instantiated as part of the test suite
-			keyVaultName := tc.keyvaultName
-
-			kvSqlUser2 = &azurev1alpha1.AzureSQLUser{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      username,
-					Namespace: "default",
-				},
-				Spec: azurev1alpha1.AzureSQLUserSpec{
-					Server:                 sqlServerName,
-					DbName:                 sqlDatabaseName1,
-					ResourceGroup:          rgName,
-					Roles:                  roles,
-					KeyVaultToStoreSecrets: keyVaultName,
-					KeyVaultSecretFormats:  formats,
-				},
-			}
-
-			EnsureInstance(ctx, t, tc, kvSqlUser2)
-
-			// Check that the user's secret is in the keyvault
-			keyVaultSecretClient := kvsecrets.New(keyVaultName, config.GlobalCredentials())
-
-			assert.Eventually(func() bool {
-				keyNamespace := "azuresqluser-" + sqlServerName + "-" + sqlDatabaseName1
-				keyName := kvSqlUser2.ObjectMeta.Name + "-adonet"
-				key := types.NamespacedName{Name: keyName, Namespace: keyNamespace}
-				var secrets, _ = keyVaultSecretClient.Get(ctx, key)
-
-				return len(string(secrets[keyNamespace+"-"+keyName])) > 0
-			}, tc.timeoutFast, tc.retry, "wait for keyvault to show azure sql user credentials with custom formats")
-
-			t.Log(kvSqlUser2.Status)
-		})
-	})
-
-	t.Run("deploy sql action and roll user credentials", func(t *testing.T) {
-		keyNamespace := "azuresqluser-" + sqlServerName + "-" + sqlDatabaseName1
-		key := types.NamespacedName{Name: kvSqlUser1.ObjectMeta.Name, Namespace: keyNamespace}
-
-		keyVaultName := tc.keyvaultName
-		keyVaultSecretClient := kvsecrets.New(keyVaultName, config.GlobalCredentials())
-		var oldSecret, _ = keyVaultSecretClient.Get(ctx, key)
-
-		sqlActionName := GenerateTestResourceNameWithRandom("azuresqlaction-dev", 10)
-		sqlActionInstance := &azurev1alpha1.AzureSqlAction{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      sqlActionName,
-				Namespace: "default",
-			},
-			Spec: azurev1alpha1.AzureSqlActionSpec{
-				ResourceGroup:      rgName,
-				ServerName:         sqlServerName,
-				ActionName:         "rollusercreds",
-				DbName:             sqlDatabaseName1,
-				DbUser:             kvSqlUser1.ObjectMeta.Name,
-				UserSecretKeyVault: keyVaultName,
-			},
-		}
-
-		err := tc.k8sClient.Create(ctx, sqlActionInstance)
-		assert.Equal(nil, err, "create sqlaction in k8s")
-
-		sqlActionInstanceNamespacedName := types.NamespacedName{Name: sqlActionName, Namespace: "default"}
-
-		assert.Eventually(func() bool {
-			_ = tc.k8sClient.Get(ctx, sqlActionInstanceNamespacedName, sqlActionInstance)
-			return sqlActionInstance.Status.Provisioned
-		}, tc.timeout, tc.retry, "wait for sql action to be submitted")
-
-		var newSecret, _ = keyVaultSecretClient.Get(ctx, key)
-
-		assert.NotEqual(oldSecret["password"], newSecret["password"], "password should have been updated")
-		assert.Equal(oldSecret["username"], newSecret["username"], "usernames should be the same")
 	})
 
 	var sqlFailoverGroupInstance *v1beta1.AzureSqlFailoverGroup

--- a/controllers/azuresql_combined_test.go
+++ b/controllers/azuresql_combined_test.go
@@ -17,11 +17,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/api/v1beta1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
+	"github.com/Azure/azure-service-operator/pkg/helpers"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqluser"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
+	kvsecrets "github.com/Azure/azure-service-operator/pkg/secrets/keyvault"
 )
 
 func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
@@ -50,6 +54,16 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 	// create and wait
 	RequireInstance(ctx, t, tc, sqlServerInstance)
 	RequireInstance(ctx, t, tc, sqlServerInstance2)
+
+	//verify secret exists in secret client for server 1 ---------------------------------
+	assert.Eventually(func() bool {
+		_, err := tc.secretClient.Get(ctx, types.NamespacedName{Name: sqlServerName, Namespace: sqlServerInstance.Namespace})
+
+		if err == nil {
+			return true
+		}
+		return false
+	}, tc.timeoutFast, tc.retry, "wait for server to have secret")
 
 	sqlDatabaseName1 := GenerateTestResourceNameWithRandom("sqldatabase", 10)
 	sqlDatabaseName2 := GenerateTestResourceNameWithRandom("sqldatabase", 10)
@@ -242,6 +256,177 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 			t.Parallel()
 			RunAzureSqlVNetRuleHappyPath(t, sqlServerName, rgLocation)
 		})
+
+	})
+
+	var sqlUser *azurev1alpha1.AzureSQLUser
+	var kvSqlUser1 *azurev1alpha1.AzureSQLUser
+	var kvSqlUser2 *azurev1alpha1.AzureSQLUser
+
+	// run sub tests that require 2 servers or have to be run after rolladmincreds test ------------------
+	t.Run("group2", func(t *testing.T) {
+
+		t.Run("set up user in first db", func(t *testing.T) {
+			t.Parallel()
+
+			// create a sql user and verify it provisions
+			username := "sql-test-user" + helpers.RandomString(10)
+			roles := []string{"db_owner"}
+			keyVaultSecretFormats := []string{"adonet"}
+
+			sqlUser = &azurev1alpha1.AzureSQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      username,
+					Namespace: "default",
+				},
+				Spec: azurev1alpha1.AzureSQLUserSpec{
+					Server:                sqlServerName,
+					DbName:                sqlDatabaseName1,
+					ResourceGroup:         rgName,
+					Roles:                 roles,
+					KeyVaultSecretFormats: keyVaultSecretFormats,
+				},
+			}
+
+			EnsureInstance(ctx, t, tc, sqlUser)
+
+			// Verify user's secret has been created. This controller
+			// generates different key name/namespace combinations
+			// depending on the secret client implementation (but
+			// without it being part of the SecretClient interface).
+			// TODO(creds-refactor): we should make this more sane.
+			assert.Eventually(func() bool {
+				key := azuresqluser.GetNamespacedName(sqlUser, tc.secretClient)
+				secrets, _ := tc.secretClient.Get(ctx, key)
+
+				return strings.Contains(string(secrets["azureSqlDatabaseName"]), sqlDatabaseName1)
+			}, tc.timeoutFast, tc.retry, "wait for secret store to show azure sql user credentials")
+
+			t.Log(sqlUser.Status)
+		})
+
+		t.Run("set up user in first db with custom keyvault", func(t *testing.T) {
+			t.Parallel()
+
+			// create a sql user and verify it provisions
+			username := "sql-test-user" + helpers.RandomString(10)
+			roles := []string{"db_owner"}
+
+			// This test will attempt to persist secrets to the KV that was instantiated as part of the test suite
+			keyVaultName := tc.keyvaultName
+
+			kvSqlUser1 = &azurev1alpha1.AzureSQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      username,
+					Namespace: "default",
+				},
+				Spec: azurev1alpha1.AzureSQLUserSpec{
+					Server:                 sqlServerName,
+					DbName:                 sqlDatabaseName1,
+					ResourceGroup:          rgName,
+					Roles:                  roles,
+					KeyVaultToStoreSecrets: keyVaultName,
+				},
+			}
+
+			EnsureInstance(ctx, t, tc, kvSqlUser1)
+
+			// Check that the user's secret is in the keyvault
+			keyVaultSecretClient := kvsecrets.New(keyVaultName, config.GlobalCredentials())
+
+			assert.Eventually(func() bool {
+				keyNamespace := "azuresqluser-" + sqlServerName + "-" + sqlDatabaseName1
+				key := types.NamespacedName{Name: kvSqlUser1.ObjectMeta.Name, Namespace: keyNamespace}
+				var secrets, _ = keyVaultSecretClient.Get(ctx, key)
+
+				return strings.Contains(string(secrets["azureSqlDatabaseName"]), sqlDatabaseName1)
+			}, tc.timeoutFast, tc.retry, "wait for keyvault to show azure sql user credentials")
+
+			t.Log(kvSqlUser1.Status)
+		})
+
+		t.Run("set up user in first db with custom keyvault and custom formatting", func(t *testing.T) {
+			t.Parallel()
+
+			// create a sql user and verify it provisions
+			username := "sql-test-user" + helpers.RandomString(10)
+			roles := []string{"db_owner"}
+			formats := []string{"adonet"}
+
+			// This test will attempt to persist secrets to the KV that was instantiated as part of the test suite
+			keyVaultName := tc.keyvaultName
+
+			kvSqlUser2 = &azurev1alpha1.AzureSQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      username,
+					Namespace: "default",
+				},
+				Spec: azurev1alpha1.AzureSQLUserSpec{
+					Server:                 sqlServerName,
+					DbName:                 sqlDatabaseName1,
+					ResourceGroup:          rgName,
+					Roles:                  roles,
+					KeyVaultToStoreSecrets: keyVaultName,
+					KeyVaultSecretFormats:  formats,
+				},
+			}
+
+			EnsureInstance(ctx, t, tc, kvSqlUser2)
+
+			// Check that the user's secret is in the keyvault
+			keyVaultSecretClient := kvsecrets.New(keyVaultName, config.GlobalCredentials())
+
+			assert.Eventually(func() bool {
+				keyNamespace := "azuresqluser-" + sqlServerName + "-" + sqlDatabaseName1
+				keyName := kvSqlUser2.ObjectMeta.Name + "-adonet"
+				key := types.NamespacedName{Name: keyName, Namespace: keyNamespace}
+				var secrets, _ = keyVaultSecretClient.Get(ctx, key)
+
+				return len(string(secrets[keyNamespace+"-"+keyName])) > 0
+			}, tc.timeoutFast, tc.retry, "wait for keyvault to show azure sql user credentials with custom formats")
+
+			t.Log(kvSqlUser2.Status)
+		})
+	})
+
+	t.Run("deploy sql action and roll user credentials", func(t *testing.T) {
+		keyNamespace := "azuresqluser-" + sqlServerName + "-" + sqlDatabaseName1
+		key := types.NamespacedName{Name: kvSqlUser1.ObjectMeta.Name, Namespace: keyNamespace}
+
+		keyVaultName := tc.keyvaultName
+		keyVaultSecretClient := kvsecrets.New(keyVaultName, config.GlobalCredentials())
+		var oldSecret, _ = keyVaultSecretClient.Get(ctx, key)
+
+		sqlActionName := GenerateTestResourceNameWithRandom("azuresqlaction-dev", 10)
+		sqlActionInstance := &azurev1alpha1.AzureSqlAction{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sqlActionName,
+				Namespace: "default",
+			},
+			Spec: azurev1alpha1.AzureSqlActionSpec{
+				ResourceGroup:      rgName,
+				ServerName:         sqlServerName,
+				ActionName:         "rollusercreds",
+				DbName:             sqlDatabaseName1,
+				DbUser:             kvSqlUser1.ObjectMeta.Name,
+				UserSecretKeyVault: keyVaultName,
+			},
+		}
+
+		err := tc.k8sClient.Create(ctx, sqlActionInstance)
+		assert.Equal(nil, err, "create sqlaction in k8s")
+
+		sqlActionInstanceNamespacedName := types.NamespacedName{Name: sqlActionName, Namespace: "default"}
+
+		assert.Eventually(func() bool {
+			_ = tc.k8sClient.Get(ctx, sqlActionInstanceNamespacedName, sqlActionInstance)
+			return sqlActionInstance.Status.Provisioned
+		}, tc.timeout, tc.retry, "wait for sql action to be submitted")
+
+		var newSecret, _ = keyVaultSecretClient.Get(ctx, key)
+
+		assert.NotEqual(oldSecret["password"], newSecret["password"], "password should have been updated")
+		assert.Equal(oldSecret["username"], newSecret["username"], "usernames should be the same")
 	})
 
 	var sqlFailoverGroupInstance *v1beta1.AzureSqlFailoverGroup

--- a/controllers/azuresqlaction_controller_test.go
+++ b/controllers/azuresqlaction_controller_test.go
@@ -14,7 +14,6 @@ import (
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func RunSQLActionHappy(t *testing.T, server string) {
@@ -30,7 +29,7 @@ func RunSQLActionHappy(t *testing.T, server string) {
 	assert.Eventually(func() bool {
 		secretName := getSecretName(server)
 		var err error
-		secret, err = tc.secretClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: "default"})
+		secret, err = tc.secretClient.Get(ctx, secrets.SecretKey{Name: secretName, Namespace: "default"})
 		if err != nil {
 			return false
 		}
@@ -64,7 +63,7 @@ func RunSQLActionHappy(t *testing.T, server string) {
 			secretName = "azuresqlserver-" + server
 		}
 		var err error
-		secretAfter, err = tc.secretClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: "default"})
+		secretAfter, err = tc.secretClient.Get(ctx, secrets.SecretKey{Name: secretName, Namespace: "default"})
 		if err != nil {
 			return false
 		}

--- a/pkg/resourcemanager/apim/apimgmt/apimgmt.go
+++ b/pkg/resourcemanager/apim/apimgmt/apimgmt.go
@@ -8,20 +8,20 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-01-01/apimanagement"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-01-01/apimanagement"
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
-
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/apim/apimshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 // Manager represents an API Management type
@@ -32,6 +32,11 @@ type Manager struct {
 // NewManager returns an API Manager type
 func NewManager(creds config.Credentials) *Manager {
 	return &Manager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewManager(creds)
 }
 
 // CreateAPI creates an API within an API management service

--- a/pkg/resourcemanager/apim/apimservice/apimservice_manager.go
+++ b/pkg/resourcemanager/apim/apimservice/apimservice_manager.go
@@ -7,10 +7,13 @@ import (
 	"context"
 
 	apim "github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-01-01/apimanagement"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 	telemetry "github.com/Azure/azure-service-operator/pkg/telemetry"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // NewAzureAPIMgmtServiceManager creates a new instance of AzureAPIMgmtServiceManager
@@ -22,6 +25,11 @@ func NewAzureAPIMgmtServiceManager(creds config.Credentials) *AzureAPIMgmtServic
 			ctrl.Log.WithName("controllers").WithName("ApimService"),
 		),
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureAPIMgmtServiceManager(creds)
 }
 
 // APIMgmtServiceManager manages Azure Application Insights service components

--- a/pkg/resourcemanager/appinsights/api_keys_client.go
+++ b/pkg/resourcemanager/appinsights/api_keys_client.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type InsightsAPIKeysClient struct {
@@ -26,6 +28,11 @@ func NewAPIKeyClient(creds config.Credentials, secretClient secrets.SecretClient
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewAPIKeyARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAPIKeyClient(creds, secretClient, scheme)
 }
 
 func getApiKeysClient(creds config.Credentials) (insights.APIKeysClient, error) {

--- a/pkg/resourcemanager/appinsights/appinsights.go
+++ b/pkg/resourcemanager/appinsights/appinsights.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Azure/azure-service-operator/pkg/secrets"
-
 	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -22,6 +20,7 @@ import (
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 // Manager manages Azure Application Insights services
@@ -40,6 +39,11 @@ func NewManager(creds config.Credentials, secretClient secrets.SecretClient, sch
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewManager(creds, secretClient, scheme)
 }
 
 func (m *Manager) convert(obj runtime.Object) (*v1alpha1.AppInsights, error) {

--- a/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
+++ b/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
@@ -16,6 +16,7 @@ import (
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlserver"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqluser"
@@ -35,6 +36,11 @@ func NewAzureSqlActionManager(creds config.Credentials, secretClient secrets.Sec
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlActionManager(creds, secretClient, scheme)
 }
 
 func (s *AzureSqlActionManager) UpdateUserPassword(

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb.go
@@ -8,15 +8,17 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/Azure/azure-service-operator/api/v1beta1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
-
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type AzureSqlDbManager struct {
@@ -28,6 +30,11 @@ var _ SqlDbManager = &AzureSqlDbManager{}
 
 func NewAzureSqlDbManager(creds config.Credentials) *AzureSqlDbManager {
 	return &AzureSqlDbManager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlDbManager(creds)
 }
 
 // GetServer returns a SQL server

--- a/pkg/resourcemanager/azuresql/azuresqlfailovergroup/azuresqlfailovergroup.go
+++ b/pkg/resourcemanager/azuresql/azuresqlfailovergroup/azuresqlfailovergroup.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/Azure/azure-service-operator/api/v1beta1"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -29,6 +30,11 @@ func NewAzureSqlFailoverGroupManager(creds config.Credentials, secretClient secr
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlFailoverGroupManager(creds, secretClient, scheme)
 }
 
 // GetServer returns a SQL server

--- a/pkg/resourcemanager/azuresql/azuresqlfirewallrule/azuresqlfirewallrule.go
+++ b/pkg/resourcemanager/azuresql/azuresqlfirewallrule/azuresqlfirewallrule.go
@@ -7,10 +7,13 @@ import (
 	"context"
 
 	sql "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
-
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type AzureSqlFirewallRuleManager struct {
@@ -19,6 +22,11 @@ type AzureSqlFirewallRuleManager struct {
 
 func NewAzureSqlFirewallRuleManager(creds config.Credentials) *AzureSqlFirewallRuleManager {
 	return &AzureSqlFirewallRuleManager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlFirewallRuleManager(creds)
 }
 
 // GetServer returns a SQL server

--- a/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser.go
+++ b/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
@@ -33,6 +34,11 @@ func NewAzureSqlManagedUserManager(creds config.Credentials, secretClient secret
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlManagedUserManager(creds, secretClient, scheme)
 }
 
 // GetDB retrieves a database

--- a/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver.go
+++ b/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -32,6 +33,11 @@ func NewAzureSqlServerManager(creds config.Credentials, secretClient secrets.Sec
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlServerManager(creds, secretClient, scheme)
 }
 
 // DeleteSQLServer deletes a SQL server

--- a/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser.go
+++ b/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -44,6 +45,11 @@ func NewAzureSqlUserManager(creds config.Credentials, secretClient secrets.Secre
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlUserManager(creds, secretClient, scheme)
 }
 
 // GetDB retrieves a database

--- a/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule.go
+++ b/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule.go
@@ -7,8 +7,12 @@ import (
 	"context"
 
 	sql "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type AzureSqlVNetRuleManager struct {
@@ -17,6 +21,11 @@ type AzureSqlVNetRuleManager struct {
 
 func NewAzureSqlVNetRuleManager(creds config.Credentials) *AzureSqlVNetRuleManager {
 	return &AzureSqlVNetRuleManager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureSqlVNetRuleManager(creds)
 }
 
 // GetSQLVNetRule returns a VNet rule

--- a/pkg/resourcemanager/cosmosdbs/cosmosdb_manager.go
+++ b/pkg/resourcemanager/cosmosdbs/cosmosdb_manager.go
@@ -6,12 +6,14 @@ package cosmosdbs
 import (
 	"context"
 
+	"github.com/Azure/go-autorest/autorest"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb"
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	"github.com/Azure/go-autorest/autorest"
 )
 
 // NewAzureCosmosDBManager creates a new cosmos db client
@@ -20,6 +22,11 @@ func NewAzureCosmosDBManager(creds config.Credentials, secretClient secrets.Secr
 		Creds:        creds,
 		SecretClient: secretClient,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureCosmosDBManager(creds, secretClient)
 }
 
 // CosmosDBManager client functions

--- a/pkg/resourcemanager/eventhubs/consumergroup.go
+++ b/pkg/resourcemanager/eventhubs/consumergroup.go
@@ -9,17 +9,18 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
+	"github.com/Azure/go-autorest/autorest"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
-	"github.com/Azure/go-autorest/autorest"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type azureConsumerGroupManager struct {
@@ -28,6 +29,11 @@ type azureConsumerGroupManager struct {
 
 func NewConsumerGroupClient(creds config.Credentials) *azureConsumerGroupManager {
 	return &azureConsumerGroupManager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewConsumerGroupARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewConsumerGroupClient(creds)
 }
 
 func getConsumerGroupsClient(creds config.Credentials) (eventhub.ConsumerGroupsClient, error) {

--- a/pkg/resourcemanager/eventhubs/hub.go
+++ b/pkg/resourcemanager/eventhubs/hub.go
@@ -51,6 +51,11 @@ func NewEventhubClient(creds config.Credentials, secretClient secrets.SecretClie
 	}
 }
 
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewEventhubClient(creds, secretClient, scheme)
+}
+
 func (m *azureEventHubManager) DeleteHub(ctx context.Context, resourceGroupName string, namespaceName string, eventHubName string) (result autorest.Response, err error) {
 	hubClient, err := getHubsClient(m.Creds)
 	if err != nil {

--- a/pkg/resourcemanager/eventhubs/namespace.go
+++ b/pkg/resourcemanager/eventhubs/namespace.go
@@ -9,21 +9,20 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
-
-	"github.com/Azure/go-autorest/autorest"
-
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
-
-	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
-	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type azureEventHubNamespaceManager struct {
@@ -43,6 +42,11 @@ func getNamespacesClient(creds config.Credentials) (eventhub.NamespacesClient, e
 
 func NewEventHubNamespaceClient(creds config.Credentials) *azureEventHubNamespaceManager {
 	return &azureEventHubNamespaceManager{creds: creds}
+}
+
+// NewNamespaceARMClient returns a new manager (but as an ARMClient).
+func NewNamespaceARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewEventHubNamespaceClient(creds)
 }
 
 // DeleteNamespace deletes an existing namespace. This operation also removes all associated resources under the namespace.

--- a/pkg/resourcemanager/interfaces.go
+++ b/pkg/resourcemanager/interfaces.go
@@ -6,10 +6,12 @@ package resourcemanager
 import (
 	"context"
 
-	"github.com/Azure/azure-service-operator/api/v1alpha1"
-	"github.com/Azure/azure-service-operator/pkg/secrets"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/Azure/azure-service-operator/api/v1alpha1"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 const (
@@ -36,9 +38,15 @@ type KubeParent struct {
 	Target runtime.Object
 }
 
+// ARMClient provides methods to create/update, delete and query a
+// specific resource in ARM.
 type ARMClient interface {
 	Ensure(context.Context, runtime.Object, ...ConfigOption) (bool, error)
 	Delete(context.Context, runtime.Object, ...ConfigOption) (bool, error)
 	GetParents(runtime.Object) ([]KubeParent, error)
 	GetStatus(obj runtime.Object) (*v1alpha1.ASOStatus, error)
 }
+
+// ClientFactory constructs an ARMClient with the specified
+// dependencies.
+type ClientFactory func(config.Credentials, secrets.SecretClient, *runtime.Scheme) ARMClient

--- a/pkg/resourcemanager/keyvaults/keyops.go
+++ b/pkg/resourcemanager/keyvaults/keyops.go
@@ -9,15 +9,17 @@ import (
 	"net/http"
 
 	kvops "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
-	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 // KeyvaultKeyClient emcompasses the methods needed for the keyops client to fulfill the ARMClient interface
@@ -31,6 +33,12 @@ func NewKeyvaultKeyClient(creds config.Credentials, client *AzureKeyVaultManager
 		Creds:          creds,
 		KeyvaultClient: client,
 	}
+}
+
+// NewKeyARMClient returns a new manager (but as an ARMClient).
+func NewKeyARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	kvManager := NewAzureKeyVaultManager(creds, scheme)
+	return NewKeyvaultKeyClient(creds, kvManager)
 }
 
 // Ensure idempotently implements the user's requested state

--- a/pkg/resourcemanager/keyvaults/keyvault.go
+++ b/pkg/resourcemanager/keyvaults/keyvault.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type AzureKeyVaultManager struct {
@@ -40,6 +41,11 @@ func NewAzureKeyVaultManager(creds config.Credentials, scheme *runtime.Scheme) *
 		Creds:  creds,
 		Scheme: scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureKeyVaultManager(creds, scheme)
 }
 
 func GetKeyVaultClient(creds config.Credentials) (keyvault.VaultsClient, error) {

--- a/pkg/resourcemanager/loadbalancer/client.go
+++ b/pkg/resourcemanager/loadbalancer/client.go
@@ -8,11 +8,13 @@ import (
 	"strings"
 
 	vnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type AzureLoadBalancerClient struct {
@@ -27,6 +29,11 @@ func NewAzureLoadBalancerClient(creds config.Credentials, secretclient secrets.S
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureLoadBalancerClient(creds, secretClient, scheme)
 }
 
 func getLoadBalancerClient(creds config.Credentials) vnetwork.LoadBalancersClient {

--- a/pkg/resourcemanager/mysql/aadadmin/reconcile.go
+++ b/pkg/resourcemanager/mysql/aadadmin/reconcile.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type MySQLServerAdministratorManager struct {
@@ -31,6 +32,11 @@ func NewMySQLServerAdministratorManager(creds config.Credentials) *MySQLServerAd
 	return &MySQLServerAdministratorManager{
 		creds: creds,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewMySQLServerAdministratorManager(creds)
 }
 
 func newMySQLServerAdministratorsClient(creds config.Credentials) (mysql.ServerAdministratorsClient, error) {

--- a/pkg/resourcemanager/mysql/database/client.go
+++ b/pkg/resourcemanager/mysql/database/client.go
@@ -7,9 +7,12 @@ import (
 	"context"
 
 	mysql "github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
+	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 //MySQLDatabaseClient struct
@@ -20,6 +23,11 @@ type MySQLDatabaseClient struct {
 //NewMySQLDatabaseClient create a new MySQLDatabaseClient
 func NewMySQLDatabaseClient(creds config.Credentials) *MySQLDatabaseClient {
 	return &MySQLDatabaseClient{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewMySQLDatabaseClient(creds)
 }
 
 //GetMySQLDatabasesClient return the mysqldatabaseclient

--- a/pkg/resourcemanager/mysql/firewallrule/client.go
+++ b/pkg/resourcemanager/mysql/firewallrule/client.go
@@ -7,9 +7,13 @@ import (
 	"context"
 
 	mysql "github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type MySQLFirewallRuleClient struct {
@@ -18,6 +22,11 @@ type MySQLFirewallRuleClient struct {
 
 func NewMySQLFirewallRuleClient(creds config.Credentials) *MySQLFirewallRuleClient {
 	return &MySQLFirewallRuleClient{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewMySQLFirewallRuleClient(creds)
 }
 
 func getMySQLFirewallRulesClient(creds config.Credentials) mysql.FirewallRulesClient {

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
@@ -11,7 +11,6 @@ import (
 	mysqlmgmt "github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	_ "github.com/go-sql-driver/mysql" //mysql drive link
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/Azure/azure-service-operator/api/v1alpha2"
 	"github.com/Azure/azure-service-operator/pkg/helpers"

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser.go
@@ -11,9 +11,11 @@ import (
 	mysqlmgmt "github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	_ "github.com/go-sql-driver/mysql" //mysql drive link
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/Azure/azure-service-operator/api/v1alpha2"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/mysql"
 	mysqldatabase "github.com/Azure/azure-service-operator/pkg/resourcemanager/mysql/database"
@@ -41,6 +43,11 @@ func NewMySqlUserManager(creds config.Credentials, secretClient secrets.SecretCl
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewMySqlUserManager(creds, secretClient, scheme)
 }
 
 // GetDB retrieves a database

--- a/pkg/resourcemanager/mysql/server/client.go
+++ b/pkg/resourcemanager/mysql/server/client.go
@@ -7,12 +7,14 @@ import (
 	"context"
 
 	mysql "github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-service-operator/api/v1alpha2"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type MySQLServerClient struct {
@@ -27,6 +29,11 @@ func NewMySQLServerClient(creds config.Credentials, secretclient secrets.SecretC
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewMySQLServerClient(creds, secretClient, scheme)
 }
 
 func getMySQLServersClient(creds config.Credentials) mysql.ServersClient {

--- a/pkg/resourcemanager/mysql/vnetrule/client.go
+++ b/pkg/resourcemanager/mysql/vnetrule/client.go
@@ -8,8 +8,12 @@ import (
 
 	mysql "github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type MySQLVNetRuleClient struct {
@@ -18,6 +22,11 @@ type MySQLVNetRuleClient struct {
 
 func NewMySQLVNetRuleClient(creds config.Credentials) *MySQLVNetRuleClient {
 	return &MySQLVNetRuleClient{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewMySQLVNetRuleClient(creds)
 }
 
 func getMySQLVNetRulesClient(creds config.Credentials) mysql.VirtualNetworkRulesClient {

--- a/pkg/resourcemanager/nic/client.go
+++ b/pkg/resourcemanager/nic/client.go
@@ -7,11 +7,13 @@ import (
 	"context"
 
 	vnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type AzureNetworkInterfaceClient struct {
@@ -26,6 +28,11 @@ func NewAzureNetworkInterfaceClient(creds config.Credentials, secretclient secre
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureNetworkInterfaceClient(creds, secretClient, scheme)
 }
 
 func getNetworkInterfaceClient(creds config.Credentials) vnetwork.InterfacesClient {

--- a/pkg/resourcemanager/pip/client.go
+++ b/pkg/resourcemanager/pip/client.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	vnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type AzurePublicIPAddressClient struct {
@@ -26,6 +28,11 @@ func NewAzurePublicIPAddressClient(creds config.Credentials, secretclient secret
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzurePublicIPAddressClient(creds, secretClient, scheme)
 }
 
 func getPublicIPAddressClient(creds config.Credentials) vnetwork.PublicIPAddressesClient {

--- a/pkg/resourcemanager/psql/database/database.go
+++ b/pkg/resourcemanager/psql/database/database.go
@@ -8,8 +8,12 @@ import (
 	"net/http"
 
 	psql "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type PSQLDatabaseClient struct {
@@ -18,6 +22,11 @@ type PSQLDatabaseClient struct {
 
 func NewPSQLDatabaseClient(creds config.Credentials) *PSQLDatabaseClient {
 	return &PSQLDatabaseClient{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewPSQLDatabaseClient(creds)
 }
 
 //GetPSQLDatabasesClient retrieves the psqldabase

--- a/pkg/resourcemanager/psql/firewallrule/firewallrule.go
+++ b/pkg/resourcemanager/psql/firewallrule/firewallrule.go
@@ -8,9 +8,13 @@ import (
 	"net/http"
 
 	psql "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
-	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type PSQLFirewallRuleClient struct {
@@ -19,6 +23,11 @@ type PSQLFirewallRuleClient struct {
 
 func NewPSQLFirewallRuleClient(creds config.Credentials) *PSQLFirewallRuleClient {
 	return &PSQLFirewallRuleClient{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewPSQLFirewallRuleClient(creds)
 }
 
 func getPSQLFirewallRulesClient(creds config.Credentials) (psql.FirewallRulesClient, error) {

--- a/pkg/resourcemanager/psql/psqluser/psqluser.go
+++ b/pkg/resourcemanager/psql/psqluser/psqluser.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 
 	psql "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
-	_ "github.com/lib/pq" //the pg lib
+	_ "github.com/lib/pq" //the pg lib registers itself with database/sql
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	psdatabase "github.com/Azure/azure-service-operator/pkg/resourcemanager/psql/database"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -46,6 +47,11 @@ func NewPostgreSqlUserManager(creds config.Credentials, secretClient secrets.Sec
 		SecretClient: secretClient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewPostgreSqlUserManager(creds, secretClient, scheme)
 }
 
 // GetDB retrieves a database

--- a/pkg/resourcemanager/psql/server/server.go
+++ b/pkg/resourcemanager/psql/server/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-service-operator/api/v1alpha2"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -30,6 +31,11 @@ func NewPSQLServerClient(creds config.Credentials, secretclient secrets.SecretCl
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewPSQLServerClient(creds, secretClient, scheme)
 }
 
 func getPSQLServersClient(creds config.Credentials) (psql.ServersClient, error) {

--- a/pkg/resourcemanager/psql/vnetrule/client.go
+++ b/pkg/resourcemanager/psql/vnetrule/client.go
@@ -8,8 +8,12 @@ import (
 
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	psql "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 type PostgreSQLVNetRuleClient struct {
@@ -18,6 +22,11 @@ type PostgreSQLVNetRuleClient struct {
 
 func NewPostgreSQLVNetRuleClient(creds config.Credentials) *PostgreSQLVNetRuleClient {
 	return &PostgreSQLVNetRuleClient{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewPostgreSQLVNetRuleClient(creds)
 }
 
 func GetPostgreSQLVNetRulesClient(creds config.Credentials) psql.VirtualNetworkRulesClient {

--- a/pkg/resourcemanager/rediscaches/actions/rediscacheactions.go
+++ b/pkg/resourcemanager/rediscaches/actions/rediscacheactions.go
@@ -7,14 +7,14 @@ import (
 	"context"
 	"fmt"
 
+	model "github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/rediscaches"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-
-	model "github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
-
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // AzureRedisCacheActionManager creates a new RedisCacheManager
@@ -31,6 +31,11 @@ func NewAzureRedisCacheActionManager(creds config.Credentials, secretClient secr
 			Scheme:       scheme,
 		},
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureRedisCacheActionManager(creds, secretClient, scheme)
 }
 
 // RegeneratePrimaryAccessKey regenerates either the primary or secondary access keys

--- a/pkg/resourcemanager/rediscaches/firewallrule/rediscachefirewallrule.go
+++ b/pkg/resourcemanager/rediscaches/firewallrule/rediscachefirewallrule.go
@@ -8,11 +8,15 @@ import (
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
-	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
-	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
-	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 // AzureRedisCacheFirewallRuleManager creates a new AzureRedisCacheFirewallRuleManager
@@ -23,6 +27,11 @@ type AzureRedisCacheFirewallRuleManager struct {
 // NewAzureRedisCacheFirewallRuleManager creates a new AzureRedisCacheFirewallRuleManager
 func NewAzureRedisCacheFirewallRuleManager(creds config.Credentials) *AzureRedisCacheFirewallRuleManager {
 	return &AzureRedisCacheFirewallRuleManager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureRedisCacheFirewallRuleManager(creds)
 }
 
 // getRedisCacheFirewallRuleClient retrieves a firewallrules client

--- a/pkg/resourcemanager/rediscaches/redis/rediscaches.go
+++ b/pkg/resourcemanager/rediscaches/redis/rediscaches.go
@@ -8,16 +8,18 @@ import (
 	"errors"
 	"log"
 
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/rediscaches"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/vnet"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/to"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // AzureRedisCacheManager creates a new RedisCacheManager
@@ -34,6 +36,11 @@ func NewAzureRedisCacheManager(creds config.Credentials, secretClient secrets.Se
 			Scheme:       scheme,
 		},
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureRedisCacheManager(creds, secretClient, scheme)
 }
 
 // CreateRedisCache creates a new RedisCache

--- a/pkg/resourcemanager/resourcegroups/resourcegroup_manager.go
+++ b/pkg/resourcemanager/resourcegroups/resourcegroup_manager.go
@@ -7,15 +7,21 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
-	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
-
-// var AzureResourceGroupManager ResourceGroupManager = &azureResourceGroupManager{}
 
 func NewAzureResourceGroupManager(creds config.Credentials) *AzureResourceGroupManager {
 	return &AzureResourceGroupManager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureResourceGroupManager(creds)
 }
 
 type ResourceGroupManager interface {

--- a/pkg/resourcemanager/storages/blobcontainer/blob_container_manager.go
+++ b/pkg/resourcemanager/storages/blobcontainer/blob_container_manager.go
@@ -8,13 +8,22 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	s "github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
-	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/go-autorest/autorest"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 // New returns a pointer to a new instance of a blob container client
 func New(creds config.Credentials) *AzureBlobContainerManager {
 	return &AzureBlobContainerManager{creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return New(creds)
 }
 
 // BlobContainerManager exists in case we need it

--- a/pkg/resourcemanager/storages/storageaccount/storageaccount_manager.go
+++ b/pkg/resourcemanager/storages/storageaccount/storageaccount_manager.go
@@ -25,6 +25,11 @@ func New(creds config.Credentials, secretClient secrets.SecretClient, scheme *ru
 	}
 }
 
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return New(creds, secretClient, scheme)
+}
+
 type StorageManager interface {
 	CreateStorage(ctx context.Context,
 		groupName string,

--- a/pkg/resourcemanager/vm/client.go
+++ b/pkg/resourcemanager/vm/client.go
@@ -13,6 +13,7 @@ import (
 
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -30,6 +31,11 @@ func NewAzureVirtualMachineClient(creds config.Credentials, secretclient secrets
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureVirtualMachineClient(creds, secretClient, scheme)
 }
 
 func getVirtualMachineClient(creds config.Credentials) compute.VirtualMachinesClient {

--- a/pkg/resourcemanager/vmext/client.go
+++ b/pkg/resourcemanager/vmext/client.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -28,6 +29,11 @@ func NewAzureVirtualMachineExtensionClient(creds config.Credentials, secretclien
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureVirtualMachineExtensionClient(creds, secretClient, scheme)
 }
 
 func getVirtualMachineExtensionClient(creds config.Credentials) compute.VirtualMachineExtensionsClient {

--- a/pkg/resourcemanager/vmss/client.go
+++ b/pkg/resourcemanager/vmss/client.go
@@ -13,6 +13,7 @@ import (
 
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/iam"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
@@ -30,6 +31,11 @@ func NewAzureVMScaleSetClient(creds config.Credentials, secretclient secrets.Sec
 		SecretClient: secretclient,
 		Scheme:       scheme,
 	}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureVMScaleSetClient(creds, secretClient, scheme)
 }
 
 func getVMScaleSetClient(creds config.Credentials) compute.VirtualMachineScaleSetsClient {

--- a/pkg/resourcemanager/vnet/vnet_manager.go
+++ b/pkg/resourcemanager/vnet/vnet_manager.go
@@ -7,15 +7,23 @@ import (
 	"context"
 
 	vnetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	azurev1alpha1 "github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
-	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
 )
 
 // NewAzureVNetManager creates a new instance of AzureVNetManager
 func NewAzureVNetManager(creds config.Credentials) *AzureVNetManager {
 	return &AzureVNetManager{Creds: creds}
+}
+
+// NewARMClient returns a new manager (but as an ARMClient).
+func NewARMClient(creds config.Credentials, secretClient secrets.SecretClient, scheme *runtime.Scheme) resourcemanager.ARMClient {
+	return NewAzureVNetManager(creds)
 }
 
 // VNetManager manages VNet service components

--- a/pkg/secrets/keyvault/client.go
+++ b/pkg/secrets/keyvault/client.go
@@ -56,11 +56,11 @@ func GetVaultsURL(vaultName string) string {
 }
 
 // New instantiates a new KeyVaultSecretClient instance.
-// TODO(creds-refactor): The keyvaultName argument seems seems
-// redundant since that's in the credentials, but it's used to
-// override the one specified in credentials so it might be right to
-// keep it. Confirm this.
-func New(keyVaultName string, creds config.Credentials, secretNamingVersion secrets.SecretNamingVersion) *SecretClient {
+// TODO(creds-refactor): The keyvaultName argument seems redundant
+// since that's in the credentials, but it's used to override the one
+// specified in credentials so it might be right to keep it. Confirm
+// this.
+func New(keyVaultName string, creds config.Credentials) *KeyvaultSecretClient {
 	keyvaultClient := keyvaults.New()
 	a, _ := iam.GetKeyvaultAuthorizer(creds)
 	keyvaultClient.Authorizer = a

--- a/pkg/secrets/keyvault/client.go
+++ b/pkg/secrets/keyvault/client.go
@@ -55,12 +55,12 @@ func GetVaultsURL(vaultName string) string {
 	return vaultURL
 }
 
-// New instantiates a new KeyVaultSecretClient instance.
+// New instantiates a new SecretClient instance.
 // TODO(creds-refactor): The keyvaultName argument seems redundant
 // since that's in the credentials, but it's used to override the one
 // specified in credentials so it might be right to keep it. Confirm
 // this.
-func New(keyVaultName string, creds config.Credentials) *KeyvaultSecretClient {
+func New(keyVaultName string, creds config.Credentials, secretNamingVersion secrets.SecretNamingVersion) *SecretClient {
 	keyvaultClient := keyvaults.New()
 	a, _ := iam.GetKeyvaultAuthorizer(creds)
 	keyvaultClient.Authorizer = a


### PR DESCRIPTION
**What this PR does / why we need it**:
This defers constructing the ARM client instances until we get a request, so that in future the reconciler can get credentials from a location specific to the resource being reconciled.

Add resourcemanager.ClientFactory type, and change AsyncReconciler to accept a ClientFactory so that it can construct the client on each request.

Add a NewARMClient function conforming to ClientFactory every resource package, and pass those in to the reconcilers.

This is part of implementing #1173 based on the work in #1206.

**How does this PR make you feel**:
![gif](https://media2.giphy.com/media/3q1yzTVtfHkcKtUZp6/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
