### PR TITLE
Remove dangerous format specifiers

### DIFF
--- a/hack/generated/controllers/generic_controller.go
+++ b/hack/generated/controllers/generic_controller.go
@@ -200,7 +200,7 @@ func (gr *GenericReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// convert itself to/from the corresponding Azure types.
 	metaObj, ok := obj.(genruntime.MetaObject)
 	if !ok {
-		return ctrl.Result{}, errors.Errorf("object is not a genruntime.MetaObject: %+v - type: %T", obj, obj)
+		return ctrl.Result{}, errors.Errorf("object is not a genruntime.MetaObject, found type: %T", obj)
 	}
 
 	// TODO: We need some factory-lookup here

--- a/hack/generated/pkg/genruntime/errors.go
+++ b/hack/generated/pkg/genruntime/errors.go
@@ -62,9 +62,3 @@ func (e *ReferenceNotFound) Format(s fmt.State, verb rune) {
 		_, _ = fmt.Fprintf(s, "%q", e.Error())
 	}
 }
-
-// stackTracer allows access to the stack trace of an error
-// This should be exposed by the errors package, but it is not
-type stackTracer interface {
-	StackTrace() errors.StackTrace
-}

--- a/hack/generated/pkg/genruntime/errors.go
+++ b/hack/generated/pkg/genruntime/errors.go
@@ -28,7 +28,7 @@ func NewReferenceNotFoundError(name types.NamespacedName, cause error) *Referenc
 var _ error = &ReferenceNotFound{}
 
 func (e *ReferenceNotFound) Error() string {
-	return fmt.Sprintf("%s does not exist", e.NamespacedName)
+	return fmt.Sprintf("%s does not exist (%s)", e.NamespacedName, e.cause)
 }
 
 func (e *ReferenceNotFound) Is(err error) bool {

--- a/hack/generated/pkg/genruntime/errors.go
+++ b/hack/generated/pkg/genruntime/errors.go
@@ -62,3 +62,20 @@ func (e *ReferenceNotFound) Format(s fmt.State, verb rune) {
 		_, _ = fmt.Fprintf(s, "%q", e.Error())
 	}
 }
+
+// stackTracer allows access to the stack trace of an error
+// This should be exposed by the errors package, but it is not
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+// StackTrace returns the stack trace of the cause of the error
+func (e *ReferenceNotFound) StackTrace() errors.StackTrace {
+	if e.cause != nil {
+		if st, ok := e.cause.(stackTracer); ok {
+			return st.StackTrace()
+		}
+	}
+
+	return []errors.Frame{}
+}

--- a/hack/generated/pkg/genruntime/errors.go
+++ b/hack/generated/pkg/genruntime/errors.go
@@ -48,7 +48,7 @@ func (e *ReferenceNotFound) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			n, _ := fmt.Fprintf(s, "%+v", e.Cause())
+			n, _ := fmt.Fprintf(s, "%s", e.Cause())
 			if n > 0 {
 				_, _ = fmt.Fprintf(s, "\n")
 			}

