### PR TITLE
Improve record/replay tests

### DIFF
--- a/hack/generated/controllers/recordings/Test_CosmosDB_CRUD.yaml
+++ b/hack/generated/controllers/recordings/Test_CosmosDB_CRUD.yaml
@@ -2,28 +2,28 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-dnhfns","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-dnhfns'')]"}}}}}'
+    body: '{"name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-dnhfns","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'',
+      ''k8sinfratest-rg-dnhfns'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.7346576Z","duration":"PT4.4337753S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2397933948036734993","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.0220129S","correlationId":"028dad20-0def-41d1-8650-f45c3d8737dd","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5/operationStatuses/08585903342251767316?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5/operationStatuses/08585802230786810238?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
       - "690"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -41,19 +41,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.7346576Z","duration":"PT4.4337753S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2397933948036734993","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.9681445S","correlationId":"028dad20-0def-41d1-8650-f45c3d8737dd","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -75,19 +74,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:26.0607811Z","duration":"PT5.7598988S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2397933948036734993","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.9681445S","correlationId":"028dad20-0def-41d1-8650-f45c3d8737dd","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -109,53 +107,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:26.0607811Z","duration":"PT5.7598988S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2397933948036734993","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT8.4899215S","correlationId":"028dad20-0def-41d1-8650-f45c3d8737dd","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-dnhfns"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:30 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5","name":"k8s_df555267-f893-56c9-a777-fb81bb3748d5","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"9066647199355949189","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:34.7705058Z","duration":"PT14.4696235S","correlationId":"8151a1e5-c6c3-4a1e-abf3-3770f47c6dd6","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-dnhfns"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -175,19 +138,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns","name":"k8sinfratest-rg-dnhfns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Succeeded"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns","name":"k8sinfratest-rg-dnhfns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -207,8 +168,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_df555267-f893-56c9-a777-fb81bb3748d5?api-version=2019-10-01
     method: DELETE
   response:
@@ -218,8 +179,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:44:37 GMT
       Expires:
       - "-1"
       Location:
@@ -233,33 +192,33 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14997"
+      - "14999"
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2015-04-08","kind":"GlobalDocumentDB","location":"westus","name":"k8sinfratestdbhmayhx","properties":{"databaseAccountOfferType":"Standard","locations":[{"locationName":"westus"}]},"type":"Microsoft.DocumentDB/databaseAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.DocumentDB/databaseAccounts'', ''k8sinfratestdbhmayhx'')]"}}}}}'
+    body: '{"name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2015-04-08","kind":"GlobalDocumentDB","location":"westus","name":"k8sinfratestdbhmayhx","properties":{"databaseAccountOfferType":"Standard","locations":[{"locationName":"westus"}]},"type":"Microsoft.DocumentDB/databaseAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.DocumentDB/databaseAccounts'',
+      ''k8sinfratestdbhmayhx'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:40.7109819Z","duration":"PT0.9059934S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.7057294S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1/operationStatuses/08585903342056726174?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1/operationStatuses/08585802230662866648?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
       - "711"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:40 GMT
       Expires:
       - "-1"
       Pragma:
@@ -272,58 +231,23 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2015-04-08","kind":"GlobalDocumentDB","location":"westus","name":"k8sinfratestdbhmayhx","properties":{"databaseAccountOfferType":"Standard","locations":[{"locationName":"westus"}]},"type":"Microsoft.DocumentDB/databaseAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.DocumentDB/databaseAccounts'', ''k8sinfratestdbhmayhx'')]"}}}}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
-    method: PUT
-  response:
-    body: '{"error":{"code":"DeploymentActive","message":"Unable to edit or replace deployment ''k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1'': previous deployment from ''1/21/2021 11:44:40 PM'' is still active (expiration time is ''1/28/2021 11:44:39 PM''). Please see https://aka.ms/arm-deploy for usage details."}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "297"
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:41 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Failure-Cause:
-      - gateway
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.3957342S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:41 GMT
       Expires:
       - "-1"
       Pragma:
@@ -345,19 +269,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.3957342S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:42 GMT
       Expires:
       - "-1"
       Pragma:
@@ -379,19 +302,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.3957342S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:46 GMT
       Expires:
       - "-1"
       Pragma:
@@ -413,19 +335,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.8653275Z","duration":"PT2.060339S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.3957342S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:51 GMT
       Expires:
       - "-1"
       Pragma:
@@ -447,25 +368,24 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "4"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.5688313Z","duration":"PT15.7638428S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT13.4009008S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:56 GMT
       Expires:
       - "-1"
       Pragma:
       - no-cache
       Retry-After:
-      - "15"
+      - "16"
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -481,53 +401,150 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "5"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.5688313Z","duration":"PT15.7638428S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT13.4009008S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:02 GMT
       Expires:
       - "-1"
       Pragma:
       - no-cache
       Retry-After:
+      - "11"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "6"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT13.4009008S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "7"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT29.5524558S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "16"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "8"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT29.5524558S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "11"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
       - "9"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.5688313Z","duration":"PT15.7638428S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT29.5524558S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:07 GMT
       Expires:
       - "-1"
       Pragma:
@@ -549,87 +566,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "10"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:11.9072244Z","duration":"PT32.1022359S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT29.5524558S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:12 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "15"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:11.9072244Z","duration":"PT32.1022359S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:18 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "9"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:11.9072244Z","duration":"PT32.1022359S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:23 GMT
       Expires:
       - "-1"
       Pragma:
@@ -651,59 +599,123 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "11"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:27.4863919Z","duration":"PT47.6814034S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT46.1323615S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:29 GMT
       Expires:
       - "-1"
       Pragma:
       - no-cache
       Retry-After:
+      - "11"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "12"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT46.1323615S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "6"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "13"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1M1.4670951S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "16"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
       - "14"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:27.4863919Z","duration":"PT47.6814034S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1M1.4670951S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:34 GMT
       Expires:
       - "-1"
       Pragma:
       - no-cache
       Retry-After:
-      - "9"
+      - "10"
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -719,19 +731,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "15"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:27.4863919Z","duration":"PT47.6814034S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1M1.4670951S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:40 GMT
       Expires:
       - "-1"
       Pragma:
@@ -753,87 +764,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "16"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:43.3605795Z","duration":"PT1M3.555591S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1M1.4670951S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:45 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "14"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:43.3605795Z","duration":"PT1M3.555591S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:50 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "9"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:43.3605795Z","duration":"PT1M3.555591S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:56 GMT
       Expires:
       - "-1"
       Pragma:
@@ -855,19 +797,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "17"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:46:00.7289034Z","duration":"PT1M20.9239149S","correlationId":"4c2dbabb-d675-4f55-b146-1ff14b697e1c","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","name":"k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6776755900857513625","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT1M18.9227523S","correlationId":"9828849f-e8cd-49d3-8467-8c2d628b246b","providers":[{"namespace":"Microsoft.DocumentDB","resourceTypes":[{"resourceType":"databaseAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:46:01 GMT
       Expires:
       - "-1"
       Pragma:
@@ -887,19 +828,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -921,8 +865,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.Resources/deployments/k8s_234c5afb-56ca-5133-b1e2-9d901f2b7ea1?api-version=2019-10-01
     method: DELETE
   response:
@@ -932,8 +876,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:46:03 GMT
       Expires:
       - "-1"
       Location:
@@ -947,7 +889,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14989"
+      - "14998"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -957,25 +899,23 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: DELETE
   response:
     body: '{"status":"Enqueued"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ee8b9b22-6d2e-4cf5-b9d1-40f5dcf6e8d2?api-version=2015-04-08
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/75017f00-e0e3-4121-a41a-6eadf03e1c5b?api-version=2015-04-08
       Cache-Control:
       - no-store, no-cache
       Content-Length:
       - "21"
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:05 GMT
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/ee8b9b22-6d2e-4cf5-b9d1-40f5dcf6e8d2?api-version=2015-04-08
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/75017f00-e0e3-4121-a41a-6eadf03e1c5b?api-version=2015-04-08
       Pragma:
       - no-cache
       Server:
@@ -987,7 +927,7 @@ interactions:
       X-Ms-Gatewayversion:
       - version=2.11.0
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14988"
+      - "14997"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -997,67 +937,36 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
-    headers:
-      Cache-Control:
-      - no-store, no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:05 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Gatewayversion:
-      - version=2.11.0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
-    method: GET
+    method: DELETE
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"code":"PreconditionFailed","message":"There is already an operation in
+      progress which requires exclusive lock on this service k8sinfratestdbhmayhx.
+      Please retry the operation after sometime.\r\nActivityId: e03d1b68-0d0c-4023-a8c2-ca6eab2ab77e,
+      Microsoft.Azure.Documents.Common/2.11.0"}'
     headers:
       Cache-Control:
       - no-store, no-cache
