### PR TITLE
Allow Mysql AAD User DB Name to be empty.

### DIFF
--- a/api/v1alpha1/mysqlaaduser_types.go
+++ b/api/v1alpha1/mysqlaaduser_types.go
@@ -15,9 +15,8 @@ type MySQLAADUserSpec struct {
 	// +kubebuilder:validation:Required
 	Server string `json:"server"`
 
-	// +kubebuilder:validation:MinLength:1
-	// +kubebuilder:validation:Required
-	DBName string `json:"dbName"`
+	// optional, grants to entire server if omitted.
+	DBName string `json:"dbName,omitempty"`
 
 	// +kubebuilder:validation:Pattern=^[-\w\._\(\)]+$
 	// +kubebuilder:validation:MinLength:1

--- a/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_mysqlaadusers.azure.microsoft.com.yaml
+++ b/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_mysqlaadusers.azure.microsoft.com.yaml
@@ -41,6 +41,7 @@ spec:
               description: AAD ID is the ID of the user in Azure Active Directory. When creating a user for a managed identity this must be the client id (sometimes called app id) of the managed identity. When creating a user for a "normal" (non-managed identity) user or group, this is the OID of the user or group.
               type: string
             dbName:
+              description: optional, grants to entire server if omitted.
               type: string
             resourceGroup:
               pattern: ^[-\w\._\(\)]+$
@@ -56,7 +57,6 @@ spec:
               description: optional
               type: string
           required:
-          - dbName
           - resourceGroup
           - roles
           - server

--- a/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_mysqlserveradministrators.azure.microsoft.com.yaml
+++ b/charts/azure-service-operator/crds/apiextensions.k8s.io_v1beta1_customresourcedefinition_mysqlserveradministrators.azure.microsoft.com.yaml
@@ -52,7 +52,7 @@ spec:
             server:
               type: string
             sid:
-              description: 'Sid: The server administrator Sid (Secure ID). If creating an AAD user, this is the OID of the entity in AAD.'
+              description: 'Sid: The server administrator Sid (Secure ID). If creating for an AAD user or group, this is the OID of the entity in AAD. For a managed identity this should be the Client ID (or app id) of the identity.'
               type: string
             tenantId:
               description: 'TenantId: The server Active Directory Administrator tenant id.'

--- a/config/samples/azure_v1alpha1_mysqlaaduser.yaml
+++ b/config/samples/azure_v1alpha1_mysqlaaduser.yaml
@@ -4,16 +4,18 @@ metadata:
   name: mysqlaaduser-sample
 spec:
   server: mysqlserver-sample
-  dbName: mysqldatabase-sample
+  dbName: mysqldatabase-sample # Omit to apply privileges at the server level (all databases)
   resourceGroup: resourcegroup-azure-operators
   # AAD ID is the ID of the user in Azure Active Directory.
   # When creating a user for a managed identity this must be the client id (sometimes called app id) of the managed identity.
   # When creating a user for a "normal" (non-managed identity) user or group, this is the OID of the user or group.
   aadId: 00000000-0000-0000-0000-000000000000
-  roles: 
+  roles:
+  # This adds the privileges to the specified database
   # Valid privileges are listed below:
   # SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES,
   # CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT,
   # CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
-  # This adds the privileges to the specified database
+  # Some privileges can only be applied with the dbName omitted (at the server level):
+  # RELOAD, PROCESS, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, CREATE USER
     - SELECT

--- a/pkg/helpers/mysqlrole.go
+++ b/pkg/helpers/mysqlrole.go
@@ -1,0 +1,65 @@
+package helpers
+
+import (
+	"fmt"
+)
+
+type MySQLRoleDelta struct {
+	AddedRoles   map[string]bool
+	DeletedRoles map[string]bool
+}
+
+// Boolean value is true for grants which can only be applied at the server level.
+var roles = map[string]bool{
+	"SELECT":                  false,
+	"INSERT":                  false,
+	"UPDATE":                  false,
+	"DELETE":                  false,
+	"CREATE":                  false,
+	"DROP":                    false,
+	"RELOAD":                  true,
+	"PROCESS":                 true,
+	"REFERENCES":              false,
+	"INDEX":                   false,
+	"ALTER":                   false,
+	"SHOW DATABASES":          true,
+	"CREATE TEMPORARY TABLES": false,
+	"LOCK TABLES":             false,
+	"EXECUTE":                 false,
+	"REPLICATION SLAVE":       true,
+	"REPLICATION CLIENT":      true,
+	"CREATE VIEW":             false,
+	"SHOW VIEW":               false,
+	"CREATE ROUTINE":          false,
+	"ALTER ROUTINE":           false,
+	"CREATE USER":             true,
+	"EVENT":                   false,
+	"TRIGGER":                 false,
+}
+
+func DiffCurrentAndExpectedMySQLRoles(currentRoles map[string]bool, expectedRoles map[string]bool) (MySQLRoleDelta, error) {
+	result := MySQLRoleDelta{
+		AddedRoles:   make(map[string]bool),
+		DeletedRoles: make(map[string]bool),
+	}
+
+	for role, expectedServer := range expectedRoles {
+		// If an expected role isn't in the current role set, we need to add it
+		if _, ok := currentRoles[role]; !ok {
+			if roles[role] && !expectedServer {
+				return result, fmt.Errorf("%s is a server level role and cannot be applied to a database", role)
+			} else {
+				result.AddedRoles[role] = expectedServer
+			}
+		}
+	}
+
+	for role, currentServer := range currentRoles {
+		// If a current role isn't in the expected set, we need to remove it
+		if _, ok := expectedRoles[role]; !ok {
+			result.DeletedRoles[role] = currentServer
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/helpers/mysqlrole_test.go
+++ b/pkg/helpers/mysqlrole_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffCurrentAndExpectedMySQLRoles(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := []struct {
+		name                string
+		currentRoles        map[string]bool
+		expectedRoles       map[string]bool
+		expectedRoleCreates map[string]bool
+		expectedRoleDeletes map[string]bool
+		expectedErr         bool
+	}{
+		{
+			name:                "Current and expected equal",
+			currentRoles:        map[string]bool{"INSERT": false},
+			expectedRoles:       map[string]bool{"INSERT": false},
+			expectedRoleCreates: make(map[string]bool),
+			expectedRoleDeletes: make(map[string]bool),
+			expectedErr:         false,
+		},
+		{
+			name:                "Expected has single role more than current",
+			currentRoles:        map[string]bool{"INSERT": false},
+			expectedRoles:       map[string]bool{"INSERT": false, "SELECT": false},
+			expectedRoleCreates: map[string]bool{"SELECT": false},
+			expectedRoleDeletes: make(map[string]bool),
+			expectedErr:         false,
+		},
+		{
+			name:                "Expected has single role less than current",
+			currentRoles:        map[string]bool{"INSERT": false, "SELECT": false},
+			expectedRoles:       map[string]bool{"INSERT": false},
+			expectedRoleCreates: make(map[string]bool),
+			expectedRoleDeletes: map[string]bool{"SELECT": false},
+			expectedErr:         false,
+		},
+		{
+			name:                "Expected has many roles less than current",
+			currentRoles:        map[string]bool{"SELECT": true, "INSERT": true, "UPDATE": true, "DELETE": true, "CREATE": true, "DROP": true, "RELOAD": true},
+			expectedRoles:       map[string]bool{"SELECT": true, "INSERT": true},
+			expectedRoleCreates: make(map[string]bool),
+			expectedRoleDeletes: map[string]bool{"UPDATE": true, "DELETE": true, "CREATE": true, "DROP": true, "RELOAD": true},
+			expectedErr:         false,
+		},
+		{
+			name:                "Expected has many roles more than current",
+			currentRoles:        map[string]bool{"SELECT": true, "INSERT": true},
+			expectedRoles:       map[string]bool{"SELECT": true, "INSERT": true, "UPDATE": true, "DELETE": true, "CREATE": true, "DROP": true, "RELOAD": true},
+			expectedRoleCreates: map[string]bool{"UPDATE": true, "DELETE": true, "CREATE": true, "DROP": true, "RELOAD": true},
+			expectedRoleDeletes: make(map[string]bool),
+			expectedErr:         false,
+		},
+		{
+			name:                "Expected has server level roles but at the database level",
+			currentRoles:        map[string]bool{"SELECT": false, "INSERT": false},
+			expectedRoles:       map[string]bool{"RELOAD": false},
+			expectedRoleCreates: make(map[string]bool),
+			expectedRoleDeletes: make(map[string]bool),
+			expectedErr:         true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := DiffCurrentAndExpectedMySQLRoles(c.currentRoles, c.expectedRoles)
+			if err != nil {
+				if !c.expectedErr {
+					t.Errorf("unexepected error %s", err)
+				}
+			} else {
+				assert.Equal(c.expectedRoleCreates, result.AddedRoles)
+				assert.Equal(c.expectedRoleDeletes, result.DeletedRoles)
+			}
+		})
+	}
+
+}

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
@@ -251,7 +251,7 @@ func (s *MySqlUserManager) Delete(ctx context.Context, obj runtime.Object, opts 
 
 	user := string(userSecret[MSecretUsernameKey])
 
-	err = mysql.DropUser(ctx, db, user)
+	err = mysql.DropUser(ctx, db, instance.Spec.DbName, user)
 	if err != nil {
 		instance.Status.Message = fmt.Sprintf("Delete MySqlUser failed with %s", err.Error())
 		return false, err


### PR DESCRIPTION
Leaving the DBName field empty will cause the roles to be granted on the server level, rather than just for a database.

**What this PR does / why we need it**:
This allows user privileges to be granted at the server level for all databases. This also allows for the following privileges to be used: `RELOAD, PROCESS, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, CREATE USER`

**Special notes for your reviewer**:
PostgreSQL probably needs similar work. MySQLUser could easily take advantage since it calls the same helper functions. That said, this is all that is required for the Adobe work item.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/VLe9cJCjYWXLy/giphy.gif)

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains tests
