### PR TITLE
Add /hack/ directory to IGNORE_FILTERS

### DIFF
--- a/scripts/check-changes.sh
+++ b/scripts/check-changes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-IGNORE_FILTERS=("docs/" "README.md")
+IGNORE_FILTERS=("docs/" "README.md" "hack/")
 CHANGED_FILES=$(git diff HEAD HEAD~ --name-only)
 IGNORED_COUNT=0
 NON_IGNORED_COUNT=0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

This adds the `hack` directory (where `k8s-infra`-sourced code lives) to the `IGNORE_FILTERS` set in `check-changes.sh`, which means that the ASO pipeline will not need to be re-run when only `k8s-infra` code changes.