+      Content-Length:
+      - "287"
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:05 GMT
       Pragma:
       - no-cache
       Server:
       - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Ms-Gatewayversion:
       - version=2.11.0
-    status: 200 OK
-    code: 200
+      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
+      - "14996"
+    status: 412 Precondition Failed
+    code: 412
     duration: ""
 - request:
     body: ""
@@ -1065,19 +974,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:11 GMT
       Pragma:
       - no-cache
       Server:
@@ -1099,19 +1011,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:17 GMT
       Pragma:
       - no-cache
       Server:
@@ -1133,19 +1048,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -1167,19 +1085,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "4"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -1201,19 +1122,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "5"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:33 GMT
       Pragma:
       - no-cache
       Server:
@@ -1235,19 +1159,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "6"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:40 GMT
       Pragma:
       - no-cache
       Server:
@@ -1269,19 +1196,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "7"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -1303,19 +1233,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "8"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:53 GMT
       Pragma:
       - no-cache
       Server:
@@ -1337,19 +1270,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "9"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:46:59 GMT
       Pragma:
       - no-cache
       Server:
@@ -1371,19 +1307,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "10"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:04 GMT
       Pragma:
       - no-cache
       Server:
@@ -1405,19 +1344,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "11"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:10 GMT
       Pragma:
       - no-cache
       Server:
@@ -1439,19 +1381,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "12"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:15 GMT
       Pragma:
       - no-cache
       Server:
@@ -1473,19 +1418,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "13"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:21 GMT
       Pragma:
       - no-cache
       Server:
@@ -1507,19 +1455,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "14"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -1541,19 +1492,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "15"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -1575,19 +1529,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "16"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -1609,19 +1566,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "17"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:44 GMT
       Pragma:
       - no-cache
       Server:
@@ -1643,19 +1603,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "18"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:51 GMT
       Pragma:
       - no-cache
       Server:
@@ -1677,19 +1640,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "19"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:47:56 GMT
       Pragma:
       - no-cache
       Server:
@@ -1711,19 +1677,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "20"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -1745,19 +1714,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "21"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:07 GMT
       Pragma:
       - no-cache
       Server:
@@ -1779,19 +1751,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "22"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:12 GMT
       Pragma:
       - no-cache
       Server:
@@ -1813,19 +1788,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "23"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:17 GMT
       Pragma:
       - no-cache
       Server:
@@ -1847,19 +1825,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "24"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:22 GMT
       Pragma:
       - no-cache
       Server:
@@ -1881,19 +1862,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "25"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -1915,19 +1899,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "26"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:33 GMT
       Pragma:
       - no-cache
       Server:
@@ -1949,19 +1936,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "27"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -1983,19 +1973,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "28"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -2017,19 +2010,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "29"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:51 GMT
       Pragma:
       - no-cache
       Server:
@@ -2051,19 +2047,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "30"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:48:56 GMT
       Pragma:
       - no-cache
       Server:
@@ -2085,19 +2084,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "31"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -2119,19 +2121,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "32"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:07 GMT
       Pragma:
       - no-cache
       Server:
@@ -2153,19 +2158,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "33"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:12 GMT
       Pragma:
       - no-cache
       Server:
@@ -2187,19 +2195,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "34"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:18 GMT
       Pragma:
       - no-cache
       Server:
@@ -2221,19 +2232,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "35"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -2255,19 +2269,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "36"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:29 GMT
       Pragma:
       - no-cache
       Server:
@@ -2289,19 +2306,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "37"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -2323,19 +2343,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "38"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -2357,19 +2380,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "39"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:44 GMT
       Pragma:
       - no-cache
       Server:
@@ -2391,19 +2417,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "40"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:50 GMT
       Pragma:
       - no-cache
       Server:
@@ -2425,19 +2454,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "41"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:49:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -2459,19 +2491,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "42"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:00 GMT
       Pragma:
       - no-cache
       Server:
@@ -2493,19 +2528,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "43"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:05 GMT
       Pragma:
       - no-cache
       Server:
@@ -2527,19 +2565,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "44"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:11 GMT
       Pragma:
       - no-cache
       Server:
@@ -2561,19 +2602,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "45"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:16 GMT
       Pragma:
       - no-cache
       Server:
@@ -2595,19 +2639,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "46"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:21 GMT
       Pragma:
       - no-cache
       Server:
@@ -2629,19 +2676,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "47"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:27 GMT
       Pragma:
       - no-cache
       Server:
@@ -2663,19 +2713,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "48"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:35 GMT
       Pragma:
       - no-cache
       Server:
@@ -2697,19 +2750,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "49"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:40 GMT
       Pragma:
       - no-cache
       Server:
@@ -2731,19 +2787,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "50"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:45 GMT
       Pragma:
       - no-cache
       Server:
@@ -2765,19 +2824,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "51"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:51 GMT
       Pragma:
       - no-cache
       Server:
@@ -2799,19 +2861,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "52"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:50:56 GMT
       Pragma:
       - no-cache
       Server:
@@ -2833,19 +2898,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "53"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:01 GMT
       Pragma:
       - no-cache
       Server:
@@ -2867,19 +2935,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "54"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:06 GMT
       Pragma:
       - no-cache
       Server:
@@ -2901,19 +2972,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "55"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:13 GMT
       Pragma:
       - no-cache
       Server:
@@ -2935,19 +3009,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "56"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:18 GMT
       Pragma:
       - no-cache
       Server:
@@ -2969,19 +3046,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "57"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:23 GMT
       Pragma:
       - no-cache
       Server:
@@ -3003,19 +3083,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "58"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:28 GMT
       Pragma:
       - no-cache
       Server:
@@ -3037,19 +3120,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "59"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -3071,19 +3157,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "60"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:40 GMT
       Pragma:
       - no-cache
       Server:
@@ -3105,19 +3194,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "61"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:46 GMT
       Pragma:
       - no-cache
       Server:
@@ -3139,19 +3231,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "62"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:52 GMT
       Pragma:
       - no-cache
       Server:
@@ -3173,19 +3268,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "63"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:51:57 GMT
       Pragma:
       - no-cache
       Server:
@@ -3207,19 +3305,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "64"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:02 GMT
       Pragma:
       - no-cache
       Server:
@@ -3241,19 +3342,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "65"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:07 GMT
       Pragma:
       - no-cache
       Server:
@@ -3275,19 +3379,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "66"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:13 GMT
       Pragma:
       - no-cache
       Server:
@@ -3309,19 +3416,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "67"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:18 GMT
       Pragma:
       - no-cache
       Server:
@@ -3343,19 +3453,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "68"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:24 GMT
       Pragma:
       - no-cache
       Server:
@@ -3377,19 +3490,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "69"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:29 GMT
       Pragma:
       - no-cache
       Server:
@@ -3411,19 +3527,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "70"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:34 GMT
       Pragma:
       - no-cache
       Server:
@@ -3445,19 +3564,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "71"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:39 GMT
       Pragma:
       - no-cache
       Server:
@@ -3479,19 +3601,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "72"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:45 GMT
       Pragma:
       - no-cache
       Server:
@@ -3513,19 +3638,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "73"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:50 GMT
       Pragma:
       - no-cache
       Server:
@@ -3547,19 +3675,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "74"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:52:57 GMT
       Pragma:
       - no-cache
       Server:
@@ -3581,19 +3712,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "75"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:03 GMT
       Pragma:
       - no-cache
       Server:
@@ -3615,19 +3749,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "76"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:09 GMT
       Pragma:
       - no-cache
       Server:
@@ -3649,19 +3786,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "77"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:14 GMT
       Pragma:
       - no-cache
       Server:
@@ -3683,19 +3823,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "78"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:20 GMT
       Pragma:
       - no-cache
       Server:
@@ -3717,19 +3860,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "79"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:27 GMT
       Pragma:
       - no-cache
       Server:
@@ -3751,19 +3897,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "80"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:32 GMT
       Pragma:
       - no-cache
       Server:
@@ -3785,19 +3934,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "81"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:38 GMT
       Pragma:
       - no-cache
       Server:
@@ -3819,19 +3971,22 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "82"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","documentEndpoint":"https://k8sinfratestdbhmayhx-westus.documents.azure.com:443/","provisioningState":"Deleting","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"k8sinfratestdbhmayhx-westus","locationName":"West
+      US","failoverPriority":0}],"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:43 GMT
       Pragma:
       - no-cache
       Server:
