### PR TITLE
Clarify documentation for sample MySQLAdministrator

### DIFF
--- a/api/v1alpha1/mysqlserveradministrator_types.go
+++ b/api/v1alpha1/mysqlserveradministrator_types.go
@@ -49,7 +49,10 @@ type MySQLServerAdministratorSpec struct {
 	// +kubebuilder:validation:Required
 	Login string `json:"login"`
 
-	//Sid: The server administrator Sid (Secure ID). If creating an AAD user, this is the OID of the entity in AAD.
+	//Sid: The server administrator Sid (Secure ID). If creating for
+	//an AAD user or group, this is the OID of the entity in AAD. For
+	//a managed identity this should be the Client ID (or app id) of
+	//the identity.
 	// +kubebuilder:validation:Required
 	Sid string `json:"sid"`
 

--- a/config/samples/azure_v1alpha1_mysqlserveradministrator.yaml
+++ b/config/samples/azure_v1alpha1_mysqlserveradministrator.yaml
@@ -9,7 +9,7 @@ spec:
   # This must be the name of the AAD entity. In the case of a managed identity use the name of the managed identity.
   # For example: "myuser@microsoft.com" might be the login if specifying an AAD user. "my-mi" might be the name of a managed identity.
   login: my-mi
-  # The sid is the OID of the AAD entity
+  # The sid should be the client id (sometimes called app id) for a managed identity.
+  # For a "normal" (non-managed identity) user or group, this is the OID of the user or group.
   sid: 00000000-0000-0000-0000-000000000000
   tenantId: 00000000-0000-0000-0000-000000000000
-

--- a/pkg/resourcemanager/mysql/mysqlhelper.go
+++ b/pkg/resourcemanager/mysql/mysqlhelper.go
@@ -45,7 +45,7 @@ func ConnectToSqlDB(ctx context.Context, driverName string, fullServer string, d
 
 	err = db.PingContext(ctx)
 	if err != nil {
-		return db, fmt.Errorf("error ping the mysql db:  %v", err)
+		return db, fmt.Errorf("error pinging the mysql db (%s:%d/%s): %v", fullServer, port, database, err)
 	}
 
 	return db, err
@@ -84,7 +84,7 @@ func ConnectToSQLDBAsCurrentUser(
 
 	err = db.PingContext(ctx)
 	if err != nil {
-		return db, fmt.Errorf("error ping the mysql db:  %v", err)
+		return db, fmt.Errorf("error pinging the mysql db (%s:%d/%s) as %s: %v", fullServer, port, database, user, err)
 	}
 
 	return db, err


### PR DESCRIPTION
The Sid field of a MySQLAdministrator resource referring to a managed identity should be the client ID for the identity, rather than the object ID as suggested by the comments. If the OID is used, MySQLAADUser resources that are created can't be reconciled - the error that comes back is `Azure AD access token is not valid for user 'identityname'`.

Also clarified some logging so we can see which server we're trying to connect to if there's a problem connecting.

**How does this PR make you feel**:
![gif](https://media0.giphy.com/media/TI9HXsiQr4eU9hdxgC/giphy.gif)

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains tests
