### PR TITLE
Switch to use the distroless nonroot base image and user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot
 ENV AZURE_CLIENT_ID "${AZURE_CLIENT_ID}"
 ENV AZURE_CLIENT_SECRET "{AZURE_CLIENT_SECRET}"
 ENV AZURE_SUBSCRIPTION_ID "${AZURE_SUBSCRIPTION_ID}"
@@ -29,4 +29,5 @@ ENV REQUEUE_AFTER "30"
 ENV AZURE_OPERATOR_KEYVAULT "${AZURE_OPERATOR_KEYVAULT}"
 WORKDIR /
 COPY --from=builder /workspace/manager .
+USER nonroot:nonroot
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
**What this PR does / why we need it**:
We've already changed the webhook listener to start on 9443, so there's no need for the manager to run as root - this reduces the attack surface if the pod is compromised somehow.

Closes #1406 

**How does this PR make you feel**:
![gif](https://media1.tenor.com/images/64b654e051b3807b9bfa31cda3867f4e/tenor.gif)