@@ -3853,19 +4008,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "83"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2021-01-21T23:45:30.2444381Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"instanceId":"be52cc07-6378-4a29-a5c8-9d7d7a694291","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8}}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx","name":"k8sinfratestdbhmayhx","location":"West
+      US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting","documentEndpoint":"https://k8sinfratestdbhmayhx.documents.azure.com:443/","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":null,"instanceId":"832b164e-23c4-4295-9906-ed6f0cb30801","createMode":"Default","databaseAccountOfferType":"Standard","ipRangeFilter":"","consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"cors":[],"capabilities":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}}}}'
     headers:
       Cache-Control:
       - no-store, no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:49 GMT
       Pragma:
       - no-cache
       Server:
@@ -3887,12 +4041,14 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "84"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"code":"NotFound","message":"Entity with the specified id does not exist in the system. More info: https://aka.ms/cosmosdb-tsg-not-found\r\nActivityId: 85e9dd78-5cfb-48f4-b42f-45b48e070436, Microsoft.Azure.Documents.Common/2.11.0"}'
+    body: '{"code":"NotFound","message":"Entity with the specified id does not exist
+      in the system. More info: https://aka.ms/cosmosdb-tsg-not-found\r\nActivityId:
+      b452abf8-43c9-46ea-b4a8-103e5654e475, Microsoft.Azure.Documents.Common/2.11.0"}'
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -3900,8 +4056,6 @@ interactions:
       - "232"
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:53:55 GMT
       Pragma:
       - no-cache
       Server:
@@ -3921,31 +4075,31 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "85"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-dnhfns/providers/Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx?api-version=2015-04-08
     method: GET
   response:
-    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.DocumentDB/databaseAccounts/k8sinfratestdbhmayhx'' under resource group ''k8sinfratest-rg-dnhfns'' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    body: '{"code":"NotFound","message":"Entity with the specified id does not exist
+      in the system. More info: https://aka.ms/cosmosdb-tsg-not-found\r\nActivityId:
+      3d0e5061-64fa-470a-8c9b-4158ffabb083, Microsoft.Azure.Documents.Common/2.11.0"}'
     headers:
       Cache-Control:
-      - no-cache
+      - no-store, no-cache
       Content-Length:
-      - "252"
+      - "232"
       Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:53:58 GMT
-      Expires:
-      - "-1"
+      - application/json
       Pragma:
       - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
-      X-Ms-Failure-Cause:
-      - gateway
+      X-Ms-Gatewayversion:
+      - version=2.11.0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/hack/generated/controllers/recordings/Test_ResourceGroup_CRUD.yaml
+++ b/hack/generated/controllers/recordings/Test_ResourceGroup_CRUD.yaml
@@ -2,28 +2,28 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-qwiiib","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-qwiiib'')]"}}}}}'
+    body: '{"name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-qwiiib","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'',
+      ''k8sinfratest-rg-qwiiib'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.7341525Z","duration":"PT4.4302615S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"15088721381488290909","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.5226034S","correlationId":"1c8968bf-f27f-4d2b-ac11-6664054dd6d9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93/operationStatuses/08585903342251737096?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93/operationStatuses/08585802289229303796?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "690"
+      - "691"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -41,19 +41,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.7461519Z","duration":"PT5.4422609S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"15088721381488290909","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.5226034S","correlationId":"1c8968bf-f27f-4d2b-ac11-6664054dd6d9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -75,19 +74,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.7461519Z","duration":"PT5.4422609S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"15088721381488290909","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT5.7607377S","correlationId":"1c8968bf-f27f-4d2b-ac11-6664054dd6d9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -109,19 +107,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.7461519Z","duration":"PT5.4422609S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"15088721381488290909","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT5.7607377S","correlationId":"1c8968bf-f27f-4d2b-ac11-6664054dd6d9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -143,19 +140,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"5128840256894583251","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:30.953782Z","duration":"PT10.649891S","correlationId":"d6b76128-f5ac-4e99-b953-e4bf7572c929","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-qwiiib"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","name":"k8s_390d4616-0b35-57d1-93a0-7d00b1542d93","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"15088721381488290909","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT13.1682009S","correlationId":"1c8968bf-f27f-4d2b-ac11-6664054dd6d9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-qwiiib"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -175,19 +171,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Succeeded"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -207,8 +201,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_390d4616-0b35-57d1-93a0-7d00b1542d93?api-version=2019-10-01
     method: DELETE
   response:
@@ -218,8 +212,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:44:37 GMT
       Expires:
       - "-1"
       Location:
@@ -233,7 +225,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14997"
+      - "14995"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -243,8 +235,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: DELETE
   response:
@@ -254,8 +246,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:44:40 GMT
       Expires:
       - "-1"
       Location:
@@ -269,7 +259,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14996"
+      - "14994"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -279,19 +269,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:40 GMT
       Expires:
       - "-1"
       Pragma:
@@ -311,19 +299,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:45 GMT
       Expires:
       - "-1"
       Pragma:
@@ -343,19 +329,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:50 GMT
       Expires:
       - "-1"
       Pragma:
@@ -375,19 +359,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "4"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:55 GMT
       Expires:
       - "-1"
       Pragma:
@@ -407,19 +389,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "5"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:00 GMT
       Expires:
       - "-1"
       Pragma:
@@ -439,19 +419,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "6"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -471,19 +449,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "7"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib","name":"k8sinfratest-rg-qwiiib","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:10 GMT
       Expires:
       - "-1"
       Pragma:
@@ -503,12 +479,13 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "8"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''k8sinfratest-rg-qwiiib'' could not be found."}}'
+    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''k8sinfratest-rg-qwiiib''
+      could not be found."}}'
     headers:
       Cache-Control:
       - no-cache
@@ -516,8 +493,6 @@ interactions:
       - "114"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:15 GMT
       Expires:
       - "-1"
       Pragma:
@@ -537,12 +512,13 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "9"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-qwiiib?api-version=2020-06-01
     method: GET
   response:
-    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''k8sinfratest-rg-qwiiib'' could not be found."}}'
+    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''k8sinfratest-rg-qwiiib''
+      could not be found."}}'
     headers:
       Cache-Control:
       - no-cache
@@ -550,8 +526,6 @@ interactions:
       - "114"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:18 GMT
       Expires:
       - "-1"
       Pragma:

--- a/hack/generated/controllers/recordings/Test_ServiceBus_Namespace_CRUD.yaml
+++ b/hack/generated/controllers/recordings/Test_ServiceBus_Namespace_CRUD.yaml
@@ -2,28 +2,28 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-kjqcwl","location":"westus","tags":{"CreatedAt":"2021-02-23T01:13:05Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-kjqcwl'')]"}}}}}'
+    body: '{"name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-kjqcwl","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'',
+      ''k8sinfratest-rg-kjqcwl'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11952241110080882671","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-02-23T01:13:07.3752609Z","duration":"PT1.3724779S","correlationId":"996e0c75-587d-4090-accf-30ed6a1a5579","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11025040236009672208","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT3.201352S","correlationId":"b4ffc5ab-9906-4688-826c-e344d474a8eb","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8/operationStatuses/08585875640994748288?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8/operationStatuses/08585802244095912358?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "691"
+      - "690"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:07 GMT
       Expires:
       - "-1"
       Pragma:
@@ -41,19 +41,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11952241110080882671","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-02-23T01:13:07.3752609Z","duration":"PT1.3724779S","correlationId":"996e0c75-587d-4090-accf-30ed6a1a5579","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11025040236009672208","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT3.201352S","correlationId":"b4ffc5ab-9906-4688-826c-e344d474a8eb","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:07 GMT
       Expires:
       - "-1"
       Pragma:
@@ -75,19 +74,84 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11952241110080882671","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-02-23T01:13:09.5485151Z","duration":"PT3.5457321S","correlationId":"996e0c75-587d-4090-accf-30ed6a1a5579","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-kjqcwl"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11025040236009672208","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.2856332S","correlationId":"b4ffc5ab-9906-4688-826c-e344d474a8eb","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:12 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "2"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11025040236009672208","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.2856332S","correlationId":"b4ffc5ab-9906-4688-826c-e344d474a8eb","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "3"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","name":"k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"11025040236009672208","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT11.7665526S","correlationId":"b4ffc5ab-9906-4688-826c-e344d474a8eb","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-kjqcwl"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
       Pragma:
@@ -107,19 +171,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl","name":"k8sinfratest-rg-kjqcwl","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-02-23T01:13:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl","name":"k8sinfratest-rg-kjqcwl","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:12 GMT
       Expires:
       - "-1"
       Pragma:
