### PR TITLE
Always allow converting MySQL[AAD]Users back to v1alpha1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,6 @@ coverage-existing.txt
 report-existing.xml
 testlogs-existing.txt
 
-# manager output from build
-manager
-
 # terraform artifacts
 .terraform*
 terraform.tfstate*

--- a/api/v1alpha1/conversion_stash.go
+++ b/api/v1alpha1/conversion_stash.go
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const conversionStashAnnotation = "azure.microsoft.com/convert-stash"
+
+func getStashedAnnotation(meta metav1.ObjectMeta, target interface{}) (bool, error) {
+	if meta.Annotations == nil {
+		return false, nil
+	}
+	value, found := meta.Annotations[conversionStashAnnotation]
+	if !found {
+		return false, nil
+	}
+	if err := json.Unmarshal([]byte(value), target); err != nil {
+		return false, errors.Wrap(err, "decoding stashed fields")
+	}
+	return true, nil
+}
+
+func setStashedAnnotation(meta *metav1.ObjectMeta, stashValues interface{}) error {
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+	encoded, err := json.Marshal(stashValues)
+	if err != nil {
+		return errors.Wrap(err, "encoding stashed fields")
+	}
+	meta.Annotations[conversionStashAnnotation] = string(encoded)
+	return nil
+}
+
+func clearStashedAnnotation(meta *metav1.ObjectMeta) {
+	delete(meta.Annotations, conversionStashAnnotation)
+	if len(meta.Annotations) == 0 {
+		meta.Annotations = nil
+	}
+}

--- a/api/v1alpha1/conversion_stash.go
+++ b/api/v1alpha1/conversion_stash.go
@@ -8,11 +8,18 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
 )
 
 const conversionStashAnnotation = "azure.microsoft.com/convert-stash"
 
+// getStashedAnnotation unmarshals the convert-stash annotation value
+// into the target pointer, if the annotation is present. It returns
+// whether the annotation was present, and any error from unmarshalling.
 func getStashedAnnotation(meta metav1.ObjectMeta, target interface{}) (bool, error) {
+	if _, err := conversion.EnforcePtr(target); err != nil {
+		return false, errors.Errorf("getStashedAnnotation target must be a pointer, not %T", target)
+	}
 	if meta.Annotations == nil {
 		return false, nil
 	}

--- a/api/v1alpha1/mysqlaaduser_conversion.go
+++ b/api/v1alpha1/mysqlaaduser_conversion.go
@@ -4,7 +4,11 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+	"sort"
+
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	"github.com/Azure/azure-service-operator/api/v1alpha2"
@@ -12,11 +16,36 @@ import (
 
 var _ conversion.Convertible = &MySQLAADUser{}
 
+// To avoid losing information converting a v1alpha2 instance into
+// v1alpha1, we stash the affected fields (roles and database roles)
+// into a json-serialised struct in the annotations. When converting
+// back to a v1alpha2 instance we use any stashed values, layering any
+// changes to the database roles back over the top. The conversions
+// will only return errors if JSON marshalling/unmarshalling fails.
+
 func (src *MySQLAADUser) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha2.MySQLAADUser)
 
 	// ObjectMeta
 	dst.ObjectMeta = src.ObjectMeta
+
+	// If there are stashed values in the annotations then we need to
+	// retrieve them first.
+	if encoded, found := src.getStashedAnnotation(src.ObjectMeta); found {
+		var stashedValues stashedMySQLAADUserFields
+		err := json.Unmarshal([]byte(encoded), &stashedValues)
+		if err != nil {
+			return errors.Wrap(err, "decoding stashed fields")
+		}
+		dst.Spec.Roles = stashedValues.Roles
+		dst.Spec.DatabaseRoles = stashedValues.DatabaseRoles
+
+		// Clear out the annotation to avoid confusion.
+		delete(dst.ObjectMeta.Annotations, conversionStashAnnotation)
+		if len(dst.ObjectMeta.Annotations) == 0 {
+			dst.ObjectMeta.Annotations = nil
+		}
+	}
 
 	// Spec
 	dst.Spec.ResourceGroup = src.Spec.ResourceGroup
@@ -24,10 +53,12 @@ func (src *MySQLAADUser) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.AADID = src.Spec.AADID
 	dst.Spec.Username = src.Spec.Username
 
-	// v1alpha1 doesn't support server-level roles, only
-	// database-level ones, so we move them into the new field.
-	dst.Spec.Roles = []string{}
-	dst.Spec.DatabaseRoles = make(map[string][]string)
+	if dst.Spec.Roles == nil {
+		dst.Spec.Roles = []string{}
+	}
+	if dst.Spec.DatabaseRoles == nil {
+		dst.Spec.DatabaseRoles = make(map[string][]string)
+	}
 	dst.Spec.DatabaseRoles[src.Spec.DBName] = append([]string(nil), src.Spec.Roles...)
 
 	// Status
@@ -36,21 +67,37 @@ func (src *MySQLAADUser) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
+func (dst *MySQLAADUser) getStashedAnnotation(meta metav1.ObjectMeta) (string, bool) {
+	if meta.Annotations == nil {
+		return "", false
+	}
+	value, found := meta.Annotations[conversionStashAnnotation]
+	return value, found
+}
+
 func (dst *MySQLAADUser) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha2.MySQLAADUser)
 
