### PR TITLE
Temporarily remove stderr check in pipeline clean up task

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,6 @@ cover-existing.html
 coverage-existing.txt
 report-existing.xml
 testlogs-existing.txt
+hack/generator
+hack/generated
+.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -338,7 +338,10 @@ steps:
         echo "Setting tags back to free"
         az resource tag --tags 'freeforpipeline=true' -g $(AKS_CLUSTER_RG) -n $(chosenclustername) --resource-type Microsoft.ContainerService/managedClusters
       workingDirectory: '$(System.DefaultWorkingDirectory)'
-      failOnStandardError: true
+      # Turn off this check until our aad-pod-identity dep is updated
+      # so that it's not trying to install v1beta1
+      # ClusterRoleBindings.
+      failOnStandardError: false
     
 
   - task: Docker@2


### PR DESCRIPTION
Since the clusters have been upgraded to 1.19.11 the cluster-release task has started failing since helm is complaining about deprecated v1beta1 ClusterRoleBindings in aad-pod-identity. Turn off the check so the pipeline stops failing while we upgrade the aad-pod-identity dependency.

Example of failing job: https://dev.azure.com/azure/azure-service-operator/_build/results?buildId=25000&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=bfdc8dd2-1718-51d0-a919-951535614239