@@ -139,8 +201,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_0ddcb220-cb5d-530a-b057-58a6a315ece8?api-version=2019-10-01
     method: DELETE
   response:
@@ -150,8 +212,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Tue, 23 Feb 2021 01:13:13 GMT
       Expires:
       - "-1"
       Location:
@@ -165,33 +225,33 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14999"
+      - "14998"
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2018-01-01-preview","location":"westus","name":"k8sinfratest-sbnamespace-kbvici","properties":{"zoneRedundant":false},"sku":{"name":"Basic"},"type":"Microsoft.ServiceBus/namespaces"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.ServiceBus/namespaces'', ''k8sinfratest-sbnamespace-kbvici'')]"}}}}}'
+    body: '{"name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2018-01-01-preview","location":"westus","name":"k8sinfratest-sbnamespace-kbvici","properties":{"zoneRedundant":false},"sku":{"name":"Basic"},"type":"Microsoft.ServiceBus/namespaces"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.ServiceBus/namespaces'',
+      ''k8sinfratest-sbnamespace-kbvici'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-02-23T01:13:16.0025419Z","duration":"PT0.2417835S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.7011366S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999/operationStatuses/08585875640897168566?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999/operationStatuses/08585802243928755978?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "706"
+      - "705"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:16 GMT
       Expires:
       - "-1"
       Pragma:
@@ -209,19 +269,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:16.2548472Z","duration":"PT0.4940888S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.7011366S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:16 GMT
       Expires:
       - "-1"
       Pragma:
@@ -243,19 +302,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:16.2548472Z","duration":"PT0.4940888S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.9109551S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:16 GMT
       Expires:
       - "-1"
       Pragma:
@@ -277,25 +335,24 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:19.0457892Z","duration":"PT3.2850308S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.9109551S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:21 GMT
       Expires:
       - "-1"
       Pragma:
       - no-cache
       Retry-After:
-      - "14"
+      - "5"
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -311,53 +368,216 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:19.0457892Z","duration":"PT3.2850308S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.9109551S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:26 GMT
       Expires:
       - "-1"
       Pragma:
       - no-cache
       Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "4"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT9.7591587S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "12"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "5"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT9.7591587S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "6"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "6"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT9.7591587S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "7"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT26.8534554S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "13"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "8"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT26.8534554S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "7"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
       - "9"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:19.0457892Z","duration":"PT3.2850308S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT26.8534554S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:31 GMT
       Expires:
       - "-1"
       Pragma:
@@ -379,19 +599,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "10"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:34.8346841Z","duration":"PT19.0739257S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT45.215844S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:36 GMT
       Expires:
       - "-1"
       Pragma:
@@ -413,121 +632,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "11"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:34.8346841Z","duration":"PT19.0739257S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT45.215844S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:41 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "9"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:34.8346841Z","duration":"PT19.0739257S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:46 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:51.1511105Z","duration":"PT35.3903521S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:51 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "15"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:51.1511105Z","duration":"PT35.3903521S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:13:56 GMT
       Expires:
       - "-1"
       Pragma:
@@ -549,19 +665,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "12"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:51.1511105Z","duration":"PT35.3903521S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT45.215844S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:02 GMT
       Expires:
       - "-1"
       Pragma:
@@ -583,53 +698,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "13"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-02-23T01:13:51.1511105Z","duration":"PT35.3903521S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT1M1.9624486S","correlationId":"bb7b1307-3483-494b-be40-b2f6ec7a804f","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:07 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","name":"k8s_5b3a7c53-665f-57f5-b02a-b01a67869999","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17196901949599015128","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-02-23T01:14:08.3706375Z","duration":"PT52.6098791S","correlationId":"57a3cc46-c2e1-414f-a368-09e3aed71ebf","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:12 GMT
       Expires:
       - "-1"
       Pragma:
@@ -649,19 +729,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2021-02-23T01:13:18.347Z","updatedAt":"2021-02-23T01:14:02.883Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Active"}}'
+    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West
+      US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Active"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:12 GMT
       Expires:
       - "-1"
       Pragma:
@@ -686,8 +765,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_5b3a7c53-665f-57f5-b02a-b01a67869999?api-version=2019-10-01
     method: DELETE
   response:
@@ -697,8 +776,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Tue, 23 Feb 2021 01:14:13 GMT
       Expires:
       - "-1"
       Location:
@@ -712,33 +789,33 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14998"
+      - "14997"
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2018-01-01-preview","location":"westus","name":"k8sinfratest-sbnamespace-kbvici/k8sinfratest-queue-yvjdug","properties":{},"type":"Microsoft.ServiceBus/namespaces/queues"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.ServiceBus/namespaces/queues'', ''k8sinfratest-sbnamespace-kbvici'', ''k8sinfratest-queue-yvjdug'')]"}}}}}'
+    body: '{"name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2018-01-01-preview","location":"westus","name":"k8sinfratest-sbnamespace-kbvici/k8sinfratest-queue-yvjdug","properties":{},"type":"Microsoft.ServiceBus/namespaces/queues"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.ServiceBus/namespaces/queues'',
+      ''k8sinfratest-sbnamespace-kbvici'', ''k8sinfratest-queue-yvjdug'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-02-23T01:14:15.8944083Z","duration":"PT0.2448808S","correlationId":"c6d24149-a07a-4d5d-a52f-fd5e02ae55db","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.5782876S","correlationId":"8be58333-ee21-4033-bac1-bf5e5764a116","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8/operationStatuses/08585875640298280841?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8/operationStatuses/08585802243280047454?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
       - "712"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:15 GMT
       Expires:
       - "-1"
       Pragma:
@@ -756,19 +833,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-02-23T01:14:15.8944083Z","duration":"PT0.2448808S","correlationId":"c6d24149-a07a-4d5d-a52f-fd5e02ae55db","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.5782876S","correlationId":"8be58333-ee21-4033-bac1-bf5e5764a116","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:15 GMT
       Expires:
       - "-1"
       Pragma:
@@ -790,19 +866,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-02-23T01:14:15.8944083Z","duration":"PT0.2448808S","correlationId":"c6d24149-a07a-4d5d-a52f-fd5e02ae55db","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT3.2610479S","correlationId":"8be58333-ee21-4033-bac1-bf5e5764a116","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:15 GMT
       Expires:
       - "-1"
       Pragma:
@@ -824,19 +899,51 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-02-23T01:14:20.5937199Z","duration":"PT4.9441924S","correlationId":"c6d24149-a07a-4d5d-a52f-fd5e02ae55db","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT3.2610479S","correlationId":"8be58333-ee21-4033-bac1-bf5e5764a116","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:20 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "3"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","name":"k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8","type":"Microsoft.Resources/deployments","properties":{"templateHash":"6567870679770762102","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT8.8269119S","correlationId":"8be58333-ee21-4033-bac1-bf5e5764a116","providers":[{"namespace":"Microsoft.ServiceBus","resourceTypes":[{"resourceType":"namespaces/queues","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
       Pragma:
@@ -856,19 +963,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug","name":"k8sinfratest-queue-yvjdug","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P14D","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2021-02-23T01:14:19.037Z","updatedAt":"2021-02-23T01:14:19.07Z","accessedAt":"0001-01-01T00:00:00Z"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug","name":"k8sinfratest-queue-yvjdug","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
+      US","properties":{"lockDuration":"PT1M","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P14D","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","accessedAt":"2001-02-03T04:05:06Z"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:21 GMT
       Expires:
       - "-1"
       Pragma:
@@ -893,8 +999,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.Resources/deployments/k8s_12f949fe-2f0f-5dbc-86f9-16ac18e450d8?api-version=2019-10-01
     method: DELETE
   response:
@@ -904,8 +1010,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Tue, 23 Feb 2021 01:14:21 GMT
       Expires:
       - "-1"
       Location:
@@ -919,7 +1023,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14997"
+      - "14996"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -929,8 +1033,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug?api-version=2018-01-01-preview
     method: DELETE
   response:
@@ -940,8 +1044,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Tue, 23 Feb 2021 01:14:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -956,7 +1058,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14996"
+      - "14999"
     status: 200 OK
     code: 200
     duration: ""
@@ -966,12 +1068,13 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici/queues/k8sinfratest-queue-yvjdug?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"error":{"message":"The requested resource k8sinfratest-queue-yvjdug does not exist. CorrelationId: 5322f74c-4b46-4433-8924-05edc70fcc53","code":"NotFound"}}'
+    body: '{"error":{"message":"The requested resource k8sinfratest-queue-yvjdug does
+      not exist. CorrelationId: 9deff4d3-4ed1-4e2a-b378-785356dc3bb6","code":"NotFound"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -979,8 +1082,6 @@ interactions:
       - "158"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:27 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1003,8 +1104,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: DELETE
   response:
