### PR TITLE
Prevent deadlocks in reconcilation loop

### DIFF
--- a/controllers/async_controller.go
+++ b/controllers/async_controller.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	finalizerName   string        = "azure.microsoft.com/finalizer"
-	requeueDuration time.Duration = time.Second * 20
-	successMsg      string        = "successfully provisioned"
+	finalizerName    string        = "azure.microsoft.com/finalizer"
+	requeueDuration  time.Duration = time.Second * 20
+	successMsg       string        = "successfully provisioned"
+	reconcileTimeout time.Duration = time.Minute * 5
 )
 
 // AsyncReconciler is a generic reconciler for Azure resources.
@@ -43,7 +44,8 @@ type AsyncReconciler struct {
 
 // Reconcile reconciles the change request
 func (r *AsyncReconciler) Reconcile(req ctrl.Request, obj runtime.Object) (result ctrl.Result, err error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
+	defer cancel()
 
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		r.Telemetry.LogInfoByInstance("ignorable error", "error during fetch from api server", req.String())

--- a/controllers/async_controller.go
+++ b/controllers/async_controller.go
@@ -209,7 +209,7 @@ func (r *AsyncReconciler) Reconcile(req ctrl.Request, obj runtime.Object) (resul
 		}
 	}
 
-	r.Telemetry.LogInfo("status", "exiting reconciliation")
+	r.Telemetry.LogInfoByInstance("status", "exiting reconciliation", req.String())
 
 	return result, err
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -101,7 +101,7 @@ func setup() error {
 	resourceGroupName := GenerateTestResourceNameWithRandom(TestResourceGroupPrefix, 6)
 	resourceGroupLocation := resourcemanagerconfig.DefaultLocation()
 
-	keyvaultName := GenerateAlphaNumTestResourceName("kv-prime")
+	keyvaultName := GenerateAlphaNumTestResourceNameWithRandom("kv-prime", 5)
 
 	var timeout time.Duration
 

--- a/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser.go
+++ b/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser.go
@@ -54,7 +54,8 @@ func (s *AzureSqlManagedUserManager) GetDB(ctx context.Context, resourceGroupNam
 func (s *AzureSqlManagedUserManager) ConnectToSqlDbAsCurrentUser(ctx context.Context, server string, database string) (db *sql.DB, err error) {
 
 	fullServerAddress := fmt.Sprintf("%s."+config.Environment().SQLDatabaseDNSSuffix, server)
-	connString := fmt.Sprintf("Server=%s;Database=%s", fullServerAddress, database)
+	// Make sure to set connection timeout: https://github.com/denisenkom/go-mssqldb/issues/609
+	connString := fmt.Sprintf("Server=%s;Database=%s;Connection Timeout=30", fullServerAddress, database)
 
 	tokenProvider, err := iam.GetMSITokenProviderForResource("https://database.windows.net/")
 	if err != nil {

--- a/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser.go
+++ b/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser.go
@@ -65,7 +65,14 @@ func (m *AzureSqlUserManager) GetDB(ctx context.Context, resourceGroupName strin
 func (m *AzureSqlUserManager) ConnectToSqlDb(ctx context.Context, drivername string, server string, database string, port int, user string, password string) (*sql.DB, error) {
 
 	fullServerAddress := fmt.Sprintf("%s."+config.Environment().SQLDatabaseDNSSuffix, server)
-	connString := fmt.Sprintf("server=%s;user id=%s;password=%s;port=%d;database=%s;Persist Security Info=False;Pooling=False;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30", fullServerAddress, user, password, port, database)
+	// Make sure to set connection timeout: https://github.com/denisenkom/go-mssqldb/issues/609
+	connString := fmt.Sprintf(
+		"server=%s;user id=%s;password=%s;port=%d;database=%s;Persist Security Info=False;Pooling=False;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30",
+		fullServerAddress,
+		user,
+		password,
+		port,
+		database)
 
 	db, err := sql.Open(drivername, connString)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a context with a 5 minute timeout for all reconcile loop passes to ensure that if for whatever reason something gets stuck, it doesn't block all reconciliation forever.

Also ensure that we specify a timeout when connecting to Azure SQL to avoid deadlocks in that codepath (see https://github.com/denisenkom/go-mssqldb/issues/609)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
