### PR TITLE
mysqlserver: Keep track of the polling URL when creating

### DIFF
--- a/controllers/mysql_combined_test.go
+++ b/controllers/mysql_combined_test.go
@@ -42,7 +42,7 @@ func TestMySQLHappyPath(t *testing.T) {
 	mySQLReplicaInstance := v1alpha2.NewReplicaMySQLServer(mySQLReplicaName, rgName, rgLocation, mySQLServerInstance.Status.ResourceId)
 	mySQLReplicaInstance.Spec.StorageProfile = nil
 
-	// EnsureInstance(ctx, t, tc, mySQLReplicaInstance)
+	EnsureInstance(ctx, t, tc, mySQLReplicaInstance)
 
 	mySQLDBName := GenerateTestResourceNameWithRandom("mysql-db", 10)
 

--- a/controllers/mysql_combined_test.go
+++ b/controllers/mysql_combined_test.go
@@ -30,22 +30,17 @@ func TestMySQLHappyPath(t *testing.T) {
 	rgLocation := "eastus2"
 	rgName := tc.resourceGroupName
 	mySQLServerName := GenerateTestResourceNameWithRandom("mysql-srv", 10)
-	// mySQLReplicaName := GenerateTestResourceNameWithRandom("mysql-rep", 10)
+	mySQLReplicaName := GenerateTestResourceNameWithRandom("mysql-rep", 10)
 
 	// Create the mySQLServer object and expect the Reconcile to be created
 	mySQLServerInstance := v1alpha2.NewDefaultMySQLServer(mySQLServerName, rgName, rgLocation)
 
 	RequireInstance(ctx, t, tc, mySQLServerInstance)
 
-	// Commenting the replica creation out for now - the time to
-	// provision the replica has blown out to more than an hour in
-	// some cases?
-	// TODO (babbageclunk): raise a bug with the Azure MySQL team about this.
+	// Create a mySQL replica
 
-	// // Create a mySQL replica
-
-	// mySQLReplicaInstance := v1alpha2.NewReplicaMySQLServer(mySQLReplicaName, rgName, rgLocation, mySQLServerInstance.Status.ResourceId)
-	// mySQLReplicaInstance.Spec.StorageProfile = nil
+	mySQLReplicaInstance := v1alpha2.NewReplicaMySQLServer(mySQLReplicaName, rgName, rgLocation, mySQLServerInstance.Status.ResourceId)
+	mySQLReplicaInstance.Spec.StorageProfile = nil
 
 	// EnsureInstance(ctx, t, tc, mySQLReplicaInstance)
 
@@ -114,7 +109,7 @@ func TestMySQLHappyPath(t *testing.T) {
 	EnsureDelete(ctx, t, tc, ruleInstance)
 	EnsureDelete(ctx, t, tc, mySQLDBInstance)
 	EnsureDelete(ctx, t, tc, mySQLServerInstance)
-	// EnsureDelete(ctx, t, tc, mySQLReplicaInstance)
+	EnsureDelete(ctx, t, tc, mySQLReplicaInstance)
 }
 
 func RunMySQLUserHappyPath(ctx context.Context, t *testing.T, mySQLServerName string, mySQLDBName string, rgName string) {

--- a/pkg/resourcemanager/mysql/server/reconcile.go
+++ b/pkg/resourcemanager/mysql/server/reconcile.go
@@ -190,9 +190,9 @@ func (m *MySQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts
 			instance.Status.Provisioned = false
 			instance.Status.FailedProvisioning = true
 			return true, nil
-
 		}
 
+		instance.Status.PollingURL = pollURL
 		instance.Status.Message = "request submitted to Azure"
 	}
 	return false, nil

--- a/pkg/resourcemanager/mysql/server/reconcile.go
+++ b/pkg/resourcemanager/mysql/server/reconcile.go
@@ -123,6 +123,7 @@ func (m *MySQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts
 				instance.Status.ResourceId = *server.ID
 				instance.Status.State = string(server.UserVisibleState)
 				instance.Status.SpecHash = hash
+				instance.Status.PollingURL = ""
 				return true, nil
 			}
 		}
@@ -176,7 +177,7 @@ func (m *MySQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts
 				if azerr.Type == errhelp.AsyncOpIncompleteError {
 					instance.Status.PollingURL = pollURL
 				}
-				instance.Status.Message = "Postgres server exists but may not be ready"
+				instance.Status.Message = "MySQL server exists but may not be ready"
 				instance.Status.Provisioning = true
 				return false, nil
 			}
@@ -185,7 +186,7 @@ func (m *MySQLServerClient) Ensure(ctx context.Context, obj runtime.Object, opts
 				return false, nil
 			}
 
-			// serious error occured, end reconcilliation and mark it as failed
+			// serious error occurred, end reconciliation and mark it as failed
 			instance.Status.Message = errhelp.StripErrorIDs(err)
 			instance.Status.Provisioned = false
 			instance.Status.FailedProvisioning = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously this was being dropped on the floor unless the create call returned an AsyncOpIncompleteError. This works fine as long as the server eventually is available. One situation where it fails is creating a replica at the same time as the leader server (or very quickly after). In that case the create server call returns no error, but querying the poll URL shows that the creation failed because the SourceServerID didn't match anything. Without capturing the poll URL on the initial creation the reconciliation gets stuck because it thinks that the 404 it gets when checking for the server indicates that it's just not ready yet - provisioning never goes back to false and it doesn't retry the creation. This could happen in other eventual error cases as well.

Re-enabled the replica creation in the MySQL test - we shouldn't be hitting the timeout errors we were seeing with it any longer.

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3ogwFNa3MS1vTCuTOU/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