@@ -1014,8 +1115,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Tue, 23 Feb 2021 01:14:30 GMT
       Expires:
       - "-1"
       Location:
@@ -1032,7 +1131,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14995"
+      - "14998"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1042,19 +1141,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2021-02-23T01:13:18.347Z","updatedAt":"2021-02-23T01:14:30.923Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
+    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West
+      US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1079,19 +1177,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2021-02-23T01:13:18.347Z","updatedAt":"2021-02-23T01:14:30.923Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
+    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West
+      US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1116,19 +1213,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2021-02-23T01:13:18.347Z","updatedAt":"2021-02-23T01:14:30.923Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
+    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West
+      US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:41 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1153,19 +1249,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "4"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2021-02-23T01:13:18.347Z","updatedAt":"2021-02-23T01:14:30.923Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
+    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West
+      US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:46 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1190,19 +1285,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "5"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2021-02-23T01:13:18.347Z","updatedAt":"2021-02-23T01:14:30.923Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
+    body: '{"sku":{"name":"Basic","tier":"Basic"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici","name":"k8sinfratest-sbnamespace-kbvici","type":"Microsoft.ServiceBus/Namespaces","location":"West
+      US","tags":{},"properties":{"zoneRedundant":false,"provisioningState":"Succeeded","metricId":"00000000-0000-0000-0000-000000000000:k8sinfratest-sbnamespace-kbvici","createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","serviceBusEndpoint":"https://k8sinfratest-sbnamespace-kbvici.servicebus.windows.net:443/","status":"Removing"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:51 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1227,12 +1321,12 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "6"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"error":{"message":"Namespace does not exist. CorrelationId: 819951b0-6fba-41de-84a9-3aada7146364","code":"NotFound"}}'
+    body: '{"error":{"message":"Namespace does not exist. CorrelationId: b056672e-e975-41a6-ab81-fd55f642a84f","code":"NotFound"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1240,8 +1334,6 @@ interactions:
       - "119"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:56 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1264,12 +1356,12 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.14.2 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "7"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl/providers/Microsoft.ServiceBus/namespaces/k8sinfratest-sbnamespace-kbvici?api-version=2018-01-01-preview
     method: GET
   response:
-    body: '{"error":{"message":"Namespace does not exist. CorrelationId: 46268b70-b264-45f9-9744-ec570488522f","code":"NotFound"}}'
+    body: '{"error":{"message":"Namespace does not exist. CorrelationId: 19d82d77-093c-4b30-923d-709aac1c8952","code":"NotFound"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1277,8 +1369,6 @@ interactions:
       - "119"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Tue, 23 Feb 2021 01:14:59 GMT
       Expires:
       - "-1"
       Pragma:

--- a/hack/generated/controllers/recordings/Test_StorageAccount_CRUD.yaml
+++ b/hack/generated/controllers/recordings/Test_StorageAccount_CRUD.yaml
@@ -2,28 +2,28 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-ewlqsf","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'', ''k8sinfratest-rg-ewlqsf'')]"}}}}}'
+    body: '{"name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-ewlqsf","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"type":"Microsoft.Resources/resourceGroups"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Resources/resourceGroups'',
+      ''k8sinfratest-rg-ewlqsf'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.6184114Z","duration":"PT4.3147732S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"4463076971267164984","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT3.7090715S","correlationId":"3c128c7f-c959-4c20-909b-4a61969eaa18","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e/operationStatuses/08585903342251739651?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e/operationStatuses/08585802289225113060?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "691"
+      - "690"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -41,19 +41,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:24.6184114Z","duration":"PT4.3147732S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"4463076971267164984","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.6053403S","correlationId":"3c128c7f-c959-4c20-909b-4a61969eaa18","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:25 GMT
       Expires:
       - "-1"
       Pragma:
@@ -75,19 +74,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.9167545Z","duration":"PT5.6131163S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"4463076971267164984","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.6053403S","correlationId":"3c128c7f-c959-4c20-909b-4a61969eaa18","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -109,19 +107,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:25.9167545Z","duration":"PT5.6131163S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"4463076971267164984","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.6053403S","correlationId":"3c128c7f-c959-4c20-909b-4a61969eaa18","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:30 GMT
       Expires:
       - "-1"
       Pragma:
@@ -143,19 +140,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"13595365891663933550","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:35.3534202Z","duration":"PT15.049782S","correlationId":"488e77fc-cef6-42ab-b42e-e88c3134da33","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-ewlqsf"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","name":"k8s_1e2aa8d6-8708-5041-983c-bf90493b733e","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"4463076971267164984","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT11.5660454S","correlationId":"3c128c7f-c959-4c20-909b-4a61969eaa18","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/resourceGroups/k8sinfratest-rg-ewlqsf"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -175,19 +171,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf","name":"k8sinfratest-rg-ewlqsf","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2021-01-21T23:44:14Z"},"properties":{"provisioningState":"Succeeded"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf","name":"k8sinfratest-rg-ewlqsf","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:35 GMT
       Expires:
       - "-1"
       Pragma:
@@ -207,8 +201,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8s_1e2aa8d6-8708-5041-983c-bf90493b733e?api-version=2019-10-01
     method: DELETE
   response:
@@ -218,250 +212,10 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:44:37 GMT
       Expires:
       - "-1"
       Location:
       - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtLUs4Uzo1RjFFMkFBOEQ2OjJEODcwODoyRDUwNDE6MkQ5ODNDOjJEQkY5MDQ5M0I3MzNFLSIsImpvYkxvY2F0aW9uIjoid2VzdHVzIn0?api-version=2019-10-01
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "15"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14997"
-    status: 202 Accepted
-    code: 202
-    duration: ""
-- request:
-    body: '{"name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","kind":"BlobStorage","location":"westus","name":"k8sinfrateststorgiatzw","properties":{"accessTier":"Hot"},"sku":{"name":"Standard_LRS"},"type":"Microsoft.Storage/storageAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts'', ''k8sinfrateststorgiatzw'')]"}}}}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: PUT
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:40.722357Z","duration":"PT0.8355482S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e/operationStatuses/08585903342055908086?api-version=2019-10-01
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:40 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.7145561Z","duration":"PT1.8277473S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:41 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.7145561Z","duration":"PT1.8277473S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:41 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:41.7145561Z","duration":"PT1.8277473S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:46 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "5"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:48.2432957Z","duration":"PT8.3564869S","correlationId":"31881e74-c7db-4e37-95fb-f4eb46b75ba2","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:51 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
-    method: GET
-  response:
-    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"BlobStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw","name":"k8sinfrateststorgiatzw","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2021-01-21T23:40:47.7757946Z"},"blob":{"enabled":true,"lastEnabledTime":"2021-01-21T23:40:47.7757946Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2021-01-21T23:40:47.6820376Z","primaryEndpoints":{"dfs":"https://k8sinfrateststorgiatzw.dfs.core.windows.net/","blob":"https://k8sinfrateststorgiatzw.blob.core.windows.net/","table":"https://k8sinfrateststorgiatzw.table.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:44:51 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:44:53 GMT
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtSzhTSU5GUkFURVNUOjJEUkc6MkRFV0xRU0YtSzhTOjVGN0I0RDkzNEM6MkQ5MTgxOjJENTJFNjoyRDkxMkM6MkQ2N0MxMDhBMzJDM0UtIiwiam9iTG9jYXRpb24iOiJ3ZXN0dXMifQ?api-version=2019-10-01
       Pragma:
       - no-cache
       Retry-After:
@@ -476,28 +230,28 @@ interactions:
     code: 202
     duration: ""
 - request:
-    body: '{"name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default","type":"Microsoft.Storage/storageAccounts/blobServices"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices'', ''k8sinfrateststorgiatzw'', ''default'')]"}}}}}'
+    body: '{"name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","kind":"BlobStorage","location":"westus","name":"k8sinfrateststorgiatzw","properties":{"accessTier":"Hot"},"sku":{"name":"Standard_LRS"},"type":"Microsoft.Storage/storageAccounts"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts'',
+      ''k8sinfrateststorgiatzw'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:44:55.2354202Z","duration":"PT0.7424773S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.8130626S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef/operationStatuses/08585903341909846619?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e/operationStatuses/08585802289028036943?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "717"
+      - "708"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:55 GMT
       Expires:
       - "-1"
       Pragma:
@@ -510,58 +264,23 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default","type":"Microsoft.Storage/storageAccounts/blobServices"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices'', ''k8sinfrateststorgiatzw'', ''default'')]"}}}}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
-    method: PUT
-  response:
-    body: '{"error":{"code":"DeploymentActive","message":"Unable to edit or replace deployment ''k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef'': previous deployment from ''1/21/2021 11:44:55 PM'' is still active (expiration time is ''1/28/2021 11:44:54 PM''). Please see https://aka.ms/arm-deploy for usage details."}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "297"
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:55 GMT
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Failure-Cause:
-      - gateway
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.9586818Z","duration":"PT1.4657389S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.8130626S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:56 GMT
       Expires:
       - "-1"
       Pragma:
