### PR TITLE
Add AzureSQL short term retention policies

### DIFF
--- a/api/v1beta1/azuresqldatabase_types.go
+++ b/api/v1beta1/azuresqldatabase_types.go
@@ -40,6 +40,13 @@ type SqlDatabaseSku struct {
 	Capacity *int32 `json:"capacity,omitempty"`
 }
 
+type SQLDatabaseShortTermRetentionPolicy struct {
+	// RetentionDays is the backup retention period in days. This is how many days
+	// Point-in-Time Restore will be supported.
+	// +kubebuilder:validation:Required
+	RetentionDays int32 `json:"retentionDays"`
+}
+
 // AzureSqlDatabaseSpec defines the desired state of AzureSqlDatabase
 type AzureSqlDatabaseSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -59,14 +66,15 @@ type AzureSqlDatabaseSpec struct {
 	Server string `json:"server"`
 
 	// +kubebuilder:validation:Optional
-	Edition          DBEdition          `json:"edition"`       // TODO: Remove this in v1beta2
-	Sku              *SqlDatabaseSku    `json:"sku,omitempty"` // TODO: make this required in v1beta2
-	MaxSize          *resource.Quantity `json:"maxSize,omitempty"`
-	DbName           string             `json:"dbName,omitempty"`
-	WeeklyRetention  string             `json:"weeklyRetention,omitempty"`
-	MonthlyRetention string             `json:"monthlyRetention,omitempty"`
-	YearlyRetention  string             `json:"yearlyRetention,omitempty"`
-	WeekOfYear       int32              `json:"weekOfYear,omitempty"`
+	Edition                  DBEdition                            `json:"edition"`       // TODO: Remove this in v1beta2
+	Sku                      *SqlDatabaseSku                      `json:"sku,omitempty"` // TODO: make this required in v1beta2
+	MaxSize                  *resource.Quantity                   `json:"maxSize,omitempty"`
+	DbName                   string                               `json:"dbName,omitempty"`
+	WeeklyRetention          string                               `json:"weeklyRetention,omitempty"`
+	MonthlyRetention         string                               `json:"monthlyRetention,omitempty"`
+	YearlyRetention          string                               `json:"yearlyRetention,omitempty"`
+	WeekOfYear               int32                                `json:"weekOfYear,omitempty"`
+	ShortTermRetentionPolicy *SQLDatabaseShortTermRetentionPolicy `json:"shortTermRetentionPolicy,omitempty"`
 }
 
 // AzureSqlDatabase is the Schema for the azuresqldatabases API

--- a/config/samples/azure_v1beta1_azuresqldatabase.yaml
+++ b/config/samples/azure_v1beta1_azuresqldatabase.yaml
@@ -28,4 +28,9 @@ spec:
 
   # The week of year to take the yearly backup, valid values [1, 52]
   # weekOfYear: 16
-  
+
+  # The short term retention policy to use
+  # shortTermRetentionPolicy:
+      # RetentionDays is the backup retention period in days. This is how many days
+      #	Point-in-Time Restore will be supported.
+  #   retentionDays: 21

--- a/controllers/keyvault_controller_test.go
+++ b/controllers/keyvault_controller_test.go
@@ -407,8 +407,8 @@ func TestKeyvaultControllerBadAccessPolicy(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.KeyVaultSpec{
-			Location:      keyVaultLocation,
-			ResourceGroup: tc.resourceGroupName,
+			Location:       keyVaultLocation,
+			ResourceGroup:  tc.resourceGroupName,
 			AccessPolicies: &accessPolicies,
 		},
 	}

