### PR TITLE
Allow resources to have additional properties

### DIFF
--- a/hack/generator/pkg/astmodel/property_container.go
+++ b/hack/generator/pkg/astmodel/property_container.go
@@ -11,4 +11,7 @@ type PropertyContainer interface {
 	// Properties returns all the properties from this container
 	// A sorted slice is returned to preserve immutability and provide determinism
 	Properties() []*PropertyDefinition
+
+	// Property returns the property and true if the named property is found, nil and false otherwise
+	Property(name PropertyName) (*PropertyDefinition, bool)
 }

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -288,15 +288,30 @@ func (resource *ResourceType) EmbeddedProperties() []*PropertyDefinition {
 	}
 }
 
-// WithProperty creates a new ObjectType with another property attached to it
+// WithProperty creates a new ResourceType with another property attached to it
 // Properties are unique by name, so this can be used to Add and Replace a property
 func (resource *ResourceType) WithProperty(property *PropertyDefinition) *ResourceType {
-	// Create a copy of objectType to preserve immutability
+	// Create a copy to preserve immutability
 	result := resource.copy()
 	result.properties[property.propertyName] = property
 
 	return result
 }
+
+// WithoutProperty creates a new ResourceType that's a copy without the specified property
+func (resource *ResourceType) WithoutProperty(name PropertyName) *ResourceType {
+
+	if name == "Status" || name == "Spec" {
+		panic(fmt.Sprintf("May not remove property %q from a resource", name))
+	}
+
+	// Create a copy to preserve immutability
+	result := resource.copy()
+	delete(result.properties, name)
+
+	return result
+}
+
 
 // Properties returns all the properties from this resource type
 // An ordered slice is returned to preserve immutability and provide determinism

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -290,20 +290,39 @@ func (resource *ResourceType) EmbeddedProperties() []*PropertyDefinition {
 // An ordered slice is returned to preserve immutability and provide determinism
 func (resource *ResourceType) Properties() []*PropertyDefinition {
 
-	specProperty := NewPropertyDefinition("Spec", "spec", resource.spec).
-		WithTag("json", "omitempty")
-
 	result := []*PropertyDefinition{
-		specProperty,
+		resource.createSpecProperty(),
 	}
 
 	if resource.status != nil {
-		statusProperty := NewPropertyDefinition("Status", "status", resource.status).
-			WithTag("json", "omitempty")
-		result = append(result, statusProperty)
+		result = append(result, resource.createStatusProperty())
 	}
 
 	return result
+}
+
+func (resource *ResourceType) createStatusProperty() *PropertyDefinition {
+	statusProperty := NewPropertyDefinition("Status", "status", resource.status).
+		WithTag("json", "omitempty")
+	return statusProperty
+}
+
+func (resource *ResourceType) createSpecProperty() *PropertyDefinition {
+	return NewPropertyDefinition("Spec", "spec", resource.spec).
+		WithTag("json", "omitempty")
+}
+
+// Property returns the property and true if the named property is found, nil and false otherwise
+func (resource *ResourceType) Property(name PropertyName) (*PropertyDefinition, bool) {
+	if name == "Spec" {
+		return resource.createSpecProperty(), true
+	}
+
+	if name == "Status" {
+		return resource.createStatusProperty(), true
+	}
+
+	return nil, false
 }
 
 // Functions returns all the function implementations

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -327,6 +327,15 @@ func (resource *ResourceType) Properties() []*PropertyDefinition {
 		result = append(result, resource.createStatusProperty())
 	}
 
+	for _, property := range resource.properties {
+		result = append(result, property)
+	}
+
+	// Sorted so that it's always consistent
+	sort.Slice(result, func(left int, right int) bool {
+		return result[left].propertyName < result[right].propertyName
+	})
+
 	return result
 }
 

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -291,6 +291,10 @@ func (resource *ResourceType) EmbeddedProperties() []*PropertyDefinition {
 // WithProperty creates a new ResourceType with another property attached to it
 // Properties are unique by name, so this can be used to Add and Replace a property
 func (resource *ResourceType) WithProperty(property *PropertyDefinition) *ResourceType {
+	if property.HasName("Status") || property.HasName("Spec") {
+		panic(fmt.Sprintf("May not modify property %q on a resource", property.PropertyName()))
+	}
+
 	// Create a copy to preserve immutability
 	result := resource.copy()
 	result.properties[property.propertyName] = property
@@ -300,7 +304,6 @@ func (resource *ResourceType) WithProperty(property *PropertyDefinition) *Resour
 
 // WithoutProperty creates a new ResourceType that's a copy without the specified property
 func (resource *ResourceType) WithoutProperty(name PropertyName) *ResourceType {
-
 	if name == "Status" || name == "Spec" {
 		panic(fmt.Sprintf("May not remove property %q from a resource", name))
 	}

--- a/hack/generator/pkg/astmodel/resource_type.go
+++ b/hack/generator/pkg/astmodel/resource_type.go
@@ -315,7 +315,6 @@ func (resource *ResourceType) WithoutProperty(name PropertyName) *ResourceType {
 	return result
 }
 
-
 // Properties returns all the properties from this resource type
 // An ordered slice is returned to preserve immutability and provide determinism
 func (resource *ResourceType) Properties() []*PropertyDefinition {

--- a/hack/generator/pkg/astmodel/resource_type_test.go
+++ b/hack/generator/pkg/astmodel/resource_type_test.go
@@ -104,14 +104,14 @@ func TestResourceType_WithProperty_OverridingSpec_Panics(t *testing.T) {
 	g := NewGomegaWithT(t)
 	base := NewResourceType(emptySpec, emptyStatus)
 	specProp := NewPropertyDefinition("Spec", "spec", StringType)
-	g.Expect(func() { base.WithProperty(specProp)}).To(Panic())
+	g.Expect(func() { base.WithProperty(specProp) }).To(Panic())
 }
 
 func TestResourceType_WithProperty_OverridingStatus_Panics(t *testing.T) {
 	g := NewGomegaWithT(t)
 	base := NewResourceType(emptySpec, emptyStatus)
 	statusProp := NewPropertyDefinition("Status", "status", StringType)
-	g.Expect(func() { base.WithProperty(statusProp)}).To(Panic())
+	g.Expect(func() { base.WithProperty(statusProp) }).To(Panic())
 }
 
 /*

--- a/hack/generator/pkg/astmodel/resource_type_test.go
+++ b/hack/generator/pkg/astmodel/resource_type_test.go
@@ -90,6 +90,14 @@ func TestResourceType_Property_ForSpec_ReturnsProperty(t *testing.T) {
  * WithProperty() tests
  */
 
+func TestResourceType_WithProperty_HasExpectedLength(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
+	resource := base.WithProperty(ownerProp)
+	g.Expect(resource.Properties()).To(HaveLen(3))
+}
+
 func TestResourceType_WithProperty_IncludesProperty(t *testing.T) {
 	g := NewGomegaWithT(t)
 	base := NewResourceType(emptySpec, emptyStatus)

--- a/hack/generator/pkg/astmodel/resource_type_test.go
+++ b/hack/generator/pkg/astmodel/resource_type_test.go
@@ -90,7 +90,7 @@ func TestResourceType_Property_ForSpec_ReturnsProperty(t *testing.T) {
  * WithProperty() tests
  */
 
-func TestResourceType_WithProperty_ContainsProperty(t *testing.T) {
+func TestResourceType_WithoutProperty_IncludesProperty(t *testing.T) {
 	g := NewGomegaWithT(t)
 	base := NewResourceType(emptySpec, emptyStatus)
 	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
@@ -98,4 +98,30 @@ func TestResourceType_WithProperty_ContainsProperty(t *testing.T) {
 	prop, ok := resource.Property("Owner")
 	g.Expect(ok).To(BeTrue())
 	g.Expect(prop).NotTo(BeNil())
+}
+
+/*
+ * WithoutProperty() tests
+ */
+
+func TestResourceType_WithoutProperty_ExcludesProperty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
+	base := NewResourceType(emptySpec, emptyStatus).WithProperty(ownerProp)
+	resource := base.WithoutProperty("Owner")
+	prop, ok := resource.Property("Owner")
+	g.Expect(ok).To(BeFalse())
+	g.Expect(prop).To(BeNil())
+}
+
+func TestResourceType_WithoutSpecProperty_Panics(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	g.Expect(func() { base.WithoutProperty("Spec") }).To(Panic())
+}
+
+func TestResourceType_WithoutStatusProperty_Panics(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	g.Expect(func() { base.WithoutProperty("Status") }).To(Panic())
 }

--- a/hack/generator/pkg/astmodel/resource_type_test.go
+++ b/hack/generator/pkg/astmodel/resource_type_test.go
@@ -90,7 +90,7 @@ func TestResourceType_Property_ForSpec_ReturnsProperty(t *testing.T) {
  * WithProperty() tests
  */
 
-func TestResourceType_WithoutProperty_IncludesProperty(t *testing.T) {
+func TestResourceType_WithProperty_IncludesProperty(t *testing.T) {
 	g := NewGomegaWithT(t)
 	base := NewResourceType(emptySpec, emptyStatus)
 	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
@@ -98,6 +98,20 @@ func TestResourceType_WithoutProperty_IncludesProperty(t *testing.T) {
 	prop, ok := resource.Property("Owner")
 	g.Expect(ok).To(BeTrue())
 	g.Expect(prop).NotTo(BeNil())
+}
+
+func TestResourceType_WithProperty_OverridingSpec_Panics(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	specProp := NewPropertyDefinition("Spec", "spec", StringType)
+	g.Expect(func() { base.WithProperty(specProp)}).To(Panic())
+}
+
+func TestResourceType_WithProperty_OverridingStatus_Panics(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	statusProp := NewPropertyDefinition("Status", "status", StringType)
+	g.Expect(func() { base.WithProperty(statusProp)}).To(Panic())
 }
 
 /*

--- a/hack/generator/pkg/astmodel/resource_type_test.go
+++ b/hack/generator/pkg/astmodel/resource_type_test.go
@@ -85,3 +85,17 @@ func TestResourceType_Property_ForSpec_ReturnsProperty(t *testing.T) {
 	g.Expect(ok).To(BeTrue())
 	g.Expect(prop).NotTo(BeNil())
 }
+
+/*
+ * WithProperty() tests
+ */
+
+func TestResourceType_WithProperty_ContainsProperty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
+	resource := base.WithProperty(ownerProp)
+	prop, ok := resource.Property("Owner")
+	g.Expect(ok).To(BeTrue())
+	g.Expect(prop).NotTo(BeNil())
+}

--- a/hack/generator/pkg/astmodel/resource_type_test.go
+++ b/hack/generator/pkg/astmodel/resource_type_test.go
@@ -13,6 +13,11 @@ import (
 
 //TODO (theunrepentantgeek): MOAR TESTS
 
+var (
+	emptySpec   = NewObjectType()
+	emptyStatus = NewObjectType()
+)
+
 /*
  * WithTestCase() tests
  */
@@ -20,11 +25,9 @@ import (
 func TestResourceType_WithTestCase_ReturnsExpectedInstance(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	spec := NewObjectType()
-	status := NewObjectType()
 	name := "assertStuff"
 	fake := NewFakeTestCase(name)
-	base := NewResourceType(spec, status)
+	base := NewResourceType(emptySpec, emptyStatus)
 
 	resource := base.WithTestCase(fake)
 
@@ -40,12 +43,10 @@ func TestResourceType_WithTestCase_ReturnsExpectedInstance(t *testing.T) {
 func TestResourceType_WithFunction_ReturnsExpectedInstance(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	spec := NewObjectType()
-	status := NewObjectType()
 	name := "assertStuff"
 
 	fake := NewFakeFunction(name)
-	base := NewResourceType(spec, status)
+	base := NewResourceType(emptySpec, emptyStatus)
 
 	resource := base.WithFunction(fake)
 
@@ -53,4 +54,34 @@ func TestResourceType_WithFunction_ReturnsExpectedInstance(t *testing.T) {
 	g.Expect(resource.functions).To(HaveLen(1))
 	g.Expect(resource.functions[name]).To(Equal(fake))
 
+}
+
+/*
+ * Properties() tests
+ */
+
+func TestResourceType_Properties_ReturnsExpectedCount(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	g.Expect(base.Properties()).To(HaveLen(2))
+}
+
+/*
+ * Property() tests
+ */
+
+func TestResourceType_Property_ForStatus_ReturnsProperty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	prop, ok := base.Property("Spec")
+	g.Expect(ok).To(BeTrue())
+	g.Expect(prop).NotTo(BeNil())
+}
+
+func TestResourceType_Property_ForSpec_ReturnsProperty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	base := NewResourceType(emptySpec, emptyStatus)
+	prop, ok := base.Property("Spec")
+	g.Expect(ok).To(BeTrue())
+	g.Expect(prop).NotTo(BeNil())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently resources only have `Spec` and `Status` properties, but we have a need (for storage versions) to have additional properties as well. This PR extends support to allow additional properties on resources, but treating `Spec` and `Status` as special cases.

First consumer will be for Storage versions where the original group-version-kind of the API type needs to be preserved.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/148RzvOyLJcbUQ/giphy.gif)

**If applicable**:
- [x] this PR contains tests
