### PR TITLE
Convert Direction from enum into a discriminated union

### DIFF
--- a/hack/generator/pkg/conversions/direction.go
+++ b/hack/generator/pkg/conversions/direction.go
@@ -15,6 +15,10 @@ type Direction interface {
 	SelectString(from string, to string) string
 	// SelectType returns one of the provided types, depending on the direction of conversion
 	SelectType(from astmodel.Type, to astmodel.Type) astmodel.Type
+	// WhenFrom will run the specified function only if the direction is "From", returning the current direction for chaining
+	WhenFrom(fn func()) Direction
+	// WhenTo will run the specified function only if the direction is "To", returning the current direction for chaining
+	WhenTo(fn func()) Direction
 }
 
 var (
@@ -38,6 +42,18 @@ func (dir *ConvertFromDirection) SelectType(fromType astmodel.Type, _ astmodel.T
 	return fromType
 }
 
+// WhenFrom will run the supplied function, returning this FROM direction for chaining
+func (dir *ConvertFromDirection) WhenFrom(fn func()) Direction {
+	fn()
+	return dir
+}
+
+// WhenTo will skip the supplied function, returning this FROM direction for chaining
+func (dir *ConvertFromDirection) WhenTo(_ func()) Direction {
+	// Nothing
+	return dir
+}
+
 type ConvertToDirection struct{}
 
 var _ Direction = &ConvertToDirection{}
@@ -51,3 +67,15 @@ func (dir *ConvertToDirection) SelectString(_ string, toValue string) string {
 func (dir *ConvertToDirection) SelectType(_ astmodel.Type, toType astmodel.Type) astmodel.Type {
 	return toType
 }
+
+// WhenFrom will skip the supplied function, returning this TO direction for chaining
+func (dir *ConvertToDirection) WhenFrom(_ func()) Direction {
+	return dir
+}
+
+// WhenTo will run the supplied function, returning this TO direction for chaining
+func (dir *ConvertToDirection) WhenTo(fn func()) Direction {
+	fn()
+	return dir
+}
+

--- a/hack/generator/pkg/conversions/direction.go
+++ b/hack/generator/pkg/conversions/direction.go
@@ -78,4 +78,3 @@ func (dir *ConvertToDirection) WhenTo(fn func()) Direction {
 	fn()
 	return dir
 }
-

--- a/hack/generator/pkg/conversions/direction.go
+++ b/hack/generator/pkg/conversions/direction.go
@@ -5,12 +5,49 @@
 
 package conversions
 
-// Direction specifies the direction of conversion we're implementing with this function
-type Direction int
-
-const (
-	// ConvertFrom indicates the conversion is from the passed 'other', populating the receiver with properties from the other
-	ConvertFrom = Direction(1)
-	// ConvertTo indicates the conversion is to the passed 'other', populating the other with properties from the receiver
-	ConvertTo = Direction(2)
+import (
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
 )
+
+// Direction specifies the direction of conversion we're implementing with this function
+type Direction interface {
+	// SelectString returns one of the provided strings, depending on the direction of conversion
+	SelectString(from string, to string) string
+	// SelectType returns one of the provided types, depending on the direction of conversion
+	SelectType(from astmodel.Type, to astmodel.Type) astmodel.Type
+}
+
+var (
+	// ConvertFrom indicates the conversion is from the passed 'other', populating the receiver with properties from the other
+	ConvertFrom Direction = &ConvertFromDirection{}
+	// ConvertTo indicates the conversion is to the passed 'other', populating the other with properties from the receiver
+	ConvertTo Direction = &ConvertToDirection{}
+)
+
+type ConvertFromDirection struct{}
+
+var _ Direction = &ConvertFromDirection{}
+
+// SelectString returns the string for conversion FROM
+func (dir *ConvertFromDirection) SelectString(fromString string, _ string) string {
+	return fromString
+}
+
+// SelectType returns the type for conversion FROM
+func (dir *ConvertFromDirection) SelectType(fromType astmodel.Type, _ astmodel.Type) astmodel.Type {
+	return fromType
+}
+
+type ConvertToDirection struct{}
+
+var _ Direction = &ConvertToDirection{}
+
+// SelectString returns the string for conversion TO
+func (dir *ConvertToDirection) SelectString(_ string, toValue string) string {
+	return toValue
+}
+
+// SelectType returns the type for conversion TO
+func (dir *ConvertToDirection) SelectType(_ astmodel.Type, toType astmodel.Type) astmodel.Type {
+	return toType
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Code that needed to make a decision based on the direction of conversion always needed to handle "other" values with a panic; converting the type into an interface allows us to ensure that only valid implementations are provided, simplifying consumption.

This type will be used more frequently in upcoming PRs to implement type conversion.

Harvested from PR #1533

**Prerequisites**
- [x] PR #1606 to merge 
- [x] Rebasing on `master`

**Special notes for your reviewer**:

Let us take a moment and lament how `SelectString()` and `SelectType` would be a single method if Go had generics right now.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/9GJ1sNKxkKm9JzMjk5/giphy.gif)