--- a/pkg/errhelp/errors.go
+++ b/pkg/errhelp/errors.go
@@ -66,6 +66,7 @@ const (
 	FeatureNotSupportedForEdition                  = "FeatureNotSupportedForEdition"
 	VirtualNetworkRuleBadRequest                   = "VirtualNetworkRuleBadRequest"
 	LongTermRetentionPolicyInvalid                 = "LongTermRetentionPolicyInvalid"
+	BackupRetentionPolicyInvalid                   = "InvalidBackupRetentionPeriod"
 	OperationIdNotFound                            = "OperationIdNotFound"
 )
 

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb.go
@@ -145,10 +145,7 @@ func (m *AzureSqlDbManager) AddLongTermRetention(
 	resourceGroupName string,
 	serverName string,
 	databaseName string,
-	weeklyRetention string,
-	monthlyRetention string,
-	yearlyRetention string,
-	weekOfYear int32) (*sql.BackupLongTermRetentionPoliciesCreateOrUpdateFuture, error) {
+	policy azuresqlshared.SQLDatabaseBackupLongTermRetentionPolicy) (*sql.BackupLongTermRetentionPoliciesCreateOrUpdateFuture, error) {
 
 	longTermClient, err := azuresqlshared.GetBackupLongTermRetentionPoliciesClient(m.creds)
 	if err != nil {
@@ -156,27 +153,27 @@ func (m *AzureSqlDbManager) AddLongTermRetention(
 	}
 
 	// validate the input and exit if nothing needs to happen - this is ok!
-	if weeklyRetention == "" && monthlyRetention == "" && yearlyRetention == "" {
+	if policy.WeeklyRetention == "" && policy.MonthlyRetention == "" && policy.YearlyRetention == "" {
 		return nil, nil
 	}
 
 	// validate the pairing of yearly retention and week of year
-	if yearlyRetention != "" && (weekOfYear <= 0 || weekOfYear > 52) {
+	if policy.YearlyRetention != "" && (policy.WeekOfYear <= 0 || policy.WeekOfYear > 52) {
 		return nil, fmt.Errorf("weekOfYear must be greater than 0 and less or equal to 52 when yearlyRetention is used")
 	}
 
 	// create pointers so that we can pass nils if needed
-	pWeeklyRetention := &weeklyRetention
-	if weeklyRetention == "" {
+	pWeeklyRetention := &policy.WeeklyRetention
+	if policy.WeeklyRetention == "" {
 		pWeeklyRetention = nil
 	}
-	pMonthlyRetention := &monthlyRetention
-	if monthlyRetention == "" {
+	pMonthlyRetention := &policy.MonthlyRetention
+	if policy.MonthlyRetention == "" {
 		pMonthlyRetention = nil
 	}
-	pYearlyRetention := &yearlyRetention
-	pWeekOfYear := &weekOfYear
-	if yearlyRetention == "" {
+	pYearlyRetention := &policy.YearlyRetention
+	pWeekOfYear := &policy.WeekOfYear
+	if policy.YearlyRetention == "" {
 		pYearlyRetention = nil
 		pWeekOfYear = nil
 	}

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb.go
@@ -6,10 +6,11 @@ package azuresqldb
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
-	sql3 "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-service-operator/api/v1beta1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/helpers"
 	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
@@ -139,28 +140,29 @@ func (m *AzureSqlDbManager) CreateOrUpdateDB(
 }
 
 // AddLongTermRetention enables / disables long term retention
-func (m *AzureSqlDbManager) AddLongTermRetention(ctx context.Context, resourceGroupName string, serverName string, databaseName string, weeklyRetention string, monthlyRetention string, yearlyRetention string, weekOfYear int32) (*http.Response, error) {
+func (m *AzureSqlDbManager) AddLongTermRetention(
+	ctx context.Context,
+	resourceGroupName string,
+	serverName string,
+	databaseName string,
+	weeklyRetention string,
+	monthlyRetention string,
+	yearlyRetention string,
+	weekOfYear int32) (*sql.BackupLongTermRetentionPoliciesCreateOrUpdateFuture, error) {
 
 	longTermClient, err := azuresqlshared.GetBackupLongTermRetentionPoliciesClient(m.creds)
-	// TODO: Probably shouldn't return a response at all in the err case here (all through this function)
 	if err != nil {
-		return &http.Response{
-			StatusCode: 0,
-		}, err
+		return nil, err
 	}
 
 	// validate the input and exit if nothing needs to happen - this is ok!
 	if weeklyRetention == "" && monthlyRetention == "" && yearlyRetention == "" {
-		return &http.Response{
-			StatusCode: 200,
-		}, nil
+		return nil, nil
 	}
 
 	// validate the pairing of yearly retention and week of year
 	if yearlyRetention != "" && (weekOfYear <= 0 || weekOfYear > 52) {
-		return &http.Response{
-			StatusCode: 500,
-		}, fmt.Errorf("weekOfYear must be greater than 0 and less or equal to 52 when yearlyRetention is used")
+		return nil, fmt.Errorf("weekOfYear must be greater than 0 and less or equal to 52 when yearlyRetention is used")
 	}
 
 	// create pointers so that we can pass nils if needed
@@ -184,8 +186,8 @@ func (m *AzureSqlDbManager) AddLongTermRetention(ctx context.Context, resourceGr
 		resourceGroupName,
 		serverName,
 		databaseName,
-		sql3.BackupLongTermRetentionPolicy{
-			LongTermRetentionPolicyProperties: &sql3.LongTermRetentionPolicyProperties{
+		sql.BackupLongTermRetentionPolicy{
+			LongTermRetentionPolicyProperties: &sql.LongTermRetentionPolicyProperties{
 				WeeklyRetention:  pWeeklyRetention,
 				MonthlyRetention: pMonthlyRetention,
 				YearlyRetention:  pYearlyRetention,
@@ -195,12 +197,57 @@ func (m *AzureSqlDbManager) AddLongTermRetention(ctx context.Context, resourceGr
 	)
 
 	if err != nil {
-		return &http.Response{
-			StatusCode: 500,
-		}, nil
+		return nil, err
 	}
 
-	return future.Response(), err
+	return &future, err
+}
+
+func (m *AzureSqlDbManager) AddShortTermRetention(
+	ctx context.Context,
+	resourceGroupName string,
+	serverName string,
+	databaseName string,
+	policy *v1beta1.SQLDatabaseShortTermRetentionPolicy) (*sql.BackupShortTermRetentionPoliciesCreateOrUpdateFuture, error) {
+
+	client, err := azuresqlshared.GetBackupShortTermRetentionPoliciesClient(m.creds)
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't create BackupShortTermRetentionPoliciesClient")
+	}
+
+	var policyProperties *sql.BackupShortTermRetentionPolicyProperties
+	if policy == nil {
+		// If policy is nil we're in a bit of an awkward situation since we cannot know if the customer has mutated
+		// the retention policy in a previous reconciliation loop and then subsequently removed it. If they have,
+		// "doing nothing" here is wrong because that leaves them in the previous modified state (but with no reflection
+		// of that fact in the Spec).
+		// Unfortunately you cannot update the retention policy to nil, nor can you delete it, so we must awkwardly
+		// set it back to its default configuration.
+		// Note: There are risks here, such as if the default on the server and the default in our code drift apart
+		// at some point in the future.
+		policyProperties = &sql.BackupShortTermRetentionPolicyProperties{
+			RetentionDays: to.Int32Ptr(7), // 7 is the magical default as of Jan 2021
+		}
+	} else {
+		policyProperties = &sql.BackupShortTermRetentionPolicyProperties{
+			RetentionDays: to.Int32Ptr(policy.RetentionDays),
+		}
+	}
+
+	future, err := client.CreateOrUpdate(
+		ctx,
+		resourceGroupName,
+		serverName,
+		databaseName,
+		sql.BackupShortTermRetentionPolicy{
+			BackupShortTermRetentionPolicyProperties: policyProperties,
+		})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &future, err
 }
 
 var goneCodes = []string{

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_manager.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_manager.go
@@ -5,9 +5,9 @@ package azuresqldb
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+
 	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
@@ -42,7 +42,7 @@ type SqlDbManager interface {
 		weeklyRetention string,
 		monthlyRetention string,
 		yearlyRetention string,
-		weekOfYear int32) (*http.Response, error)
+		weekOfYear int32) (*sql.BackupLongTermRetentionPoliciesCreateOrUpdateFuture, error)
 
 	resourcemanager.ARMClient
 }

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_manager.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_manager.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
 
-	azuresqlshared "github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
-
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
+	"github.com/Azure/azure-service-operator/pkg/resourcemanager/azuresql/azuresqlshared"
 )
 
 // SqlDbManager is the client for the resource manager for SQL databases
@@ -39,10 +38,7 @@ type SqlDbManager interface {
 		resourceGroupName string,
 		serverName string,
 		databaseName string,
-		weeklyRetention string,
-		monthlyRetention string,
-		yearlyRetention string,
-		weekOfYear int32) (*sql.BackupLongTermRetentionPoliciesCreateOrUpdateFuture, error)
+		policy azuresqlshared.SQLDatabaseBackupLongTermRetentionPolicy) (*sql.BackupLongTermRetentionPoliciesCreateOrUpdateFuture, error)
 
 	resourcemanager.ARMClient
 }

--- a/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqldb/azuresqldb_reconcile.go
@@ -114,10 +114,12 @@ func (db *AzureSqlDbManager) Ensure(ctx context.Context, obj runtime.Object, opt
 				groupName,
 				server,
 				dbName,
-				instance.Spec.WeeklyRetention,
-				instance.Spec.MonthlyRetention,
-				instance.Spec.YearlyRetention,
-				instance.Spec.WeekOfYear)
+				azuresqlshared.SQLDatabaseBackupLongTermRetentionPolicy{
+					WeeklyRetention: instance.Spec.WeeklyRetention,
+					MonthlyRetention: instance.Spec.MonthlyRetention,
+					YearlyRetention: instance.Spec.YearlyRetention,
+					WeekOfYear: instance.Spec.WeekOfYear,
+				})
 			if err != nil {
 				failureErrors := []string{
 					errhelp.LongTermRetentionPolicyInvalid,

--- a/pkg/resourcemanager/azuresql/azuresqlshared/getgoclients.go
+++ b/pkg/resourcemanager/azuresql/azuresqlshared/getgoclients.go
@@ -61,36 +61,48 @@ func GetGoFirewallClient(creds config.Credentials) (sql.FirewallRulesClient, err
 
 // GetGoVNetRulesClient retrieves a VirtualNetworkRulesClient
 func GetGoVNetRulesClient(creds config.Credentials) (sql.VirtualNetworkRulesClient, error) {
-	VNetRulesClient := sql.NewVirtualNetworkRulesClientWithBaseURI(config.BaseURI(), creds.SubscriptionID())
+	vnetRulesClient := sql.NewVirtualNetworkRulesClientWithBaseURI(config.BaseURI(), creds.SubscriptionID())
 	a, err := iam.GetResourceManagementAuthorizer(creds)
 	if err != nil {
 		return sql.VirtualNetworkRulesClient{}, err
 	}
-	VNetRulesClient.Authorizer = a
-	VNetRulesClient.AddToUserAgent(config.UserAgent())
-	return VNetRulesClient, nil
+	vnetRulesClient.Authorizer = a
+	vnetRulesClient.AddToUserAgent(config.UserAgent())
+	return vnetRulesClient, nil
 }
 
 // GetNetworkSubnetClient retrieves a Subnetclient
 func GetGoNetworkSubnetClient(creds config.Credentials, subscription string) (network.SubnetsClient, error) {
-	SubnetsClient := network.NewSubnetsClientWithBaseURI(config.BaseURI(), subscription)
+	subnetsClient := network.NewSubnetsClientWithBaseURI(config.BaseURI(), subscription)
 	a, err := iam.GetResourceManagementAuthorizer(creds)
 	if err != nil {
 		return network.SubnetsClient{}, err
 	}
-	SubnetsClient.Authorizer = a
-	SubnetsClient.AddToUserAgent(config.UserAgent())
-	return SubnetsClient, nil
+	subnetsClient.Authorizer = a
+	subnetsClient.AddToUserAgent(config.UserAgent())
+	return subnetsClient, nil
 }
 
-// GetBackupLongTermRetentionPoliciesClient retrieves a Subnetclient
+// GetBackupLongTermRetentionPoliciesClient retrieves a BackupLongTermRetentionPoliciesClient
 func GetBackupLongTermRetentionPoliciesClient(creds config.Credentials) (sql3.BackupLongTermRetentionPoliciesClient, error) {
-	BackupClient := sql3.NewBackupLongTermRetentionPoliciesClientWithBaseURI(config.BaseURI(), creds.SubscriptionID())
+	backupClient := sql3.NewBackupLongTermRetentionPoliciesClientWithBaseURI(config.BaseURI(), creds.SubscriptionID())
 	a, err := iam.GetResourceManagementAuthorizer(creds)
 	if err != nil {
 		return sql3.BackupLongTermRetentionPoliciesClient{}, err
 	}
-	BackupClient.Authorizer = a
-	BackupClient.AddToUserAgent(config.UserAgent())
-	return BackupClient, nil
+	backupClient.Authorizer = a
+	backupClient.AddToUserAgent(config.UserAgent())
+	return backupClient, nil
+}
+
+// GetBackupShortTermRetentionPoliciesClient retrieves a BackupShortTermRetentionPoliciesClient
+func GetBackupShortTermRetentionPoliciesClient(creds config.Credentials) (sql3.BackupShortTermRetentionPoliciesClient, error) {
+	backupClient := sql3.NewBackupShortTermRetentionPoliciesClientWithBaseURI(config.BaseURI(), creds.SubscriptionID())
+	a, err := iam.GetResourceManagementAuthorizer(creds)
+	if err != nil {
+		return sql3.BackupShortTermRetentionPoliciesClient{}, err
+	}
+	backupClient.Authorizer = a
+	backupClient.AddToUserAgent(config.UserAgent())
+	return backupClient, nil
 }

--- a/pkg/resourcemanager/azuresql/azuresqlshared/sqlproperties.go
+++ b/pkg/resourcemanager/azuresql/azuresqlshared/sqlproperties.go
@@ -83,6 +83,13 @@ type SQLFailoverGroupProperties struct {
 	DatabaseList []string
 }
 
+type SQLDatabaseBackupLongTermRetentionPolicy struct {
+	WeeklyRetention string
+	MonthlyRetention string
+	YearlyRetention string
+	WeekOfYear int32
+}
+
 // SQLServerPropertiesToServer translates SQLServerProperties to ServerProperties
 func SQLServerPropertiesToServer(properties SQLServerProperties) (result sql.ServerProperties) {
 

--- a/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
@@ -13,12 +13,13 @@ import (
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager/config"
 	"github.com/Azure/azure-service-operator/pkg/secrets"
 
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/errhelp"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
 	keyvaultSecrets "github.com/Azure/azure-service-operator/pkg/secrets/keyvault"
-	"github.com/google/uuid"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	_ "github.com/denisenkom/go-mssqldb"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
Closes #1302

**What this PR does / why we need it**:
Adds support for Azure SQL short term retention alongside existing support for long term retention on the AzureSQLDatabase object.

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains tests
