### PR TITLE
Fix small ARM conversion bug

### DIFF
--- a/hack/generator/pkg/astmodel/armconversion/shared.go
+++ b/hack/generator/pkg/astmodel/armconversion/shared.go
@@ -146,3 +146,15 @@ func NewARMTransformerImpl(
 			populateFromARMFunc)
 	}
 }
+
+func removeEmptyStatements(stmts []dst.Stmt) []dst.Stmt {
+	var result []dst.Stmt
+	for _, stmt := range stmts {
+		if _, ok := stmt.(*dst.EmptyStmt); ok {
+			continue
+		}
+		result = append(result, stmt)
+	}
+
+	return result
+}

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
@@ -945,10 +945,8 @@ func (bResource *BResource) CreateEmptyARMValue() interface{} {
 
 // PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
 func (bResource *BResource) PopulateFromARM(owner genruntime.KnownResourceReference, armInput interface{}) error {
-	typedInput, ok := armInput.(BResourceARM)
-	if !ok {
-		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BResourceARM, got %T", armInput)
-	}
+
+	// No error
 	return nil
 }
 
@@ -983,10 +981,8 @@ func (cResource *CResource) CreateEmptyARMValue() interface{} {
 
 // PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
 func (cResource *CResource) PopulateFromARM(owner genruntime.KnownResourceReference, armInput interface{}) error {
-	typedInput, ok := armInput.(CResourceARM)
-	if !ok {
-		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected CResourceARM, got %T", armInput)
-	}
+
+	// No error
 	return nil
 }
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
@@ -635,10 +635,8 @@ func (bResource *BResource) CreateEmptyARMValue() interface{} {
 
 // PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
 func (bResource *BResource) PopulateFromARM(owner genruntime.KnownResourceReference, armInput interface{}) error {
-	typedInput, ok := armInput.(BResourceARM)
-	if !ok {
-		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected BResourceARM, got %T", armInput)
-	}
+
+	// No error
 	return nil
 }
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
@@ -299,10 +299,8 @@ func (fakeResourceProperties *FakeResourceProperties) CreateEmptyARMValue() inte
 
 // PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
 func (fakeResourceProperties *FakeResourceProperties) PopulateFromARM(owner genruntime.KnownResourceReference, armInput interface{}) error {
-	typedInput, ok := armInput.(FakeResourcePropertiesARM)
-	if !ok {
-		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResourcePropertiesARM, got %T", armInput)
-	}
+
+	// No error
 	return nil
 }
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
@@ -297,10 +297,8 @@ func (fakeResourceProperties *FakeResourceProperties) CreateEmptyARMValue() inte
 
 // PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
 func (fakeResourceProperties *FakeResourceProperties) PopulateFromARM(owner genruntime.KnownResourceReference, armInput interface{}) error {
-	typedInput, ok := armInput.(FakeResourcePropertiesARM)
-	if !ok {
-		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected FakeResourcePropertiesARM, got %T", armInput)
-	}
+
+	// No error
 	return nil
 }
 


### PR DESCRIPTION
If there are no properties to actually perform conversion on, just return nil.