### PR TITLE
Fail pipeline if any type contains ErroredType with errors

### DIFF
--- a/hack/generator/pkg/astmodel/errored_type.go
+++ b/hack/generator/pkg/astmodel/errored_type.go
@@ -35,6 +35,16 @@ func NewErroredType(t Type, errors []string, warnings []string) *ErroredType {
 	return result.WithType(t) // using WithType ensures warnings and errors get merged if needed
 }
 
+// Errors returns the errors stored in this ErroredType
+func (e *ErroredType) Errors() []string {
+	return append([]string(nil), e.errors...)
+}
+
+// Warnings returns the warnings stored in this ErroredType
+func (e *ErroredType) Warnings() []string {
+	return append([]string(nil), e.warnings...)
+}
+
 func (e *ErroredType) InnerType() Type {
 	return e.inner
 }

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -129,6 +129,8 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		// ARM types for resources etc:
 		pipeline.ApplyExportFilters(configuration),
 
+		pipeline.VerifyNoErroredTypes(),
+
 		pipeline.StripUnreferencedTypeDefinitions(),
 
 		pipeline.ReplaceAnyTypeWithJSON(),

--- a/hack/generator/pkg/codegen/pipeline/apply_export_filters.go
+++ b/hack/generator/pkg/codegen/pipeline/apply_export_filters.go
@@ -15,26 +15,28 @@ import (
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/config"
 )
 
+const ApplyExportFiltersStageID = "filterTypes"
+
 // ApplyExportFilters creates a Stage to reduce our set of types for export
 func ApplyExportFilters(configuration *config.Configuration) Stage {
-	return MakeLegacyStage(
-		"filterTypes",
+	return MakeStage(
+		ApplyExportFiltersStageID,
 		"Apply export filters to reduce the number of generated types",
-		func(ctx context.Context, types astmodel.Types) (astmodel.Types, error) {
-			return filterTypes(configuration, types)
+		func(ctx context.Context, state *State) (*State, error) {
+			return filterTypes(configuration, state)
 		})
 }
 
 // filterTypes applies the configuration include/exclude filters to the generated definitions
 func filterTypes(
 	configuration *config.Configuration,
-	definitions astmodel.Types) (astmodel.Types, error) {
+	state *State) (*State, error) {
 
 	newDefinitions := make(astmodel.Types)
 
-	filterer := configuration.BuildExportFilterer(definitions)
+	filterer := configuration.BuildExportFilterer(state.types)
 
-	for _, def := range definitions {
+	for _, def := range state.types {
 		defName := def.Name()
 		shouldExport, reason := filterer(defName)
 
@@ -61,5 +63,5 @@ func filterTypes(
 		return nil, err
 	}
 
-	return newDefinitions, nil
+	return state.WithTypes(newDefinitions), nil
 }

--- a/hack/generator/pkg/codegen/pipeline/status_from_swagger.go
+++ b/hack/generator/pkg/codegen/pipeline/status_from_swagger.go
@@ -111,7 +111,7 @@ func (st statusTypes) findResourceType(typeName astmodel.TypeName) (astmodel.Typ
 		klog.V(3).Infof("Swagger information missing for %s", typeName)
 		// add a warning that the status is missing
 		// this will be reported if the type is not pruned
-		return astmodel.NewErroredType(nil, nil, []string{fmt.Sprintf("missing status information for %s", typeName)}), false
+		return astmodel.NewErroredType(nil, []string{fmt.Sprintf("missing status information for %s", typeName)}, nil), false
 	}
 }
 

--- a/hack/generator/pkg/codegen/pipeline/verify_no_errored_types.go
+++ b/hack/generator/pkg/codegen/pipeline/verify_no_errored_types.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
+)
+
+const VerifyNoErroredTypesStageID = "verifyNoErroredTypes"
+
+// VerifyNoErroredTypes creates a Stage that verifies that no types contain an ErroredType with errors
+func VerifyNoErroredTypes() Stage {
+	return MakeStage(
+		VerifyNoErroredTypesStageID,
+		"Verify there are no ErroredType's containing errors",
+		func(ctx context.Context, state *State) (*State, error) {
+			visitor := newErrorCollectingVisitor()
+
+			for _, def := range state.types {
+				_, err := visitor.visitor.Visit(def.Type(), erroredTypeVisitorContext{name: def.Name()})
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed while visiting %q", def.Name())
+				}
+			}
+
+			err := kerrors.NewAggregate(visitor.errs)
+			if err != nil {
+				return nil, err
+			}
+
+			// This stage doesn't change the generated types at all - if the verification
+			// has passed, just return the same defs we started with
+			return state, nil
+		}).RequiresPrerequisiteStages(ApplyExportFiltersStageID)
+}
+
+type errorCollectingVisitor struct {
+	errs    []error
+	visitor astmodel.TypeVisitor
+}
+
+func newErrorCollectingVisitor() *errorCollectingVisitor {
+	includePropertyContext := astmodel.MakeIdentityVisitOfObjectTypeWithPerPropertyContext(
+		func(prop *astmodel.PropertyDefinition, ctx interface{}) interface{} {
+			typedCtx := ctx.(erroredTypeVisitorContext)
+			return typedCtx.WithProperty(prop.PropertyName())
+		})
+
+	result := &errorCollectingVisitor{}
+	result.visitor = astmodel.TypeVisitorBuilder{
+		VisitErroredType:  result.catalogErrors,
+		VisitObjectType:   includePropertyContext,
+		VisitResourceType: includeResourcePropertyContext,
+	}.Build()
+
+	return result
+}
+
+func (v *errorCollectingVisitor) catalogErrors(this *astmodel.TypeVisitor, it *astmodel.ErroredType, ctx interface{}) (astmodel.Type, error) {
+	typedCtx := ctx.(erroredTypeVisitorContext)
+	if len(it.Errors()) > 0 {
+		errStrings := strings.Join(it.Errors(), ", ")
+		v.errs = append(v.errs, errors.Errorf("%q has property %q with errors: %q", typedCtx.name, typedCtx.property, errStrings))
+	}
+
+	return astmodel.IdentityVisitOfErroredType(this, it, ctx)
+}
+
+func includeResourcePropertyContext(this *astmodel.TypeVisitor, it *astmodel.ResourceType, ctx interface{}) (astmodel.Type, error) {
+	typedCtx := ctx.(erroredTypeVisitorContext)
+
+	_, err := this.Visit(it.SpecType(), typedCtx.WithProperty("Spec"))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to visit resource spec type %q", it.SpecType())
+	}
+
+	_, err = this.Visit(it.StatusType(), typedCtx.WithProperty("Status"))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to visit resource status type %q", it.StatusType())
+	}
+
+	return it, nil
+}
+
+type erroredTypeVisitorContext struct {
+	name     astmodel.TypeName
+	property *astmodel.PropertyName
+}
+
+func (e erroredTypeVisitorContext) WithProperty(prop astmodel.PropertyName) erroredTypeVisitorContext {
+	e.property = &prop
+	return e
+}

