### PR TITLE
Add tparallel linter and fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   enable:
     - gofmt
     - megacheck
+    - tparallel
   presets:
     - bugs
     - unused

--- a/hack/generated/pkg/duration/duration_test.go
+++ b/hack/generated/pkg/duration/duration_test.go
@@ -62,6 +62,8 @@ func TestDuration_String(t *testing.T) {
 }
 
 func TestDuration_JSON(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		Name   string
 		JSON   string

--- a/hack/generator/pkg/astbuilder/literals_test.go
+++ b/hack/generator/pkg/astbuilder/literals_test.go
@@ -6,11 +6,14 @@
 package astbuilder
 
 import (
-	. "github.com/onsi/gomega"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func Test_LiteralString(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		original string

--- a/hack/generator/pkg/astmodel/array_type_test.go
+++ b/hack/generator/pkg/astmodel/array_type_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestArrayType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
+
 	strArray := NewArrayType(StringType)
 	intArray := NewArrayType(IntType)
 	otherStrArray := NewArrayType(StringType)

--- a/hack/generator/pkg/astmodel/enum_type_test.go
+++ b/hack/generator/pkg/astmodel/enum_type_test.go
@@ -61,6 +61,7 @@ func Test_EnumTypeBaseType_AfterConstruction_ReturnsExpectedType(t *testing.T) {
  */
 
 func Test_EnumTypeEquals_GivenEnums_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
 
 	enum := NewEnumType(StringType, aboveValue, underValue)
 

--- a/hack/generator/pkg/astmodel/external_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/external_package_reference_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestMakeExternalPackageReference_GivenPath_ReturnsInstanceWithPath(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name string
 		path string
@@ -32,6 +34,8 @@ func TestMakeExternalPackageReference_GivenPath_ReturnsInstanceWithPath(t *testi
 }
 
 func TestExternalPackageReferences_ReturnExpectedProperties(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name        string
 		path        string
@@ -58,6 +62,7 @@ func TestExternalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 }
 
 func TestExternalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
+	t.Parallel()
 
 	fmtRef := MakeExternalPackageReference("fmt")
 	astRef := MakeExternalPackageReference("go/ast")
@@ -90,6 +95,8 @@ func TestExternalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
 }
 
 func TestExternalPackageReferenceIsPreview(t *testing.T) {
+	t.Parallel()
+
 	fmtRef := MakeExternalPackageReference("fmt")
 	astRef := MakeExternalPackageReference("go/ast")
 	otherRef := makeTestLocalPackageReference("group", "package")

--- a/hack/generator/pkg/astmodel/flagged_type_test.go
+++ b/hack/generator/pkg/astmodel/flagged_type_test.go
@@ -79,6 +79,8 @@ func TestFlaggedType_WithoutFlag_GivenUnusedFlag_ReturnsSameInstance(t *testing.
  */
 
 func TestFlaggedType_Equals_GivenOther_HasExpectedResult(t *testing.T) {
+	t.Parallel()
+
 	armString := NewFlaggedType(StringType, ARMFlag)
 	armInt := NewFlaggedType(IntType, ARMFlag)
 	storageString := NewFlaggedType(StringType, StorageFlag)
@@ -120,6 +122,8 @@ func TestFlaggedType_Equals_GivenOther_HasExpectedResult(t *testing.T) {
  */
 
 func TestFlaggedType_String_GivenTypeAndTag_ReturnsExpectedString(t *testing.T) {
+	t.Parallel()
+
 	flaggedString := NewFlaggedType(StringType, OneOfFlag)
 	cases := []struct {
 		name       string

--- a/hack/generator/pkg/astmodel/identifier_factory_test.go
+++ b/hack/generator/pkg/astmodel/identifier_factory_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func Test_CreateIdentifier_GivenName_ReturnsExpectedIdentifier(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name       string
 		visibility Visibility
@@ -58,6 +60,8 @@ func Test_CreateIdentifier_GivenName_ReturnsExpectedIdentifier(t *testing.T) {
 }
 
 func Test_SliceIntoWords_GivenIdentifier_ReturnsExpectedSlice(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		identifier string
 		expected   []string
@@ -89,6 +93,8 @@ func Test_SliceIntoWords_GivenIdentifier_ReturnsExpectedSlice(t *testing.T) {
 }
 
 func Test_TransformToSnakeCase_ReturnsExpectedString(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		string   string
 		expected string
@@ -120,6 +126,8 @@ func Test_TransformToSnakeCase_ReturnsExpectedString(t *testing.T) {
 }
 
 func Test_SimplifyIdentifier_GivenContextAndName_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		context    string
 		identifier string

--- a/hack/generator/pkg/astmodel/local_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/local_package_reference_test.go
@@ -16,6 +16,8 @@ func makeTestLocalPackageReference(group string, version string) LocalPackageRef
 }
 
 func TestMakeLocalPackageReference_GivenGroupAndPackage_ReturnsInstanceWithProperties(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name  string
 		group string
@@ -42,6 +44,8 @@ func TestMakeLocalPackageReference_GivenGroupAndPackage_ReturnsInstanceWithPrope
 }
 
 func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name         string
 		group        string
@@ -87,6 +91,7 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 }
 
 func TestLocalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
+	t.Parallel()
 
 	batchRef := makeTestLocalPackageReference("microsoft.batch", "v20200901")
 	olderRef := makeTestLocalPackageReference("microsoft.batch", "v20150101")
@@ -122,6 +127,7 @@ func TestLocalPackageReferences_Equals_GivesExpectedResults(t *testing.T) {
 }
 
 func TestLocalPackageReferenceIsPreview(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		name      string

--- a/hack/generator/pkg/astmodel/map_type_test.go
+++ b/hack/generator/pkg/astmodel/map_type_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMapType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
 
 	strToStr := NewMapType(StringType, StringType)
 	strToBool := NewMapType(StringType, BoolType)

--- a/hack/generator/pkg/astmodel/meta_type_test.go
+++ b/hack/generator/pkg/astmodel/meta_type_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAsPrimitiveType(t *testing.T) {
+	t.Parallel()
 
 	objectType := NewObjectType()
 	arrayType := NewArrayType(StringType)
@@ -56,12 +57,12 @@ func TestAsPrimitiveType(t *testing.T) {
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(ok).To(BeTrue())
 			}
-
 		})
 	}
 }
 
 func TestAsObjectType(t *testing.T) {
+	t.Parallel()
 
 	objectType := NewObjectType()
 	arrayType := NewArrayType(StringType)
@@ -106,12 +107,12 @@ func TestAsObjectType(t *testing.T) {
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(ok).To(BeTrue())
 			}
-
 		})
 	}
 }
 
 func TestAsArrayType(t *testing.T) {
+	t.Parallel()
 
 	objectType := NewObjectType()
 	arrayType := NewArrayType(StringType)
@@ -156,12 +157,12 @@ func TestAsArrayType(t *testing.T) {
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(ok).To(BeTrue())
 			}
-
 		})
 	}
 }
 
 func TestAsMapType(t *testing.T) {
+	t.Parallel()
 
 	objectType := NewObjectType()
 	arrayType := NewArrayType(StringType)
@@ -206,12 +207,12 @@ func TestAsMapType(t *testing.T) {
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(ok).To(BeTrue())
 			}
-
 		})
 	}
 }
 
 func TestAsOptionalType(t *testing.T) {
+	t.Parallel()
 
 	objectType := NewObjectType()
 	arrayType := NewArrayType(StringType)
@@ -254,12 +255,12 @@ func TestAsOptionalType(t *testing.T) {
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(ok).To(BeTrue())
 			}
-
 		})
 	}
 }
 
 func TestAsEnumType(t *testing.T) {
+	t.Parallel()
 
 	objectType := NewObjectType()
 	arrayType := NewArrayType(StringType)
@@ -302,12 +303,12 @@ func TestAsEnumType(t *testing.T) {
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(ok).To(BeTrue())
 			}
-
 		})
 	}
 }
 
 func TestAsTypeName(t *testing.T) {
+	t.Parallel()
 
 	objectType := NewObjectType()
 	arrayType := NewArrayType(StringType)
@@ -350,7 +351,6 @@ func TestAsTypeName(t *testing.T) {
 				g.Expect(actual).To(Equal(c.expected))
 				g.Expect(ok).To(BeTrue())
 			}
-
 		})
 	}
 }

