### PR TITLE
RedisCache - ensure FailedProvisioning=false when Provisioned=true

### DIFF
--- a/pkg/resourcemanager/rediscaches/redis/rediscache_reconcile.go
+++ b/pkg/resourcemanager/rediscaches/redis/rediscache_reconcile.go
@@ -50,13 +50,13 @@ func (rc *AzureRedisCacheManager) Ensure(ctx context.Context, obj runtime.Object
 				instance.Status.Message = err.Error()
 				return false, err
 			}
-			instance.Status.State = string(newRc.ProvisioningState)
 
 			if newRc.StaticIP != nil {
 				instance.Status.Output = *newRc.StaticIP
 			}
 
 			instance.Status.ResourceId = *newRc.ID
+			instance.Status.State = string(newRc.ProvisioningState)
 			instance.Status.SetProvisioned(resourcemanager.SuccessMsg)
 			return true, nil
 		}
@@ -90,8 +90,6 @@ func (rc *AzureRedisCacheManager) Ensure(ctx context.Context, obj runtime.Object
 			instance.Status.SetProvisioning("RedisCache exists but may not be ready")
 			return false, nil
 		} else if helpers.ContainsString(catchKnownError, azerr.Type) {
-			// TODO: Not sure why we want this to be provisioning=false?
-			instance.Status.Provisioning = false
 			return false, nil
 		} else {
 			// serious error occured, end reconcilliation and mark it as failed


### PR DESCRIPTION
**What this PR does / why we need it**:
A user reported a case where a RedisCache was provisioned and working but was marked as FailedProvisioning=true. This seems to have happened because it initially failed (possibly a temporary error that we aren't checking for), and then on a subsequent periodic reconciliation the ARM query reported that it was deployed successfully. Use the SetProvisioned helper method (and friends) to prevent this state.

Fixes #1394 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
