### PR TITLE
Bug fixes for release 1.0.19504

### DIFF
--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -16,4 +16,4 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/controllers/async_controller.go
+++ b/controllers/async_controller.go
@@ -72,24 +72,11 @@ func (r *AsyncReconciler) Reconcile(req ctrl.Request, obj runtime.Object) (resul
 	}
 
 	var keyvaultSecretClient secrets.SecretClient
-
 	// Determine if we need to check KeyVault for secrets
 	keyVaultName := keyvaultsecretlib.GetKeyVaultName(obj)
-
 	if len(keyVaultName) != 0 {
 		// Instantiate the KeyVault Secret Client
 		keyvaultSecretClient = keyvaultsecretlib.New(keyVaultName, config.GlobalCredentials(), config.SecretNamingVersion())
-
-		r.Telemetry.LogInfoByInstance("status", "ensuring vault", req.String())
-
-		// TODO: It's really awkward that we do this so often?
-		if !keyvaultsecretlib.IsKeyVaultAccessible(keyvaultSecretClient) {
-			r.Telemetry.LogInfoByInstance("requeuing", "awaiting vault verification", req.String())
-
-			// update the status of the resource in kubernetes
-			status.Message = "Waiting for secretclient keyvault to be available"
-			return ctrl.Result{RequeueAfter: requeueDuration}, r.Status().Update(ctx, obj)
-		}
 	}
 
 	// Check to see if the skipreconcile annotation is on

--- a/pkg/resourcemanager/appinsights/api_keys_reconcile.go
+++ b/pkg/resourcemanager/appinsights/api_keys_reconcile.go
@@ -98,7 +98,7 @@ func (c *InsightsAPIKeysClient) Ensure(ctx context.Context, obj runtime.Object, 
 		secrets.WithScheme(c.Scheme),
 	)
 	if err != nil {
-		instance.Status.Message = "api key created but key was lost before storage"
+		instance.Status.Message = fmt.Sprintf("api key created but key was lost before storage. err: %v", err)
 		instance.Status.FailedProvisioning = true
 		return false, err
 	}

--- a/pkg/resourcemanager/appinsights/appinsights.go
+++ b/pkg/resourcemanager/appinsights/appinsights.go
@@ -167,6 +167,7 @@ func (m *Manager) Ensure(ctx context.Context, obj runtime.Object, opts ...resour
 					instance,
 				)
 				if err != nil {
+					instance.Status.Message = err.Error()
 					return false, err
 				}
 			}

--- a/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction_reconcile.go
@@ -20,9 +20,6 @@ import (
 	keyvaultsecretlib "github.com/Azure/azure-service-operator/pkg/secrets/keyvault"
 )
 