@@ -583,19 +302,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+      Test-Request-Attempt:
+      - "1"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:44:55.9586818Z","duration":"PT1.4657389S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.6426706S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:44:56 GMT
       Expires:
       - "-1"
       Pragma:
@@ -617,19 +335,216 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+      Test-Request-Attempt:
+      - "2"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:44:59.2547469Z","duration":"PT4.761804S","correlationId":"9d183ed2-dae4-40a4-bf43-910f1dd071c9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.6426706S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:00 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "3"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.6426706S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "4"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT12.6646486S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "16"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "5"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT12.6646486S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "11"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "6"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT12.6646486S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "7"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT12.6646486S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "8"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","name":"k8s_7b4d934c-9181-52e6-912c-67c108a32c3e","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10656703011749167364","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT36.2114176S","correlationId":"5b6b95de-ba0d-42d0-80b5-7006199dfdad","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["westus"]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
       Pragma:
@@ -649,19 +564,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default?api-version=2019-04-01
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/blobServices","properties":{"cors":{"corsRules":[]},"deleteRetentionPolicy":{"enabled":false}}}'
+    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"BlobStorage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw","name":"k8sinfrateststorgiatzw","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"},"blob":{"enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2001-02-03T04:05:06Z","primaryEndpoints":{"dfs":"https://k8sinfrateststorgiatzw.dfs.core.windows.net/","blob":"https://k8sinfrateststorgiatzw.blob.core.windows.net/","table":"https://k8sinfrateststorgiatzw.table.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:45:01 GMT
       Expires:
       - "-1"
       Pragma:
@@ -683,8 +596,238 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_7b4d934c-9181-52e6-912c-67c108a32c3e?api-version=2019-10-01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "0"
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/operationresults/eyJqb2JJZCI6IkRlcGxveW1lbnREZWxldGlvbkpvYi1HTlMtSzhTSU5GUkFURVNUOjJEUkc6MkRFV0xRU0YtSzhTOjVGN0I0RDkzNEM6MkQ5MTgxOjJENTJFNjoyRDkxMkM6MkQ2N0MxMDhBMzJDM0UtIiwiam9iTG9jYXRpb24iOiJ3ZXN0dXMifQ?api-version=2019-10-01
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Ratelimit-Remaining-Subscription-Deletes:
+      - "14989"
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: '{"name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default","type":"Microsoft.Storage/storageAccounts/blobServices"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices'',
+      ''k8sinfrateststorgiatzw'', ''default'')]"}}}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: PUT
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.7218862S","correlationId":"2b199669-fbe1-4ae8-bd49-71993f0e8eb9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    headers:
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef/operationStatuses/08585802288630934048?api-version=2019-10-01
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "717"
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.7218862S","correlationId":"2b199669-fbe1-4ae8-bd49-71993f0e8eb9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "1"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.5421401S","correlationId":"2b199669-fbe1-4ae8-bd49-71993f0e8eb9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "2"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.5421401S","correlationId":"2b199669-fbe1-4ae8-bd49-71993f0e8eb9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "3"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","name":"k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef","type":"Microsoft.Resources/deployments","properties":{"templateHash":"14644625414381836457","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT6.2519073S","correlationId":"2b199669-fbe1-4ae8-bd49-71993f0e8eb9","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default?api-version=2019-04-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/blobServices","properties":{"cors":{"corsRules":[]},"deleteRetentionPolicy":{"enabled":false}}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_38cdf7b5-24aa-54c3-87df-f7da086033ef?api-version=2019-10-01
     method: DELETE
   response:
@@ -694,8 +837,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:45:03 GMT
       Expires:
       - "-1"
       Location:
@@ -709,33 +850,33 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14994"
+      - "14988"
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default/k8sinfratest-container-ntusgr","type":"Microsoft.Storage/storageAccounts/blobServices/containers"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices/containers'', ''k8sinfrateststorgiatzw'', ''default'', ''k8sinfratest-container-ntusgr'')]"}}}}}'
+    body: '{"name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2019-04-01","name":"k8sinfrateststorgiatzw/default/k8sinfratest-container-ntusgr","type":"Microsoft.Storage/storageAccounts/blobServices/containers"}],"outputs":{"resourceId":{"type":"string","value":"[resourceId(''Microsoft.Storage/storageAccounts/blobServices/containers'',
+      ''k8sinfrateststorgiatzw'', ''default'', ''k8sinfratest-container-ntusgr'')]"}}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2021-01-21T23:45:05.2236792Z","duration":"PT0.7133481S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT0.5908458S","correlationId":"adc7624e-f233-4696-8a42-db62d0ca71f1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a/operationStatuses/08585903341809672774?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a/operationStatuses/08585802288480653576?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Length:
       - "727"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -753,19 +894,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:05.8898399Z","duration":"PT1.3795088S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.2834719S","correlationId":"adc7624e-f233-4696-8a42-db62d0ca71f1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -787,19 +927,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2021-01-21T23:45:05.8898399Z","duration":"PT1.3795088S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.2834719S","correlationId":"adc7624e-f233-4696-8a42-db62d0ca71f1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:05 GMT
       Expires:
       - "-1"
       Pragma:
@@ -821,19 +960,51 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2021-01-21T23:45:06.8927877Z","duration":"PT2.3824566S","correlationId":"a2699b98-bb66-4032-a1c8-985a7a70c346","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT1.2834719S","correlationId":"adc7624e-f233-4696-8a42-db62d0ca71f1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:10 GMT
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "5"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "3"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","name":"k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a","type":"Microsoft.Resources/deployments","properties":{"templateHash":"8405540082520381987","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT5.8367617S","correlationId":"adc7624e-f233-4696-8a42-db62d0ca71f1","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts/blobServices/containers","locations":[null]}]}],"dependencies":[],"outputs":{"resourceId":{"type":"String","value":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
       Pragma:
