### PR TITLE
Prune unused types after flattening

### DIFF
--- a/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
+++ b/hack/generator/pkg/astmodel/armconversion/arm_conversion_function.go
@@ -6,8 +6,9 @@
 package armconversion
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
 	"github.com/dave/dst"
+
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
 )
 
 // ARMConversionFunction represents an ARM conversion function for converting between a Kubernetes resource
@@ -53,7 +54,9 @@ func (c *ARMConversionFunction) RequiredPackageReferences() *astmodel.PackageRef
 	return result
 }
 
-// References this type has to the given type
+// References returns the set of types to which this function refers.
+// SHOULD include any types which this function references but its receiver doesn't.
+// SHOULD NOT include the receiver of this function.
 func (c *ARMConversionFunction) References() astmodel.TypeNameSet {
 	return c.armType.References()
 }

--- a/hack/generator/pkg/astmodel/function.go
+++ b/hack/generator/pkg/astmodel/function.go
@@ -18,7 +18,8 @@ type Function interface {
 	RequiredPackageReferences() *PackageReferenceSet
 
 	// References returns the set of types to which this function refers.
-	// Should *not* include the receiver of this function
+	// SHOULD include any types which this function references but its receiver doesn't.
+	// SHOULD NOT include the receiver of this function.
 	References() TypeNameSet
 
 	// AsFunc renders the current instance as a Go abstract syntax tree
@@ -53,9 +54,11 @@ func (k *objectFunction) RequiredPackageReferences() *PackageReferenceSet {
 	return k.requiredPackages
 }
 
-// References returns the TypeName's referenced by this function
+// References returns the set of types to which this function refers.
+// SHOULD include any types which this function references but its receiver doesn't.
+// SHOULD NOT include the receiver of this function.
 func (k *objectFunction) References() TypeNameSet {
-	return k.o.References()
+	return nil
 }
 
 // AsFunc renders the current instance as a Go abstract syntax tree
@@ -97,9 +100,11 @@ func (r *resourceFunction) RequiredPackageReferences() *PackageReferenceSet {
 	return r.requiredPackages
 }
 
-// References returns the TypeName's referenced by this function
+// References returns the set of types to which this function refers.
+// SHOULD include any types which this function references but its receiver doesn't.
+// SHOULD NOT include the receiver of this function.
 func (r *resourceFunction) References() TypeNameSet {
-	return r.resource.References()
+	return nil
 }
 
 // AsFunc renders the current instance as a Go abstract syntax tree

--- a/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
+++ b/hack/generator/pkg/astmodel/one_of_json_marshal_function.go
@@ -43,10 +43,11 @@ func (f *OneOfJSONMarshalFunction) Equals(other Function) bool {
 	return false
 }
 
-// References returns the set of references for the underlying object.
+// References returns the set of types to which this function refers.
+// SHOULD include any types which this function references but its receiver doesn't.
+// SHOULD NOT include the receiver of this function.
 func (f *OneOfJSONMarshalFunction) References() TypeNameSet {
-	// Defer this check to the owning object as we only refer to its properties and it
-	return f.oneOfObject.References()
+	return nil
 }
 
 // AsFunc returns the function as a go dst

--- a/hack/generator/pkg/astmodel/package_definition.go
+++ b/hack/generator/pkg/astmodel/package_definition.go
@@ -153,7 +153,7 @@ func (p *PackageDefinition) writeTestFile(
 }
 
 func allocateTypesToFiles(types Types) map[string][]TypeDefinition {
-	graph := NewReferenceGraphWithResourcesAsRoots(types)
+	graph := MakeReferenceGraphWithResourcesAsRoots(types)
 
 	type Root struct {
 		depth int

--- a/hack/generator/pkg/astmodel/reference_graph.go
+++ b/hack/generator/pkg/astmodel/reference_graph.go
@@ -68,28 +68,33 @@ func CollectARMSpecAndStatusDefinitions(definitions Types) TypeNameSet {
 	return armSpecAndStatus
 }
 
-// NewReferenceGraph produces a new ReferenceGraph with the given roots and references
-func NewReferenceGraph(roots TypeNameSet, references map[TypeName]TypeNameSet) ReferenceGraph {
+// MakeReferenceGraph produces a new ReferenceGraph with the given roots and references
+func MakeReferenceGraph(roots TypeNameSet, references map[TypeName]TypeNameSet) ReferenceGraph {
 	return ReferenceGraph{
 		roots:      roots,
 		references: references,
 	}
 }
 
-// NewReferenceGraphWithResourcesAsRoots produces a ReferenceGraph for the given set of
-// types, where the Resource types (and their ARM spec/status) are the roots.
-func NewReferenceGraphWithResourcesAsRoots(types Types) ReferenceGraph {
-	resources := CollectResourceDefinitions(types)
-	armSpecAndStatus := CollectARMSpecAndStatusDefinitions(types)
-
-	roots := SetUnion(resources, armSpecAndStatus)
-
+// MakeReferenceGraphWithRoots produces a ReferenceGraph with the given roots, and references
+// derived from the provided types collection.
+func MakeReferenceGraphWithRoots(roots TypeNameSet, types Types) ReferenceGraph {
 	references := make(map[TypeName]TypeNameSet)
 	for _, def := range types {
 		references[def.Name()] = def.References()
 	}
 
-	return NewReferenceGraph(roots, references)
+	return MakeReferenceGraph(roots, references)
+}
+
+// MakeReferenceGraphWithResourcesAsRoots produces a ReferenceGraph for the given set of
+// types, where the Resource types (and their ARM spec/status) are the roots.
+func MakeReferenceGraphWithResourcesAsRoots(types Types) ReferenceGraph {
+	resources := CollectResourceDefinitions(types)
+	armSpecAndStatus := CollectARMSpecAndStatusDefinitions(types)
+	roots := SetUnion(resources, armSpecAndStatus)
+
+	return MakeReferenceGraphWithRoots(roots, types)
 }
 
 type ReachableTypes map[TypeName]int // int = depth

--- a/hack/generator/pkg/astmodel/reference_graph_test.go
+++ b/hack/generator/pkg/astmodel/reference_graph_test.go
@@ -49,7 +49,7 @@ func Test_ReferenceGraph_Gives_Correct_Depth(t *testing.T) {
 
 	roots := names("r")
 
-	graph := NewReferenceGraph(roots, references)
+	graph := MakeReferenceGraph(roots, references)
 
 	result := graph.Connected()
 

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -145,6 +145,9 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		// Effects the "flatten" property of Properties:
 		pipeline.FlattenProperties(),
 
+		// Remove types which may not be needed after flattening
+		pipeline.StripUnreferencedTypeDefinitions(),
+
 		pipeline.AddCrossplaneOwnerProperties(idFactory).UsedFor(pipeline.CrossplaneTarget),
 		pipeline.AddCrossplaneForProvider(idFactory).UsedFor(pipeline.CrossplaneTarget),
 		pipeline.AddCrossplaneAtProvider(idFactory).UsedFor(pipeline.CrossplaneTarget),

--- a/hack/generator/pkg/codegen/pipeline/create_arm_types.go
+++ b/hack/generator/pkg/codegen/pipeline/create_arm_types.go
@@ -159,7 +159,12 @@ func (c *armTypeCreator) createARMTypeDefinition(isSpecType bool, def astmodel.T
 	}
 
 	armName := astmodel.CreateARMTypeName(def.Name())
-	armDef, err := def.WithName(armName).ApplyObjectTransformations(removeValidations, convertObjectPropertiesForARM, addOneOfConversionFunctionIfNeeded, removeFlattening)
+	armDef, err := def.WithName(armName).ApplyObjectTransformations(
+		removeValidations,
+		convertObjectPropertiesForARM,
+		addOneOfConversionFunctionIfNeeded,
+		removeFlattening)
+
 	if err != nil {
 		return astmodel.TypeDefinition{},
 			errors.Wrapf(err, "creating ARM prototype %v from Kubernetes definition %v", armName, def.Name())
@@ -265,6 +270,22 @@ func (c *armTypeCreator) convertObjectPropertiesForARM(t *astmodel.ObjectType, i
 			} else {
 				result = result.WithProperty(prop.WithType(newType))
 			}
+		}
+	}
+
+	// Also convert embedded properties if there are any
+	result = result.WithoutEmbeddedProperties() // Clear them out first so we're starting with a clean slate
+	for _, prop := range t.EmbeddedProperties() {
+		newType, err := c.convertARMPropertyTypeIfNeeded(prop.PropertyType())
+
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		result, err = result.WithEmbeddedProperty(prop.WithType(newType))
+		if err != nil {
+			errs = append(errs, err)
+			continue
 		}
 	}
 

--- a/hack/generator/pkg/codegen/pipeline/strip_unused_types_test.go
+++ b/hack/generator/pkg/codegen/pipeline/strip_unused_types_test.go
@@ -40,7 +40,7 @@ func TestConnectionChecker_Avoids_Cycles(t *testing.T) {
 		makeName("D"):    makeSet("A"), // cyclic
 	}
 
-	graph := astmodel.NewReferenceGraph(roots, references)
+	graph := astmodel.MakeReferenceGraph(roots, references)
 	connectedSet := graph.Connected()
 
 	names := astmodel.NewTypeNameSet()

--- a/hack/generator/pkg/codegen/testdata/ARMCodeGeneratorPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/ARMCodeGeneratorPipeline.golden
@@ -24,6 +24,7 @@ createArmTypes                      azure      Create types for interaction with
 applyArmConversionInterface         azure      Add ARM conversion interfaces to Kubernetes types
 applyKubernetesResourceInterface    azure      Add the KubernetesResource interface to every resource
 flattenProperties                              Apply flattening to properties marked for flattening
+stripUnreferenced                              Strip unreferenced types
 addCrossplaneOwnerProperties        crossplane Add the 3-tuple of (xName, xNameRef, xNameSelector) for each owning resource
 addCrossplaneForProviderProperty    crossplane Add a 'ForProvider' property on every spec
 addCrossplaneAtProviderProperty     crossplane Add an 'AtProvider' property on every status

--- a/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -13,10 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-type EmbeddedTestTypeARM struct {
-	FancyProp int `json:"fancyProp"`
-}
-
 // +kubebuilder:rbac:groups=test.infra.azure.com,resources=fakeresources,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=test.infra.azure.com,resources={fakeresources/status,fakeresources/finalizers},verbs=get;update;patch
 
@@ -157,13 +153,13 @@ type FakeResourceList struct {
 }
 
 type FakeResource_SpecARM struct {
-	EmbeddedTestType `json:",inline"`
-	APIVersion       FakeResourceSpecAPIVersion `json:"apiVersion"`
-	Color            *FakeResourceSpecColor     `json:"color,omitempty"`
-	Foo              FooARM                     `json:"foo"`
-	Name             string                     `json:"name"`
-	OptionalFoo      *FooARM                    `json:"optionalFoo,omitempty"`
-	Type             FakeResourceSpecType       `json:"type"`
+	EmbeddedTestTypeARM `json:",inline"`
+	APIVersion          FakeResourceSpecAPIVersion `json:"apiVersion"`
+	Color               *FakeResourceSpecColor     `json:"color,omitempty"`
+	Foo                 FooARM                     `json:"foo"`
+	Name                string                     `json:"name"`
+	OptionalFoo         *FooARM                    `json:"optionalFoo,omitempty"`
+	Type                FakeResourceSpecType       `json:"type"`
 }
 
 var _ genruntime.ARMResourceSpec = &FakeResource_SpecARM{}
@@ -183,41 +179,8 @@ func (fakeResourceSpecARM FakeResource_SpecARM) GetType() string {
 	return string(fakeResourceSpecARM.Type)
 }
 
-type EmbeddedTestType struct {
+type EmbeddedTestTypeARM struct {
 	FancyProp int `json:"fancyProp"`
-}
-
-var _ genruntime.ARMTransformer = &EmbeddedTestType{}
-
-// ConvertToARM converts from a Kubernetes CRD object to an ARM object
-func (embeddedTestType *EmbeddedTestType) ConvertToARM(name string, resolvedReferences genruntime.ResolvedReferences) (interface{}, error) {
-	if embeddedTestType == nil {
-		return nil, nil
-	}
-	var result EmbeddedTestTypeARM
-
-	// Set property ‘FancyProp’:
-	result.FancyProp = embeddedTestType.FancyProp
-	return result, nil
-}
-
-// CreateEmptyARMValue returns an empty ARM value suitable for deserializing into
-func (embeddedTestType *EmbeddedTestType) CreateEmptyARMValue() interface{} {
-	return EmbeddedTestTypeARM{}
-}
-
-// PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
-func (embeddedTestType *EmbeddedTestType) PopulateFromARM(owner genruntime.KnownResourceReference, armInput interface{}) error {
-	typedInput, ok := armInput.(EmbeddedTestTypeARM)
-	if !ok {
-		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EmbeddedTestTypeARM, got %T", armInput)
-	}
-
-	// Set property ‘FancyProp’:
-	embeddedTestType.FancyProp = typedInput.FancyProp
-
-	// No error
-	return nil
 }
 
 // +kubebuilder:validation:Enum={"2020-06-01"}
@@ -352,8 +315,45 @@ func (fakeResourceSpec *FakeResource_Spec) SetAzureName(azureName string) {
 
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/Foo
 type FooARM struct {
-	EmbeddedTestType `json:",inline"`
-	Name             *string `json:"name,omitempty"`
+	EmbeddedTestTypeARM `json:",inline"`
+	Name                *string `json:"name,omitempty"`
+}
+
+type EmbeddedTestType struct {
+	FancyProp int `json:"fancyProp"`
+}
+
+var _ genruntime.ARMTransformer = &EmbeddedTestType{}
+
+// ConvertToARM converts from a Kubernetes CRD object to an ARM object
+func (embeddedTestType *EmbeddedTestType) ConvertToARM(name string, resolvedReferences genruntime.ResolvedReferences) (interface{}, error) {
+	if embeddedTestType == nil {
+		return nil, nil
+	}
+	var result EmbeddedTestTypeARM
+
+	// Set property ‘FancyProp’:
+	result.FancyProp = embeddedTestType.FancyProp
+	return result, nil
+}
+
+// CreateEmptyARMValue returns an empty ARM value suitable for deserializing into
+func (embeddedTestType *EmbeddedTestType) CreateEmptyARMValue() interface{} {
+	return EmbeddedTestTypeARM{}
+}
+
+// PopulateFromARM populates a Kubernetes CRD object from an Azure ARM object
+func (embeddedTestType *EmbeddedTestType) PopulateFromARM(owner genruntime.KnownResourceReference, armInput interface{}) error {
+	typedInput, ok := armInput.(EmbeddedTestTypeARM)
+	if !ok {
+		return fmt.Errorf("unexpected type supplied for PopulateFromARM() function. Expected EmbeddedTestTypeARM, got %T", armInput)
+	}
+
+	// Set property ‘FancyProp’:
+	embeddedTestType.FancyProp = typedInput.FancyProp
+
+	// No error
+	return nil
 }
 
 //Generated from: https://test.test/schemas/2020-01-01/test.json#/definitions/Foo

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
@@ -145,11 +145,6 @@ type AResourceList struct {
 	Items           []AResource `json:"items"`
 }
 
-// +kubebuilder:validation:Enum={"onlyonevalue"}
-type AResourceSpecName string
-
-const AResourceSpecNameOnlyonevalue = AResourceSpecName("onlyonevalue")
-
 type AResource_SpecARM struct {
 	APIVersion AResourceSpecAPIVersion `json:"apiVersion"`
 	Name       string                  `json:"name"`

--- a/hack/generator/pkg/codegen/testdata/TestCodeGeneratorPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestCodeGeneratorPipeline.golden
@@ -19,6 +19,7 @@ replaceAnyTypeWithJSON                         Replace properties using interfac
 addCrossResourceReferences          azure      Replace cross-resource references with genruntime.ResourceReference
 applyKubernetesResourceInterface    azure      Add the KubernetesResource interface to every resource
 flattenProperties                              Apply flattening to properties marked for flattening
+stripUnused                                    Strip unused types for test
 simplifyDefinitions                            Flatten definitions by removing wrapper types
 jsonTestCases                       azure      Add test cases to verify JSON serialization
 markStorageVersion                             Mark the latest version of each resource as the storage version


### PR DESCRIPTION
* Flattening can cause types which were previously being used to no longer be used. 
   Run a prune after flattening to ensure that we remove these unneeded types.
* Fix bug in Function References() where many functions were incorrectly referring to 
   their receiverType, resulting in types remaining included when they should have been
   removed.
* Fix small bug in embedded type handling exposed by this change so that 
   the golden tests pass.