--- a/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -16,6 +16,7 @@ stripUnreferenced                                    Strip unreferenced types
 assertTypesStructureValid                            Verify that all local TypeNames refer to a type
 removeEmbeddedResources                   azure      Remove properties that point to embedded resources. Only removes structural aspects of embedded resources, Id/ARMId references are retained.
 filterTypes                                          Apply export filters to reduce the number of generated types
+verifyNoErroredTypes                                 Verify there are no ErroredType's containing errors
 stripUnreferenced                                    Strip unreferenced types
 replaceAnyTypeWithJSON                               Replace properties using interface{} with arbitrary JSON
 addCrossResourceReferences                azure      Replace cross-resource references with genruntime.ResourceReference

--- a/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -15,6 +15,7 @@ pluralizeNames                                     Improve resource pluralizatio
 stripUnreferenced                                  Strip unreferenced types
 assertTypesStructureValid                          Verify that all local TypeNames refer to a type
 filterTypes                                        Apply export filters to reduce the number of generated types
+verifyNoErroredTypes                               Verify there are no ErroredType's containing errors
 stripUnreferenced                                  Strip unreferenced types
 replaceAnyTypeWithJSON                             Replace properties using interface{} with arbitrary JSON
 flattenProperties                                  Apply flattening to properties marked for flattening

--- a/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
@@ -14,6 +14,7 @@ pluralizeNames                                       Improve resource pluralizat
 stripUnused                                          Strip unused types for test
 assertTypesStructureValid                            Verify that all local TypeNames refer to a type
 filterTypes                                          Apply export filters to reduce the number of generated types
+verifyNoErroredTypes                                 Verify there are no ErroredType's containing errors
 stripUnused                                          Strip unused types for test
 replaceAnyTypeWithJSON                               Replace properties using interface{} with arbitrary JSON
 addCrossResourceReferences                azure      Replace cross-resource references with genruntime.ResourceReference


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds a new stage requiring that all generated types do not contain an `ErroredType` with errors (warnings are ok). 
* Missing `Status` types now produce an `ErroredType` with errors (before it was warnings). This is required for future work where resource Status's will begin to have more information in addition to just the response from Azure, such as `Conditions` and possibly other things going forward.