@@ -853,21 +1024,19 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr?api-version=2019-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr","name":"k8sinfratest-container-ntusgr","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8D8BE6694CC917A\"","properties":{"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2021-01-21T23:45:06.0000000Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr","name":"k8sinfratest-container-ntusgr","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8D91A4EE6A23157\"","properties":{"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2001-02-03T04:05:06Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:45:10 GMT
       Etag:
-      - '"0x8D8BE6694CC917A"'
+      - '"0x8D91A4EE6A23157"'
       Expires:
       - "-1"
       Pragma:
@@ -889,8 +1058,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Resources/deployments/k8s_854dcd17-12e8-5b6c-b7a6-25298d2f652a?api-version=2019-10-01
     method: DELETE
   response:
@@ -900,8 +1069,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Thu, 21 Jan 2021 23:45:12 GMT
       Expires:
       - "-1"
       Location:
@@ -915,7 +1082,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14993"
+      - "14987"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -925,8 +1092,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr?api-version=2019-04-01
     method: DELETE
   response:
@@ -938,8 +1105,6 @@ interactions:
       - "0"
       Content-Type:
       - text/plain; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:13 GMT
       Expires:
       - "-1"
       Pragma:
@@ -951,7 +1116,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14992"
+      - "14986"
     status: 200 OK
     code: 200
     duration: ""
@@ -961,12 +1126,13 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw/blobServices/default/containers/k8sinfratest-container-ntusgr?api-version=2019-04-01
     method: GET
   response:
-    body: '{"error":{"code":"ContainerNotFound","message":"The specified container does not exist.\nRequestId:eaa0d743-a01e-0025-4f4f-f0f0b4000000\nTime:2021-01-21T23:45:15.3623348Z"}}'
+    body: '{"error":{"code":"ContainerNotFound","message":"The specified container
+      does not exist.\nRequestId:4f0424d8-d01e-002c-7b37-4c9ead000000\nTime:2001-02-03T04:05:06Z"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -974,8 +1140,6 @@ interactions:
       - "173"
       Content-Type:
       - application/json
-      Date:
-      - Thu, 21 Jan 2021 23:45:14 GMT
       Expires:
       - "-1"
       Pragma:
@@ -995,8 +1159,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
     method: DELETE
   response:
@@ -1008,8 +1172,6 @@ interactions:
       - "0"
       Content-Type:
       - text/plain; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:24 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1021,7 +1183,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14991"
+      - "14985"
     status: 200 OK
     code: 200
     duration: ""
@@ -1031,12 +1193,14 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
     method: GET
   response:
-    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw'' under resource group ''k8sinfratest-rg-ewlqsf'' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw''
+      under resource group ''k8sinfratest-rg-ewlqsf'' was not found. For more details
+      please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1044,8 +1208,6 @@ interactions:
       - "250"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:24 GMT
       Expires:
       - "-1"
       Pragma:
@@ -1065,12 +1227,14 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.6 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-ewlqsf/providers/Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw?api-version=2019-04-01
     method: GET
   response:
-    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw'' under resource group ''k8sinfratest-rg-ewlqsf'' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Storage/storageAccounts/k8sinfrateststorgiatzw''
+      under resource group ''k8sinfratest-rg-ewlqsf'' was not found. For more details
+      please go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1078,8 +1242,6 @@ interactions:
       - "250"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 21 Jan 2021 23:45:29 GMT
       Expires:
       - "-1"
       Pragma:

--- a/hack/generated/pkg/armclient/recordings/Test_NewResourceGroupDeployment.yaml
+++ b/hack/generated/pkg/armclient/recordings/Test_NewResourceGroupDeployment.yaml
@@ -2,26 +2,25 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8sinfratest-deployment-cbdeue","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-neasns","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"type":"Microsoft.Resources/resourceGroups"}]}}}'
+    body: '{"name":"k8sinfratest-deployment-cbdeue","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-neasns","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"type":"Microsoft.Resources/resourceGroups"}]}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2271546588852531505","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-09T23:02:59.9652193Z","duration":"PT3.8051375S","correlationId":"aaa34ff9-7ed5-4d24-99f3-33d1feb1600d","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2829459153152994322","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Accepted","timestamp":"2001-02-03T04:05:06Z","duration":"PT3.9778671S","correlationId":"79b29592-66b9-44fa-adb1-feabf02ea9c9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue/operationStatuses/08585966439093175267?api-version=2019-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue/operationStatuses/08585802289262272931?api-version=2019-10-01
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:00 GMT
       Expires:
       - "-1"
       Pragma:
@@ -41,19 +40,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2271546588852531505","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Accepted","timestamp":"2020-11-09T23:02:59.9652193Z","duration":"PT3.8051375S","correlationId":"aaa34ff9-7ed5-4d24-99f3-33d1feb1600d","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2829459153152994322","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.8286472S","correlationId":"79b29592-66b9-44fa-adb1-feabf02ea9c9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:01 GMT
       Expires:
       - "-1"
       Pragma:
@@ -75,19 +73,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2271546588852531505","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Running","timestamp":"2020-11-09T23:03:01.18263Z","duration":"PT5.0225482S","correlationId":"aaa34ff9-7ed5-4d24-99f3-33d1feb1600d","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2829459153152994322","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Running","timestamp":"2001-02-03T04:05:06Z","duration":"PT4.8286472S","correlationId":"79b29592-66b9-44fa-adb1-feabf02ea9c9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:06 GMT
       Expires:
       - "-1"
       Pragma:
@@ -109,19 +106,18 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue?api-version=2019-10-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2271546588852531505","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent, ResponseContent"},"provisioningState":"Succeeded","timestamp":"2020-11-09T23:03:08.1391879Z","duration":"PT11.9791061S","correlationId":"aaa34ff9-7ed5-4d24-99f3-33d1feb1600d","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns"}]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-cbdeue","name":"k8sinfratest-deployment-cbdeue","type":"Microsoft.Resources/deployments","location":"westus","properties":{"templateHash":"2829459153152994322","mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+      ResponseContent"},"provisioningState":"Succeeded","timestamp":"2001-02-03T04:05:06Z","duration":"PT10.6145878S","correlationId":"79b29592-66b9-44fa-adb1-feabf02ea9c9","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"resourceGroups","locations":["westus"]}]}],"dependencies":[],"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns"}]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:11 GMT
       Expires:
       - "-1"
       Pragma:
@@ -141,8 +137,8 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: DELETE
   response:
@@ -152,8 +148,6 @@ interactions:
       - no-cache
       Content-Length:
       - "0"
-      Date:
-      - Mon, 09 Nov 2020 23:03:14 GMT
       Expires:
       - "-1"
       Location:
@@ -167,7 +161,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Ratelimit-Remaining-Subscription-Deletes:
-      - "14998"
+      - "14999"
     status: 202 Accepted
     code: 202
     duration: ""
@@ -177,19 +171,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:14 GMT
       Expires:
       - "-1"
       Pragma:
@@ -209,19 +201,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:19 GMT
       Expires:
       - "-1"
       Pragma:
@@ -241,19 +231,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "2"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:24 GMT
       Expires:
       - "-1"
       Pragma:
@@ -273,19 +261,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:29 GMT
       Expires:
       - "-1"
       Pragma:
@@ -305,19 +291,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "4"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:34 GMT
       Expires:
       - "-1"
       Pragma:
@@ -337,19 +321,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "5"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:39 GMT
       Expires:
       - "-1"
       Pragma:
@@ -369,19 +351,17 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "6"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2020-11-09T23:02:52Z"},"properties":{"provisioningState":"Deleting"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns","name":"k8sinfratest-rg-neasns","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:44 GMT
       Expires:
       - "-1"
       Pragma:
@@ -401,12 +381,13 @@ interactions:
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "7"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-neasns?api-version=2020-06-01
     method: GET
   response:
-    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''k8sinfratest-rg-neasns'' could not be found."}}'
+    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''k8sinfratest-rg-neasns''
+      could not be found."}}'
     headers:
       Cache-Control:
       - no-cache
@@ -414,8 +395,6 @@ interactions:
       - "114"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:49 GMT
       Expires:
       - "-1"
       Pragma:

--- a/hack/generated/pkg/armclient/recordings/Test_NewResourceGroupDeployment_Error.yaml
+++ b/hack/generated/pkg/armclient/recordings/Test_NewResourceGroupDeployment_Error.yaml
@@ -2,26 +2,26 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"k8sinfratest-deployment-mzojax","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-kheqhf","location":"BadLocation","tags":{"CreatedAt":"2020-11-09T23:03:51Z"},"type":"Microsoft.Resources/resourceGroups"}]}}}'
+    body: '{"name":"k8sinfratest-deployment-mzojax","location":"westus","Properties":{"Error":null,"debugSetting":{"detailLevel":"requestContent,responseContent"},"mode":"Incremental","template":{"$schema":"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#","contentVersion":"1.0.0.0","resources":[{"apiVersion":"2020-06-01","name":"k8sinfratest-rg-kheqhf","location":"BadLocation","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"type":"Microsoft.Resources/resourceGroups"}]}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
-      User-Agent:
-      - Go/go1.15.3 (amd64-linux) go-autorest/v14.1.1 k8sinfra-generated
+      Test-Request-Attempt:
+      - "0"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Resources/deployments/k8sinfratest-deployment-mzojax?api-version=2019-10-01
     method: PUT
   response:
-    body: '{"error":{"code":"LocationNotAvailableForResourceGroup","message":"The provided location ''BadLocation'' is not available for resource group. List of available regions is ''centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,koreasouth,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast''."}}'
+    body: '{"error":{"code":"LocationNotAvailableForResourceGroup","message":"The
+      provided location ''BadLocation'' is not available for resource group. List
+      of available regions is ''centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,koreasouth,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast,jioindiawest''."}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "571"
+      - "584"
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Mon, 09 Nov 2020 23:03:49 GMT
       Expires:
       - "-1"
       Pragma:

--- a/hack/generated/pkg/testcommon/counting_roundtripper.go
+++ b/hack/generated/pkg/testcommon/counting_roundtripper.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package testcommon
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Wraps an inner HTTP roundtripper to add a
+// counter for duplicated request URIs. This
+// is then used to match up requests in the recorder
+// - it is needed as we have multiple requests with
+// the same Request URL and it will return the first
+// one that matches.
+type requestCounter struct {
+	inner  http.RoundTripper
+	counts map[string]uint32
+}
+
+func addCountHeader(inner http.RoundTripper) *requestCounter {
+	return &requestCounter{
+		inner:  inner,
+		counts: make(map[string]uint32),
+	}
+}
+
+var COUNT_HEADER string = "TEST-REQUEST-ATTEMPT"
+
+func (rt *requestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.Method + ":" + req.URL.String()
+	count := rt.counts[key]
+	req.Header.Add(COUNT_HEADER, fmt.Sprintf("%v", count))
+	rt.counts[key] = count + 1
+	return rt.inner.RoundTrip(req)
+}
+
+var _ http.RoundTripper = &requestCounter{}