--- a/hack/generator/pkg/astmodel/object_type_test.go
+++ b/hack/generator/pkg/astmodel/object_type_test.go
@@ -84,6 +84,7 @@ func Test_EmbeddedProperties_GivenObjectWithProperties_ReturnsExpectedSortedSlic
  */
 
 func TestObjectType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
 
 	clanName := NewStringPropertyDefinition("Clan")
 	testcaseA := NewFakeTestCase("testcaseA")

--- a/hack/generator/pkg/astmodel/package_import_set_test.go
+++ b/hack/generator/pkg/astmodel/package_import_set_test.go
@@ -197,6 +197,7 @@ func TestRemove_WhenItemNotInSet_LeavesSetWithoutIt(t *testing.T) {
  */
 
 func TestByNameInGroups_AppliesExpectedOrdering(t *testing.T) {
+	t.Parallel()
 
 	fmtRef := MakeExternalPackageReference("fmt")
 	testingRef := MakeExternalPackageReference("testing")
@@ -265,6 +266,7 @@ func TestPackageImportSet_ResolveConflicts_GivenExplicitlyNamedConflicts_Returns
 }
 
 func TestPackageImportSet_ResolveConflicts_GivenImplicityNamedConflicts_AssignsExpectedNames(t *testing.T) {
+	t.Parallel()
 
 	createSet := func(refs ...PackageReference) *PackageImportSet {
 		result := NewPackageImportSet()
@@ -303,7 +305,8 @@ func TestPackageImportSet_ResolveConflicts_GivenImplicityNamedConflicts_AssignsE
 			"Import conflicts with versioned resolution (ii)",
 			createSet(emailTestRef, networkTestRef, emailTestAltRef, networkTestAltRef),
 			networkTestRef,
-			"networkv20180801"},
+			"networkv20180801",
+		},
 		{
 			"Import conflicts with versioned resolution (iii)",
 			createSet(emailTestRef, networkTestRef, emailTestAltRef, networkTestAltRef),
@@ -339,6 +342,7 @@ func TestPackageImportSet_ResolveConflicts_GivenImplicityNamedConflicts_AssignsE
  */
 
 func Test_PackageSet_OrderImports(t *testing.T) {
+	t.Parallel()
 
 	alphaRef := MakeExternalPackageReference("alpha")
 	betaRef := MakeExternalPackageReference("beta")

--- a/hack/generator/pkg/astmodel/package_import_test.go
+++ b/hack/generator/pkg/astmodel/package_import_test.go
@@ -71,6 +71,8 @@ func Test_PackageImportWithName_GivenExistingName_ReturnsEqualInstance(t *testin
  */
 
 func TestPackageImport_Equals(t *testing.T) {
+	t.Parallel()
+
 	var zeroPkgRef PackageImport
 	localPkgRef := makeTestLocalPackageReference("group", "ver")
 	localPkgImport := NewPackageImport(localPkgRef)
@@ -107,6 +109,8 @@ func TestPackageImport_Equals(t *testing.T) {
  */
 
 func TestPackageImport_ServiceNameForImport_GivenImport_ReturnsExpectedName(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		ref      PackageReference

--- a/hack/generator/pkg/astmodel/package_reference_test.go
+++ b/hack/generator/pkg/astmodel/package_reference_test.go
@@ -29,6 +29,8 @@ func TestSortPackageReferencesByPathAndVersion(t *testing.T) {
 }
 
 func TestComparePackageReferencesByPathAndVersion(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		left     string
@@ -74,6 +76,8 @@ func TestComparePackageReferencesByPathAndVersion(t *testing.T) {
 }
 
 func TestVersionComparerCompareNumeric(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		left     string

--- a/hack/generator/pkg/astmodel/primitive_type_test.go
+++ b/hack/generator/pkg/astmodel/primitive_type_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPrimitiveType_Equals_WhenGivenType_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
+
 	otherType := NewArrayType(IntType)
 
 	cases := []struct {

--- a/hack/generator/pkg/astmodel/property_definition_test.go
+++ b/hack/generator/pkg/astmodel/property_definition_test.go
@@ -334,6 +334,8 @@ func Test_PropertyDefinitionMakeRequired_WhenTypeOptionalAndIsRequired_ReturnsNe
 }
 
 func Test_PropertyDefinitionMakeRequired_PropertyTypeArrayAndMap(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name         string
 		propertyType Type
@@ -402,6 +404,8 @@ func Test_PropertyDefinitionMakeOptional_WhenTypeMandatoryAndIsRequiredFalse_Ret
 }
 
 func Test_PropertyDefinitionMakeOptional_PropertyTypeArrayAndMap(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name                  string
 		propertyType          Type
@@ -474,6 +478,8 @@ func Test_PropertyDefinition_WithValidation_ReturnsNewPropertyDefinition(t *test
  */
 
 func TestPropertyDefinition_Equals_WhenGivenPropertyDefinition_ReturnsExpectedResult(t *testing.T) {
+	t.Parallel()
+
 	strProperty := createStringProperty("FullName", "Full Legal Name")
 	otherStrProperty := createStringProperty("FullName", "Full Legal Name")
 

--- a/hack/generator/pkg/astmodel/storage_package_reference_test.go
+++ b/hack/generator/pkg/astmodel/storage_package_reference_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMakeStoragePackageReference(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		group           string
@@ -37,6 +38,8 @@ func TestMakeStoragePackageReference(t *testing.T) {
 }
 
 func TestStoragePackageReferenceEquals(t *testing.T) {
+	t.Parallel()
+
 	localRef := makeTestLocalPackageReference("group", "v1")
 	storageRef := MakeStoragePackageReference(localRef)
 	otherRef := MakeStoragePackageReference(localRef)
@@ -67,6 +70,8 @@ func TestStoragePackageReferenceEquals(t *testing.T) {
 }
 
 func TestStoragePackageReferenceIsPreview(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name      string
 		version   string

--- a/hack/generator/pkg/astmodel/type_flag_test.go
+++ b/hack/generator/pkg/astmodel/type_flag_test.go
@@ -27,6 +27,7 @@ func TestTypeFlag_Wrap_GivenType_ReturnsWrappedType(t *testing.T) {
  */
 
 func TestTypeFlag_IsOn_GivenType_ReturnsExpectedValue(t *testing.T) {
+	t.Parallel()
 
 	armString := ARMFlag.ApplyTo(StringType)
 
@@ -57,6 +58,7 @@ func TestTypeFlag_IsOn_GivenType_ReturnsExpectedValue(t *testing.T) {
  */
 
 func TestTypeFlag_RemoveFrom_ReturnsExpectedValue(t *testing.T) {
+	t.Parallel()
 
 	armString := ARMFlag.ApplyTo(StringType)
 	armStorageString := StorageFlag.ApplyTo(armString)

--- a/hack/generator/pkg/astmodel/type_name_test.go
+++ b/hack/generator/pkg/astmodel/type_name_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSingular_GivesExpectedResults(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		expected string
@@ -43,6 +45,8 @@ func TestSingular_GivesExpectedResults(t *testing.T) {
 }
 
 func TestPlural_GivesExpectedResults(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name     string
 		expected string

--- a/hack/generator/pkg/astmodel/type_test.go
+++ b/hack/generator/pkg/astmodel/type_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestWriteDebugDescription(t *testing.T) {
+	t.Parallel()
 
 	here := MakeLocalPackageReference("local", "test", "v1")
 

--- a/hack/generator/pkg/astmodel/type_visitor_test.go
+++ b/hack/generator/pkg/astmodel/type_visitor_test.go
@@ -6,13 +6,15 @@
 package astmodel
 
 import (
-	"github.com/pkg/errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	. "github.com/onsi/gomega"
 )
 
 func Test_Visit_GivenCountingTypeVisitor_ReturnsExpectedCounts(t *testing.T) {
+	t.Parallel()
 
 	arrType := NewArrayType(StringType)
 	mapType := NewMapType(StringType, StringType)
@@ -123,6 +125,7 @@ func MakeCountingTypeVisitor() *CountingTypeVisitor {
 }
 
 func TestIdentityVisitorReturnsEqualResult(t *testing.T) {
+	t.Parallel()
 
 	mapOfStringToString := NewMapType(StringType, StringType)
 	mapOfStringToBool := NewMapType(StringType, BoolType)
@@ -177,6 +180,7 @@ func TestIdentityVisitorReturnsEqualResult(t *testing.T) {
 }
 
 func TestMakeTypeVisitorWithInjectedFunctions(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		name          string

--- a/hack/generator/pkg/codegen/pipeline/status_from_swagger_test.go
+++ b/hack/generator/pkg/codegen/pipeline/status_from_swagger_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func Test_ShouldSkipDir_GivenPath_HasExpectedResult(t *testing.T) {
+	t.Parallel()
+
 	linuxCases := []struct {
 		name       string
 		path       string

--- a/hack/generator/pkg/config/create_globbing_regex_test.go
+++ b/hack/generator/pkg/config/create_globbing_regex_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func Test_CreateGlobbingRegex_ReturnsExpectedRegex(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		glob  string
@@ -36,6 +37,7 @@ func Test_CreateGlobbingRegex_ReturnsExpectedRegex(t *testing.T) {
 }
 
 func Test_GlobbingRegex_MatchesExpectedStrings(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		regex       string

--- a/hack/generator/pkg/functions/property_assignment_function_test.go
+++ b/hack/generator/pkg/functions/property_assignment_function_test.go
@@ -23,7 +23,6 @@ type StorageConversionPropertyTestCase struct {
 }
 
 func CreatePropertyAssignmentFunctionTestCases() []*StorageConversionPropertyTestCase {
-
 	// Package References
 	vCurrent := test.MakeLocalPackageReference("Verification", "vCurrent")
 	vNext := test.MakeLocalPackageReference("Verification", "vNext")
@@ -207,6 +206,8 @@ func CreatePropertyAssignmentFunctionTestCases() []*StorageConversionPropertyTes
 }
 
 func TestPropertyAssignmentFunction_AsFunc(t *testing.T) {
+	t.Parallel()
+
 	for _, c := range CreatePropertyAssignmentFunctionTestCases() {
 		c := c
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
If subtests are going to run in parallel the parent test needs to be marked as well; this linter catches it.