### PR TITLE
Minor Azure SQL FailoverGroup improvements

### DIFF
--- a/api/v1beta1/azuresqlfailovergroup_types.go
+++ b/api/v1beta1/azuresqlfailovergroup_types.go
@@ -9,7 +9,9 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+
 // ReadWriteEndpointFailoverPolicy - wraps https://godoc.org/github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql#ReadWriteEndpointFailoverPolicy
+// +kubebuilder:validation:Enum=Automatic;Manual
 type ReadWriteEndpointFailoverPolicy string
 
 const (

--- a/config/samples/azure_v1alpha1_azuresqlfailovergroup.yaml
+++ b/config/samples/azure_v1alpha1_azuresqlfailovergroup.yaml
@@ -6,7 +6,7 @@ spec:
   location: eastus
   resourcegroup: resourcegroup-azure-operators
   server: sqlserver-samplepri
-  failoverpolicy: automatic
+  failoverpolicy: Automatic
   failovergraceperiod: 30
   secondaryserver: sqlserver-samplesec
   secondaryserverresourcegroup: resourcegroup-azure-operators

--- a/controllers/azuresqlfailovergroup_controller_test.go
+++ b/controllers/azuresqlfailovergroup_controller_test.go
@@ -43,7 +43,7 @@ func TestAzureSqlFailoverGroupControllerNoResourceGroup(t *testing.T) {
 			Location:                     rgLocation1,
 			ResourceGroup:                GenerateTestResourceNameWithRandom("rg-fake", 10),
 			Server:                       sqlServerOneName,
-			FailoverPolicy:               "automatic",
+			FailoverPolicy:               v1beta1.FailoverPolicyAutomatic,
 			FailoverGracePeriod:          30,
 			SecondaryServer:              sqlServerTwoName,
 			SecondaryServerResourceGroup: rgName,

--- a/pkg/resourcemanager/azuresql/azuresqlshared/sqlproperties.go
+++ b/pkg/resourcemanager/azuresql/azuresqlshared/sqlproperties.go
@@ -164,7 +164,7 @@ func MergeDBEditionAndSku(in v1beta1.DBEdition, sku *v1beta1.SqlDatabaseSku) (*S
 	}
 }
 
-// translateFailoverPolicy translates the enum
+// TranslateFailoverPolicy translates the enum
 func TranslateFailoverPolicy(in v1beta1.ReadWriteEndpointFailoverPolicy) (sql.ReadWriteEndpointFailoverPolicy, error) {
 	var result sql.ReadWriteEndpointFailoverPolicy
 


### PR DESCRIPTION
- Validate FailoverGroup policy has valid values
  - This fixes #1386.
- Fix AzureSQLFailoverGroup sample