-const usernameLength = 8
-const passwordLength = 16
-
 // Ensure creates an AzureSqlAction
 func (s *AzureSqlActionManager) Ensure(ctx context.Context, obj runtime.Object, opts ...resourcemanager.ConfigOption) (bool, error) {
 	instance, err := s.convert(obj)
@@ -51,8 +48,9 @@ func (s *AzureSqlActionManager) Ensure(ctx context.Context, obj runtime.Object, 
 				adminSecretClient = s.SecretClient
 			} else {
 				adminSecretClient = keyvaultsecretlib.New(instance.Spec.ServerSecretKeyVault, s.Creds, s.SecretClient.GetSecretNamingVersion())
-				if !keyvaultsecretlib.IsKeyVaultAccessible(adminSecretClient) {
-					instance.Status.Message = "InvalidKeyVaultAccess: Keyvault not accessible yet"
+				err = keyvaultsecretlib.CheckKeyVaultAccessibility(ctx, adminSecretClient)
+				if err != nil {
+					instance.Status.Message = "InvalidKeyVaultAccess: Keyvault not accessible yet: " + err.Error()
 					return false, nil
 				}
 			}
@@ -99,8 +97,9 @@ func (s *AzureSqlActionManager) Ensure(ctx context.Context, obj runtime.Object, 
 				adminSecretClient = s.SecretClient
 			} else {
 				adminSecretClient = keyvaultsecretlib.New(instance.Spec.ServerSecretKeyVault, s.Creds, s.SecretClient.GetSecretNamingVersion())
-				if !keyvaultsecretlib.IsKeyVaultAccessible(adminSecretClient) {
-					instance.Status.Message = "InvalidKeyVaultAccess: Keyvault not accessible yet"
+				err = keyvaultsecretlib.CheckKeyVaultAccessibility(ctx, adminSecretClient)
+				if err != nil {
+					instance.Status.Message = "InvalidKeyVaultAccess: Keyvault not accessible yet: " + err.Error()
 					return false, nil
 				}
 			}
@@ -111,8 +110,9 @@ func (s *AzureSqlActionManager) Ensure(ctx context.Context, obj runtime.Object, 
 				userSecretClient = s.SecretClient
 			} else {
 				userSecretClient = keyvaultsecretlib.New(instance.Spec.UserSecretKeyVault, s.Creds, s.SecretClient.GetSecretNamingVersion())
-				if !keyvaultsecretlib.IsKeyVaultAccessible(userSecretClient) {
-					instance.Status.Message = "InvalidKeyVaultAccess: Keyvault not accessible yet"
+				err = keyvaultsecretlib.CheckKeyVaultAccessibility(ctx, adminSecretClient)
+				if err != nil {
+					instance.Status.Message = "InvalidKeyVaultAccess: Keyvault not accessible yet: " + err.Error()
 					return false, nil
 				}
 			}

--- a/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
@@ -87,6 +87,7 @@ func (s *AzureSqlServerManager) Ensure(ctx context.Context, obj runtime.Object, 
 			secrets.WithScheme(s.Scheme),
 		)
 		if err != nil {
+			instance.Status.Message = err.Error()
 			return false, err
 		}
 	}

--- a/pkg/resourcemanager/mysql/server/reconcile.go
+++ b/pkg/resourcemanager/mysql/server/reconcile.go
@@ -56,6 +56,7 @@ func (m *MySQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts
 	// Check to see if secret exists and if yes retrieve the admin login and password
 	secret, err := m.GetOrPrepareSecret(ctx, instance)
 	if err != nil {
+		instance.Status.Message = fmt.Sprintf("Failed to get or prepare secret: %s", err.Error())
 		return false, err
 	}
 

--- a/pkg/resourcemanager/psql/server/server_reconcile.go
+++ b/pkg/resourcemanager/psql/server/server_reconcile.go
@@ -60,6 +60,7 @@ func (c *PSQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts 
 	// Update secret with the fully qualified server name
 	err = c.AddServerCredsToSecrets(ctx, secret, instance)
 	if err != nil {
+		instance.Status.Message = err.Error()
 		return false, err
 	}
 

--- a/pkg/resourcemanager/storages/storageaccount/storageaccount_reconcile.go
+++ b/pkg/resourcemanager/storages/storageaccount/storageaccount_reconcile.go
@@ -86,6 +86,7 @@ func (m *azureStorageManager) Ensure(ctx context.Context, obj runtime.Object, op
 		// upsert
 		err = m.StoreSecrets(ctx, groupName, name, instance)
 		if err != nil {
+			instance.Status.Message = err.Error()
 			return false, err
 		}
 

--- a/pkg/resourcemanager/vm/reconcile.go
+++ b/pkg/resourcemanager/vm/reconcile.go
@@ -44,6 +44,7 @@ func (c *AzureVirtualMachineClient) Ensure(ctx context.Context, obj runtime.Obje
 	// Update secret
 	err = c.AddVirtualMachineCredsToSecrets(ctx, secret, instance)
 	if err != nil {
+		instance.Status.Message = err.Error()
 		return false, err
 	}
 

--- a/pkg/resourcemanager/vmext/reconcile.go
+++ b/pkg/resourcemanager/vmext/reconcile.go
@@ -44,6 +44,7 @@ func (c *AzureVirtualMachineExtensionClient) Ensure(ctx context.Context, obj run
 	// Update secret
 	err = c.AddVirtualMachineExtensionCredsToSecrets(ctx, instance.Name, secret, instance)
 	if err != nil {
+		instance.Status.Message = err.Error()
 		return false, err
 	}
 

--- a/pkg/resourcemanager/vmss/reconcile.go
+++ b/pkg/resourcemanager/vmss/reconcile.go
@@ -47,6 +47,7 @@ func (c *AzureVMScaleSetClient) Ensure(ctx context.Context, obj runtime.Object, 
 	// Update secret
 	err = c.AddVMScaleSetCredsToSecrets(ctx, secret, instance)
 	if err != nil {
+		instance.Status.Message = err.Error()
 		return false, err
 	}
 


### PR DESCRIPTION
- Fix issue where we were checking if a KeyVault was accessible very frequently. Instead just rely on error handling in the resource itself if creating a secret fails. This also gives a better error message.
- Fix bug in templates preventing webhook from getting correct certificate injected by `cert-manager`.