### PR TITLE
Update to support MySQL AAD users and groups too

### DIFF
--- a/api/v1alpha1/mysqlaaduser_types.go
+++ b/api/v1alpha1/mysqlaaduser_types.go
@@ -29,11 +29,12 @@ type MySQLAADUserSpec struct {
 	// +kubebuilder:validation:Required
 	Roles []string `json:"roles"`
 
-	// Note: We current do not support arbitrary AAD users (although the MySQL API does).
-
-	// ClientID is the client ID of the identity backing the user.
+	// AAD ID is the ID of the user in Azure Active Directory.
+	// When creating a user for a managed identity this must be the client id (sometimes called app id) of the managed identity.
+	// When creating a user for a "normal" (non-managed identity) user or group, this is the OID of the user or group.
+	// +kubebuilder:validation:MinLength:1
 	// +kubebuilder:validation:Required
-	ClientID string `json:"clientId,omitempty"`
+	AADID string `json:"aadId,omitempty"`
 
 	// optional
 	Username string `json:"username,omitempty"`

--- a/config/samples/azure_v1alpha1_mysqlaaduser.yaml
+++ b/config/samples/azure_v1alpha1_mysqlaaduser.yaml
@@ -1,27 +1,19 @@
 apiVersion: azure.microsoft.com/v1alpha1
 kind: MySQLAADUser
 metadata:
-  name: matthchr-mi-2
+  name: mysqlaaduser-sample
 spec:
-  # TODO: Fix this to be more generic names
-  server: matthchr-mysql-serv
-  dbName: matthchr-mysql-db
-  resourceGroup: matthchr-rg
-  clientId: 519fadb2-1737-4e6b-ac09-a8632da37766
+  server: mysqlserver-sample
+  dbName: mysqldatabase-sample
+  resourceGroup: resourcegroup-azure-operators
+  # AAD ID is the ID of the user in Azure Active Directory.
+  # When creating a user for a managed identity this must be the client id (sometimes called app id) of the managed identity.
+  # When creating a user for a "normal" (non-managed identity) user or group, this is the OID of the user or group.
+  aadId: 00000000-0000-0000-0000-000000000000
   roles: 
-  #now only supports granting privileges to a new user. Valid privileges are listed below:
-  #SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, 
-  #CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, 
-  #CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
+  # Valid privileges are listed below:
+  # SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES,
+  # CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT,
+  # CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   # This adds the privileges to the specified database
     - SELECT
-  # Specify a specific username for the user
-  # username: mysqluser-sample
-  # Specify adminSecret and adminSecretKeyVault if you want to 
-  # read the MYSQL server admin creds from a specific keyvault secret
-  # adminSecret: mysqlserver-sample
-  # adminSecretKeyVault: asokeyvault
-
-  # Use the field below to optionally specify a different keyvault 
-  # to store the secrets in
-  # keyVaultToStoreSecrets: asokeyvault


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for MySQL AAD Users and Groups.

**Special notes for your reviewer**:
Difficult to test currently given the existing test infrastructure. As before with the Managed Identity pieces of this work I have confirmed this works manually (and we can rely somewhat on the standard user create tests to test the basic connect/etc pieces of the workflow).

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