-	// Converting a v1alpha2 user into a v1alpha1 one is only allowed
-	// if it has exactly one database...
-	if len(src.Spec.DatabaseRoles) != 1 {
-		return errors.Errorf("can't convert user %q to %T because it has privileges in %d databases", src.ObjectMeta.Name, dst, len(src.Spec.DatabaseRoles))
-	}
-	// ...and no server-level roles.
-	if len(src.Spec.Roles) != 0 {
-		return errors.Errorf("can't convert user %q to %T because it has server-level roles", src.ObjectMeta.Name, dst)
-	}
-
 	// ObjectMeta
 	dst.ObjectMeta = src.ObjectMeta
+
+	if len(src.Spec.DatabaseRoles) != 1 || len(src.Spec.Roles) != 0 {
+		// If this can't be represented exactly as a v1alpha1, store
+		// the original server-level and database roles in an
+		// annotation.
+		if dst.ObjectMeta.Annotations == nil {
+			dst.ObjectMeta.Annotations = make(map[string]string)
+		}
+		stashValues := stashedMySQLAADUserFields{
+			DatabaseRoles: src.Spec.DatabaseRoles,
+			Roles:         src.Spec.Roles,
+		}
+		encoded, err := json.Marshal(stashValues)
+		if err != nil {
+			return errors.Wrap(err, "encoding stashed fields")
+		}
+		dst.ObjectMeta.Annotations[conversionStashAnnotation] = string(encoded)
+	}
 
 	// Spec
 	dst.Spec.ResourceGroup = src.Spec.ResourceGroup
@@ -58,15 +105,37 @@ func (dst *MySQLAADUser) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.AADID = src.Spec.AADID
 	dst.Spec.Username = src.Spec.Username
 
-	for dbName, roles := range src.Spec.DatabaseRoles {
-		dst.Spec.DBName = dbName
-		dst.Spec.Roles = append(dst.Spec.Roles, roles...)
-		break
+	// Pick the first database name to include as the DBName.
+	var dbNames []string
+	for dbName := range src.Spec.DatabaseRoles {
+		dbNames = append(dbNames, dbName)
 	}
+	sort.Strings(dbNames)
+	var (
+		dbName string
+		roles  []string
+	)
+	if len(dbNames) != 0 {
+		dbName = dbNames[0]
+		roles = src.Spec.DatabaseRoles[dbName]
+	}
+
+	dst.Spec.DBName = dbName
+	dst.Spec.Roles = append(dst.Spec.Roles, roles...)
 
 	// Status
 	dst.Status = ASOStatus(src.Status)
 
 	return nil
 
+}
+
+const conversionStashAnnotation = "azure.microsoft.com/convert-stash"
+
+// stashedMySQLAADUserFields stores values that can't be represented
+// directly on a v1alpha1 spec struct, so that they can be stored in
+// an annotation and used when converting to v1alpha2.
+type stashedMySQLAADUserFields struct {
+	DatabaseRoles map[string][]string `json:"databaseRoles,omitempty"`
+	Roles         []string            `json:"roles,omitempty"`
 }