--- a/hack/generated/pkg/testcommon/error_translating_roundtripper.go
+++ b/hack/generated/pkg/testcommon/error_translating_roundtripper.go
@@ -39,7 +39,7 @@ type errorTranslation struct {
 	cassette *cassette.Cassette
 }
 
-func (w errorTranslation) ensure_cassette() *cassette.Cassette {
+func (w errorTranslation) ensureCassette() *cassette.Cassette {
 	if w.cassette == nil {
 		cassette, err := cassette.Load(w.cassetteName)
 		if err != nil {
@@ -73,7 +73,7 @@ func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
 	// find all request bodies for the specified method/URL combination
 	urlString := req.URL.String()
 	var bodiesForMethodAndURL []string
-	for _, interaction := range w.ensure_cassette().Interactions {
+	for _, interaction := range w.ensureCassette().Interactions {
 		if urlString == interaction.URL && req.Method == interaction.Request.Method &&
 			req.Header.Get(COUNT_HEADER) == interaction.Request.Headers.Get(COUNT_HEADER) {
 			bodiesForMethodAndURL = append(bodiesForMethodAndURL, interaction.Request.Body)

--- a/hack/generated/pkg/testcommon/error_translating_roundtripper.go
+++ b/hack/generated/pkg/testcommon/error_translating_roundtripper.go
@@ -20,7 +20,7 @@ import (
 // and log better information about what the expected request was.
 //
 // By default the error will be returned to the controller which might ignore/retry it
-// and not log any useful information. So instead here we find  the recorded request with
+// and not log any useful information. So instead here we find the recorded request with
 // the body that most closely matches what was sent and report the "expected" body.
 //
 // Ideally we would panic on this error but we don't have a good way to deal with the following

--- a/hack/generated/pkg/testcommon/error_translating_roundtripper.go
+++ b/hack/generated/pkg/testcommon/error_translating_roundtripper.go
@@ -1,0 +1,100 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package testcommon
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/recorder"
+	"github.com/google/go-cmp/cmp"
+)
+
+// translateErrors wraps the given Recorder to handle any "Requested interaction not found"
+// and log better information about what the expected request was.
+//
+// By default the error will be returned to the controller which might ignore/retry it
+// and not log any useful information. So instead here we find  the recorded request with
+// the body that most closely matches what was sent and report the "expected" body.
+//
+// Ideally we would panic on this error but we don't have a good way to deal with the following
+// problem at the moment:
+// - during record the controller does GET (404), PUT, … GET (OK)
+// - during playback the controller does GET (which now returns OK), DELETE, PUT, …
+//   and fails due to a missing DELETE recording
+func translateErrors(r *recorder.Recorder, cassetteName string) http.RoundTripper {
+	return errorTranslation{r, cassetteName, nil}
+}
+
+type errorTranslation struct {
+	recorder     *recorder.Recorder
+	cassetteName string
+
+	cassette *cassette.Cassette
+}
+
+func (w errorTranslation) ensure_cassette() *cassette.Cassette {
+	if w.cassette == nil {
+		cassette, err := cassette.Load(w.cassetteName)
+		if err != nil {
+			panic(fmt.Sprintf("unable to load casette %q", w.cassetteName))
+		}
+
+		w.cassette = cassette
+	}
+
+	return w.cassette
+}
+
+func (w errorTranslation) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, originalErr := w.recorder.RoundTrip(req)
+	// sorry, go-vcr doesn't expose the error type or message
+	if originalErr == nil || !strings.Contains(originalErr.Error(), "interaction not found") {
+		return resp, originalErr
+	}
+
+	sentBodyString := "<nil>"
+	if req.Body != nil {
+		bodyBytes, bodyErr := io.ReadAll(req.Body)
+		if bodyErr != nil {
+			// see invocation of SetMatcher in the createRecorder, which does this
+			panic("io.ReadAll(req.Body) failed, this should always succeed because req.Body has been replaced by a buffer")
+		}
+
+		sentBodyString = string(bodyBytes)
+	}
+
+	// find all request bodies for the specified method/URL combination
+	urlString := req.URL.String()
+	var bodiesForMethodAndURL []string
+	for _, interaction := range w.ensure_cassette().Interactions {
+		if urlString == interaction.URL && req.Method == interaction.Request.Method &&
+			req.Header.Get(COUNT_HEADER) == interaction.Request.Headers.Get(COUNT_HEADER) {
+			bodiesForMethodAndURL = append(bodiesForMethodAndURL, interaction.Request.Body)
+			break
+		}
+	}
+
+	if len(bodiesForMethodAndURL) == 0 {
+		fmt.Printf("\n*** Cannot find go-vcr recording for request (no responses recorded for this method/URL): %s %s (attempt: %s)\n\n", req.Method, req.URL.String(), req.Header.Get(COUNT_HEADER))
+		return nil, originalErr
+	}
+
+	// locate the request body with the shortest diff from the sent body
+	shortestDiff := ""
+	for i, bodyString := range bodiesForMethodAndURL {
+		diff := cmp.Diff(sentBodyString, bodyString)
+		if i == 0 || len(diff) < len(shortestDiff) {
+			shortestDiff = diff
+		}
+	}
+
+	fmt.Printf("\n*** Cannot find go-vcr recording for request (body mismatch): %s %s\nShortest body diff: %s\n\n", req.Method, req.URL.String(), shortestDiff)
+	return nil, originalErr
+}

--- a/hack/generated/pkg/testcommon/kube_test_context_envtest.go
+++ b/hack/generated/pkg/testcommon/kube_test_context_envtest.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -137,33 +136,3 @@ func waitForWebhooks(env envtest.Environment) {
 		return
 	}
 }
-
-// Wraps an inner HTTP roundtripper to add a
-// counter for duplicated request URIs. This
-// is then used to match up requests in the recorder
-// - it is needed as we have multiple requests with
-// the same Request URL and it will return the first
-// one that matches.
-type requestCounter struct {
-	inner  http.RoundTripper
-	counts map[string]uint32
-}
-
-func MakeRoundTripper(inner http.RoundTripper) *requestCounter {
-	return &requestCounter{
-		inner:  inner,
-		counts: make(map[string]uint32),
-	}
-}
-
-var COUNT_HEADER string = "TEST-REQUEST-ATTEMPT"
-
-func (rt *requestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
-	key := req.Method + ":" + req.URL.String()
-	count := rt.counts[key]
-	req.Header.Add(COUNT_HEADER, fmt.Sprintf("%v", count))
-	rt.counts[key] = count + 1
-	return rt.inner.RoundTrip(req)
-}
-
-var _ http.RoundTripper = &requestCounter{}

--- a/hack/generated/pkg/testcommon/test_context.go
+++ b/hack/generated/pkg/testcommon/test_context.go
@@ -194,6 +194,7 @@ func createRecorder(cassetteName string, recordReplay bool) (autorest.Authorizer
 var dateMatcher *regexp.Regexp = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z`)
 
 // hideDates replaces all ISO8601 datetimes with a fixed value
+// this lets us match requests that may contain time-sensitive information (timestamps, etc)
 func hideDates(s string) string {
 	return dateMatcher.ReplaceAllLiteralString(s, "2001-02-03T04:05:06Z") // this should be recognizable/parseable as a fake date
 }


### PR DESCRIPTION
A few changes here:

### Check bodies in requests

This makes sure the request/response pair is for the correct request (by default, `go-vcr` only checks the HTTP method/URL). To achieve this we blank out any dates/timestamps that are found in bodies, since they cause a mismatch when the test is rerun.

### Fix "count" header addition

We had code to track the request count at a per-URL level so that we handle multiple requests to the same URL properly in recordings (so that a series of polling GETs can get back different responses, for example), but this was not being added properly. Now it is.

### Better messages when go-vcr interaction cannot be found

At the moment when running record/replay tests and an interaction (request+response) cannot be located, it is hard to figure out what went wrong. This PR adds a wrapper around the `go-vcr` code to add more context about what went wrong.

An example message in the output looks like:

```
*** Cannot find go-vcr recording for request (no responses recorded for this method/URL): DELETE https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/k8sinfratest-rg-kjqcwl?api-version=2020-06-01
```

Ideally we would `panic` when this happens, but we can't at the moment (the code explains why).

Closes #1432.

**How does this PR make you feel**:
![VCR error](https://media.giphy.com/media/yugSj8GSC0wXm/giphy.gif)

