### PR TITLE
Add ResourceReference Validator

### DIFF
--- a/hack/generated/pkg/genruntime/resource_reference_test.go
+++ b/hack/generated/pkg/genruntime/resource_reference_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package genruntime_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+)
+
+var validARMIDRef = genruntime.ResourceReference{ARMID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/microsoft.compute/VirtualMachine/myvm"}
+var validKubRef = genruntime.ResourceReference{Group: "microsoft.resources.infra.azure.com", Kind: "ResourceGroup", Namespace: "default", Name: "myrg"}
+var invalidRefBothSpecified = genruntime.ResourceReference{Group: "microsoft.resources.infra.azure.com", Kind: "ResourceGroup", Namespace: "default", Name: "myrg", ARMID: "oops"}
+var invalidRefNeitherSpecified = genruntime.ResourceReference{}
+var invalidRefIncompleteKubReference = genruntime.ResourceReference{Group: "microsoft.resources.infra.azure.com", Namespace: "default", Name: "myrg"}
+
+func Test_ResourceReference_Validate(t *testing.T) {
+	tests := []struct {
+		name         string
+		ref          genruntime.ResourceReference
+		errSubstring string
+	}{
+		{
+			name:         "valid ARM reference is valid",
+			ref:          validARMIDRef,
+			errSubstring: "",
+		},
+		{
+			name:         "valid Kubernetes reference is valid",
+			ref:          validKubRef,
+			errSubstring: "",
+		},
+		{
+			name:         "both ARM and Kubernetes fields filled out, reference is invalid",
+			ref:          invalidRefBothSpecified,
+			errSubstring: "'ARMID' field is mutually exclusive with",
+		},
+		{
+			name:         "nothing filled out, reference is invalid",
+			ref:          invalidRefNeitherSpecified,
+			errSubstring: "at least one of ['ARMID'] or ['Group', 'Kind', 'Namespace', 'Name'] must be set for ResourceReference",
+		},
+		{
+			name:         "incomplete Kubernetes reference is invalid",
+			ref:          invalidRefIncompleteKubReference,
+			errSubstring: "'Group', 'Kind', 'Namespace', and 'Name' must all be specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := tt.ref.Validate()
+			if tt.errSubstring != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errSubstring))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func Test_ResourceReference_IsARMOrKubernetes(t *testing.T) {
+	tests := []struct {
+		name         string
+		ref          genruntime.ResourceReference
+		isARM        bool
+		isKubernetes bool
+	}{
+		{
+			name:         "valid ARM reference is ARM",
+			ref:          validARMIDRef,
+			isARM:        true,
+			isKubernetes: false,
+		},
+		{
+			name:         "valid Kubernetes reference is Kubernetes",
+			ref:          validKubRef,
+			isARM:        false,
+			isKubernetes: true,
+		},
+		{
+			name:         "both ARM and Kubernetes fields filled out, reference is neither",
+			ref:          invalidRefBothSpecified,
+			isARM:        false,
+			isKubernetes: false,
+		},
+		{
+			name:         "nothing filled out, reference is neither",
+			ref:          invalidRefNeitherSpecified,
+			isARM:        false,
+			isKubernetes: false,
+		},
+		{
+			name:         "incomplete Kubernetes reference is neither",
+			ref:          invalidRefIncompleteKubReference,
+			isARM:        false,
+			isKubernetes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(tt.ref.IsDirectARMReference()).To(Equal(tt.isARM))
+			g.Expect(tt.ref.IsKubernetesReference()).To(Equal(tt.isKubernetes))
+		})
+	}
+}

--- a/hack/generated/pkg/reflecthelpers/reflect_helpers_test.go
+++ b/hack/generated/pkg/reflecthelpers/reflect_helpers_test.go
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package reflecthelpers
+package reflecthelpers_test
 
 import (
 	"context"
@@ -15,14 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-
 	//nolint:staticcheck // ignoring deprecation (SA1019) to unblock CI builds
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	resources "github.com/Azure/azure-service-operator/hack/generated/_apis/microsoft.resources/v1alpha1api20200601"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/util/kubeclient"
-
 	// TODO: Do we want to use a sample object rather than a code generated one?
 	batch "github.com/Azure/azure-service-operator/hack/generated/_apis/microsoft.batch/v1alpha1api20170901"
 
@@ -141,7 +140,7 @@ func Test_ConvertResourceToDeployableResource(t *testing.T) {
 	account := createDummyResource()
 	g.Expect(test.client.Create(ctx, account)).To(Succeed())
 
-	resource, err := ConvertResourceToDeployableResource(ctx, test.resolver, account)
+	resource, err := reflecthelpers.ConvertResourceToDeployableResource(ctx, test.resolver, account)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	rgResource, ok := resource.(*genruntime.ResourceGroupResource)
@@ -168,7 +167,7 @@ func Test_FindReferences(t *testing.T) {
 	}
 	g.Expect(test.client.Create(ctx, account)).To(Succeed())
 
-	refs, err := FindResourceReferences(&account.Spec)
+	refs, err := reflecthelpers.FindResourceReferences(&account.Spec)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(refs).To(HaveLen(1))
 	g.Expect(refs).To(HaveKey(ref))
@@ -179,7 +178,7 @@ func Test_NewStatus(t *testing.T) {
 
 	account := createDummyResource()
 
-	status, err := NewEmptyStatus(account)
+	status, err := reflecthelpers.NewEmptyStatus(account)
 	g.Expect(err).To(BeNil())
 	g.Expect(status).To(BeAssignableToTypeOf(&batch.BatchAccount_Status{}))
 }
@@ -189,7 +188,7 @@ func Test_EmptyArmResourceStatus(t *testing.T) {
 
 	account := createDummyResource()
 
-	status, err := NewEmptyArmResourceStatus(account)
+	status, err := reflecthelpers.NewEmptyArmResourceStatus(account)
 	g.Expect(err).To(BeNil())
 	g.Expect(status).To(BeAssignableToTypeOf(&batch.BatchAccount_StatusARM{}))
 }
@@ -198,7 +197,7 @@ func Test_HasStatus(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	account := createDummyResource()
-	result, err := HasStatus(account)
+	result, err := reflecthelpers.HasStatus(account)
 	g.Expect(err).To(BeNil())
 	g.Expect(result).To(BeFalse())
 }
@@ -207,7 +206,7 @@ func Test_NewPtrFromStruct_ReturnsPtr(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	v := DummyStruct{}
-	ptr := NewPtrFromValue(v)
+	ptr := reflecthelpers.NewPtrFromValue(v)
 	g.Expect(ptr).To(BeAssignableToTypeOf(&DummyStruct{}))
 }
 
@@ -215,7 +214,7 @@ func Test_NewPtrFromPrimitive_ReturnsPtr(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	v := 5
-	ptr := NewPtrFromValue(v)
+	ptr := reflecthelpers.NewPtrFromValue(v)
 
 	expectedValue := &v
 
@@ -226,6 +225,6 @@ func Test_NewPtrFromPtr_ReturnsPtrPtr(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	ptr := &DummyStruct{}
-	ptrPtr := NewPtrFromValue(ptr)
+	ptrPtr := reflecthelpers.NewPtrFromValue(ptr)
 	g.Expect(ptrPtr).To(BeAssignableToTypeOf(&ptr))
 }

--- a/hack/generator/pkg/astmodel/kubernetes_admissions_validations.go
+++ b/hack/generator/pkg/astmodel/kubernetes_admissions_validations.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"go/token"
+
+	"github.com/dave/dst"
+
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astbuilder"
+)
+
+func NewValidateResourceReferencesFunction(resource *ResourceType, idFactory IdentifierFactory) *resourceFunction {
+	return &resourceFunction{
+		name:             "validateResourceReferences",
+		resource:         resource,
+		idFactory:        idFactory,
+		asFunc:           validateResourceReferences,
+		requiredPackages: NewPackageReferenceSet(GenRuntimeReference, ReflectHelpersReference),
+	}
+}
+
+func validateResourceReferences(k *resourceFunction, codeGenerationContext *CodeGenerationContext, receiver TypeName, methodName string) *dst.FuncDecl {
+	receiverIdent := k.idFactory.CreateIdentifier(receiver.Name(), NotExported)
+	receiverType := receiver.AsType(codeGenerationContext)
+
+	fn := &astbuilder.FuncDetails{
+		Name:          methodName,
+		ReceiverIdent: receiverIdent,
+		ReceiverType: &dst.StarExpr{
+			X: receiverType,
+		},
+		Returns: []*dst.Field{
+			{
+				Type: dst.NewIdent("error"),
+			},
+		},
+		Body: validateResourceReferencesBody(codeGenerationContext, receiverIdent),
+	}
+
+	fn.AddComments("validates all resource references")
+	return fn.DefineFunc()
+}
+
+// validateResourceReferencesBody helps generate the body of the validateResourceReferences function:
+// 	refs, err := reflecthelpers.FindResourceReferences(&<resource>.Spec)
+//	if err != nil {
+//		return err
+//	}
+//	return genruntime.ValidateResourceReferences(refs)
+func validateResourceReferencesBody(codeGenerationContext *CodeGenerationContext, receiverIdent string) []dst.Stmt {
+	reflectHelpers, err := codeGenerationContext.GetImportedPackageName(ReflectHelpersReference)
+	if err != nil {
+		panic(err)
+	}
+
+	genRuntime, err := codeGenerationContext.GetImportedPackageName(GenRuntimeReference)
+	if err != nil {
+		panic(err)
+	}
+	var body []dst.Stmt
+
+	body = append(
+		body,
+		astbuilder.SimpleAssignmentWithErr(
+			dst.NewIdent("refs"),
+			token.DEFINE,
+			astbuilder.CallQualifiedFunc(
+				reflectHelpers,
+				"FindResourceReferences",
+				astbuilder.AddrOf(astbuilder.Selector(dst.NewIdent(receiverIdent), "Spec")))))
+	body = append(body, astbuilder.CheckErrorAndReturn())
+	body = append(
+		body,
+		astbuilder.Returns(
+			astbuilder.CallQualifiedFunc(
+				genRuntime,
+				"ValidateResourceReferences",
+				dst.NewIdent("refs"))))
+
+	return body
+}

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -109,6 +109,9 @@ func AddKubernetesResourceInterfaceImpls(
 
 	// Add validations
 	validatorBuilder := NewValidatorBuilder(resourceName, r, idFactory)
+	validatorBuilder.AddValidation(ValidationKindCreate, NewValidateResourceReferencesFunction(r, idFactory))
+	validatorBuilder.AddValidation(ValidationKindUpdate, NewValidateResourceReferencesFunction(r, idFactory))
+
 	r = r.WithInterface(validatorBuilder.ToInterfaceImplementation())
 
 	return r, nil

--- a/hack/generator/pkg/astmodel/std_references.go
+++ b/hack/generator/pkg/astmodel/std_references.go
@@ -5,6 +5,10 @@
 
 package astmodel
 
+const (
+	reflectHelpersPath = "github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+)
+
 var (
 	// References to standard Go Libraries
 	ErrorsReference  = MakeExternalPackageReference("errors")
@@ -14,7 +18,8 @@ var (
 	TestingReference = MakeExternalPackageReference("testing")
 
 	// References to our Libraries
-	GenRuntimeReference = MakeExternalPackageReference(genRuntimePathPrefix)
+	GenRuntimeReference     = MakeExternalPackageReference(genRuntimePathPrefix)
+	ReflectHelpersReference = MakeExternalPackageReference(reflectHelpersPath)
 
 	// References to other libraries
 	APIExtensionsReference       = MakeExternalPackageReference("k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1")

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -118,7 +119,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -128,7 +129,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (a *A) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (a *A) createValidations() []func() error {
-	return nil
+	return []func() error{a.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (a *A) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (a *A) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return a.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (a *A) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&a.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -266,7 +280,7 @@ func (b *B) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (b *B) createValidations() []func() error {
-	return nil
+	return []func() error{b.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -276,7 +290,20 @@ func (b *B) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (b *B) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return b.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (b *B) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&b.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -415,7 +442,7 @@ func (c *C) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (c *C) createValidations() []func() error {
-	return nil
+	return []func() error{c.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -425,7 +452,20 @@ func (c *C) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (c *C) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return c.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (c *C) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&c.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -564,7 +604,7 @@ func (d *D) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (d *D) createValidations() []func() error {
-	return nil
+	return []func() error{d.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -574,7 +614,20 @@ func (d *D) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (d *D) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return d.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (d *D) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&d.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (a *A) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (a *A) createValidations() []func() error {
-	return nil
+	return []func() error{a.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (a *A) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (a *A) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return a.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (a *A) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&a.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -267,7 +281,7 @@ func (b *B) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (b *B) createValidations() []func() error {
-	return nil
+	return []func() error{b.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -277,7 +291,20 @@ func (b *B) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (b *B) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return b.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (b *B) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&b.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (a *A) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (a *A) createValidations() []func() error {
-	return nil
+	return []func() error{a.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (a *A) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (a *A) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return a.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (a *A) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&a.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -267,7 +281,7 @@ func (b *B) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (b *B) createValidations() []func() error {
-	return nil
+	return []func() error{b.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -277,7 +291,20 @@ func (b *B) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (b *B) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return b.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (b *B) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&b.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -417,7 +444,7 @@ func (c *C) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (c *C) createValidations() []func() error {
-	return nil
+	return []func() error{c.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -427,7 +454,20 @@ func (c *C) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (c *C) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return c.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (c *C) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&c.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (a *A) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (a *A) createValidations() []func() error {
-	return nil
+	return []func() error{a.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (a *A) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (a *A) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return a.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (a *A) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&a.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (a *A) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (a *A) createValidations() []func() error {
-	return nil
+	return []func() error{a.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (a *A) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (a *A) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return a.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (a *A) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&a.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -267,7 +281,7 @@ func (b *B) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (b *B) createValidations() []func() error {
-	return nil
+	return []func() error{b.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -277,7 +291,20 @@ func (b *B) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (b *B) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return b.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (b *B) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&b.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (a *A) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (a *A) createValidations() []func() error {
-	return nil
+	return []func() error{a.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (a *A) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (a *A) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return a.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (a *A) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&a.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -267,7 +281,7 @@ func (b *B) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (b *B) createValidations() []func() error {
-	return nil
+	return []func() error{b.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -277,7 +291,20 @@ func (b *B) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (b *B) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return b.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (b *B) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&b.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (a *A) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (a *A) createValidations() []func() error {
-	return nil
+	return []func() error{a.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (a *A) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (a *A) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return a.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (a *A) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&a.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true
@@ -267,7 +281,7 @@ func (b *B) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (b *B) createValidations() []func() error {
-	return nil
+	return []func() error{b.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -277,7 +291,20 @@ func (b *B) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (b *B) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return b.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (b *B) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&b.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -118,7 +119,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -128,7 +129,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -121,7 +122,7 @@ func (fakeResource *FakeResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (fakeResource *FakeResource) createValidations() []func() error {
-	return nil
+	return []func() error{fakeResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -131,7 +132,20 @@ func (fakeResource *FakeResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (fakeResource *FakeResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return fakeResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (fakeResource *FakeResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&fakeResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -117,7 +118,7 @@ func (aResource *AResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (aResource *AResource) createValidations() []func() error {
-	return nil
+	return []func() error{aResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -127,7 +128,20 @@ func (aResource *AResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (aResource *AResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return aResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (aResource *AResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&aResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
@@ -6,6 +6,7 @@ package v1alpha1api20200101
 import (
 	"fmt"
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -110,7 +111,7 @@ func (aResource *AResource) ValidateUpdate(old runtime.Object) error {
 
 // createValidations validates the creation of the resource
 func (aResource *AResource) createValidations() []func() error {
-	return nil
+	return []func() error{aResource.validateResourceReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -120,7 +121,20 @@ func (aResource *AResource) deleteValidations() []func() error {
 
 // updateValidations validates the update of the resource
 func (aResource *AResource) updateValidations() []func(old runtime.Object) error {
-	return nil
+	return []func(old runtime.Object) error{
+		func(old runtime.Object) error {
+			return aResource.validateResourceReferences()
+		},
+	}
+}
+
+// validateResourceReferences validates all resource references
+func (aResource *AResource) validateResourceReferences() error {
+	refs, err := reflecthelpers.FindResourceReferences(&aResource.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateResourceReferences(refs)
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
Validator for ResourceReference which ensures that all references provided to us are formatted property.

Valid ResourceReference formats are: only ARMID, or Group, Kind, Namespace, Name.

An upcoming PR will perform namespace defaulting so that the namespace parameter can be left empty.
