### PR TITLE
Build & push Devcontainer image to GitHub Container Registry

### DIFF
--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -2,9 +2,18 @@ name: Build Devcontainer image
 on:
   workflow_dispatch:
     # no content, allows manual triggering
+
   schedule:
     # 5:30 pm every Sunday (UTC)
+    # to pick up any important bug fixes etc in base image
     - cron: '30 17 * * 7'
+
+  push:
+    # run when changes pushed to master if any devcontainer files changed
+    branches:
+    - master
+    paths:
+    - .devcontainer/**
 
 jobs:
   # Based on: https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages

--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -6,7 +6,7 @@ on:
   schedule:
     # 5:30 pm every Sunday (UTC)
     # to pick up any important bug fixes etc in base image
-    - cron: '30 17 * * 7'
+    - cron: '30 17 * * 0'
 
   push:
     # run when changes pushed to master if any devcontainer files changed

--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -1,5 +1,7 @@
 name: Build Devcontainer image
 on:
+  workflow_dispatch:
+    # no content, allows manual triggering
   schedule:
     # 5:30 pm every Sunday (UTC)
     - cron: '30 17 * * 7'

--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -1,0 +1,38 @@
+name: Build Devcontainer image
+on:
+  schedule:
+    # 5:30 pm every Sunday (UTC)
+    - cron: '30 17 * * 7'
+
+jobs:
+  # Based on: https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages
+  build-devcontainer-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }
+
+      - name: Build & push Devcontainer image 
+        uses: docker/build-push-action@v2
+        with:
+          context: .devcontainer
+          push: true
+          # Build an image usable as cache-from, per: https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
+          build-args: BUILDKIT_INLINE_CACHE=1
+          tags: |
+            docker.pkg.github.com/${{ github.repository }}/devcontainer:latest
+            docker.pkg.github.com/${{ github.repository }}/devcontainer:${{ github.sha }}


### PR DESCRIPTION
Build a Devcontainer image at least once a week and push it to GitHub Container Registry. We can use this as a base/cache-from image to speed up builds and mitigate [flaky upstream dependencies](https://arstechnica.com/gadgets/2021/06/microsofts-linux-repositories-were-down-for-18-hours/).