### PR TITLE
Update webhook patch files to produce valid v1 CRDs

### DIFF
--- a/config/crd/patches/webhook_in_apimgmtapis.yaml
+++ b/config/crd/patches/webhook_in_apimgmtapis.yaml
@@ -7,8 +7,11 @@ metadata:
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_apimservices.yaml
+++ b/config/crd/patches/webhook_in_apimservices.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_appinsights.yaml
+++ b/config/crd/patches/webhook_in_appinsights.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_appinsightsapikeys.yaml
+++ b/config/crd/patches/webhook_in_appinsightsapikeys.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azureloadbalancers.yaml
+++ b/config/crd/patches/webhook_in_azureloadbalancers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azurenetworkinterfaces.yaml
+++ b/config/crd/patches/webhook_in_azurenetworkinterfaces.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azurepublicipaddresses.yaml
+++ b/config/crd/patches/webhook_in_azurepublicipaddresses.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqlactions.yaml
+++ b/config/crd/patches/webhook_in_azuresqlactions.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqldatabases.yaml
+++ b/config/crd/patches/webhook_in_azuresqldatabases.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqlfailovergroups.yaml
+++ b/config/crd/patches/webhook_in_azuresqlfailovergroups.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqlfirewallrules.yaml
+++ b/config/crd/patches/webhook_in_azuresqlfirewallrules.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqlmanagedusers.yaml
+++ b/config/crd/patches/webhook_in_azuresqlmanagedusers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqlservers.yaml
+++ b/config/crd/patches/webhook_in_azuresqlservers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqlusers.yaml
+++ b/config/crd/patches/webhook_in_azuresqlusers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azuresqlvnetrules.yaml
+++ b/config/crd/patches/webhook_in_azuresqlvnetrules.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azurevirtualmachineextensions.yaml
+++ b/config/crd/patches/webhook_in_azurevirtualmachineextensions.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azurevirtualmachines.yaml
+++ b/config/crd/patches/webhook_in_azurevirtualmachines.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_azurevmscalesets.yaml
+++ b/config/crd/patches/webhook_in_azurevmscalesets.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_blobcontainers.yaml
+++ b/config/crd/patches/webhook_in_blobcontainers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_consumergroups.yaml
+++ b/config/crd/patches/webhook_in_consumergroups.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_cosmosdbs.yaml
+++ b/config/crd/patches/webhook_in_cosmosdbs.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_eventhubnamespaces.yaml
+++ b/config/crd/patches/webhook_in_eventhubnamespaces.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_eventhubs.yaml
+++ b/config/crd/patches/webhook_in_eventhubs.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_keyvaultkeys.yaml
+++ b/config/crd/patches/webhook_in_keyvaultkeys.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_keyvaults.yaml
+++ b/config/crd/patches/webhook_in_keyvaults.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_mysqlaadusers.yaml
+++ b/config/crd/patches/webhook_in_mysqlaadusers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_mysqldatabases.yaml
+++ b/config/crd/patches/webhook_in_mysqldatabases.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_mysqlfirewallrules.yaml
+++ b/config/crd/patches/webhook_in_mysqlfirewallrules.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_mysqlserveradministrators.yaml
+++ b/config/crd/patches/webhook_in_mysqlserveradministrators.yaml
@@ -7,8 +7,11 @@ metadata:
 spec:
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_mysqlservers.yaml
+++ b/config/crd/patches/webhook_in_mysqlservers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_mysqlusers.yaml
+++ b/config/crd/patches/webhook_in_mysqlusers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_mysqlvnetrules.yaml
+++ b/config/crd/patches/webhook_in_mysqlvnetrules.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_postgresqldatabases.yaml
+++ b/config/crd/patches/webhook_in_postgresqldatabases.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_postgresqlfirewallrules.yaml
+++ b/config/crd/patches/webhook_in_postgresqlfirewallrules.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_postgresqlservers.yaml
+++ b/config/crd/patches/webhook_in_postgresqlservers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_postgresqlusers.yaml
+++ b/config/crd/patches/webhook_in_postgresqlusers.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_postgresqlvnetrules.yaml
+++ b/config/crd/patches/webhook_in_postgresqlvnetrules.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_rediscacheactions.yaml
+++ b/config/crd/patches/webhook_in_rediscacheactions.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_rediscachefirewallrules.yaml
+++ b/config/crd/patches/webhook_in_rediscachefirewallrules.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_rediscaches.yaml
+++ b/config/crd/patches/webhook_in_rediscaches.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_resourcegroups.yaml
+++ b/config/crd/patches/webhook_in_resourcegroups.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_storageaccounts.yaml
+++ b/config/crd/patches/webhook_in_storageaccounts.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_virtualnetworks.yaml
+++ b/config/crd/patches/webhook_in_virtualnetworks.yaml
@@ -8,8 +8,11 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions:
+        - v1beta1
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert


### PR DESCRIPTION
I really should have tried deploying the resulting CRDs after the changes in #1428, rather than just seeing that the patches applied cleanly after the update. It turns out the `webhookClientConfig` field has been moved down into a parent `webhook` key, which also has a required list of acceptable conversion review versions.

See https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/#CustomResourceDefinitionSpec

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
