### PR TITLE
Don't fail on flattening collisions

### DIFF
--- a/hack/generator/pkg/codegen/pipeline/flatten_properties.go
+++ b/hack/generator/pkg/codegen/pipeline/flatten_properties.go
@@ -53,7 +53,7 @@ func makeFlatteningVisitor(defs astmodel.Types) astmodel.TypeVisitor {
 
 			// safety check:
 			if err := checkForDuplicateNames(newProps); err != nil {
-				klog.V(1).Infof("Flattening caused duplicate property names, skipping flattening")
+				klog.Warningf("Flattening caused duplicate property names, skipping flattening")
 				return it, nil // nolint:nilerr
 			}
 

--- a/hack/generator/pkg/codegen/pipeline/flatten_properties.go
+++ b/hack/generator/pkg/codegen/pipeline/flatten_properties.go
@@ -53,7 +53,7 @@ func makeFlatteningVisitor(defs astmodel.Types) astmodel.TypeVisitor {
 
 			// safety check:
 			if err := checkForDuplicateNames(newProps); err != nil {
-				klog.Warningf("Flattening caused duplicate property names, skipping flattening")
+				klog.Warningf("Flattening caused duplicate property names, skipping flattening: %s", err)
 				return it, nil // nolint:nilerr
 			}
 

--- a/hack/generator/pkg/codegen/pipeline/flatten_properties.go
+++ b/hack/generator/pkg/codegen/pipeline/flatten_properties.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
 )
@@ -52,7 +53,8 @@ func makeFlatteningVisitor(defs astmodel.Types) astmodel.TypeVisitor {
 
 			// safety check:
 			if err := checkForDuplicateNames(newProps); err != nil {
-				return nil, err
+				klog.V(1).Infof("Flattening caused duplicate property names, skipping flattening")
+				return it, nil // nolint:nilerr
 			}
 
 			result := it.WithoutProperties().WithProperties(newProps...)

--- a/hack/generator/pkg/codegen/pipeline/flatten_properties_test.go
+++ b/hack/generator/pkg/codegen/pipeline/flatten_properties_test.go
@@ -30,8 +30,9 @@ func TestDuplicateNamesAreCaught(t *testing.T) {
 	types.Add(astmodel.MakeTypeDefinition(astmodel.MakeTypeName(placeholderPackage, "objType"), objType))
 
 	result, err := applyPropertyFlattening(context.Background(), types)
-	g.Expect(result).To(BeNil())
-	g.Expect(err).To(MatchError("visit of type of \"prefix/group/version/objType\" failed: flattening caused duplicate property name \"duplicate\""))
+	// We don't fail but flattening does not occur
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(types))
 }
 
 func TestFlatteningWorks(t *testing.T) {


### PR DESCRIPTION
The new VMSS resources do this (a collision on `Type` property). Technically we can handle this case properly but it will require more work.

We can handle the VMSS case because the user can't normally overwrite the top-level `Type` property, so any `Type` property in the CRD must point to the flattened `Type`. 