### PR TITLE
Clean up autogenerated properties

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -15,12 +15,6 @@ typeFilters:
     group: microsoft.servicebus
     version: v*api20210101preview
     because: We want to export this particular preview version
-  # TODO: This is temporarily included because the SB RP doesn't support queue/topic
-  # TODO: in 20210101preview right now.
-  - action: include
-    group: microsoft.servicebus
-    version: v*api20180101preview
-    because: We want to export this particular preview version
   - action: prune
     version: '*preview'
     because: preview SDK versions are excluded by default
@@ -210,7 +204,6 @@ typeTransformers:
     target:
       name: string
     because: Modeling this as an enum doesn't work well in the context of CRDs because new regions are regularly added
-
   - name: "*"
     property: Condition
     ifType:
@@ -300,9 +293,29 @@ typeTransformers:
     because: it has no writable properties in swagger
 
   # Deal with properties that should have been marked readOnly but weren't
-  - name: Namespaces_Spec
-    group: microsoft.servicebus
+  - group: microsoft.servicebus
+    name: Namespaces_Spec_Properties  # This type is subsequently flattened into Namespaces_Spec. I don't know why it's called this either (I think it should be SBNamespaceProperties?)
     property: PrivateEndpointConnections
+    remove: true
+    because: This property should have been marked readonly but wasn't.
+  - group: microsoft.servicebus
+    name: SBQueueProperties  # This type is subsequently flattened into NamespacesQueues_Spec
+    property: Status
+    remove: true
+    because: This property should have been marked readonly but wasn't.
+  - group: microsoft.servicebus
+    name: SBTopicProperties  # This type is subsequently flattened into NamespacesTopics_Spec
+    property: Status
+    remove: true
+    because: This property should have been marked readonly but wasn't.
+  - group: microsoft.documentdb
+    name: Location  # This type is subsequently flattened into NamespacesTopics_Spec
+    property: ProvisioningState
+    remove: true
+    because: This property should have been marked readonly but wasn't.
+  - group: microsoft.compute
+    name: DiskProperties  # This type is subsequently flattened into Disks_Spec
+    property: DiskState
     remove: true
     because: This property should have been marked readonly but wasn't.
 

--- a/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_to_arm_function_builder.go
@@ -259,7 +259,14 @@ func (builder *convertToARMBuilder) flattenedPropertyHandler(
 	// Copy each from-prop into the to-prop
 	for _, fromProp := range fromProps {
 		// find the corresponding inner property on the to-prop type
-		toSubProp, ok := toPropObjType.Property(fromProp.PropertyName())
+		// TODO: If this property is an ARM reference we need a bit of special handling.
+		// TODO: See https://github.com/Azure/azure-service-operator/issues/1651 for possible improvements to this.
+		toSubPropName := fromProp.PropertyName()
+		if values, ok := fromProp.Tag(astmodel.ARMReferenceTag); ok {
+			toSubPropName = astmodel.PropertyName(values[0])
+		}
+
+		toSubProp, ok := toPropObjType.Property(toSubPropName)
 		if !ok {
 			panic(fmt.Sprintf("unable to find expected property %s inside property %s", fromProp.PropertyName(), toPropName))
 		}

--- a/hack/generator/pkg/codegen/pipeline/add_cross_resource_references.go
+++ b/hack/generator/pkg/codegen/pipeline/add_cross_resource_references.go
@@ -18,7 +18,7 @@ import (
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/config"
 )
 
-var armIDDescriptionRegex = regexp.MustCompile("(?i).*/subscriptions/.*?/resourceGroups/.*")
+var armIDDescriptionRegex = regexp.MustCompile("(?i)(.*/subscriptions/.*?/resourceGroups/.*|ARM ID|Resource ID)")
 
 // TODO: For now not supporting array or map of references. Unsure if it actually ever happens in practice.
 
@@ -186,6 +186,10 @@ func newKnownReferencesMap(configuration *config.Configuration) map[referencePai
 			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.batch", "v1alpha1api20210101"), "KeyVaultReference"),
 			propName: "Id",
 		}: true,
+		{
+			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.batch", "v1alpha1api20210101"), "AutoStorageBaseProperties"),
+			propName: "StorageAccountId",
+		}: true,
 		// Document DB
 		{
 			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.documentdb", "v1alpha1api20210515"), "VirtualNetworkRule"),
@@ -196,15 +200,31 @@ func newKnownReferencesMap(configuration *config.Configuration) map[referencePai
 			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.storage", "v1alpha1api20210401"), "VirtualNetworkRule"),
 			propName: "Id",
 		}: true,
+		{
+			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.storage", "v1alpha1api20210401"), "EncryptionIdentity"),
+			propName: "UserAssignedIdentity",
+		}: true,
+		{
+			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.storage", "v1alpha1api20210401"), "ResourceAccessRule"),
+			propName: "ResourceId",
+		}: true,
 		// Service bus
 		{
 			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.servicebus", "v1alpha1api20210101preview"), "PrivateEndpoint"),
 			propName: "Id",
 		}: true,
+		{
+			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.servicebus", "v1alpha1api20210101preview"), "UserAssignedIdentityProperties"),
+			propName: "UserAssignedIdentity",
+		}: true,
 		// Network
 		{
 			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.network", "v1alpha1api20201101"), "SubResource"),
 			propName: "Id",
+		}: true,
+		{
+			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.network", "v1alpha1api20201101"), "VirtualNetworkGateways_Spec_Properties"),
+			propName: "VNetExtendedLocationResourceId",
 		}: true,
 		// Compute
 		{
@@ -245,6 +265,15 @@ func newKnownReferencesMap(configuration *config.Configuration) map[referencePai
 		{
 			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.compute", "v1alpha1api20201201"), "SubResource"),
 			propName: "Id",
+		}: true,
+		// Disk (this is also under microsoft.compute)
+		{
+			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.compute", "v1alpha1api20200930"), "CreationData"),
+			propName: "SourceResourceId",
+		}: true,
+		{
+			typeName: astmodel.MakeTypeName(configuration.MakeLocalPackageReference("microsoft.compute", "v1alpha1api20200930"), "DiskProperties"),
+			propName: "DiskAccessId",
 		}: true,
 	}
 }

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -109,6 +109,9 @@ func (config *Configuration) GetPropertyTransformersError() error {
 		if !filter.MatchedRequiredTypes() {
 			return errors.Errorf("Type transformer target: %q for property %q matched no types", filter.String(), filter.Property)
 		}
+		if !filter.MatchedRequiredProperties() {
+			return errors.Errorf("Type transformer target: %q for property %q matched types, but no types had the property", filter.String(), filter.Property)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
* Improve errors from property type transformers further.
* Add missed reference properties.
* Exclude some readonly properties