### PR TITLE
Fix v1 secret naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test-integration-controllers: generate fmt vet manifests
 .PHONY: test-v1-secret-naming
 test-v1-secret-naming: generate fmt vet manifests
 	TEST_RESOURCE_PREFIX=$(TEST_RESOURCE_PREFIX) TEST_USE_EXISTING_CLUSTER=false REQUEUE_AFTER=20 AZURE_SECRET_NAMING_VERSION=1 \
-	go test -v -run "^.*_SecretNamedCorrectly$$" -tags "$(BUILD_TAGS)" -coverprofile=reports/v1-secret-naming-coverage-output.txt -coverpkg=./... -covermode count -parallel 4 -timeout 10m \
+	go test -v -run "^.*_SecretNamedCorrectly$$" -tags "$(BUILD_TAGS)" -coverprofile=reports/v1-secret-naming-coverage-output.txt -coverpkg=./... -covermode count -parallel 4 -timeout 15m \
 		./controllers/...
 
 # Run Resource Manager tests against the configured cluster

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,8 @@ resources:
 - repo: self
 
 pool:
-   vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-latest'
+  timeoutInMinutes: 80
 
 variables:
   tag: '$(Build.BuildId)'

--- a/controllers/azurevirtualmachine_controller_test.go
+++ b/controllers/azurevirtualmachine_controller_test.go
@@ -27,6 +27,7 @@ func TestVirtualMachineControllerNoResourceGroup(t *testing.T) {
 	sshPublicKeyData := GenerateTestResourceNameWithRandom("ssh", 10)
 	nicName := GenerateTestResourceNameWithRandom("nic", 10)
 	platformImageUrn := "Canonical:UbuntuServer:16.04-LTS:latest"
+	location := tc.resourceGroupLocation
 
 	// Create a VM
 	vmInstance := &azurev1alpha1.AzureVirtualMachine{
@@ -35,7 +36,7 @@ func TestVirtualMachineControllerNoResourceGroup(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureVirtualMachineSpec{
-			Location:             tc.resourceGroupLocation,
+			Location:             location,
 			ResourceGroup:        rgName,
 			VMSize:               vmSize,
 			OSType:               osType,
@@ -56,6 +57,9 @@ func TestVirtualMachineHappyPathWithNicPipVNetAndSubnet(t *testing.T) {
 	defer PanicRecover(t)
 	ctx := context.Background()
 
+	// location := tc.resourceGroupLocation
+	location := "australiaeast"
+
 	// Create a vnet with a subnet
 	vnetName := GenerateTestResourceNameWithRandom("vnt", 10)
 	subnetName := GenerateTestResourceNameWithRandom("snt", 10)
@@ -70,7 +74,7 @@ func TestVirtualMachineHappyPathWithNicPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.VirtualNetworkSpec{
-			Location:      tc.resourceGroupLocation,
+			Location:      location,
 			ResourceGroup: tc.resourceGroupName,
 			AddressSpace:  "110.0.0.0/8",
 			Subnets:       []azurev1alpha1.VNetSubnets{vnetSubNetInstance},
@@ -90,7 +94,7 @@ func TestVirtualMachineHappyPathWithNicPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzurePublicIPAddressSpec{
-			Location:                 tc.resourceGroupLocation,
+			Location:                 location,
 			ResourceGroup:            tc.resourceGroupName,
 			PublicIPAllocationMethod: publicIPAllocationMethod,
 			IdleTimeoutInMinutes:     idleTimeoutInMinutes,
@@ -109,7 +113,7 @@ func TestVirtualMachineHappyPathWithNicPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureNetworkInterfaceSpec{
-			Location:            tc.resourceGroupLocation,
+			Location:            location,
 			ResourceGroup:       tc.resourceGroupName,
 			VNetName:            vnetName,
 			SubnetName:          subnetName,
@@ -134,7 +138,7 @@ func TestVirtualMachineHappyPathWithNicPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureVirtualMachineSpec{
-			Location:             tc.resourceGroupLocation,
+			Location:             location,
 			ResourceGroup:        tc.resourceGroupName,
 			VMSize:               vmSize,
 			OSType:               osType,

--- a/controllers/azurevirtualmachineextension_controller_test.go
+++ b/controllers/azurevirtualmachineextension_controller_test.go
@@ -52,6 +52,9 @@ func TestVirtualMachineExtensionHappyPath(t *testing.T) {
 	defer PanicRecover(t)
 	ctx := context.Background()
 
+	// location := tc.resourceGroupLocation
+	location := "australiaeast"
+
 	// Create a vnet with a subnet
 	vnetName := GenerateTestResourceNameWithRandom("vnt", 10)
 	subnetName := GenerateTestResourceNameWithRandom("snt", 10)
@@ -66,7 +69,7 @@ func TestVirtualMachineExtensionHappyPath(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.VirtualNetworkSpec{
-			Location:      tc.resourceGroupLocation,
+			Location:      location,
 			ResourceGroup: tc.resourceGroupName,
 			AddressSpace:  "110.0.0.0/8",
 			Subnets:       []azurev1alpha1.VNetSubnets{vnetSubNetInstance},
@@ -86,7 +89,7 @@ func TestVirtualMachineExtensionHappyPath(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzurePublicIPAddressSpec{
-			Location:                 tc.resourceGroupLocation,
+			Location:                 location,
 			ResourceGroup:            tc.resourceGroupName,
 			PublicIPAllocationMethod: publicIPAllocationMethod,
 			IdleTimeoutInMinutes:     idleTimeoutInMinutes,
@@ -105,7 +108,7 @@ func TestVirtualMachineExtensionHappyPath(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureNetworkInterfaceSpec{
-			Location:            tc.resourceGroupLocation,
+			Location:            location,
 			ResourceGroup:       tc.resourceGroupName,
 			VNetName:            vnetName,
 			SubnetName:          subnetName,
@@ -130,7 +133,7 @@ func TestVirtualMachineExtensionHappyPath(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureVirtualMachineSpec{
-			Location:             tc.resourceGroupLocation,
+			Location:             location,
 			ResourceGroup:        tc.resourceGroupName,
 			VMSize:               vmSize,
 			OSType:               osType,
@@ -151,7 +154,7 @@ func TestVirtualMachineExtensionHappyPath(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureVirtualMachineExtensionSpec{
-			Location:                tc.resourceGroupLocation,
+			Location:                location,
 			ResourceGroup:           tc.resourceGroupName,
 			VMName:                  vmName,
 			AutoUpgradeMinorVersion: true,

--- a/controllers/azurevmscaleset_controller_test.go
+++ b/controllers/azurevmscaleset_controller_test.go
@@ -66,6 +66,9 @@ func TestVMScaleSetHappyPathWithLbPipVNetAndSubnet(t *testing.T) {
 	defer PanicRecover(t)
 	ctx := context.Background()
 
+	// location := tc.resourceGroupLocation
+	location := "australiaeast"
+
 	// Create a vnet with a subnet
 	vnetName := GenerateTestResourceNameWithRandom("vnt", 10)
 	subnetName := GenerateTestResourceNameWithRandom("snt", 10)
@@ -80,7 +83,7 @@ func TestVMScaleSetHappyPathWithLbPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.VirtualNetworkSpec{
-			Location:      tc.resourceGroupLocation,
+			Location:      location,
 			ResourceGroup: tc.resourceGroupName,
 			AddressSpace:  "110.0.0.0/8",
 			Subnets:       []azurev1alpha1.VNetSubnets{vnetSubNetInstance},
@@ -100,7 +103,7 @@ func TestVMScaleSetHappyPathWithLbPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzurePublicIPAddressSpec{
-			Location:                 tc.resourceGroupLocation,
+			Location:                 location,
 			ResourceGroup:            tc.resourceGroupName,
 			PublicIPAllocationMethod: publicIPAllocationMethod,
 			IdleTimeoutInMinutes:     idleTimeoutInMinutes,
@@ -124,7 +127,7 @@ func TestVMScaleSetHappyPathWithLbPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureLoadBalancerSpec{
-			Location:               tc.resourceGroupLocation,
+			Location:               location,
 			ResourceGroup:          tc.resourceGroupName,
 			PublicIPAddressName:    pipName,
 			BackendAddressPoolName: bpName,
@@ -152,7 +155,7 @@ func TestVMScaleSetHappyPathWithLbPipVNetAndSubnet(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: azurev1alpha1.AzureVMScaleSetSpec{
-			Location:               tc.resourceGroupLocation,
+			Location:               location,
 			ResourceGroup:          tc.resourceGroupName,
 			VMSize:                 vmSize,
 			Capacity:               capacity,

--- a/pkg/helpers/stringhelper.go
+++ b/pkg/helpers/stringhelper.go
@@ -8,10 +8,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"regexp"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/sethvargo/go-password/password"
@@ -75,7 +73,6 @@ func RemoveString(slice []string, s string) (result []string) {
 }
 
 func randomStringWithCharset(length int, charset string) string {
-	var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = charset[seededRand.Intn(len(charset))]

--- a/pkg/resourcemanager/appinsights/manager.go
+++ b/pkg/resourcemanager/appinsights/manager.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
 	"github.com/Azure/azure-service-operator/api/v1alpha1"
 	"github.com/Azure/azure-service-operator/pkg/resourcemanager"
+	"github.com/Azure/azure-service-operator/pkg/secrets"
+
 	"github.com/Azure/go-autorest/autorest"
 )
 
@@ -24,9 +26,9 @@ type ApplicationInsightsManager interface {
 	DeleteAppInsights(ctx context.Context, resourceGroupName string, resourceName string) (autorest.Response, error)
 	GetAppInsights(ctx context.Context, resourceGroupName string, resourceName string) (insights.ApplicationInsightsComponent, error)
 
-	StoreSecrets(ctx context.Context, instrumentationKey string, instance *v1alpha1.AppInsights) error
+	StoreSecrets(ctx context.Context, secretClient secrets.SecretClient, instrumentationKey string, instance *v1alpha1.AppInsights) error
 
-	DeleteSecret(ctx context.Context, instance *v1alpha1.AppInsights) error
+	DeleteSecret(ctx context.Context, secretClient secrets.SecretClient, instance *v1alpha1.AppInsights) error
 
 	// ARM Client
 	resourcemanager.ARMClient

--- a/pkg/resourcemanager/azuresql/azuresqlfailovergroup/azuresqlfailovergroup_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlfailovergroup/azuresqlfailovergroup_reconcile.go
@@ -28,8 +28,9 @@ func (fg *AzureSqlFailoverGroupManager) Ensure(ctx context.Context, obj runtime.
 		opt(options)
 	}
 
+	secretClient := fg.SecretClient
 	if options.SecretClient != nil {
-		fg.SecretClient = options.SecretClient
+		secretClient = options.SecretClient
 	}
 
 	instance, err := fg.convert(obj)
@@ -86,7 +87,7 @@ func (fg *AzureSqlFailoverGroupManager) Ensure(ctx context.Context, obj runtime.
 		}
 
 		secretKey := secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
-		_, err := fg.SecretClient.Get(ctx, secretKey)
+		_, err := secretClient.Get(ctx, secretKey)
 		// We make the same assumption many other places in the code make which is that if we cannot
 		// get the secret it must not exist.
 		if err != nil {
@@ -94,7 +95,7 @@ func (fg *AzureSqlFailoverGroupManager) Ensure(ctx context.Context, obj runtime.
 			secret := fg.NewSecret(instance)
 
 			// create or update the secret
-			err = fg.SecretClient.Upsert(
+			err = secretClient.Upsert(
 				ctx,
 				secretKey,
 				secret,
@@ -142,8 +143,9 @@ func (fg *AzureSqlFailoverGroupManager) Delete(ctx context.Context, obj runtime.
 		opt(options)
 	}
 
+	secretClient := fg.SecretClient
 	if options.SecretClient != nil {
-		fg.SecretClient = options.SecretClient
+		secretClient = options.SecretClient
 	}
 
 	instance, err := fg.convert(obj)
@@ -180,7 +182,7 @@ func (fg *AzureSqlFailoverGroupManager) Delete(ctx context.Context, obj runtime.
 
 		if helpers.ContainsString(finished, azerr.Type) {
 			// Best case deletion of secret
-			fg.SecretClient.Delete(ctx, secretKey)
+			secretClient.Delete(ctx, secretKey)
 			return false, nil
 		}
 		instance.Status.Message = fmt.Sprintf("AzureSqlFailoverGroup Delete failed with: %s", err.Error())
@@ -189,7 +191,7 @@ func (fg *AzureSqlFailoverGroupManager) Delete(ctx context.Context, obj runtime.
 
 	instance.Status.Message = fmt.Sprintf("Delete AzureSqlFailoverGroup succeeded")
 	// Best case deletion of secret
-	fg.SecretClient.Delete(ctx, secretKey)
+	secretClient.Delete(ctx, secretKey)
 	return false, nil
 }
 

--- a/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser.go
+++ b/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser.go
@@ -216,8 +216,8 @@ func findBadChars(stack string) error {
 
 func makeSecretKey(secretClient secrets.SecretClient, instance *v1alpha1.AzureSQLManagedUser) secrets.SecretKey {
 	if secretClient.GetSecretNamingVersion() == secrets.SecretNamingV1 {
-		if len(instance.Spec.KeyVaultSecretPrefix) != 0 { // If KeyVaultSecretPrefix is specified, use that for secrets
-			return secrets.SecretKey{Name: instance.Spec.KeyVaultSecretPrefix, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
+		if len(instance.Spec.KeyVaultSecretPrefix) != 0 { // If KeyVaultSecretPrefix is specified, use that for secrets. Namespace is ignored in this case
+			return secrets.SecretKey{Name: instance.Spec.KeyVaultSecretPrefix, Namespace: "", Kind: instance.TypeMeta.Kind}
 		}
 		return secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
 	}

--- a/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlserver/azuresqlserver_reconcile.go
@@ -34,8 +34,9 @@ func (s *AzureSqlServerManager) Ensure(ctx context.Context, obj runtime.Object, 
 		opt(options)
 	}
 
+	secretClient := s.SecretClient
 	if options.SecretClient != nil {
-		s.SecretClient = options.SecretClient
+		secretClient = options.SecretClient
 	}
 
 	instance, err := s.convert(obj)
@@ -49,7 +50,7 @@ func (s *AzureSqlServerManager) Ensure(ctx context.Context, obj runtime.Object, 
 	// Check to see if secret already exists for admin username/password
 	// create or update the secret
 	secretKey := secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
-	secret, err := s.SecretClient.Get(ctx, secretKey)
+	secret, err := secretClient.Get(ctx, secretKey)
 	if err != nil {
 		if instance.Status.Provisioned {
 			instance.Status.Message = err.Error()
@@ -79,7 +80,7 @@ func (s *AzureSqlServerManager) Ensure(ctx context.Context, obj runtime.Object, 
 		if err != nil {
 			return false, err
 		}
-		err = s.SecretClient.Upsert(
+		err = secretClient.Upsert(
 			ctx,
 			secretKey,
 			secret,
@@ -252,8 +253,9 @@ func (s *AzureSqlServerManager) Delete(ctx context.Context, obj runtime.Object, 
 		opt(options)
 	}
 
+	secretClient := s.SecretClient
 	if options.SecretClient != nil {
-		s.SecretClient = options.SecretClient
+		secretClient = options.SecretClient
 	}
 
 	instance, err := s.convert(obj)
@@ -293,7 +295,7 @@ func (s *AzureSqlServerManager) Delete(ctx context.Context, obj runtime.Object, 
 
 		if helpers.ContainsString(finished, azerr.Type) {
 			//Best effort deletion of secrets
-			s.SecretClient.Delete(ctx, secretKey)
+			secretClient.Delete(ctx, secretKey)
 			return false, nil
 		}
 
@@ -301,7 +303,7 @@ func (s *AzureSqlServerManager) Delete(ctx context.Context, obj runtime.Object, 
 	}
 
 	//Best effort deletion of secrets
-	s.SecretClient.Delete(ctx, secretKey)
+	secretClient.Delete(ctx, secretKey)
 	return false, nil
 }
 

--- a/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
@@ -26,7 +26,6 @@ import (
 )
 
 func GetAdminSecretKey(adminSecretName string, namespace string) secrets.SecretKey {
-	// TODO: Is there a better way to get TypeMeta here?
 	return secrets.SecretKey{Name: adminSecretName, Namespace: namespace, Kind: reflect.TypeOf(v1beta1.AzureSqlServer{}).Name()}
 }
 
@@ -41,6 +40,11 @@ func (s *AzureSqlUserManager) getAdminSecret(ctx context.Context, instance *v1al
 	// if the admin secret keyvault is not specified, fall back to global secretclient
 	if len(instance.Spec.AdminSecretKeyVault) != 0 {
 		adminSecretClient = keyvaultSecrets.New(instance.Spec.AdminSecretKeyVault, s.Creds, s.SecretClient.GetSecretNamingVersion())
+
+		// This is here for legacy reasons
+		if len(instance.Spec.AdminSecret) != 0 && s.SecretClient.GetSecretNamingVersion() == secrets.SecretNamingV1 {
+			adminSecretKey.Namespace = ""
+		}
 	}
 
 	// get admin creds for server

--- a/pkg/resourcemanager/psql/server/server.go
+++ b/pkg/resourcemanager/psql/server/server.go
@@ -193,10 +193,10 @@ func (c *PSQLServerClient) GetServer(ctx context.Context, resourcegroup string, 
 	return client.Get(ctx, resourcegroup, servername)
 }
 
-func (c *PSQLServerClient) AddServerCredsToSecrets(ctx context.Context, data map[string][]byte, instance *v1alpha2.PostgreSQLServer) error {
+func (c *PSQLServerClient) AddServerCredsToSecrets(ctx context.Context, secretClient secrets.SecretClient, data map[string][]byte, instance *v1alpha2.PostgreSQLServer) error {
 	secretKey := secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
 
-	err := c.SecretClient.Upsert(ctx,
+	err := secretClient.Upsert(ctx,
 		secretKey,
 		data,
 		secrets.WithOwner(instance),
@@ -209,12 +209,12 @@ func (c *PSQLServerClient) AddServerCredsToSecrets(ctx context.Context, data map
 	return nil
 }
 
-func (c *PSQLServerClient) UpdateSecretWithFullServerName(ctx context.Context, data map[string][]byte, instance *v1alpha2.PostgreSQLServer, fullServerName string) error {
+func (c *PSQLServerClient) UpdateSecretWithFullServerName(ctx context.Context, secretClient secrets.SecretClient, data map[string][]byte, instance *v1alpha2.PostgreSQLServer, fullServerName string) error {
 	secretKey := secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
 
 	data["fullyQualifiedServerName"] = []byte(fullServerName)
 
-	err := c.SecretClient.Upsert(ctx,
+	err := secretClient.Upsert(ctx,
 		secretKey,
 		data,
 		secrets.WithOwner(instance),
@@ -227,13 +227,13 @@ func (c *PSQLServerClient) UpdateSecretWithFullServerName(ctx context.Context, d
 	return nil
 }
 
-func (c *PSQLServerClient) GetOrPrepareSecret(ctx context.Context, instance *v1alpha2.PostgreSQLServer) (map[string][]byte, error) {
+func (c *PSQLServerClient) GetOrPrepareSecret(ctx context.Context, secretClient secrets.SecretClient, instance *v1alpha2.PostgreSQLServer) (map[string][]byte, error) {
 	usernameLength := 8
 
 	secret := map[string][]byte{}
 
 	secretKey := secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
-	if stored, err := c.SecretClient.Get(ctx, secretKey); err == nil {
+	if stored, err := secretClient.Get(ctx, secretKey); err == nil {
 		return stored, nil
 	}
 

--- a/pkg/resourcemanager/rediscaches/actions/rediscacheaction_reconcile.go
+++ b/pkg/resourcemanager/rediscaches/actions/rediscacheaction_reconcile.go
@@ -20,8 +20,9 @@ func (m *AzureRedisCacheActionManager) Ensure(ctx context.Context, obj runtime.O
 		opt(options)
 	}
 
+	secretClient := m.SecretClient
 	if options.SecretClient != nil {
-		m.SecretClient = options.SecretClient
+		secretClient = options.SecretClient
 	}
 
 	instance, err := m.convert(obj)
@@ -61,7 +62,7 @@ func (m *AzureRedisCacheActionManager) Ensure(ctx context.Context, obj runtime.O
 				ResourceGroupName: instance.Spec.ResourceGroup,
 			},
 		}
-		if err = m.ListKeysAndCreateSecrets(ctx, cacheInstance); err != nil {
+		if err = m.ListKeysAndCreateSecrets(ctx, secretClient, cacheInstance); err != nil {
 			instance.Status.Provisioning = true
 			instance.Status.Provisioned = false
 			instance.Status.FailedProvisioning = true

--- a/pkg/resourcemanager/rediscaches/shared.go
+++ b/pkg/resourcemanager/rediscaches/shared.go
@@ -46,14 +46,14 @@ func (m *AzureRedisManager) ListKeys(ctx context.Context, resourceGroupName stri
 }
 
 // CreateSecrets creates a secret for a redis cache
-func (m *AzureRedisManager) CreateSecrets(ctx context.Context, instance *v1alpha1.RedisCache, data map[string][]byte) error {
+func (m *AzureRedisManager) CreateSecrets(ctx context.Context, secretClient secrets.SecretClient, instance *v1alpha1.RedisCache, data map[string][]byte) error {
 	secretName := instance.Spec.SecretName
 	if secretName == "" {
 		secretName = instance.Name
 	}
 
 	secretKey := secrets.SecretKey{Name: secretName, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
-	err := m.SecretClient.Upsert(
+	err := secretClient.Upsert(
 		ctx,
 		secretKey,
 		data,
@@ -68,7 +68,7 @@ func (m *AzureRedisManager) CreateSecrets(ctx context.Context, instance *v1alpha
 }
 
 // ListKeysAndCreateSecrets lists keys and creates secrets
-func (m *AzureRedisManager) ListKeysAndCreateSecrets(ctx context.Context, instance *v1alpha1.RedisCache) error {
+func (m *AzureRedisManager) ListKeysAndCreateSecrets(ctx context.Context, secretClient secrets.SecretClient, instance *v1alpha1.RedisCache) error {
 	var err error
 	var result redis.AccessKeys
 
@@ -83,6 +83,7 @@ func (m *AzureRedisManager) ListKeysAndCreateSecrets(ctx context.Context, instan
 
 	err = m.CreateSecrets(
 		ctx,
+		secretClient,
 		instance,
 		data,
 	)

--- a/pkg/secrets/keyvault/client.go
+++ b/pkg/secrets/keyvault/client.go
@@ -289,16 +289,16 @@ func (k *SecretClient) Get(ctx context.Context, key secrets.SecretKey, opts ...s
 }
 
 func (k *SecretClient) makeLegacySecretName(key secrets.SecretKey) (string, error) {
-	if len(key.Namespace) == 0 {
-		return "", errors.Errorf("secret key missing required namespace field, %s", key)
-	}
 	if len(key.Name) == 0 {
 		return "", errors.Errorf("secret key missing required name field, %s", key)
 	}
 
 	var parts []string
 
-	parts = append(parts, key.Namespace)
+	// A few secrets allow empty namespace
+	if len(key.Namespace) != 0 {
+		parts = append(parts, key.Namespace)
+	}
 	parts = append(parts, key.Name)
 
 	return strings.Join(parts, "-"), nil


### PR DESCRIPTION
  - Fix issue where namespace was mistakenly included in v1 secret
    naming key generation. Some resources are not expected to have
    namespace prefix in certain KeyVault scenarios.
 - Increase CI timeout a bit.
 - SecretClient should not be modified by options in Ensure as Managers are singletons and share state between resources.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/27EhcDHnlkw1O/giphy.gif)

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains tests
