### PR TITLE
Ensure DB connections are closed when we've finished with them

### DIFF
--- a/controllers/mysql_combined_test.go
+++ b/controllers/mysql_combined_test.go
@@ -27,7 +27,7 @@ func TestMySQLHappyPath(t *testing.T) {
 	ctx := context.Background()
 
 	// Add any setup steps that needs to be executed before each test
-	rgLocation := "eastus2"
+	rgLocation := "westus2"
 	rgName := tc.resourceGroupName
 	mySQLServerName := GenerateTestResourceNameWithRandom("mysql-srv", 10)
 	mySQLReplicaName := GenerateTestResourceNameWithRandom("mysql-rep", 10)

--- a/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
+++ b/pkg/resourcemanager/azuresql/azuresqlaction/azuresqlaction.go
@@ -57,6 +57,7 @@ func (s *AzureSqlActionManager) UpdateUserPassword(
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	instance := &azurev1alpha1.AzureSQLUser{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqlmanageduser/azuresqlmanageduser_reconcile.go
@@ -85,6 +85,7 @@ func (s *AzureSqlManagedUserManager) Ensure(ctx context.Context, obj runtime.Obj
 		instance.Status.SetFailedProvisioning(instance.Status.Message)
 		return false, nil
 	}
+	defer db.Close()
 
 	userExists, err := s.UserExists(ctx, db, requestedUsername)
 	if err != nil {
@@ -189,6 +190,7 @@ func (s *AzureSqlManagedUserManager) Delete(ctx context.Context, obj runtime.Obj
 
 		return true, nil
 	}
+	defer db.Close()
 
 	userExists, err := s.UserExists(ctx, db, requestedUsername)
 	if err != nil {

--- a/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
+++ b/pkg/resourcemanager/azuresql/azuresqluser/azuresqluser_reconcile.go
@@ -134,6 +134,7 @@ func (s *AzureSqlUserManager) Ensure(ctx context.Context, obj runtime.Object, op
 
 		return false, err
 	}
+	defer db.Close()
 
 	userSecretKey := MakeSecretKey(userSecretClient, instance)
 
@@ -352,6 +353,7 @@ func (s *AzureSqlUserManager) Delete(ctx context.Context, obj runtime.Object, op
 		}
 		return false, err
 	}
+	defer db.Close()
 
 	var sqlUserSecretClient secrets.SecretClient
 	if options.SecretClient != nil {

--- a/pkg/resourcemanager/mysql/mysqlaaduser/reconcile.go
+++ b/pkg/resourcemanager/mysql/mysqlaaduser/reconcile.go
@@ -108,6 +108,7 @@ func (m *MySQLAADUserManager) Ensure(ctx context.Context, obj runtime.Object, op
 
 		return false, mysql.IgnoreDatabaseBusy(err)
 	}
+	defer db.Close()
 
 	instance.Status.SetProvisioning("")
 
@@ -179,6 +180,7 @@ func (m *MySQLAADUserManager) Delete(ctx context.Context, obj runtime.Object, op
 		}
 		return false, err
 	}
+	defer db.Close()
 
 	err = mysql.DropUser(ctx, db, instance.Username())
 	if err != nil {

--- a/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
+++ b/pkg/resourcemanager/mysql/mysqluser/mysqluser_reconcile.go
@@ -104,6 +104,7 @@ func (s *MySqlUserManager) Ensure(ctx context.Context, obj runtime.Object, opts 
 
 		return false, err
 	}
+	defer db.Close()
 
 	secretKey := secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
 	// create or get new user secret
@@ -228,6 +229,7 @@ func (s *MySqlUserManager) Delete(ctx context.Context, obj runtime.Object, opts 
 		}
 		return false, err
 	}
+	defer db.Close()
 
 	var userSecretClient secrets.SecretClient
 	if options.SecretClient != nil {

--- a/pkg/resourcemanager/psql/psqluser/psqluser_reconcile.go
+++ b/pkg/resourcemanager/psql/psqluser/psqluser_reconcile.go
@@ -124,6 +124,7 @@ func (m *PostgreSqlUserManager) Ensure(ctx context.Context, obj runtime.Object, 
 
 		return false, err
 	}
+	defer db.Close()
 
 	secretKey := secrets.SecretKey{Name: instance.Name, Namespace: instance.Namespace, Kind: instance.TypeMeta.Kind}
 
@@ -250,6 +251,7 @@ func (m *PostgreSqlUserManager) Delete(ctx context.Context, obj runtime.Object, 
 		//stop the reconcile with unkown error
 		return false, err
 	}
+	defer db.Close()
 
 	var psqlUserSecretClient secrets.SecretClient
 	if options.SecretClient != nil {


### PR DESCRIPTION
Closes #1576 

**What this PR does / why we need it**:
Before this change, the different resources would leak database connections whenever they were reconciled. Add `defer db.Close()` to all of the places that open database connections so that they are closed at the end of the method.

**Special notes for your reviewer**:
I started off making a cache to keep the `*sql.DB`s in so that they could be reused between reconciliations, but then the difficulty was ensuring we didn't keep the DBs in the cache indefinitely. One option was to hook up the database controller so it could remove the cached entry when the database was deleted, but that's quite fiddly architecturally. I also wrote [some code](https://github.com/Azure/azure-service-operator/compare/master...babbageclunk:bug/postgres-connections) to clear DBs from the cache if they haven't been requested after a fixed amount of time, which would work but would be really difficult to test (to an extent that is probably not worth it). 

**How does this PR make you feel**:
![gif](https://media1.tenor.com/images/f2a1b4ca0a0d8e12182f61efdf855247/tenor.gif?itemid=5730421)

