### PR TITLE
Change interface of WriteDebugDescription to use the io.StringWriter interface

### DIFF
--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -165,12 +165,12 @@ func (allOf *AllOfType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (allOf *AllOfType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("AllOf[")
+	_, _ = writer.WriteString("AllOf[")
 	allOf.types.ForEach(func(t Type, ix int) {
 		if ix > 0 {
-			_ = writer.WriteString("|")
+			_, _ = writer.WriteString("|")
 		}
 		t.WriteDebugDescription(writer, types)
 	})
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -161,15 +162,15 @@ func (allOf *AllOfType) String() string {
 }
 
 // WriteDebugDescription adds a description of the current AnyOf type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (allOf *AllOfType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("AllOf[")
+func (allOf *AllOfType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("AllOf[")
 	allOf.types.ForEach(func(t Type, ix int) {
 		if ix > 0 {
-			builder.WriteString("|")
+			writer.WriteString("|")
 		}
-		t.WriteDebugDescription(builder, types)
+		t.WriteDebugDescription(writer, types)
 	})
-	builder.WriteString("]")
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -122,7 +122,7 @@ func (allOf AllOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationCon
 
 // AsZero always panics; AllOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (allOf AllOfType) AsZero(types Types, ctx *CodeGenerationContext) dst.Expr {
+func (allOf AllOfType) AsZero(_ Types, _ *CodeGenerationContext) dst.Expr {
 	panic(errors.New(allOfPanicMsg))
 }
 

--- a/hack/generator/pkg/astmodel/allof_type.go
+++ b/hack/generator/pkg/astmodel/allof_type.go
@@ -165,12 +165,12 @@ func (allOf *AllOfType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (allOf *AllOfType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("AllOf[")
+	_ = writer.WriteString("AllOf[")
 	allOf.types.ForEach(func(t Type, ix int) {
 		if ix > 0 {
-			writer.WriteString("|")
+			_ = writer.WriteString("|")
 		}
 		t.WriteDebugDescription(writer, types)
 	})
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -41,7 +41,7 @@ func (array *ArrayType) AsType(codeGenerationContext *CodeGenerationContext) dst
 }
 
 // AsZero renders an expression for the "zero" value of the array by calling make()
-func (array *ArrayType) AsZero(_ Types, ctx *CodeGenerationContext) dst.Expr {
+func (array *ArrayType) AsZero(_ Types, _ *CodeGenerationContext) dst.Expr {
 	return dst.NewIdent("nil")
 }
 

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -78,7 +78,7 @@ func (array *ArrayType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (array *ArrayType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("Array[")
+	_, _ = writer.WriteString("Array[")
 	array.element.WriteDebugDescription(writer, types)
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -7,9 +7,8 @@ package astmodel
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/dave/dst"
+	"io"
 )
 
 // ArrayType is used for properties that contain an array of values
@@ -75,10 +74,10 @@ func (array *ArrayType) String() string {
 }
 
 // WriteDebugDescription adds a description of the current array type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (array *ArrayType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("Array[")
-	array.element.WriteDebugDescription(builder, types)
-	builder.WriteString("]")
+func (array *ArrayType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("Array[")
+	array.element.WriteDebugDescription(writer, types)
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/array_type.go
+++ b/hack/generator/pkg/astmodel/array_type.go
@@ -7,8 +7,9 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/dave/dst"
 	"io"
+
+	"github.com/dave/dst"
 )
 
 // ArrayType is used for properties that contain an array of values
@@ -77,7 +78,7 @@ func (array *ArrayType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (array *ArrayType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("Array[")
+	_ = writer.WriteString("Array[")
 	array.element.WriteDebugDescription(writer, types)
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -8,9 +8,9 @@ package astmodel
 import (
 	"fmt"
 	"go/token"
+	"io"
 	"sort"
-	"strings"
-
+	
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/astbuilder"
 	"github.com/dave/dst"
 	"k8s.io/klog/v2"
@@ -188,15 +188,15 @@ func (enum *EnumType) String() string {
 // passed builder
 // builder receives the full description
 // types is a dictionary for resolving named types
-func (enum *EnumType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("Enum[")
-	enum.baseType.WriteDebugDescription(builder, types)
-	builder.WriteString(":")
+func (enum *EnumType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("Enum[")
+	enum.baseType.WriteDebugDescription(writer, types)
+	writer.WriteString(":")
 	for i, v := range enum.options {
 		if i > 0 {
-			builder.WriteString("|")
+			writer.WriteString("|")
 		}
-		builder.WriteString(v.Identifier)
+		writer.WriteString(v.Identifier)
 	}
-	builder.WriteString("]")
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -189,14 +189,14 @@ func (enum *EnumType) String() string {
 // builder receives the full description
 // types is a dictionary for resolving named types
 func (enum *EnumType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("Enum[")
+	_, _ = writer.WriteString("Enum[")
 	enum.baseType.WriteDebugDescription(writer, types)
-	_ = writer.WriteString(":")
+	_, _ = writer.WriteString(":")
 	for i, v := range enum.options {
 		if i > 0 {
-			_ = writer.WriteString("|")
+			_, _ = writer.WriteString("|")
 		}
-		_ = writer.WriteString(v.Identifier)
+		_, _ = writer.WriteString(v.Identifier)
 	}
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/enum_type.go
+++ b/hack/generator/pkg/astmodel/enum_type.go
@@ -10,7 +10,7 @@ import (
 	"go/token"
 	"io"
 	"sort"
-	
+
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/astbuilder"
 	"github.com/dave/dst"
 	"k8s.io/klog/v2"
@@ -189,14 +189,14 @@ func (enum *EnumType) String() string {
 // builder receives the full description
 // types is a dictionary for resolving named types
 func (enum *EnumType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("Enum[")
+	_ = writer.WriteString("Enum[")
 	enum.baseType.WriteDebugDescription(writer, types)
-	writer.WriteString(":")
+	_ = writer.WriteString(":")
 	for i, v := range enum.options {
 		if i > 0 {
-			writer.WriteString("|")
+			_ = writer.WriteString("|")
 		}
-		writer.WriteString(v.Identifier)
+		_ = writer.WriteString(v.Identifier)
 	}
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -162,18 +162,18 @@ func (e *ErroredType) Unwrap() Type {
 // builder receives the full description, including the nested type, errors and warnings
 // types is a dictionary for resolving named types
 func (e *ErroredType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("Error[")
+	_ = writer.WriteString("Error[")
 	e.inner.WriteDebugDescription(writer, types)
 
 	for _, e := range e.errors {
-		writer.WriteString("|")
-		writer.WriteString(e)
+		_ = writer.WriteString("|")
+		_ = writer.WriteString(e)
 	}
 
 	for _, w := range e.warnings {
-		writer.WriteString("|")
-		writer.WriteString(w)
+		_ = writer.WriteString("|")
+		_ = writer.WriteString(w)
 	}
 
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -162,18 +162,18 @@ func (e *ErroredType) Unwrap() Type {
 // builder receives the full description, including the nested type, errors and warnings
 // types is a dictionary for resolving named types
 func (e *ErroredType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("Error[")
+	_, _ = writer.WriteString("Error[")
 	e.inner.WriteDebugDescription(writer, types)
 
 	for _, e := range e.errors {
-		_ = writer.WriteString("|")
-		_ = writer.WriteString(e)
+		_, _ = writer.WriteString("|")
+		_, _ = writer.WriteString(e)
 	}
 
 	for _, w := range e.warnings {
-		_ = writer.WriteString("|")
-		_ = writer.WriteString(w)
+		_, _ = writer.WriteString("|")
+		_, _ = writer.WriteString(w)
 	}
 
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -7,7 +7,7 @@ package astmodel
 
 import (
 	"fmt"
-	"strings"
+	"io"
 
 	"github.com/dave/dst"
 	"github.com/pkg/errors"
@@ -161,19 +161,19 @@ func (e *ErroredType) Unwrap() Type {
 // WriteDebugDescription adds a description of the current errored type to the passed builder,
 // builder receives the full description, including the nested type, errors and warnings
 // types is a dictionary for resolving named types
-func (e *ErroredType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("Error[")
-	e.inner.WriteDebugDescription(builder, types)
+func (e *ErroredType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("Error[")
+	e.inner.WriteDebugDescription(writer, types)
 
 	for _, e := range e.errors {
-		builder.WriteString("|")
-		builder.WriteString(e)
+		writer.WriteString("|")
+		writer.WriteString(e)
 	}
 
 	for _, w := range e.warnings {
-		builder.WriteString("|")
-		builder.WriteString(w)
+		writer.WriteString("|")
+		writer.WriteString(w)
 	}
 
-	builder.WriteString("]")
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -183,8 +183,8 @@ func (ft *FlaggedType) Unwrap() Type {
 func (ft *FlaggedType) WriteDebugDescription(writer io.StringWriter, types Types) {
 	ft.element.WriteDebugDescription(writer, types)
 	for f := range ft.flags {
-		writer.WriteString("[#")
-		writer.WriteString(f.String())
-		writer.WriteString("]")
+		_ = writer.WriteString("[#")
+		_ = writer.WriteString(f.String())
+		_ = writer.WriteString("]")
 	}
 }

--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -183,8 +183,8 @@ func (ft *FlaggedType) Unwrap() Type {
 func (ft *FlaggedType) WriteDebugDescription(writer io.StringWriter, types Types) {
 	ft.element.WriteDebugDescription(writer, types)
 	for f := range ft.flags {
-		_ = writer.WriteString("[#")
-		_ = writer.WriteString(f.String())
-		_ = writer.WriteString("]")
+		_, _ = writer.WriteString("[#")
+		_, _ = writer.WriteString(f.String())
+		_, _ = writer.WriteString("]")
 	}
 }

--- a/hack/generator/pkg/astmodel/flagged_type.go
+++ b/hack/generator/pkg/astmodel/flagged_type.go
@@ -6,6 +6,7 @@
 package astmodel
 
 import (
+	"io"
 	"sort"
 	"strings"
 
@@ -177,13 +178,13 @@ func (ft *FlaggedType) Unwrap() Type {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (ft *FlaggedType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	ft.element.WriteDebugDescription(builder, types)
+func (ft *FlaggedType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	ft.element.WriteDebugDescription(writer, types)
 	for f := range ft.flags {
-		builder.WriteString("[#")
-		builder.WriteString(f.String())
-		builder.WriteString("]")
+		writer.WriteString("[#")
+		writer.WriteString(f.String())
+		writer.WriteString("]")
 	}
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -7,9 +7,8 @@ package astmodel
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/dave/dst"
+	"io"
 )
 
 // MapType is used to define properties that contain additional property values
@@ -90,11 +89,11 @@ func (m *MapType) String() string {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (m *MapType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("Map[")
-	m.key.WriteDebugDescription(builder, types)
-	builder.WriteString("]")
-	m.value.WriteDebugDescription(builder, types)
+func (m *MapType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("Map[")
+	m.key.WriteDebugDescription(writer, types)
+	writer.WriteString("]")
+	m.value.WriteDebugDescription(writer, types)
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -53,7 +53,7 @@ func (m *MapType) AsType(codeGenerationContext *CodeGenerationContext) dst.Expr 
 }
 
 // AsZero renders an expression for the "zero" value of a map by calling make()
-func (m *MapType) AsZero(_ Types, ctx *CodeGenerationContext) dst.Expr {
+func (m *MapType) AsZero(_ Types, _ *CodeGenerationContext) dst.Expr {
 	return dst.NewIdent("nil")
 }
 

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -7,8 +7,9 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/dave/dst"
 	"io"
+
+	"github.com/dave/dst"
 )
 
 // MapType is used to define properties that contain additional property values
@@ -92,8 +93,8 @@ func (m *MapType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (m *MapType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("Map[")
+	_ = writer.WriteString("Map[")
 	m.key.WriteDebugDescription(writer, types)
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 	m.value.WriteDebugDescription(writer, types)
 }

--- a/hack/generator/pkg/astmodel/map_type.go
+++ b/hack/generator/pkg/astmodel/map_type.go
@@ -93,8 +93,8 @@ func (m *MapType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (m *MapType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("Map[")
+	_, _ = writer.WriteString("Map[")
 	m.key.WriteDebugDescription(writer, types)
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 	m.value.WriteDebugDescription(writer, types)
 }

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -7,8 +7,8 @@ package astmodel
 
 import (
 	"go/token"
+	"io"
 	"sort"
-	"strings"
 
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/astbuilder"
 	"github.com/dave/dst"
@@ -547,8 +547,8 @@ func extractEmbeddedTypeName(t Type) (TypeName, error) {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// wreiter receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (objectType *ObjectType) WriteDebugDescription(builder *strings.Builder, _ Types) {
-	builder.WriteString("Object")
+func (objectType *ObjectType) WriteDebugDescription(writer io.StringWriter, _ Types) {
+	writer.WriteString("Object")
 }

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -550,5 +550,5 @@ func extractEmbeddedTypeName(t Type) (TypeName, error) {
 // wreiter receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (objectType *ObjectType) WriteDebugDescription(writer io.StringWriter, _ Types) {
-	writer.WriteString("Object")
+	_ = writer.WriteString("Object")
 }

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -550,5 +550,5 @@ func extractEmbeddedTypeName(t Type) (TypeName, error) {
 // wreiter receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (objectType *ObjectType) WriteDebugDescription(writer io.StringWriter, _ Types) {
-	_ = writer.WriteString("Object")
+	_, _ = writer.WriteString("Object")
 }

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -125,15 +126,15 @@ func (oneOf *OneOfType) String() string {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (oneOf *OneOfType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("OneOf[")
+func (oneOf *OneOfType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("OneOf[")
 	oneOf.types.ForEach(func(t Type, ix int) {
 		if ix > 0 {
-			builder.WriteString("|")
+			writer.WriteString("|")
 		}
-		t.WriteDebugDescription(builder, types)
+		t.WriteDebugDescription(writer, types)
 	})
-	builder.WriteString("]")
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -87,7 +87,7 @@ func (oneOf OneOfType) AsDeclarations(_ *CodeGenerationContext, _ DeclarationCon
 
 // AsZero always panics; OneOf cannot be represented by the Go AST and must be
 // lowered to an object type
-func (oneOf OneOfType) AsZero(types Types, ctx *CodeGenerationContext) dst.Expr {
+func (oneOf OneOfType) AsZero(_ Types, _ *CodeGenerationContext) dst.Expr {
 	panic(errors.New(oneOfPanicMsg))
 }
 

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -129,12 +129,12 @@ func (oneOf *OneOfType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (oneOf *OneOfType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("OneOf[")
+	_ = writer.WriteString("OneOf[")
 	oneOf.types.ForEach(func(t Type, ix int) {
 		if ix > 0 {
-			writer.WriteString("|")
+			_ = writer.WriteString("|")
 		}
 		t.WriteDebugDescription(writer, types)
 	})
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/oneof_type.go
+++ b/hack/generator/pkg/astmodel/oneof_type.go
@@ -129,12 +129,12 @@ func (oneOf *OneOfType) String() string {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (oneOf *OneOfType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("OneOf[")
+	_, _ = writer.WriteString("OneOf[")
 	oneOf.types.ForEach(func(t Type, ix int) {
 		if ix > 0 {
-			_ = writer.WriteString("|")
+			_, _ = writer.WriteString("|")
 		}
 		t.WriteDebugDescription(writer, types)
 	})
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -7,9 +7,8 @@ package astmodel
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/dave/dst"
+	"io"
 )
 
 // OptionalType is used for items that may or may not be present
@@ -113,10 +112,10 @@ func (optional *OptionalType) Unwrap() Type {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (optional *OptionalType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("Optional[")
-	optional.element.WriteDebugDescription(builder, types)
-	builder.WriteString("]")
+func (optional *OptionalType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("Optional[")
+	optional.element.WriteDebugDescription(writer, types)
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -116,7 +116,7 @@ func (optional *OptionalType) Unwrap() Type {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (optional *OptionalType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("Optional[")
+	_, _ = writer.WriteString("Optional[")
 	optional.element.WriteDebugDescription(writer, types)
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/optional_type.go
+++ b/hack/generator/pkg/astmodel/optional_type.go
@@ -7,8 +7,9 @@ package astmodel
 
 import (
 	"fmt"
-	"github.com/dave/dst"
 	"io"
+
+	"github.com/dave/dst"
 )
 
 // OptionalType is used for items that may or may not be present
@@ -115,7 +116,7 @@ func (optional *OptionalType) Unwrap() Type {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (optional *OptionalType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("Optional[")
+	_ = writer.WriteString("Optional[")
 	optional.element.WriteDebugDescription(writer, types)
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -6,8 +6,9 @@
 package astmodel
 
 import (
-	"github.com/dave/dst"
 	"io"
+
+	"github.com/dave/dst"
 )
 
 // PrimitiveType represents a Go primitive type
@@ -90,5 +91,5 @@ func (prim *PrimitiveType) String() string {
 
 // WriteDebugDescription adds a description of this primitive type to the passed builder
 func (prim *PrimitiveType) WriteDebugDescription(writer io.StringWriter, _ Types) {
-	writer.WriteString(prim.name)
+	_ = writer.WriteString(prim.name)
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -7,7 +7,7 @@ package astmodel
 
 import (
 	"github.com/dave/dst"
-	"strings"
+	"io"
 )
 
 // PrimitiveType represents a Go primitive type
@@ -89,6 +89,6 @@ func (prim *PrimitiveType) String() string {
 }
 
 // WriteDebugDescription adds a description of this primitive type to the passed builder
-func (prim *PrimitiveType) WriteDebugDescription(builder *strings.Builder, _ Types) {
-	builder.WriteString(prim.name)
+func (prim *PrimitiveType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString(prim.name)
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -91,5 +91,5 @@ func (prim *PrimitiveType) String() string {
 
 // WriteDebugDescription adds a description of this primitive type to the passed builder
 func (prim *PrimitiveType) WriteDebugDescription(writer io.StringWriter, _ Types) {
-	_ = writer.WriteString(prim.name)
+	_, _ = writer.WriteString(prim.name)
 }

--- a/hack/generator/pkg/astmodel/primitive_type.go
+++ b/hack/generator/pkg/astmodel/primitive_type.go
@@ -57,7 +57,7 @@ func (prim *PrimitiveType) RequiredPackageReferences() *PackageReferenceSet {
 // AsZero renders an expression for the "zero" value of the type
 // types allows TypeName to resolve to the underlying type
 // ctx allows current imports to be correctly identified where needed
-func (prim *PrimitiveType) AsZero(types Types, ctx *CodeGenerationContext) dst.Expr {
+func (prim *PrimitiveType) AsZero(_ Types, _ *CodeGenerationContext) dst.Expr {
 	return &dst.BasicLit{
 		Value: prim.zero,
 	}
@@ -89,6 +89,6 @@ func (prim *PrimitiveType) String() string {
 }
 
 // WriteDebugDescription adds a description of this primitive type to the passed builder
-func (prim *PrimitiveType) WriteDebugDescription(writer io.StringWriter, types Types) {
+func (prim *PrimitiveType) WriteDebugDescription(writer io.StringWriter, _ Types) {
 	writer.WriteString(prim.name)
 }

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -8,6 +8,7 @@ package astmodel
 import (
 	"fmt"
 	"go/token"
+	"io"
 	"sort"
 	"strings"
 
@@ -558,12 +559,12 @@ func (resource *ResourceType) HasTestCases() bool {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (resource *ResourceType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("Resource[spec:")
-	resource.spec.WriteDebugDescription(builder, types)
-	builder.WriteString("|status:")
-	resource.status.WriteDebugDescription(builder, types)
-	builder.WriteString("]")
+func (resource *ResourceType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("Resource[spec:")
+	resource.spec.WriteDebugDescription(writer, types)
+	writer.WriteString("|status:")
+	resource.status.WriteDebugDescription(writer, types)
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -562,9 +562,9 @@ func (resource *ResourceType) HasTestCases() bool {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (resource *ResourceType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("Resource[spec:")
+	_, _ = writer.WriteString("Resource[spec:")
 	resource.spec.WriteDebugDescription(writer, types)
-	_ = writer.WriteString("|status:")
+	_, _ = writer.WriteString("|status:")
 	resource.status.WriteDebugDescription(writer, types)
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -562,9 +562,9 @@ func (resource *ResourceType) HasTestCases() bool {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (resource *ResourceType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("Resource[spec:")
+	_ = writer.WriteString("Resource[spec:")
 	resource.spec.WriteDebugDescription(writer, types)
-	writer.WriteString("|status:")
+	_ = writer.WriteString("|status:")
 	resource.status.WriteDebugDescription(writer, types)
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -7,9 +7,8 @@ package astmodel
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/dave/dst"
+	"io"
 )
 
 // Type represents something that is a Go type
@@ -42,9 +41,9 @@ type Type interface {
 	fmt.Stringer
 
 	// WriteDebugDescription adds a description of the current type to the passed builder
-	// builder receives the full description, including nested types
+	// writer receives the full description, including nested types
 	// types is a dictionary for resolving named types
-	WriteDebugDescription(builder *strings.Builder, types Types)
+	WriteDebugDescription(writer io.StringWriter, types Types)
 }
 
 // IgnoringErrors returns the type stripped of any ErroredType wrapper

--- a/hack/generator/pkg/astmodel/type.go
+++ b/hack/generator/pkg/astmodel/type.go
@@ -36,7 +36,7 @@ type Type interface {
 	// Equals returns true if the passed type is the same as this one, false otherwise
 	Equals(t Type) bool
 
-	// Make sure all Types have a printable version for debugging/user info.
+	// Stringer ensures all Types have a printable version for debugging/user info.
 	// This doesn't need to be a full representation of the type.
 	fmt.Stringer
 

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -172,16 +172,16 @@ func (typeName TypeName) Plural() TypeName {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (typeName TypeName) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString(typeName.PackageReference.String())
-	writer.WriteString("/")
-	writer.WriteString(typeName.name)
+	_ = writer.WriteString(typeName.PackageReference.String())
+	_ = writer.WriteString("/")
+	_ = writer.WriteString(typeName.name)
 
 	if _, ok := typeName.PackageReference.AsLocalPackage(); ok {
-		writer.WriteString(":")
+		_ = writer.WriteString(":")
 		if definition, ok := types[typeName]; ok {
 			definition.Type().WriteDebugDescription(writer, types)
 		} else {
-			writer.WriteString("NOTDEFINED")
+			_ = writer.WriteString("NOTDEFINED")
 		}
 	}
 }

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -7,6 +7,7 @@ package astmodel
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/dave/dst"
@@ -168,19 +169,19 @@ func (typeName TypeName) Plural() TypeName {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (typeName TypeName) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString(typeName.PackageReference.String())
-	builder.WriteString("/")
-	builder.WriteString(typeName.name)
+func (typeName TypeName) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString(typeName.PackageReference.String())
+	writer.WriteString("/")
+	writer.WriteString(typeName.name)
 
 	if _, ok := typeName.PackageReference.AsLocalPackage(); ok {
-		builder.WriteString(":")
+		writer.WriteString(":")
 		if definition, ok := types[typeName]; ok {
-			definition.Type().WriteDebugDescription(builder, types)
+			definition.Type().WriteDebugDescription(writer, types)
 		} else {
-			builder.WriteString("NOTDEFINED")
+			writer.WriteString("NOTDEFINED")
 		}
 	}
 }

--- a/hack/generator/pkg/astmodel/type_name.go
+++ b/hack/generator/pkg/astmodel/type_name.go
@@ -172,16 +172,16 @@ func (typeName TypeName) Plural() TypeName {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (typeName TypeName) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString(typeName.PackageReference.String())
-	_ = writer.WriteString("/")
-	_ = writer.WriteString(typeName.name)
+	_, _ = writer.WriteString(typeName.PackageReference.String())
+	_, _ = writer.WriteString("/")
+	_, _ = writer.WriteString(typeName.name)
 
 	if _, ok := typeName.PackageReference.AsLocalPackage(); ok {
-		_ = writer.WriteString(":")
+		_, _ = writer.WriteString(":")
 		if definition, ok := types[typeName]; ok {
 			definition.Type().WriteDebugDescription(writer, types)
 		} else {
-			_ = writer.WriteString("NOTDEFINED")
+			_, _ = writer.WriteString("NOTDEFINED")
 		}
 	}
 }

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -8,8 +8,8 @@ package astmodel
 import (
 	"fmt"
 	"math/big"
+	"io"
 	"regexp"
-	"strings"
 
 	"github.com/dave/dst"
 )
@@ -233,10 +233,10 @@ func (v ValidatedType) Unwrap() Type {
 }
 
 // WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
+// writer receives the full description, including nested types
 // types is a dictionary for resolving named types
-func (v ValidatedType) WriteDebugDescription(builder *strings.Builder, types Types) {
-	builder.WriteString("Validated[")
-	v.element.WriteDebugDescription(builder, types)
-	builder.WriteString("]")
+func (v ValidatedType) WriteDebugDescription(writer io.StringWriter, types Types) {
+	writer.WriteString("Validated[")
+	v.element.WriteDebugDescription(writer, types)
+	writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -177,7 +177,7 @@ func (v *ValidatedType) AsType(_ *CodeGenerationContext) dst.Expr {
 }
 
 // AsZero panics because validated types should always be named
-func (v *ValidatedType) AsZero(types Types, ctx *CodeGenerationContext) dst.Expr {
+func (v *ValidatedType) AsZero(_ Types, _ *CodeGenerationContext) dst.Expr {
 	panic("Should never happen: validated types must either be named (handled by 'name types for CRDs' pipeline stage) or be directly under properties (handled by PropertyDefinition.AsField)")
 }
 

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -236,7 +236,7 @@ func (v ValidatedType) Unwrap() Type {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (v ValidatedType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	_ = writer.WriteString("Validated[")
+	_, _ = writer.WriteString("Validated[")
 	v.element.WriteDebugDescription(writer, types)
-	_ = writer.WriteString("]")
+	_, _ = writer.WriteString("]")
 }

--- a/hack/generator/pkg/astmodel/validated_type.go
+++ b/hack/generator/pkg/astmodel/validated_type.go
@@ -7,8 +7,8 @@ package astmodel
 
 import (
 	"fmt"
-	"math/big"
 	"io"
+	"math/big"
 	"regexp"
 
 	"github.com/dave/dst"
@@ -236,7 +236,7 @@ func (v ValidatedType) Unwrap() Type {
 // writer receives the full description, including nested types
 // types is a dictionary for resolving named types
 func (v ValidatedType) WriteDebugDescription(writer io.StringWriter, types Types) {
-	writer.WriteString("Validated[")
+	_ = writer.WriteString("Validated[")
 	v.element.WriteDebugDescription(writer, types)
-	writer.WriteString("]")
+	_ = writer.WriteString("]")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Tidies up the func signature for `WriteDebugDescription()` to better reflect it's constraints, allowing uses other than a `strings.Builder`.

**How does this PR make you feel**:
[#serene](https://media.giphy.com/media/QPzxH1j3eWkGaGYtCR/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
