### PR TITLE
Fix missing controller RBAC permissions

### DIFF
--- a/hack/generated/_apis/microsoft.resources/v1alpha1api20200601/resourcegroup_types.go
+++ b/hack/generated/_apis/microsoft.resources/v1alpha1api20200601/resourcegroup_types.go
@@ -11,6 +11,13 @@ import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 )
 
+// TODO: it doesn't really matter where these are (as long as they're in _apis, where is where we run controller-gen).
+// These are the permissions required by the generic_controller. They're here because they can't go outside the _apis
+// directory.
+
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
+
 // +kubebuilder:rbac:groups=microsoft.resources.infra.azure.com,resources=resourcegroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=microsoft.resources.infra.azure.com,resources={resourcegroups/status,resourcegroups/finalizers},verbs=get;update;patch
 

--- a/hack/generated/config/manager/manager.yaml
+++ b/hack/generated/config/manager/manager.yaml
@@ -23,9 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - # command:
-        # - /manager
-        args:
+      - args:
         - --enable-leader-election
         image: controller:latest
         name: manager

--- a/hack/generated/controllers/generic_controller.go
+++ b/hack/generated/controllers/generic_controller.go
@@ -29,8 +29,6 @@ import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/util/kubeclient"
 )
 
-// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
-
 // GenericReconciler reconciles resources
 type GenericReconciler struct {
 	Log                  logr.Logger


### PR DESCRIPTION
controller-gen is only run inside the _apis directory, and we had annotations outside next to generic_controller.go which were not
being honored. We needed those permissions (and also leases which we had missed).