### PR TITLE
Add optional VNET Subscription ID to VNET rules.

### DIFF
--- a/api/v1alpha1/azuresqlvnetrule_types.go
+++ b/api/v1alpha1/azuresqlvnetrule_types.go
@@ -20,6 +20,7 @@ type AzureSQLVNetRuleSpec struct {
 	VNetResourceGroup            string `json:"vNetResourceGroup"`
 	VNetName                     string `json:"vNetName"`
 	SubnetName                   string `json:"subnetName"`
+	VNetSubscriptionID           string `json:"vNetSubscriptionID,omitempty"`
 	IgnoreMissingServiceEndpoint bool   `json:"ignoreMissingServiceEndpoint,omitempty"`
 }
 

--- a/api/v1alpha1/mysqlvnetrule_types.go
+++ b/api/v1alpha1/mysqlvnetrule_types.go
@@ -22,6 +22,7 @@ type MySQLVNetRuleSpec struct {
 	VNetResourceGroup            string `json:"vNetResourceGroup"`
 	VNetName                     string `json:"vNetName"`
 	SubnetName                   string `json:"subnetName"`
+	VNetSubscriptionID           string `json:"vNetSubscriptionID,omitempty"`
 	IgnoreMissingServiceEndpoint bool   `json:"ignoreMissingServiceEndpoint,omitempty"`
 }
 

--- a/api/v1alpha1/postgresqlvnetrule_types.go
+++ b/api/v1alpha1/postgresqlvnetrule_types.go
@@ -22,6 +22,7 @@ type PostgreSQLVNetRuleSpec struct {
 	VNetResourceGroup            string `json:"vNetResourceGroup"`
 	VNetName                     string `json:"vNetName"`
 	SubnetName                   string `json:"subnetName"`
+	VNetSubscriptionID           string `json:"vNetSubscriptionID,omitempty"`
 	IgnoreMissingServiceEndpoint bool   `json:"ignoreMissingServiceEndpoint,omitempty"`
 }
 

--- a/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_azuresqlvnetrules.azure.microsoft.com.yaml
+++ b/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_azuresqlvnetrules.azure.microsoft.com.yaml
@@ -53,6 +53,8 @@ spec:
               type: string
             vNetResourceGroup:
               type: string
+            vNetSubscriptionID:
+              type: string
           required:
           - resourceGroup
           - server

--- a/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_mysqlvnetrules.azure.microsoft.com.yaml
+++ b/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_mysqlvnetrules.azure.microsoft.com.yaml
@@ -53,6 +53,8 @@ spec:
               type: string
             vNetResourceGroup:
               type: string
+            vNetSubscriptionID:
+              type: string
           required:
           - resourceGroup
           - server

--- a/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_postgresqlvnetrules.azure.microsoft.com.yaml
+++ b/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_postgresqlvnetrules.azure.microsoft.com.yaml
@@ -53,6 +53,8 @@ spec:
               type: string
             vNetResourceGroup:
               type: string
+            vNetSubscriptionID:
+              type: string
           required:
           - resourceGroup
           - server

--- a/config/samples/azure_v1alpha1_azuresqlvnetrule.yaml
+++ b/config/samples/azure_v1alpha1_azuresqlvnetrule.yaml
@@ -8,4 +8,6 @@ spec:
   vNetResourceGroup: resourcegroup-vnet
   vNetName: virtualnetwork-sample
   subnetName: test1
+  ## Optional
   ignoreMissingServiceEndpoint: true
+  vNetSubscriptionID: {vnet_subscription_id} # Specify if the VNET is in another subscription.

--- a/config/samples/azure_v1alpha1_mysqlvnetrule.yaml
+++ b/config/samples/azure_v1alpha1_mysqlvnetrule.yaml
@@ -8,4 +8,6 @@ spec:
   vNetResourceGroup: resourcegroup-vnet
   vNetName: virtualnetwork-sample
   subnetName: test1
+  ## Optional
   ignoreMissingServiceEndpoint: true
+  vNetSubscriptionID: {vnet_subscription_id} # Specify if the VNET is in another subscription.

--- a/config/samples/azure_v1alpha1_postgresqlvnetrule.yaml
+++ b/config/samples/azure_v1alpha1_postgresqlvnetrule.yaml
@@ -8,4 +8,6 @@ spec:
   vNetResourceGroup: resourcegroup-azure-operators
   vNetName: virtualnetwork-sample
   subnetName: test1
+  ## Optional
   ignoreMissingServiceEndpoint: true
