### PR TITLE
Don't ignore errors checking whether a being-deleted DB exists

### DIFF
--- a/controllers/mysql_combined_test.go
+++ b/controllers/mysql_combined_test.go
@@ -99,7 +99,7 @@ func TestMySQLHappyPath(t *testing.T) {
 	EnsureInstance(ctx, t, tc, ruleInstance)
 
 	// Create user and ensure it can be updated
-	RunMySQLUserHappyPath(ctx, t, mySQLServerName,mySQLDBName, rgName)
+	RunMySQLUserHappyPath(ctx, t, mySQLServerName, mySQLDBName, rgName)
 
 	// Create VNet and VNetRules -----
 	RunMySqlVNetRuleHappyPath(t, mySQLServerName, rgLocation)

--- a/pkg/helpers/sqlrole.go
+++ b/pkg/helpers/sqlrole.go
@@ -7,7 +7,7 @@ type SQLRoleDelta struct {
 
 func DiffCurrentAndExpectedSQLRoles(currentRoles map[string]struct{}, expectedRoles map[string]struct{}) SQLRoleDelta {
 	result := SQLRoleDelta{
-		AddedRoles: make(map[string]struct{}),
+		AddedRoles:   make(map[string]struct{}),
 		DeletedRoles: make(map[string]struct{}),
 	}
 

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_reconcile.go
@@ -218,19 +218,10 @@ func (db *AzureSqlDbManager) Delete(ctx context.Context, obj runtime.Object, opt
 
 	_, err = db.DeleteDB(ctx, groupName, server, dbName)
 	if err != nil {
-		catch := []string{
-			errhelp.AsyncOpIncompleteError,
-		}
-		gone := []string{
-			errhelp.ResourceGroupNotFoundErrorCode,
-			errhelp.ParentNotFoundErrorCode,
-			errhelp.NotFoundErrorCode,
-			errhelp.ResourceNotFound,
-		}
 		azerr := errhelp.NewAzureError(err)
-		if helpers.ContainsString(catch, azerr.Type) {
+		if isIncompleteOp(azerr) {
 			return true, nil
-		} else if helpers.ContainsString(gone, azerr.Type) {
+		} else if isNotFound(azerr) {
 			return false, nil
 		}
 		return true, fmt.Errorf("AzureSqlDb delete error %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We would treat any error from getting the database in Azure as a signal that the database had already been removed.

This can mean that if there's a communication error when checking with Azure then we just remove the k8s database resource without trying to delete the Azure one (which is then orphaned).

Closes #1335

**How does this PR make you feel**:
![gif](https://64.media.tumblr.com/54616398eb37edb934e8f6ec49219fc9/tumblr_o8l8k31W9j1ugamslo1_400.gifv)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