--- a/api/v1alpha1/mysqlaaduser_conversion.go
+++ b/api/v1alpha1/mysqlaaduser_conversion.go
@@ -91,6 +91,8 @@ func (dst *MySQLAADUser) ConvertFrom(srcRaw conversion.Hub) error {
 	for dbName := range src.Spec.DatabaseRoles {
 		dbNames = append(dbNames, dbName)
 	}
+	// Sorting the list of names for testing (and so that a client
+	// gets a consistent value back for a resource).
 	sort.Strings(dbNames)
 	var (
 		dbName string

--- a/api/v1alpha1/mysqluser_conversion.go
+++ b/api/v1alpha1/mysqluser_conversion.go
@@ -4,7 +4,8 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"sort"
+
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	"github.com/Azure/azure-service-operator/api/v1alpha2"
@@ -12,11 +13,33 @@ import (
 
 var _ conversion.Convertible = &MySQLAADUser{}
 
+// To avoid losing information converting a v1alpha2 instance into
+// v1alpha1, we stash the affected fields (roles and database roles)
+// into a json-serialised struct in the annotations. When converting
+// back to a v1alpha2 instance we use any stashed values, layering any
+// changes to the database roles back over the top. The conversions
+// will only return errors if JSON marshalling/unmarshalling fails.
+
 func (src *MySQLUser) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha2.MySQLUser)
 
 	// ObjectMeta
 	dst.ObjectMeta = src.ObjectMeta
+
+	// If there are stashed values in the annotations then we need to
+	// retrieve them first.
+	var stashedValues stashedMySQLAADUserFields
+	found, err := getStashedAnnotation(src.ObjectMeta, &stashedValues)
+	if err != nil {
+		return err
+	}
+	if found {
+		dst.Spec.Roles = stashedValues.Roles
+		dst.Spec.DatabaseRoles = stashedValues.DatabaseRoles
+
+		// Clear out the annotation to avoid confusion.
+		clearStashedAnnotation(&dst.ObjectMeta)
+	}
 
 	// Spec
 	dst.Spec.ResourceGroup = src.Spec.ResourceGroup
@@ -26,10 +49,12 @@ func (src *MySQLUser) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Username = src.Spec.Username
 	dst.Spec.KeyVaultToStoreSecrets = src.Spec.KeyVaultToStoreSecrets
 
-	// v1alpha1 doesn't support server-level roles, only
-	// database-level ones, so we move them into the new field.
-	dst.Spec.Roles = []string{}
-	dst.Spec.DatabaseRoles = make(map[string][]string)
+	if dst.Spec.Roles == nil {
+		dst.Spec.Roles = []string{}
+	}
+	if dst.Spec.DatabaseRoles == nil {
+		dst.Spec.DatabaseRoles = make(map[string][]string)
+	}
 	dst.Spec.DatabaseRoles[src.Spec.DbName] = append([]string(nil), src.Spec.Roles...)
 
 	// Status
@@ -41,18 +66,21 @@ func (src *MySQLUser) ConvertTo(dstRaw conversion.Hub) error {
 func (dst *MySQLUser) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha2.MySQLUser)
 
-	// Converting a v1alpha2 user into a v1alpha1 one is only allowed
-	// if it has exactly one database...
-	if len(src.Spec.DatabaseRoles) != 1 {
-		return errors.Errorf("can't convert user %q to %T because it has privileges in %d databases", src.ObjectMeta.Name, dst, len(src.Spec.DatabaseRoles))
-	}
-	// ...and no server-level roles.
-	if len(src.Spec.Roles) != 0 {
-		return errors.Errorf("can't convert user %q to %T because it has server-level roles", src.ObjectMeta.Name, dst)
-	}
-
 	// ObjectMeta
 	dst.ObjectMeta = src.ObjectMeta
+
+	if len(src.Spec.DatabaseRoles) != 1 || len(src.Spec.Roles) != 0 {
+		// If this can't be represented exactly as a v1alpha1, store
+		// the original server-level and database roles in an
+		// annotation.
+		err := setStashedAnnotation(&dst.ObjectMeta, stashedMySQLUserFields{
+			DatabaseRoles: src.Spec.DatabaseRoles,
+			Roles:         src.Spec.Roles,
+		})
+		if err != nil {
+			return err
+		}
+	}
 
 	// Spec
 	dst.Spec.ResourceGroup = src.Spec.ResourceGroup
@@ -62,15 +90,33 @@ func (dst *MySQLUser) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.Username = src.Spec.Username
 	dst.Spec.KeyVaultToStoreSecrets = src.Spec.KeyVaultToStoreSecrets
 
-	for dbName, roles := range src.Spec.DatabaseRoles {
-		dst.Spec.DbName = dbName
-		dst.Spec.Roles = append(dst.Spec.Roles, roles...)
-		break
+	// Pick the first database name to include as the DbName.
+	var dbNames []string
+	for dbName := range src.Spec.DatabaseRoles {
+		dbNames = append(dbNames, dbName)
 	}
+	sort.Strings(dbNames)
+	var (
+		dbName string
+		roles  []string
+	)
+	if len(dbNames) != 0 {
+		dbName = dbNames[0]
+		roles = src.Spec.DatabaseRoles[dbName]
+	}
+
+	dst.Spec.DbName = dbName
+	dst.Spec.Roles = append(dst.Spec.Roles, roles...)
 
 	// Status
 	dst.Status = ASOStatus(src.Status)
-
 	return nil
+}
 
+// stashedMySQLUserFields stores values that can't be represented
+// directly on a v1alpha1 spec struct, so that they can be stored in
+// an annotation and used when converting to v1alpha2.
+type stashedMySQLUserFields struct {
+	DatabaseRoles map[string][]string `json:"databaseRoles,omitempty"`
+	Roles         []string            `json:"roles,omitempty"`
 }

--- a/api/v1alpha1/mysqluser_conversion.go
+++ b/api/v1alpha1/mysqluser_conversion.go
@@ -95,6 +95,8 @@ func (dst *MySQLUser) ConvertFrom(srcRaw conversion.Hub) error {
 	for dbName := range src.Spec.DatabaseRoles {
 		dbNames = append(dbNames, dbName)
 	}
+	// Sorting the list of names for testing (and so that a client
+	// gets a consistent value back for a resource).
 	sort.Strings(dbNames)
 	var (
 		dbName string

--- a/api/v1alpha1/mysqluser_types_test.go
+++ b/api/v1alpha1/mysqluser_types_test.go
@@ -94,7 +94,7 @@ var _ = Describe("MySQLUser", func() {
 			}))
 		})
 
-		It("can't downgrade with roles for multiple databases", func() {
+		It("can downgrade with roles for multiple databases", func() {
 			v2 := v1alpha2.MySQLUser{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -110,10 +110,27 @@ var _ = Describe("MySQLUser", func() {
 				},
 			}
 			var v1 MySQLUser
-			Expect(v1.ConvertFrom(&v2)).To(MatchError("can't convert user \"foo\" to *v1alpha1.MySQLUser because it has privileges in 2 databases"))
+			Expect(v1.ConvertFrom(&v2)).To(Succeed())
+			Expect(v1).To(Equal(MySQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					// Might need to account for ordering here -
+					// compare deserialised instead.
+					Annotations: map[string]string{
+						"azure.microsoft.com/convert-stash": `{"databaseRoles":{"mydb":["role1","role2","role3"],"otherdb":["otherrole"]}}`,
+					},
+				},
+				Spec: MySQLUserSpec{
+					Server:        "myserver",
+					ResourceGroup: "foo-group",
+					DbName:        "mydb",
+					Roles:         []string{"role1", "role2", "role3"},
+				},
+			}))
 		})
 
-		It("can't downgrade with roles for no databases", func() {
+		It("can downgrade with roles for no databases", func() {
 			v2 := v1alpha2.MySQLUser{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -126,10 +143,25 @@ var _ = Describe("MySQLUser", func() {
 				},
 			}
 			var v1 MySQLUser
-			Expect(v1.ConvertFrom(&v2)).To(MatchError("can't convert user \"foo\" to *v1alpha1.MySQLUser because it has privileges in 0 databases"))
+			Expect(v1.ConvertFrom(&v2)).To(Succeed())
+			Expect(v1).To(Equal(MySQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"azure.microsoft.com/convert-stash": `{}`,
+					},
+				},
+				Spec: MySQLUserSpec{
+					Server:        "myserver",
+					ResourceGroup: "foo-group",
+					DbName:        "",
+					Roles:         nil,
+				},
+			}))
 		})
 
-		It("can't downgrade with server roles", func() {
+		It("can downgrade with server roles", func() {
 			v2 := v1alpha2.MySQLUser{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -145,7 +177,59 @@ var _ = Describe("MySQLUser", func() {
 				},
 			}
 			var v1 MySQLUser
-			Expect(v1.ConvertFrom(&v2)).To(MatchError("can't convert user \"foo\" to *v1alpha1.MySQLUser because it has server-level roles"))
+			Expect(v1.ConvertFrom(&v2)).To(Succeed())
+			Expect(v1).To(Equal(MySQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"azure.microsoft.com/convert-stash": `{"databaseRoles":{"mydb":["role1","role2","role3"]},"roles":["somekindofsuperuser"]}`,
+					},
+				},
+				Spec: MySQLUserSpec{
+					Server:        "myserver",
+					ResourceGroup: "foo-group",
+					DbName:        "mydb",
+					Roles:         []string{"role1", "role2", "role3"},
+				},
+			}))
+		})
+
+		It("can incorporate annotations when upgrading", func() {
+			// Server-level roles should just be carried forwards.
+			// Database roles need to be applied to the ones in the annotation.
+			v1 := MySQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"azure.microsoft.com/convert-stash": `{"databaseRoles":{"mydb":["role1","role2","role3"],"otherdb":["anotherrole"]},"roles":["somekindofsuperuser"]}`,
+					},
+				},
+				Spec: MySQLUserSpec{
+					Server:        "myserver",
+					ResourceGroup: "foo-group",
+					DbName:        "mydb",
+					Roles:         []string{"role3", "role4"},
+				},
+			}
+			var v2 v1alpha2.MySQLUser
+			Expect(v1.ConvertTo(&v2)).To(Succeed())
+			Expect(v2).To(Equal(v1alpha2.MySQLUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: v1alpha2.MySQLUserSpec{
+					Server:        "myserver",
+					ResourceGroup: "foo-group",
+					Roles:         []string{"somekindofsuperuser"},
+					DatabaseRoles: map[string][]string{
+						"mydb":    {"role3", "role4"},
+						"otherdb": {"anotherrole"},
+					},
+				},
+			}))
 		})
 
 	})