+  vNetSubscriptionID: {vnet_subscription_id} # Specify if the VNET is in another subscription.

--- a/pkg/resourcemanager/azuresql/azuresqlshared/getgoclients.go
+++ b/pkg/resourcemanager/azuresql/azuresqlshared/getgoclients.go
@@ -72,8 +72,8 @@ func GetGoVNetRulesClient(creds config.Credentials) (sql.VirtualNetworkRulesClie
 }
 
 // GetNetworkSubnetClient retrieves a Subnetclient
-func GetGoNetworkSubnetClient(creds config.Credentials) (network.SubnetsClient, error) {
-	SubnetsClient := network.NewSubnetsClientWithBaseURI(config.BaseURI(), creds.SubscriptionID())
+func GetGoNetworkSubnetClient(creds config.Credentials, subscription string) (network.SubnetsClient, error) {
+	SubnetsClient := network.NewSubnetsClientWithBaseURI(config.BaseURI(), subscription)
 	a, err := iam.GetResourceManagementAuthorizer(creds)
 	if err != nil {
 		return network.SubnetsClient{}, err

--- a/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule.go
+++ b/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule.go
@@ -67,6 +67,7 @@ func (m *AzureSqlVNetRuleManager) CreateOrUpdateSQLVNetRule(ctx context.Context,
 		return sql.VirtualNetworkRule{}, err
 	}
 
+	// Subnet may be in another subscription
 	if subscription == "" {
 		subscription = m.creds.SubscriptionID()
 	}

--- a/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule.go
+++ b/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule.go
@@ -60,14 +60,17 @@ func (m *AzureSqlVNetRuleManager) DeleteSQLVNetRule(ctx context.Context, resourc
 
 // CreateOrUpdateSQLVNetRule creates or updates a VNet rule
 // based on code from: https://godoc.org/github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql#VirtualNetworkRulesClient.CreateOrUpdate
-func (m *AzureSqlVNetRuleManager) CreateOrUpdateSQLVNetRule(ctx context.Context, resourceGroupName string, serverName string, ruleName string, VNetRG string, VNetName string, SubnetName string, IgnoreServiceEndpoint bool) (vnr sql.VirtualNetworkRule, err error) {
+func (m *AzureSqlVNetRuleManager) CreateOrUpdateSQLVNetRule(ctx context.Context, resourceGroupName string, serverName string, ruleName string, VNetRG string, VNetName string, SubnetName string, subscription string, IgnoreServiceEndpoint bool) (vnr sql.VirtualNetworkRule, err error) {
 
 	VNetRulesClient, err := azuresqlshared.GetGoVNetRulesClient(m.creds)
 	if err != nil {
 		return sql.VirtualNetworkRule{}, err
 	}
 
-	SubnetClient, err := azuresqlshared.GetGoNetworkSubnetClient(m.creds)
+	if subscription == "" {
+		subscription = m.creds.SubscriptionID()
+	}
+	SubnetClient, err := azuresqlshared.GetGoNetworkSubnetClient(m.creds, subscription)
 	if err != nil {
 		return sql.VirtualNetworkRule{}, err
 	}

--- a/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlvnetrule/azuresqlvnetrule_reconcile.go
@@ -30,6 +30,7 @@ func (vr *AzureSqlVNetRuleManager) Ensure(ctx context.Context, obj runtime.Objec
 	virtualNetworkRG := instance.Spec.VNetResourceGroup
 	virtualnetworkname := instance.Spec.VNetName
 	subnetName := instance.Spec.SubnetName
+	virtualNetworkSubscription := instance.Spec.VNetSubscriptionID
 	ignoreendpoint := instance.Spec.IgnoreMissingServiceEndpoint
 
 	vnetrule, err := vr.GetSQLVNetRule(ctx, groupName, server, ruleName)
@@ -55,7 +56,7 @@ func (vr *AzureSqlVNetRuleManager) Ensure(ctx context.Context, obj runtime.Objec
 	}
 
 	instance.Status.Provisioning = true
-	_, err = vr.CreateOrUpdateSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, ignoreendpoint)
+	_, err = vr.CreateOrUpdateSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, virtualNetworkSubscription, ignoreendpoint)
 	if err != nil {
 		instance.Status.Message = err.Error()
 		azerr := errhelp.NewAzureError(err)

--- a/pkg/resourcemanager/mysql/vnetrule/reconcile.go
+++ b/pkg/resourcemanager/mysql/vnetrule/reconcile.go
@@ -30,6 +30,7 @@ func (vr *MySQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Object, o
 	virtualNetworkRG := instance.Spec.VNetResourceGroup
 	virtualnetworkname := instance.Spec.VNetName
 	subnetName := instance.Spec.SubnetName
+	virtualNetworkSubscription := instance.Spec.VNetSubscriptionID
 	ignoreendpoint := instance.Spec.IgnoreMissingServiceEndpoint
 
 	vnetrule, err := vr.GetSQLVNetRule(ctx, groupName, server, ruleName)
@@ -55,7 +56,7 @@ func (vr *MySQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Object, o
 	}
 
 	instance.Status.Provisioning = true
-	_, err = vr.CreateOrUpdateSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, ignoreendpoint)
+	_, err = vr.CreateOrUpdateSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, virtualNetworkSubscription, ignoreendpoint)
 	if err != nil {
 		instance.Status.Message = err.Error()
 		azerr := errhelp.NewAzureError(err)

--- a/pkg/resourcemanager/psql/vnetrule/client.go
+++ b/pkg/resourcemanager/psql/vnetrule/client.go
@@ -29,8 +29,8 @@ func GetPostgreSQLVNetRulesClient(creds config.Credentials) psql.VirtualNetworkR
 }
 
 // retrieves the Subnetclient
-func GetGoNetworkSubnetClient(creds config.Credentials) network.SubnetsClient {
-	SubnetsClient := network.NewSubnetsClientWithBaseURI(config.BaseURI(), creds.SubscriptionID())
+func GetGoNetworkSubnetClient(creds config.Credentials, subscription string) network.SubnetsClient {
+	SubnetsClient := network.NewSubnetsClientWithBaseURI(config.BaseURI(), subscription)
 	a, _ := iam.GetResourceManagementAuthorizer(creds)
 	SubnetsClient.Authorizer = a
 	SubnetsClient.AddToUserAgent(config.UserAgent())
@@ -83,10 +83,15 @@ func (c *PostgreSQLVNetRuleClient) CreateOrUpdatePostgreSQLVNetRule(
 	VNetRG string,
 	VNetName string,
 	SubnetName string,
+	subscription string,
 	IgnoreServiceEndpoint bool) (vnr psql.VirtualNetworkRule, err error) {
 
 	VNetRulesClient := GetPostgreSQLVNetRulesClient(c.creds)
-	SubnetClient := GetGoNetworkSubnetClient(c.creds)
+	// Subnet may be in another subscription
+	if subscription == "" {
+		subscription = c.creds.SubscriptionID()
+	}
+	SubnetClient := GetGoNetworkSubnetClient(c.creds, subscription)
 
 	// Get ARM Resource ID of Subnet based on the VNET name, Subnet name and Subnet Address Prefix
 	subnet, err := SubnetClient.Get(ctx, VNetRG, VNetName, SubnetName, "")

--- a/pkg/resourcemanager/psql/vnetrule/reconcile.go
+++ b/pkg/resourcemanager/psql/vnetrule/reconcile.go
@@ -31,6 +31,7 @@ func (vr *PostgreSQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Obje
 	virtualNetworkRG := instance.Spec.VNetResourceGroup
 	virtualnetworkname := instance.Spec.VNetName
 	subnetName := instance.Spec.SubnetName
+	virtualNetworkSubscription := instance.Spec.VNetSubscriptionID
 	ignoreendpoint := instance.Spec.IgnoreMissingServiceEndpoint
 
 	vnetrule, err := vr.GetPostgreSQLVNetRule(ctx, groupName, server, ruleName)
@@ -56,7 +57,7 @@ func (vr *PostgreSQLVNetRuleClient) Ensure(ctx context.Context, obj runtime.Obje
 	}
 
 	instance.Status.Provisioning = true
-	_, err = vr.CreateOrUpdatePostgreSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, ignoreendpoint)
+	_, err = vr.CreateOrUpdatePostgreSQLVNetRule(ctx, groupName, server, ruleName, virtualNetworkRG, virtualnetworkname, subnetName, virtualNetworkSubscription, ignoreendpoint)
 	if err != nil {
 		instance.Status.Message = err.Error()
 		azerr := errhelp.NewAzureError(err)


### PR DESCRIPTION
VNET Rules may be required for VNETs in other subscriptions. The VNET rules continue to be created in the ASO's subscription. I've tested all three CRD changes.

- [x] this PR contains documentation
- [ ] this PR contains tests
