### PR TITLE
Create TypeNameProcessingRegister

### DIFF
--- a/hack/generator/pkg/astmodel/interface_implementation.go
+++ b/hack/generator/pkg/astmodel/interface_implementation.go
@@ -47,7 +47,7 @@ func (iface *InterfaceImplementation) RequiredPackageReferences() *PackageRefere
 
 // References indicates whether this type includes any direct references to the given type
 func (iface *InterfaceImplementation) References() TypeNameSet {
-	var results TypeNameSet
+	results := NewTypeNameSet()
 	for _, f := range iface.functions {
 		for ref := range f.References() {
 			results.Add(ref)

--- a/hack/generator/pkg/astmodel/interface_implementer.go
+++ b/hack/generator/pkg/astmodel/interface_implementer.go
@@ -41,10 +41,10 @@ func (i InterfaceImplementer) WithInterface(iface *InterfaceImplementation) Inte
 }
 
 func (i InterfaceImplementer) References() TypeNameSet {
-	var results TypeNameSet
+	results := NewTypeNameSet()
 	for _, iface := range i.interfaces {
 		for ref := range iface.References() {
-			results = results.Add(ref)
+			results.Add(ref)
 		}
 	}
 

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -233,11 +233,11 @@ func (objectType *ObjectType) RequiredPackageReferences() *PackageReferenceSet {
 func (objectType *ObjectType) References() TypeNameSet {
 	results := NewTypeNameSet()
 	for _, property := range objectType.properties {
-		results = results.AddAll(property.PropertyType().References())
+		results.AddAll(property.PropertyType().References())
 	}
 
 	for _, property := range objectType.embedded {
-		results = results.AddAll(property.PropertyType().References())
+		results.AddAll(property.PropertyType().References())
 	}
 
 	// Not collecting types from functions deliberately.

--- a/hack/generator/pkg/astmodel/type_name_processing_register.go
+++ b/hack/generator/pkg/astmodel/type_name_processing_register.go
@@ -1,0 +1,100 @@
+package astmodel
+
+// TypeNameProcessingRegister is a register of TypeNames that require processing, keeping track of which names have been
+// processed and which are still outstanding. This is used, for example, for a consistency check that all TypeName
+// references can be satisfied
+type TypeNameProcessingRegister struct {
+	// known is the set of all known type names, each with reasons why it's included
+	known map[TypeName][]string
+	// completed is the set of all names that have been processed
+	completed TypeNameSet
+}
+
+// NewTypeNameProcessingRegister constructs a new empty TypeNameProcessingRegister
+func NewTypeNameProcessingRegister() *TypeNameProcessingRegister {
+	return &TypeNameProcessingRegister{
+		completed: NewTypeNameSet(),
+		known:     make(map[TypeName][]string),
+	}
+}
+
+// IsCompleted returns true if the specified TypeName is in the register and processing has been completed
+func (reg *TypeNameProcessingRegister) IsCompleted(name TypeName) bool {
+	_, found := reg.known[name]
+	return found && reg.completed.Contains(name)
+}
+
+// IsPending returns true if the specified TypeName is in the register and processing has not been completed
+func (reg *TypeNameProcessingRegister) IsPending(name TypeName) bool {
+	_, found := reg.known[name]
+	return found && !reg.completed.Contains(name)
+}
+
+// Complete marks the specified name as processing complete
+// As a side effect, the name will be added to the register if it is missing
+func (reg *TypeNameProcessingRegister) Complete(name TypeName) {
+	if _, found := reg.known[name]; !found {
+		reg.known[name] = []string{}
+	}
+
+	reg.completed.Add(name)
+}
+
+// Reset marks the specified name as unprocessed (ie not complete)
+// As a side effect, the name will be added to the checklist if it is missing
+func (reg *TypeNameProcessingRegister) Reset(name TypeName) {
+	if _, found := reg.known[name]; !found {
+		reg.known[name] = []string{}
+	}
+
+	reg.completed.Remove(name)
+}
+
+// Requires indicates that processing of the specified name is required - this may already have taken place.
+// name is the TypeName to include
+// because is the reason why it has been included
+// Other reasons are preserved, if present
+func (reg *TypeNameProcessingRegister) Requires(name TypeName, because string) {
+	reg.known[name] = append(reg.known[name], because)
+}
+
+// Remove removes the specified name from the list
+// A single call to Remove can undo many calls to Requires()
+func (reg *TypeNameProcessingRegister) Remove(name TypeName) {
+	delete(reg.known, name)
+	reg.completed.Remove(name)
+}
+
+// Length returns the count of names in the checklist
+func (reg *TypeNameProcessingRegister) Length() int {
+	return len(reg.known)
+}
+
+// Pending gets a map all of the type names that have not been processed, along with the reasons why they were included
+// in the register in the first place
+func (reg *TypeNameProcessingRegister) Pending() map[TypeName][]string {
+	return reg.collect(func(name TypeName) bool {
+		_, completed := reg.completed[name]
+		return !completed
+	})
+}
+
+// Completed gets all of the type names that have been processed, along with the reasons why they were included in the
+// register in the first place
+func (reg *TypeNameProcessingRegister) Completed() map[TypeName][]string {
+	return reg.collect(func(name TypeName) bool {
+		_, completed := reg.completed[name]
+		return completed
+	})
+}
+
+func (reg *TypeNameProcessingRegister) collect(predicate func(TypeName) bool) map[TypeName][]string {
+	result := make(map[TypeName][]string)
+	for name, because := range reg.known {
+		if predicate(name) {
+			result[name] = because
+		}
+	}
+
+	return result
+}

--- a/hack/generator/pkg/astmodel/type_name_processing_register_test.go
+++ b/hack/generator/pkg/astmodel/type_name_processing_register_test.go
@@ -1,0 +1,181 @@
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var (
+	alphaTypeName = MakeTypeName(GenRuntimeReference, "Alpha")
+	betaTypeName  = MakeTypeName(GenRuntimeReference, "Beta")
+	gammaTypeName = MakeTypeName(GenRuntimeReference, "Gamma")
+)
+
+/*
+ * Construction Tests
+ */
+
+func Test_TypeNameProcessingRegister_AfterConstruction_IsEmpty(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	g.Expect(register.Length()).To(Equal(0))
+}
+
+/*
+ * Empty Register tests
+ */
+
+func Test_EmptyTypeNameRegister_DoesNotContainTypeNames(t *testing.T) {
+	g := NewGomegaWithT(t)
+	emptyRegister := NewTypeNameProcessingRegister()
+	g.Expect(emptyRegister.IsCompleted(alphaTypeName)).To(BeFalse())
+	g.Expect(emptyRegister.IsPending(alphaTypeName)).To(BeFalse())
+}
+
+/*
+ * Requires() tests
+ */
+
+func Test_TypeNameProcessingRegister_Requires_IncreasesLengthOfList(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(betaTypeName, "because")
+	g.Expect(register.Length()).To(Equal(1))
+}
+
+func Test_TypeNameProcessingRegister_Requires_NewNameIsPending(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(betaTypeName, "because")
+	g.Expect(register.IsPending(betaTypeName)).To(BeTrue())
+}
+
+func Test_TypeNameProcessingRegister_Requires_NewNameIsNotComplete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(betaTypeName, "because")
+	g.Expect(register.IsCompleted(betaTypeName)).To(BeFalse())
+}
+
+func Test_TypeNameProcessingRegister_Requires_DoesNotResetCompletedStatus(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(betaTypeName, "because")
+	register.Complete(betaTypeName)
+	register.Requires(betaTypeName, "because")
+	g.Expect(register.IsPending(betaTypeName)).To(BeFalse())
+	g.Expect(register.IsCompleted(betaTypeName)).To(BeTrue())
+}
+
+/*
+ * Complete() Tests
+ */
+
+func Test_TypeNameProcessingRegister_Complete_MarksNameAsCompleted(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(gammaTypeName, "because")
+	register.Complete(gammaTypeName)
+	g.Expect(register.IsCompleted(gammaTypeName)).To(BeTrue())
+}
+
+func Test_TypeNameProcessingRegister_Complete_MarksNameNotPending(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(gammaTypeName, "because")
+	register.Complete(gammaTypeName)
+	g.Expect(register.IsPending(gammaTypeName)).To(BeFalse())
+}
+
+func Test_TypeNameProcessingRegister_Complete_MakesRegisterLargerIfMissing(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	initialLength := register.Length()
+	register.Complete(gammaTypeName)
+	g.Expect(register.Length()).To(BeNumerically(">", initialLength))
+}
+
+func Test_TypeNameProcessingRegister_Complete_DoesNotIncludeNameInPending(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Complete(gammaTypeName)
+	g.Expect(register.Pending()).NotTo(HaveKey(gammaTypeName))
+}
+
+func Test_TypeNameProcessingRegister_Complete_IncludesNameInCompleted(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Complete(gammaTypeName)
+	g.Expect(register.Completed()).To(HaveKey(gammaTypeName))
+}
+
+/*
+ * Reset() Tests
+ */
+
+func Test_TypeNameProcessingRegister_Reset_MarksNameAsPending(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(gammaTypeName, "because")
+	register.Complete(gammaTypeName)
+	register.Reset(gammaTypeName)
+	g.Expect(register.IsCompleted(gammaTypeName)).To(BeFalse())
+}
+
+func Test_TypeNameProcessingRegister_Reset_MarksNameAsNotComplete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Requires(gammaTypeName, "because")
+	register.Complete(gammaTypeName)
+	register.Reset(gammaTypeName)
+	g.Expect(register.IsPending(gammaTypeName)).To(BeTrue())
+}
+
+func Test_TypeNameProcessingRegister_Reset_MakesRegisterLargerIfMissing(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	initialLength := register.Length()
+	register.Reset(gammaTypeName)
+	g.Expect(register.Length()).To(BeNumerically(">", initialLength))
+}
+
+func Test_TypeNameProcessingRegister_Reset_IncludesNameInPending(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Reset(gammaTypeName)
+	g.Expect(register.Pending()).To(HaveKey(gammaTypeName))
+}
+
+func Test_TypeNameProcessingRegister_Reset_DoesNotIncludeNameInCompleted(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Reset(gammaTypeName)
+	g.Expect(register.Completed()).NotTo(HaveKey(gammaTypeName))
+}
+
+/*
+ * Remove() tests
+ */
+
+func Test_TypeNameProcessingRegister_Remove_NameIsNoLongerPending(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Reset(gammaTypeName)
+	g.Expect(register.IsPending(gammaTypeName)).To(BeTrue())
+	g.Expect(register.IsCompleted(gammaTypeName)).To(BeFalse())
+	register.Remove(gammaTypeName)
+	g.Expect(register.IsPending(gammaTypeName)).To(BeFalse())
+	g.Expect(register.IsCompleted(gammaTypeName)).To(BeFalse())
+}
+
+func Test_TypeNameProcessingRegister_Remove_NameIsNoLongerCompleted(t *testing.T) {
+	g := NewGomegaWithT(t)
+	register := NewTypeNameProcessingRegister()
+	register.Complete(gammaTypeName)
+	g.Expect(register.IsCompleted(gammaTypeName)).To(BeTrue())
+	g.Expect(register.IsPending(gammaTypeName)).To(BeFalse())
+	register.Remove(gammaTypeName)
+	g.Expect(register.IsCompleted(gammaTypeName)).To(BeFalse())
+	g.Expect(register.IsPending(gammaTypeName)).To(BeFalse())
+}

--- a/hack/generator/pkg/astmodel/type_name_set.go
+++ b/hack/generator/pkg/astmodel/type_name_set.go
@@ -5,7 +5,9 @@
 
 package astmodel
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // TypeNameSet stores type names in no particular order without
 // duplicates.
@@ -14,23 +16,17 @@ type TypeNameSet map[TypeName]struct{}
 // NewTypeNameSet makes a TypeNameSet containing the specified
 // names. If no elements are passed it might be nil.
 func NewTypeNameSet(initial ...TypeName) TypeNameSet {
-	var result TypeNameSet
+	result := make(TypeNameSet)
 	for _, name := range initial {
-		result = result.Add(name)
+		result.Add(name)
 	}
+
 	return result
 }
 
-// Add includes the passed name in the set and returns the updated
-// set, so that adding can work for a nil set - this makes it more
-// convenient to add to sets kept in a map (in the way you might with
-// a map of slices).
-func (ts TypeNameSet) Add(val TypeName) TypeNameSet {
-	if ts == nil {
-		ts = make(TypeNameSet)
-	}
+// Add includes the passed name in the set
+func (ts TypeNameSet) Add(val TypeName) {
 	ts[val] = struct{}{}
-	return ts
 }
 
 // Contains returns whether this name is in the set. Works for nil
@@ -43,16 +39,9 @@ func (ts TypeNameSet) Contains(val TypeName) bool {
 	return found
 }
 
-// Remove removes the specified item if it is in the set. If it is not in
-// the set this is a no-op.
-func (ts TypeNameSet) Remove(val TypeName) TypeNameSet {
-	if ts == nil {
-		return ts
-	}
-
+// Remove removes the specified item if it is in the set. If it is not in the set this is a no-op.
+func (ts TypeNameSet) Remove(val TypeName) {
 	delete(ts, val)
-
-	return ts
 }
 
 func (ts TypeNameSet) Equals(set TypeNameSet) bool {
@@ -72,39 +61,33 @@ func (ts TypeNameSet) Equals(set TypeNameSet) bool {
 }
 
 // AddAll adds the provided TypeNameSet to the set
-func (ts TypeNameSet) AddAll(other TypeNameSet) TypeNameSet {
-	if ts == nil {
-		ts = make(TypeNameSet)
+func (ts TypeNameSet) AddAll(other TypeNameSet) {
+	if other != nil {
+		for val := range other {
+			ts[val] = struct{}{}
+		}
 	}
-
-	for val := range other {
-		ts[val] = struct{}{}
-	}
-
-	return ts
 }
 
 // Single returns the single TypeName in the set. This panics if there is not a single item in the set.
 func (ts TypeNameSet) Single() TypeName {
-	if len(ts) != 1 {
-		panic(fmt.Sprintf("Single() cannot be called with %d types in the set", len(ts)))
+	if len(ts) == 1 {
+		for name := range ts {
+			return name
+		}
 	}
 
-	for name := range ts {
-		return name
-	}
-
-	panic("Reached unreachable code")
+	panic(fmt.Sprintf("Single() cannot be called with %d types in the set", len(ts)))
 }
 
 // SetUnion returns a new set with all of the names in s1 or s2.
 func SetUnion(s1, s2 TypeNameSet) TypeNameSet {
-	var result TypeNameSet
+	result := make(TypeNameSet)
 	for val := range s1 {
-		result = result.Add(val)
+		result.Add(val)
 	}
 	for val := range s2 {
-		result = result.Add(val)
+		result.Add(val)
 	}
 	return result
 }

--- a/hack/generator/pkg/astmodel/type_name_set_test.go
+++ b/hack/generator/pkg/astmodel/type_name_set_test.go
@@ -1,0 +1,1 @@
+package astmodel

--- a/hack/generator/pkg/astmodel/type_name_set_test.go
+++ b/hack/generator/pkg/astmodel/type_name_set_test.go
@@ -1,1 +1,43 @@
 package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var (
+	oneTypeName = MakeTypeName(GenRuntimeReference, "One")
+	twoTypeName  = MakeTypeName(GenRuntimeReference, "Two")
+)
+
+
+/*
+ * Empty Set tests
+ */
+
+func Test_TypeNameSet_WhenEmpty_HasLengthZero(t *testing.T) {
+	g := NewGomegaWithT(t)
+	emptySet := NewTypeNameSet()
+	g.Expect(len(emptySet)).To(Equal(0))
+}
+
+/*
+ * Add() Tests
+ */
+
+func Test_TypeNameSet_AfterAddingFirstItem_ContainsItem(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := NewTypeNameSet()
+	set.Add(oneTypeName)
+	g.Expect(set.Contains(oneTypeName)).To(BeTrue())
+}
+
+func Test_TypeNameSet_AfterAddingSecondItem_ContainsItem(t *testing.T) {
+	g := NewGomegaWithT(t)
+	set := NewTypeNameSet()
+	set.Add(oneTypeName)
+	set.Add(twoTypeName)
+	g.Expect(set.Contains(twoTypeName)).To(BeTrue())
+}
+

--- a/hack/generator/pkg/codegen/embeddedresources/remover.go
+++ b/hack/generator/pkg/codegen/embeddedresources/remover.go
@@ -273,11 +273,21 @@ func findSubResourcePropertiesTypeNames(types astmodel.Types) (map[astmodel.Type
 			errs = append(errs, errors.Wrapf(err, "couldn't extract spec/status properties from %q", def.Name()))
 			continue
 		}
+
 		if specPropertiesTypeName != nil {
-			result[owner] = result[owner].Add(*specPropertiesTypeName)
+			if result[owner] == nil {
+				result[owner] = astmodel.NewTypeNameSet(*specPropertiesTypeName)
+			} else {
+				result[owner].Add(*specPropertiesTypeName)
+			}
 		}
+
 		if statusPropertiesTypeName != nil {
-			result[owner] = result[owner].Add(*statusPropertiesTypeName)
+			if result[owner] == nil {
+				result[owner] = astmodel.NewTypeNameSet(*statusPropertiesTypeName)
+			} else {
+				result[owner].Add(*statusPropertiesTypeName)
+			}
 		}
 	}
 
@@ -338,11 +348,13 @@ func findAllResourcePropertiesTypes(types astmodel.Types) (astmodel.TypeNameSet,
 			errs = append(errs, errors.Wrapf(err, "couldn't extract spec/status properties from %q", def.Name()))
 			continue
 		}
+
 		if specPropertiesTypeName != nil {
-			result = result.Add(*specPropertiesTypeName)
+			result.Add(*specPropertiesTypeName)
 		}
+
 		if statusPropertiesTypeName != nil {
-			result = result.Add(*statusPropertiesTypeName)
+			result.Add(*statusPropertiesTypeName)
 		}
 	}
 
@@ -378,7 +390,7 @@ func findAllResourceStatusTypes(types astmodel.Types) astmodel.TypeNameSet {
 			continue
 		}
 
-		result = result.Add(statusName)
+		result.Add(statusName)
 	}
 
 	return result
@@ -412,7 +424,7 @@ func requiredResourceProperties() []string {
 }
 
 // optionalResourceProperties are properties which may or may not be on a resource. Technically all resources
-// should have all of these properties, but because we drop the top-level allof that joins resource types with
+// should have all of these properties, but because we drop the top-level AllOf that joins resource types with
 // ResourceBase when parsing schemas sometimes they aren't defined.
 func optionalResourceProperties() []string {
 	return []string{

--- a/hack/generator/pkg/codegen/embeddedresources/renamer.go
+++ b/hack/generator/pkg/codegen/embeddedresources/renamer.go
@@ -145,7 +145,11 @@ func simplifyTypeNames(types astmodel.Types, flag astmodel.TypeFlag) (astmodel.T
 				return nil, err
 			}
 
-			updatedNames[embeddedName.original] = updatedNames[embeddedName.original].Add(def.Name())
+			if updatedNames[embeddedName.original] == nil {
+				updatedNames[embeddedName.original] = astmodel.NewTypeNameSet(def.Name())
+			} else {
+				updatedNames[embeddedName.original].Add(def.Name())
+			}
 		}
 	}
 

--- a/hack/generator/pkg/codegen/golden_files_test.go
+++ b/hack/generator/pkg/codegen/golden_files_test.go
@@ -284,7 +284,7 @@ func stripUnusedTypesPipelineStage() PipelineStage {
 }
 
 // TODO: Ideally we wouldn't need a test specific function here, but currently
-// TODO: we're hardcoding references, and even if we were sourcing them from Swagger
+// TODO: we're hard-coding references, and even if we were sourcing them from Swagger
 // TODO: we have no way to give Swagger to the golden files tests currently.
 func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) PipelineStage {
 	return MakePipelineStage(

--- a/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
+++ b/hack/generator/pkg/codegen/pipeline_strip_unused_types_test.go
@@ -43,9 +43,9 @@ func TestConnectionChecker_Avoids_Cycles(t *testing.T) {
 	graph := astmodel.NewReferenceGraph(roots, references)
 	connectedSet := graph.Connected()
 
-	var names astmodel.TypeNameSet
+	names := astmodel.NewTypeNameSet()
 	for name := range connectedSet {
-		names = names.Add(name)
+		names.Add(name)
 	}
 
 	g.Expect(names).To(Equal(makeSet("res1", "res2", "A", "B", "C", "D")))


### PR DESCRIPTION
**What this PR does / why we need it**:

I have a need in `StorageTypeFactory` to track all of the `TypeName` references encountered, checking to see if we process a `TypeDefinition` for each one. I've factored this out as a utility type and intend to use it from at least two different locations. 

We'd brainstormed the name `DynamicTypeNameCheckList` for this type, but that didn't work quite so well in use. 

I've also changed the API for `TypeNameSet` to remove the returns from mutators, and cleaned up code that was reliant upon them.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/QtvvwuvZUYD0hvTzpl/giphy.gif)

**If applicable**:
- [x] this PR contains tests