--- a/hack/generated/pkg/genruntime/errors.go
+++ b/hack/generated/pkg/genruntime/errors.go
@@ -68,14 +68,3 @@ func (e *ReferenceNotFound) Format(s fmt.State, verb rune) {
 type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
-
-// StackTrace returns the stack trace of the cause of the error
-func (e *ReferenceNotFound) StackTrace() errors.StackTrace {
-	if e.cause != nil {
-		if st, ok := e.cause.(stackTracer); ok {
-			return st.StackTrace()
-		}
-	}
-
-	return []errors.Frame{}
-}

--- a/hack/generated/pkg/genruntime/errors_test.go
+++ b/hack/generated/pkg/genruntime/errors_test.go
@@ -6,6 +6,7 @@ Licensed under the MIT license.
 package genruntime
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -111,7 +112,13 @@ func TestOwnerNotFound_RemembersCause(t *testing.T) {
 
 	g.Expect(errors.Cause(err)).To(Equal(cause))
 
-	fmtedErr := err.Error()
+	var builder strings.Builder
+	for err != nil {
+		builder.WriteString(err.Error())
+		err = errors.Unwrap(err)
+	}
+
+	fmtedErr := builder.String()
 	g.Expect(fmtedErr).To(ContainSubstring("I caused the problem"))
 	g.Expect(fmtedErr).To(ContainSubstring("default/foo does not exist"))
 	// Note that both of the below lines are fragile with respect to line number and will

--- a/hack/generated/pkg/genruntime/errors_test.go
+++ b/hack/generated/pkg/genruntime/errors_test.go
@@ -124,11 +124,15 @@ func TestOwnerNotFound_RemembersCause(t *testing.T) {
 }
 
 func StackTraceOf(e error) string {
-	var stack strings.Builder
-	if st, ok := e.(stackTracer); ok {
-		for _, f := range st.StackTrace() {
+	var tracer stackTracer
+	if  errors.As(e, &tracer) {
+		var stack strings.Builder
+		for _, f := range tracer.StackTrace() {
 			stack.WriteString(fmt.Sprintf("%+s:%d\n", f, f))
 		}
+		
+		return stack.String()
 	}
-	return stack.String()
+
+	return ""
 }

--- a/hack/generated/pkg/genruntime/errors_test.go
+++ b/hack/generated/pkg/genruntime/errors_test.go
@@ -6,7 +6,6 @@ Licensed under the MIT license.
 package genruntime
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -112,7 +111,7 @@ func TestOwnerNotFound_RemembersCause(t *testing.T) {
 
 	g.Expect(errors.Cause(err)).To(Equal(cause))
 
-	fmtedErr := fmt.Sprintf("%+v", err)
+	fmtedErr := err.Error()
 	g.Expect(fmtedErr).To(ContainSubstring("I caused the problem"))
 	g.Expect(fmtedErr).To(ContainSubstring("default/foo does not exist"))
 	// Note that both of the below lines are fragile with respect to line number and will

--- a/hack/generated/pkg/genruntime/errors_test.go
+++ b/hack/generated/pkg/genruntime/errors_test.go
@@ -136,3 +136,9 @@ func StackTraceOf(e error) string {
 
 	return ""
 }
+
+// stackTracer allows access to the stack trace of an error
+// This should be exposed by the errors package, but it is not
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}

--- a/hack/generated/pkg/genruntime/errors_test.go
+++ b/hack/generated/pkg/genruntime/errors_test.go
@@ -125,12 +125,12 @@ func TestOwnerNotFound_RemembersCause(t *testing.T) {
 
 func StackTraceOf(e error) string {
 	var tracer stackTracer
-	if  errors.As(e, &tracer) {
+	if errors.As(e, &tracer) {
 		var stack strings.Builder
 		for _, f := range tracer.StackTrace() {
 			stack.WriteString(fmt.Sprintf("%+s:%d\n", f, f))
 		}
-		
+
 		return stack.String()
 	}
 

--- a/hack/generated/pkg/reconcilers/azure_deployment_reconciler.go
+++ b/hack/generated/pkg/reconcilers/azure_deployment_reconciler.go
@@ -706,7 +706,7 @@ func (r *AzureDeploymentReconciler) resourceSpecToDeployment(ctx context.Context
 	deploymentName, deploymentNameOk := r.GetDeploymentName()
 	if deploymentIDOk != deploymentNameOk {
 		return nil, errors.Errorf(
-			"deploymentIDOk: %t (id: %v), deploymentNameOk: %t (name: %v) expected to match, but didn't",
+			"deploymentIDOk: %t (id: %s), deploymentNameOk: %t (name: %s) expected to match, but didn't",
 			deploymentIDOk,
 			deploymentID,
 			deploymentNameOk,

--- a/hack/generated/pkg/testcommon/counting_roundtripper.go
+++ b/hack/generated/pkg/testcommon/counting_roundtripper.go
@@ -40,7 +40,7 @@ func (rt *requestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
 	count := rt.counts[key]
 	rt.counts[key] = count + 1
 	rt.countsMutex.Unlock()
-	req.Header.Add(COUNT_HEADER, fmt.Sprintf("%v", count))
+	req.Header.Add(COUNT_HEADER, fmt.Sprintf("%d", count))
 	return rt.inner.RoundTrip(req)
 }
 

--- a/hack/generated/pkg/util/kubeclient/kube_client.go
+++ b/hack/generated/pkg/util/kubeclient/kube_client.go
@@ -34,7 +34,7 @@ func NewClient(
 func (k *Client) GetObject(ctx context.Context, namespacedName types.NamespacedName, gvk schema.GroupVersionKind) (runtime.Object, error) {
 	obj, err := k.Scheme.New(gvk)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to create object from gvk %+v with", gvk)
+		return nil, errors.Wrapf(err, "unable to create object from gvk %s with", gvk)
 	}
 
 	if err := k.Client.Get(ctx, namespacedName, obj); err != nil {

--- a/hack/generated/pkg/util/patch/patch_test.go
+++ b/hack/generated/pkg/util/patch/patch_test.go
@@ -233,7 +233,7 @@ func TestHelperPatch(t *testing.T) {
 func IsSucceeded(obj *unstructured.Unstructured) (bool, error) {
 	ready, found, err := unstructured.NestedString(obj.Object, "status", "provisioningState")
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to determine %v %q readiness",
+		return false, errors.Wrapf(err, "failed to determine %s %q readiness",
 			obj.GroupVersionKind(), obj.GetName())
 	}
 	return ready == "Succeeded" && found, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes all uses of the format specifiers `%v` and `%+v` as those dump entire objects into the log, which very likely will include secrets (e.g. credentials etc); we don't want those exposed in the logs.

Closes #1470

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/1k03DWas9bfbYcbb33/giphy.gif)