--- a/controllers/mysql_combined_test.go
+++ b/controllers/mysql_combined_test.go
@@ -30,19 +30,24 @@ func TestMySQLHappyPath(t *testing.T) {
 	rgLocation := "eastus2"
 	rgName := tc.resourceGroupName
 	mySQLServerName := GenerateTestResourceNameWithRandom("mysql-srv", 10)
-	mySQLReplicaName := GenerateTestResourceNameWithRandom("mysql-rep", 10)
+	// mySQLReplicaName := GenerateTestResourceNameWithRandom("mysql-rep", 10)
 
 	// Create the mySQLServer object and expect the Reconcile to be created
 	mySQLServerInstance := v1alpha2.NewDefaultMySQLServer(mySQLServerName, rgName, rgLocation)
 
 	RequireInstance(ctx, t, tc, mySQLServerInstance)
 
-	// Create a mySQL replica
+	// Commenting the replica creation out for now - the time to
+	// provision the replica has blown out to more than an hour in
+	// some cases?
+	// TODO (babbageclunk): raise a bug with the Azure MySQL team about this.
 
-	mySQLReplicaInstance := v1alpha2.NewReplicaMySQLServer(mySQLReplicaName, rgName, rgLocation, mySQLServerInstance.Status.ResourceId)
-	mySQLReplicaInstance.Spec.StorageProfile = nil
+	// // Create a mySQL replica
 
-	EnsureInstance(ctx, t, tc, mySQLReplicaInstance)
+	// mySQLReplicaInstance := v1alpha2.NewReplicaMySQLServer(mySQLReplicaName, rgName, rgLocation, mySQLServerInstance.Status.ResourceId)
+	// mySQLReplicaInstance.Spec.StorageProfile = nil
+
+	// EnsureInstance(ctx, t, tc, mySQLReplicaInstance)
 
 	mySQLDBName := GenerateTestResourceNameWithRandom("mysql-db", 10)
 
@@ -109,7 +114,7 @@ func TestMySQLHappyPath(t *testing.T) {
 	EnsureDelete(ctx, t, tc, ruleInstance)
 	EnsureDelete(ctx, t, tc, mySQLDBInstance)
 	EnsureDelete(ctx, t, tc, mySQLServerInstance)
-	EnsureDelete(ctx, t, tc, mySQLReplicaInstance)
+	// EnsureDelete(ctx, t, tc, mySQLReplicaInstance)
 }
 
 func RunMySQLUserHappyPath(ctx context.Context, t *testing.T, mySQLServerName string, mySQLDBName string, rgName string) {


### PR DESCRIPTION
Previously if a v1alpha2 `MySQLUser` or `MySQLAADUser` had server-level roles or roles in more or fewer than one database, trying to convert it to a v1alpha1 representation would fail because the older format could only refer to exactly one database. This caused something (likely a cache but I'm not entirely sure ☹️) in the system to go into a loop trying to request the resource as v1alpha1 every second and spamming the log with errors.

Change the *from* conversion to store the affected fields as JSON in an `azure.microsoft.com/convert-stash` annotation, and the *to* conversion to incorporate the annotation values when going back to v1alpha2.

Fixes #1388.

**How does this PR make you feel**:
![gif](https://media1.tenor.com/images/4f6139aebaa7c558dc717a1a1f47dd25/tenor.gif)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
