### PR TITLE
Code gardening for code generation

### DIFF
--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -6,20 +6,22 @@
 package astbuilder
 
 import (
+	"fmt"
 	"go/token"
 
 	"github.com/dave/dst"
 )
 
 // SimpleAssignment performs a simple assignment like:
-//     <lhs> := <rhs>       // tok = token.DEFINE
-// or  <lhs> = <rhs>        // tok = token.ASSIGN
-func SimpleAssignment(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
+//
+//     <lhs> = <rhs>
+//
+func SimpleAssignment(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 	return &dst.AssignStmt{
 		Lhs: []dst.Expr{
 			dst.Clone(lhs).(dst.Expr),
 		},
-		Tok: tok,
+		Tok: token.ASSIGN,
 		Rhs: []dst.Expr{
 			dst.Clone(rhs).(dst.Expr),
 		},

--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -44,6 +44,21 @@ func SimpleDeclaration(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 	}
 }
 
+// SetVariable allows for either variable declaration or assignment by passing the required token
+// Only token.DEFINE and token.ASSIGN are supported, other values will panic.
+// Use SimpleAssignment or SimpleDeclaration by preference
+func SetVariable(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
+	if tok == token.ASSIGN {
+		return SimpleAssignment(lhs, rhs)
+	}
+
+	if tok == token.DEFINE {
+		return SimpleDeclaration(lhs, rhs)
+	}
+
+	panic(fmt.Sprintf("token %q not supported in VariableAssignment", tok))
+}
+
 // QualifiedAssignment performs a simple assignment like:
 //     <lhs>.<lhsSel> := <rhs>       // tok = token.DEFINE
 // or  <lhs>.<lhsSel> = <rhs>        // tok = token.ASSIGN

--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -30,12 +30,12 @@ func SimpleAssignment(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 
 // SimpleDeclaration performs a simple assignment like:
 //
-//     <lhs> := <rhs>
+//     <id> := <rhs>
 //
-func SimpleDeclaration(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
+func SimpleDeclaration(id string, rhs dst.Expr) *dst.AssignStmt {
 	return &dst.AssignStmt{
 		Lhs: []dst.Expr{
-			dst.Clone(lhs).(dst.Expr),
+			dst.NewIdent(id),
 		},
 		Tok: token.DEFINE,
 		Rhs: []dst.Expr{
@@ -48,15 +48,15 @@ func SimpleDeclaration(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 // Only token.DEFINE and token.ASSIGN are supported, other values will panic.
 // Use SimpleAssignment or SimpleDeclaration by preference
 func SetVariable(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
-	if tok == token.ASSIGN {
-		return SimpleAssignment(lhs, rhs)
+	if tok != token.ASSIGN && tok != token.DEFINE {
+		panic(fmt.Sprintf("token %q not supported in VariableAssignment", tok))
 	}
 
-	if tok == token.DEFINE {
-		return SimpleDeclaration(lhs, rhs)
+	return &dst.AssignStmt{
+		Lhs: Expressions(lhs),
+		Tok: tok,
+		Rhs: Expressions(rhs),
 	}
-
-	panic(fmt.Sprintf("token %q not supported in VariableAssignment", tok))
 }
 
 // QualifiedAssignment performs a simple assignment like:

--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -46,10 +46,10 @@ func ShortDeclaration(id string, rhs dst.Expr) *dst.AssignStmt {
 	}
 }
 
-// SetVariable allows for either variable declaration or assignment by passing the required token
+// AssignmentStatement allows for either variable declaration or assignment by passing the required token
 // Only token.DEFINE and token.ASSIGN are supported, other values will panic.
 // Use SimpleAssignment or ShortDeclaration if possible; use this method only if you must.
-func SetVariable(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
+func AssignmentStatement(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
 	if tok != token.ASSIGN && tok != token.DEFINE {
 		panic(fmt.Sprintf("token %q not supported in VariableAssignment", tok))
 	}

--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -28,6 +28,22 @@ func SimpleAssignment(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 	}
 }
 
+// SimpleDeclaration performs a simple assignment like:
+//
+//     <lhs> := <rhs>
+//
+func SimpleDeclaration(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
+	return &dst.AssignStmt{
+		Lhs: []dst.Expr{
+			dst.Clone(lhs).(dst.Expr),
+		},
+		Tok: token.DEFINE,
+		Rhs: []dst.Expr{
+			dst.Clone(rhs).(dst.Expr),
+		},
+	}
+}
+
 // QualifiedAssignment performs a simple assignment like:
 //     <lhs>.<lhsSel> := <rhs>       // tok = token.DEFINE
 // or  <lhs>.<lhsSel> = <rhs>        // tok = token.ASSIGN

--- a/hack/generator/pkg/astbuilder/assignments.go
+++ b/hack/generator/pkg/astbuilder/assignments.go
@@ -16,6 +16,7 @@ import (
 //
 //     <lhs> = <rhs>
 //
+// See also ShortDeclaration
 func SimpleAssignment(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 	return &dst.AssignStmt{
 		Lhs: []dst.Expr{
@@ -28,11 +29,12 @@ func SimpleAssignment(lhs dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 	}
 }
 
-// SimpleDeclaration performs a simple assignment like:
+// ShortDeclaration performs a simple assignment like:
 //
 //     <id> := <rhs>
 //
-func SimpleDeclaration(id string, rhs dst.Expr) *dst.AssignStmt {
+// Method naming inspired by https://tour.golang.org/basics/10
+func ShortDeclaration(id string, rhs dst.Expr) *dst.AssignStmt {
 	return &dst.AssignStmt{
 		Lhs: []dst.Expr{
 			dst.NewIdent(id),
@@ -46,7 +48,7 @@ func SimpleDeclaration(id string, rhs dst.Expr) *dst.AssignStmt {
 
 // SetVariable allows for either variable declaration or assignment by passing the required token
 // Only token.DEFINE and token.ASSIGN are supported, other values will panic.
-// Use SimpleAssignment or SimpleDeclaration by preference
+// Use SimpleAssignment or ShortDeclaration if possible; use this method only if you must.
 func SetVariable(lhs dst.Expr, tok token.Token, rhs dst.Expr) *dst.AssignStmt {
 	if tok != token.ASSIGN && tok != token.DEFINE {
 		panic(fmt.Sprintf("token %q not supported in VariableAssignment", tok))

--- a/hack/generator/pkg/astbuilder/builder.go
+++ b/hack/generator/pkg/astbuilder/builder.go
@@ -386,20 +386,19 @@ func Nil() *dst.Ident {
 }
 
 // StatementBlock generates a block containing the supplied statements
+// If we're given a single statement that's already a block, we won't double wrap it
 func StatementBlock(statements ...dst.Stmt) *dst.BlockStmt {
+	stmts := Statements(statements)
+
+	if len(stmts) == 1 {
+		if block, ok := stmts[0].(*dst.BlockStmt); ok {
+			return block
+		}
+	}
+
 	return &dst.BlockStmt{
-		List: Statements(statements),
+		List: stmts,
 	}
-}
-
-// EnsureStatementBlock wraps any statement into a block safely
-// (without double wrapping an existing block)
-func EnsureStatementBlock(statement dst.Stmt) *dst.BlockStmt {
-	if block, ok := statement.(*dst.BlockStmt); ok {
-		return block
-	}
-
-	return StatementBlock(statement)
 }
 
 // Statements creates a sequence of statements from the provided values, each of which may be a

--- a/hack/generator/pkg/astbuilder/conditions.go
+++ b/hack/generator/pkg/astbuilder/conditions.go
@@ -19,11 +19,11 @@ import (
 //     <falseBranch>
 // }
 //
-func SimpleIfElse(condition dst.Expr, trueBranch dst.Stmt, falseBranch dst.Stmt) *dst.IfStmt {
+func SimpleIfElse(condition dst.Expr, trueBranch []dst.Stmt, falseBranch []dst.Stmt) *dst.IfStmt {
 	result := &dst.IfStmt{
 		Cond: condition,
-		Body: EnsureStatementBlock(trueBranch),
-		Else: EnsureStatementBlock(falseBranch),
+		Body: StatementBlock(trueBranch...),
+		Else: StatementBlock(falseBranch...),
 	}
 
 	return result

--- a/hack/generator/pkg/astbuilder/lists.go
+++ b/hack/generator/pkg/astbuilder/lists.go
@@ -6,8 +6,9 @@
 package astbuilder
 
 import (
-	"github.com/dave/dst"
 	"go/token"
+
+	"github.com/dave/dst"
 )
 
 // MakeList returns the call expression for making a slice
@@ -31,7 +32,6 @@ func MakeList(listType dst.Expr, len dst.Expr) *dst.CallExpr {
 func AppendList(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
 	return SimpleAssignment(
 		dst.Clone(lhs).(dst.Expr),
-		token.ASSIGN,
 		CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr)))
 }
 

--- a/hack/generator/pkg/astbuilder/maps.go
+++ b/hack/generator/pkg/astbuilder/maps.go
@@ -6,8 +6,9 @@
 package astbuilder
 
 import (
-	"github.com/dave/dst"
 	"go/token"
+
+	"github.com/dave/dst"
 )
 
 // MakeMap returns the call expression for making a map
@@ -36,7 +37,6 @@ func InsertMap(mapExpr dst.Expr, key dst.Expr, rhs dst.Expr) *dst.AssignStmt {
 			X:     dst.Clone(mapExpr).(dst.Expr),
 			Index: dst.Clone(key).(dst.Expr),
 		},
-		token.ASSIGN,
 		dst.Clone(rhs).(dst.Expr))
 }
 

--- a/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
@@ -431,7 +431,7 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(conversionB
 	results = append(results, newVariable)
 	results = append(
 		results,
-		astbuilder.SetVariable(
+		astbuilder.AssignmentStatement(
 			dst.NewIdent("err"),
 			tok,
 			astbuilder.CallQualifiedFunc(

--- a/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
@@ -442,7 +442,6 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(conversionB
 			results,
 			astbuilder.SimpleAssignment(
 				params.GetDestination(),
-				token.ASSIGN,
 				dst.NewIdent(propertyLocalVar)))
 	} else {
 		results = append(

--- a/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
+++ b/hack/generator/pkg/astmodel/armconversion/convert_from_arm_function_builder.go
@@ -431,7 +431,7 @@ func (builder *convertFromARMBuilder) convertComplexTypeNameProperty(conversionB
 	results = append(results, newVariable)
 	results = append(
 		results,
-		astbuilder.SimpleAssignment(
+		astbuilder.SetVariable(
 			dst.NewIdent("err"),
 			tok,
 			astbuilder.CallQualifiedFunc(

--- a/hack/generator/pkg/astmodel/conversion_function_builder.go
+++ b/hack/generator/pkg/astmodel/conversion_function_builder.go
@@ -574,7 +574,7 @@ func IdentityDeepCopyJSON(builder *ConversionFunctionBuilder, params ConversionP
 
 // AssignmentHandlerDefine is an assignment handler for definitions, using :=
 func AssignmentHandlerDefine(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
-	return astbuilder.SimpleDeclaration(lhs, rhs)
+	return astbuilder.SetVariable(lhs, token.DEFINE, rhs)
 }
 
 // AssignmentHandlerAssign is an assignment handler for standard assignments to existing variables, using =

--- a/hack/generator/pkg/astmodel/conversion_function_builder.go
+++ b/hack/generator/pkg/astmodel/conversion_function_builder.go
@@ -575,7 +575,7 @@ func IdentityDeepCopyJSON(builder *ConversionFunctionBuilder, params ConversionP
 
 // AssignmentHandlerDefine is an assignment handler for definitions, using :=
 func AssignmentHandlerDefine(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
-	return astbuilder.SimpleAssignment(lhs, token.DEFINE, rhs)
+	return astbuilder.SimpleDeclaration(lhs, rhs)
 }
 
 // AssignmentHandlerAssign is an assignment handler for standard assignments to existing variables, using =

--- a/hack/generator/pkg/astmodel/conversion_function_builder.go
+++ b/hack/generator/pkg/astmodel/conversion_function_builder.go
@@ -210,7 +210,6 @@ func IdentityConvertComplexOptionalProperty(builder *ConversionFunctionBuilder, 
 		innerStatements,
 		astbuilder.SimpleAssignment(
 			params.GetDestination(),
-			token.ASSIGN,
 			astbuilder.AddrOf(dst.NewIdent(tempVarIdent))))
 
 	result := &dst.IfStmt{

--- a/hack/generator/pkg/astmodel/conversion_function_builder.go
+++ b/hack/generator/pkg/astmodel/conversion_function_builder.go
@@ -344,7 +344,7 @@ func IdentityConvertComplexMapProperty(builder *ConversionFunctionBuilder, param
 	keyTypeAst := destinationType.KeyType().AsType(builder.CodeGenerationContext)
 	valueTypeAst := destinationType.ValueType().AsType(builder.CodeGenerationContext)
 
-	makeMapStatement := astbuilder.SetVariable(
+	makeMapStatement := astbuilder.AssignmentStatement(
 		destination,
 		makeMapToken,
 		astbuilder.MakeMap(keyTypeAst, valueTypeAst))
@@ -574,7 +574,7 @@ func IdentityDeepCopyJSON(builder *ConversionFunctionBuilder, params ConversionP
 
 // AssignmentHandlerDefine is an assignment handler for definitions, using :=
 func AssignmentHandlerDefine(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
-	return astbuilder.SetVariable(lhs, token.DEFINE, rhs)
+	return astbuilder.AssignmentStatement(lhs, token.DEFINE, rhs)
 }
 
 // AssignmentHandlerAssign is an assignment handler for standard assignments to existing variables, using =

--- a/hack/generator/pkg/astmodel/conversion_function_builder.go
+++ b/hack/generator/pkg/astmodel/conversion_function_builder.go
@@ -344,8 +344,8 @@ func IdentityConvertComplexMapProperty(builder *ConversionFunctionBuilder, param
 	keyTypeAst := destinationType.KeyType().AsType(builder.CodeGenerationContext)
 	valueTypeAst := destinationType.ValueType().AsType(builder.CodeGenerationContext)
 
-	makeMapStatement := astbuilder.SimpleAssignment(
-		dst.Clone(destination).(dst.Expr),
+	makeMapStatement := astbuilder.SetVariable(
+		destination,
 		makeMapToken,
 		astbuilder.MakeMap(keyTypeAst, valueTypeAst))
 	rangeStatement := &dst.RangeStmt{

--- a/hack/generator/pkg/astmodel/conversion_function_builder.go
+++ b/hack/generator/pkg/astmodel/conversion_function_builder.go
@@ -580,7 +580,7 @@ func AssignmentHandlerDefine(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
 
 // AssignmentHandlerAssign is an assignment handler for standard assignments to existing variables, using =
 func AssignmentHandlerAssign(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
-	return astbuilder.SimpleAssignment(lhs, token.ASSIGN, rhs)
+	return astbuilder.SimpleAssignment(lhs, rhs)
 }
 
 // CreateLocal creates an unused local variable name.

--- a/hack/generator/pkg/astmodel/kubernetes_admissions_defaults.go
+++ b/hack/generator/pkg/astmodel/kubernetes_admissions_defaults.go
@@ -60,7 +60,6 @@ func defaultAzureNameFunction(k *resourceFunction, codeGenerationContext *CodeGe
 				Body: astbuilder.StatementBlock(
 					astbuilder.SimpleAssignment(
 						azureNameProp,
-						token.ASSIGN,
 						nameProp)),
 			},
 		},

--- a/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
+++ b/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
@@ -295,7 +295,6 @@ func (v *ValidatorBuilder) validateBody(codeGenerationContext *CodeGenerationCon
 					// Not using astbuilder.AppendList here as we want to tack on a "..." at the end
 					astbuilder.SimpleAssignment(
 						dst.NewIdent(validationsIdent),
-						token.ASSIGN,
 						appendFuncCall),
 				},
 			},

--- a/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
+++ b/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
@@ -266,7 +266,7 @@ func (v *ValidatorBuilder) validateBody(codeGenerationContext *CodeGenerationCon
 		Tok:   token.DEFINE,
 		Body: &dst.BlockStmt{
 			List: []dst.Stmt{
-				astbuilder.SimpleDeclaration("err", astbuilder.CallFunc(validationIdent, args...)),
+				astbuilder.ShortDeclaration("err", astbuilder.CallFunc(validationIdent, args...)),
 				astbuilder.CheckErrorAndSingleStatement(astbuilder.AppendList(dst.NewIdent(errsIdent), dst.NewIdent("err"))),
 			},
 		},
@@ -279,7 +279,7 @@ func (v *ValidatorBuilder) validateBody(codeGenerationContext *CodeGenerationCon
 	appendFuncCall.Ellipsis = true
 
 	body := []dst.Stmt{
-		astbuilder.SimpleDeclaration(
+		astbuilder.ShortDeclaration(
 			validationsIdent,
 			astbuilder.CallQualifiedFunc(receiverIdent, implFunctionName)),
 		astbuilder.AssignToInterface(tempVarIdent, dst.NewIdent(receiverIdent)),

--- a/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
+++ b/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
@@ -266,7 +266,7 @@ func (v *ValidatorBuilder) validateBody(codeGenerationContext *CodeGenerationCon
 		Tok:   token.DEFINE,
 		Body: &dst.BlockStmt{
 			List: []dst.Stmt{
-				astbuilder.SimpleDeclaration(dst.NewIdent("err"), astbuilder.CallFunc(validationIdent, args...)),
+				astbuilder.SimpleDeclaration("err", astbuilder.CallFunc(validationIdent, args...)),
 				astbuilder.CheckErrorAndSingleStatement(astbuilder.AppendList(dst.NewIdent(errsIdent), dst.NewIdent("err"))),
 			},
 		},
@@ -280,7 +280,7 @@ func (v *ValidatorBuilder) validateBody(codeGenerationContext *CodeGenerationCon
 
 	body := []dst.Stmt{
 		astbuilder.SimpleDeclaration(
-			dst.NewIdent(validationsIdent),
+			validationsIdent,
 			astbuilder.CallQualifiedFunc(receiverIdent, implFunctionName)),
 		astbuilder.AssignToInterface(tempVarIdent, dst.NewIdent(receiverIdent)),
 		&dst.IfStmt{

--- a/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
+++ b/hack/generator/pkg/astmodel/kubernetes_admissions_validator.go
@@ -266,7 +266,7 @@ func (v *ValidatorBuilder) validateBody(codeGenerationContext *CodeGenerationCon
 		Tok:   token.DEFINE,
 		Body: &dst.BlockStmt{
 			List: []dst.Stmt{
-				astbuilder.SimpleAssignment(dst.NewIdent("err"), token.DEFINE, astbuilder.CallFunc(validationIdent, args...)),
+				astbuilder.SimpleDeclaration(dst.NewIdent("err"), astbuilder.CallFunc(validationIdent, args...)),
 				astbuilder.CheckErrorAndSingleStatement(astbuilder.AppendList(dst.NewIdent(errsIdent), dst.NewIdent("err"))),
 			},
 		},
@@ -279,9 +279,8 @@ func (v *ValidatorBuilder) validateBody(codeGenerationContext *CodeGenerationCon
 	appendFuncCall.Ellipsis = true
 
 	body := []dst.Stmt{
-		astbuilder.SimpleAssignment(
+		astbuilder.SimpleDeclaration(
 			dst.NewIdent(validationsIdent),
-			token.DEFINE,
 			astbuilder.CallQualifiedFunc(receiverIdent, implFunctionName)),
 		astbuilder.AssignToInterface(tempVarIdent, dst.NewIdent(receiverIdent)),
 		&dst.IfStmt{

--- a/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/astmodel/kubernetes_resource_interface.go
@@ -247,7 +247,6 @@ func setEnumAzureNameFunction(enumType TypeName) objectFunctionHandler {
 			Body: []dst.Stmt{
 				astbuilder.SimpleAssignment(
 					azureNameProp,
-					token.ASSIGN,
 					&dst.CallExpr{
 						// cast from the string value to the enum
 						Fun:  enumTypeAST,

--- a/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
+++ b/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
@@ -262,7 +262,7 @@ func (r *ResourceRegistrationFile) createCreateSchemeFunc(codeGenerationContext 
 	ignore := "_"
 	addToScheme := "AddToScheme"
 
-	initSchemeVar := astbuilder.SimpleDeclaration(scheme, astbuilder.CallQualifiedFunc(runtime, "NewScheme"))
+	initSchemeVar := astbuilder.ShortDeclaration(scheme, astbuilder.CallQualifiedFunc(runtime, "NewScheme"))
 
 	clientGoSchemeAssign := astbuilder.SimpleAssignment(
 		dst.NewIdent(ignore),

--- a/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
+++ b/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
@@ -304,16 +304,8 @@ func (r *ResourceRegistrationFile) createCreateSchemeFunc(codeGenerationContext 
 	for _, group := range importedPackageNames {
 		groupSchemeAssign := astbuilder.SimpleAssignment(
 			dst.NewIdent(ignore),
-			token.ASSIGN,
-			&dst.CallExpr{
-				Fun: &dst.SelectorExpr{
-					X:   dst.NewIdent(group),
-					Sel: dst.NewIdent(addToScheme),
-				},
-				Args: []dst.Expr{
-					dst.NewIdent(scheme),
-				},
-			})
+			astbuilder.CallQualifiedFunc(group, addToScheme, dst.NewIdent(scheme)))
+
 		groupVersionAssignments = append(groupVersionAssignments, groupSchemeAssign)
 	}
 

--- a/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
+++ b/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
@@ -262,29 +262,13 @@ func (r *ResourceRegistrationFile) createCreateSchemeFunc(codeGenerationContext 
 	ignore := "_"
 	addToScheme := "AddToScheme"
 
-	initSchemeVar := astbuilder.SimpleAssignment(
+	initSchemeVar := astbuilder.SimpleDeclaration(
 		dst.NewIdent(scheme),
-		token.DEFINE,
-		&dst.CallExpr{
-			Fun: &dst.SelectorExpr{
-				X:   dst.NewIdent(runtime),
-				Sel: dst.NewIdent("NewScheme"),
-			},
-			Args: []dst.Expr{},
-		})
+		astbuilder.CallQualifiedFunc(runtime, "NewScheme"))
 
 	clientGoSchemeAssign := astbuilder.SimpleAssignment(
 		dst.NewIdent(ignore),
-		token.ASSIGN,
-		&dst.CallExpr{
-			Fun: &dst.SelectorExpr{
-				X:   dst.NewIdent(clientGoScheme),
-				Sel: dst.NewIdent(addToScheme),
-			},
-			Args: []dst.Expr{
-				dst.NewIdent(scheme),
-			},
-		})
+		astbuilder.CallQualifiedFunc(clientGoScheme, addToScheme, dst.NewIdent(scheme)))
 
 	var importedPackageNames []string
 	for pkg := range r.getImportedPackages() {

--- a/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
+++ b/hack/generator/pkg/codegen/pipeline/resource_registration_file.go
@@ -262,9 +262,7 @@ func (r *ResourceRegistrationFile) createCreateSchemeFunc(codeGenerationContext 
 	ignore := "_"
 	addToScheme := "AddToScheme"
 
-	initSchemeVar := astbuilder.SimpleDeclaration(
-		dst.NewIdent(scheme),
-		astbuilder.CallQualifiedFunc(runtime, "NewScheme"))
+	initSchemeVar := astbuilder.SimpleDeclaration(scheme, astbuilder.CallQualifiedFunc(runtime, "NewScheme"))
 
 	clientGoSchemeAssign := astbuilder.SimpleAssignment(
 		dst.NewIdent(ignore),

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -274,8 +274,8 @@ func assignFromOptional(
 
 		stmt := astbuilder.SimpleIfElse(
 			checkForNil,
-			astbuilder.StatementBlock(writeActualValue...),
-			astbuilder.StatementBlock(writeZeroValue...))
+			writeActualValue,
+			writeZeroValue)
 
 		return astbuilder.Statements(cacheOriginal, stmt)
 	}

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -861,13 +861,13 @@ func assignObjectFromObject(
 		var conversion dst.Stmt
 		if destinationName.PackageReference.Equals(generationContext.CurrentPackage()) {
 			// Destination is our current type
-			conversion = astbuilder.SimpleAssignment(
+			conversion = astbuilder.SetVariable(
 				errLocal,
 				tok,
 				astbuilder.CallExpr(localId, functionName, actualReader))
 		} else {
 			// Destination is another type
-			conversion = astbuilder.SimpleAssignment(
+			conversion = astbuilder.SetVariable(
 				errLocal,
 				tok,
 				astbuilder.CallExpr(reader, functionName, astbuilder.AddrOf(localId)))

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -570,7 +570,6 @@ func assignArrayFromArray(
 						X:     dst.NewIdent(tempId),
 						Index: dst.NewIdent(indexId),
 					},
-					token.ASSIGN,
 					expr),
 			}
 		}
@@ -654,7 +653,6 @@ func assignMapFromMap(
 						X:     dst.NewIdent(tempId),
 						Index: dst.NewIdent(keyId),
 					},
-					token.ASSIGN,
 					expr),
 			}
 		}

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -188,9 +188,8 @@ func assignToOptional(
 			// (this avoids reserving the name and not using it, which can interact with other conversions)
 			local := destinationEndpoint.CreateLocal("", "Temp")
 
-			assignment := astbuilder.SimpleAssignment(
+			assignment := astbuilder.SimpleDeclaration(
 				dst.NewIdent(local),
-				token.DEFINE,
 				expr)
 
 			writing := writer(astbuilder.AddrOf(dst.NewIdent(local)))
@@ -254,9 +253,8 @@ func assignFromOptional(
 			// (this avoids reserving the name and not using it, which can interact with other conversions)
 			local := sourceEndpoint.CreateLocal("", "Read")
 
-			cacheOriginal = astbuilder.SimpleAssignment(
+			cacheOriginal = astbuilder.SimpleDeclaration(
 				dst.NewIdent(local),
-				token.DEFINE,
 				reader)
 			actualReader = dst.NewIdent(local)
 		}
@@ -558,9 +556,8 @@ func assignArrayFromArray(
 		indexId := sourceEndpoint.CreateLocal("Index")
 		tempId := sourceEndpoint.CreateLocal("List")
 
-		declaration := astbuilder.SimpleAssignment(
+		declaration := astbuilder.SimpleDeclaration(
 			dst.NewIdent(tempId),
-			token.DEFINE,
 			astbuilder.MakeList(destinationArray.AsType(generationContext), astbuilder.CallFunc("len", reader)))
 
 		writeToElement := func(expr dst.Expr) []dst.Stmt {
@@ -574,7 +571,7 @@ func assignArrayFromArray(
 			}
 		}
 
-		avoidAliasing := astbuilder.SimpleAssignment(dst.NewIdent(itemId), token.DEFINE, dst.NewIdent(itemId))
+		avoidAliasing := astbuilder.SimpleDeclaration(dst.NewIdent(itemId), dst.NewIdent(itemId))
 		avoidAliasing.Decs.Start.Append("// Shadow the loop variable to avoid aliasing")
 		avoidAliasing.Decs.Before = dst.NewLine
 
@@ -641,9 +638,8 @@ func assignMapFromMap(
 		keyId := sourceEndpoint.CreateLocal("Key")
 		tempId := sourceEndpoint.CreateLocal("Map")
 
-		declaration := astbuilder.SimpleAssignment(
+		declaration := astbuilder.SimpleDeclaration(
 			dst.NewIdent(tempId),
-			token.DEFINE,
 			astbuilder.MakeMap(destinationMap.KeyType().AsType(generationContext), destinationMap.ValueType().AsType(generationContext)))
 
 		assignToItem := func(expr dst.Expr) []dst.Stmt {
@@ -657,7 +653,7 @@ func assignMapFromMap(
 			}
 		}
 
-		avoidAliasing := astbuilder.SimpleAssignment(dst.NewIdent(itemId), token.DEFINE, dst.NewIdent(itemId))
+		avoidAliasing := astbuilder.SimpleDeclaration(dst.NewIdent(itemId), dst.NewIdent(itemId))
 		avoidAliasing.Decs.Start.Append("// Shadow the loop variable to avoid aliasing")
 		avoidAliasing.Decs.Before = dst.NewLine
 
@@ -721,9 +717,8 @@ func assignEnumFromEnum(
 	local := destinationEndpoint.CreateLocal("", "As"+destinationName.Name(), "Value")
 	return func(reader dst.Expr, writer func(dst.Expr) []dst.Stmt, ctx *astmodel.CodeGenerationContext) []dst.Stmt {
 		result := []dst.Stmt{
-			astbuilder.SimpleAssignment(
+			astbuilder.SimpleDeclaration(
 				dst.NewIdent(local),
-				token.DEFINE,
 				astbuilder.CallFunc(destinationName.Name(), reader)),
 		}
 

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -855,13 +855,13 @@ func assignObjectFromObject(
 		var conversion dst.Stmt
 		if destinationName.PackageReference.Equals(generationContext.CurrentPackage()) {
 			// Destination is our current type
-			conversion = astbuilder.SetVariable(
+			conversion = astbuilder.AssignmentStatement(
 				errLocal,
 				tok,
 				astbuilder.CallExpr(localId, functionName, actualReader))
 		} else {
 			// Destination is another type
-			conversion = astbuilder.SetVariable(
+			conversion = astbuilder.AssignmentStatement(
 				errLocal,
 				tok,
 				astbuilder.CallExpr(reader, functionName, astbuilder.AddrOf(localId)))

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -188,9 +188,7 @@ func assignToOptional(
 			// (this avoids reserving the name and not using it, which can interact with other conversions)
 			local := destinationEndpoint.CreateLocal("", "Temp")
 
-			assignment := astbuilder.SimpleDeclaration(
-				dst.NewIdent(local),
-				expr)
+			assignment := astbuilder.SimpleDeclaration(local, expr)
 
 			writing := writer(astbuilder.AddrOf(dst.NewIdent(local)))
 
@@ -253,9 +251,7 @@ func assignFromOptional(
 			// (this avoids reserving the name and not using it, which can interact with other conversions)
 			local := sourceEndpoint.CreateLocal("", "Read")
 
-			cacheOriginal = astbuilder.SimpleDeclaration(
-				dst.NewIdent(local),
-				reader)
+			cacheOriginal = astbuilder.SimpleDeclaration(local, reader)
 			actualReader = dst.NewIdent(local)
 		}
 
@@ -557,7 +553,7 @@ func assignArrayFromArray(
 		tempId := sourceEndpoint.CreateLocal("List")
 
 		declaration := astbuilder.SimpleDeclaration(
-			dst.NewIdent(tempId),
+			tempId,
 			astbuilder.MakeList(destinationArray.AsType(generationContext), astbuilder.CallFunc("len", reader)))
 
 		writeToElement := func(expr dst.Expr) []dst.Stmt {
@@ -571,7 +567,7 @@ func assignArrayFromArray(
 			}
 		}
 
-		avoidAliasing := astbuilder.SimpleDeclaration(dst.NewIdent(itemId), dst.NewIdent(itemId))
+		avoidAliasing := astbuilder.SimpleDeclaration(itemId, dst.NewIdent(itemId))
 		avoidAliasing.Decs.Start.Append("// Shadow the loop variable to avoid aliasing")
 		avoidAliasing.Decs.Before = dst.NewLine
 
@@ -639,7 +635,7 @@ func assignMapFromMap(
 		tempId := sourceEndpoint.CreateLocal("Map")
 
 		declaration := astbuilder.SimpleDeclaration(
-			dst.NewIdent(tempId),
+			tempId,
 			astbuilder.MakeMap(destinationMap.KeyType().AsType(generationContext), destinationMap.ValueType().AsType(generationContext)))
 
 		assignToItem := func(expr dst.Expr) []dst.Stmt {
@@ -653,7 +649,7 @@ func assignMapFromMap(
 			}
 		}
 
-		avoidAliasing := astbuilder.SimpleDeclaration(dst.NewIdent(itemId), dst.NewIdent(itemId))
+		avoidAliasing := astbuilder.SimpleDeclaration(itemId, dst.NewIdent(itemId))
 		avoidAliasing.Decs.Start.Append("// Shadow the loop variable to avoid aliasing")
 		avoidAliasing.Decs.Before = dst.NewLine
 
@@ -717,9 +713,7 @@ func assignEnumFromEnum(
 	local := destinationEndpoint.CreateLocal("", "As"+destinationName.Name(), "Value")
 	return func(reader dst.Expr, writer func(dst.Expr) []dst.Stmt, ctx *astmodel.CodeGenerationContext) []dst.Stmt {
 		result := []dst.Stmt{
-			astbuilder.SimpleDeclaration(
-				dst.NewIdent(local),
-				astbuilder.CallFunc(destinationName.Name(), reader)),
+			astbuilder.SimpleDeclaration(local, astbuilder.CallFunc(destinationName.Name(), reader)),
 		}
 
 		result = append(result, writer(dst.NewIdent(local))...)

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -188,7 +188,7 @@ func assignToOptional(
 			// (this avoids reserving the name and not using it, which can interact with other conversions)
 			local := destinationEndpoint.CreateLocal("", "Temp")
 
-			assignment := astbuilder.SimpleDeclaration(local, expr)
+			assignment := astbuilder.ShortDeclaration(local, expr)
 
 			writing := writer(astbuilder.AddrOf(dst.NewIdent(local)))
 
@@ -251,7 +251,7 @@ func assignFromOptional(
 			// (this avoids reserving the name and not using it, which can interact with other conversions)
 			local := sourceEndpoint.CreateLocal("", "Read")
 
-			cacheOriginal = astbuilder.SimpleDeclaration(local, reader)
+			cacheOriginal = astbuilder.ShortDeclaration(local, reader)
 			actualReader = dst.NewIdent(local)
 		}
 
@@ -552,7 +552,7 @@ func assignArrayFromArray(
 		indexId := sourceEndpoint.CreateLocal("Index")
 		tempId := sourceEndpoint.CreateLocal("List")
 
-		declaration := astbuilder.SimpleDeclaration(
+		declaration := astbuilder.ShortDeclaration(
 			tempId,
 			astbuilder.MakeList(destinationArray.AsType(generationContext), astbuilder.CallFunc("len", reader)))
 
@@ -567,7 +567,7 @@ func assignArrayFromArray(
 			}
 		}
 
-		avoidAliasing := astbuilder.SimpleDeclaration(itemId, dst.NewIdent(itemId))
+		avoidAliasing := astbuilder.ShortDeclaration(itemId, dst.NewIdent(itemId))
 		avoidAliasing.Decs.Start.Append("// Shadow the loop variable to avoid aliasing")
 		avoidAliasing.Decs.Before = dst.NewLine
 
@@ -634,7 +634,7 @@ func assignMapFromMap(
 		keyId := sourceEndpoint.CreateLocal("Key")
 		tempId := sourceEndpoint.CreateLocal("Map")
 
-		declaration := astbuilder.SimpleDeclaration(
+		declaration := astbuilder.ShortDeclaration(
 			tempId,
 			astbuilder.MakeMap(destinationMap.KeyType().AsType(generationContext), destinationMap.ValueType().AsType(generationContext)))
 
@@ -649,7 +649,7 @@ func assignMapFromMap(
 			}
 		}
 
-		avoidAliasing := astbuilder.SimpleDeclaration(itemId, dst.NewIdent(itemId))
+		avoidAliasing := astbuilder.ShortDeclaration(itemId, dst.NewIdent(itemId))
 		avoidAliasing.Decs.Start.Append("// Shadow the loop variable to avoid aliasing")
 		avoidAliasing.Decs.Before = dst.NewLine
 
@@ -713,7 +713,7 @@ func assignEnumFromEnum(
 	local := destinationEndpoint.CreateLocal("", "As"+destinationName.Name(), "Value")
 	return func(reader dst.Expr, writer func(dst.Expr) []dst.Stmt, ctx *astmodel.CodeGenerationContext) []dst.Stmt {
 		result := []dst.Stmt{
-			astbuilder.SimpleDeclaration(local, astbuilder.CallFunc(destinationName.Name(), reader)),
+			astbuilder.ShortDeclaration(local, astbuilder.CallFunc(destinationName.Name(), reader)),
 		}
 
 		result = append(result, writer(dst.NewIdent(local))...)

--- a/hack/generator/pkg/conversions/property_conversions.go
+++ b/hack/generator/pkg/conversions/property_conversions.go
@@ -272,11 +272,10 @@ func assignFromOptional(
 		writeZeroValue := writer(
 			destinationEndpoint.Type().AsZero(conversionContext.Types(), generationContext))
 
-		stmt := &dst.IfStmt{
-			Cond: checkForNil,
-			Body: astbuilder.StatementBlock(writeActualValue...),
-			Else: astbuilder.StatementBlock(writeZeroValue...),
-		}
+		stmt := astbuilder.SimpleIfElse(
+			checkForNil,
+			astbuilder.StatementBlock(writeActualValue...),
+			astbuilder.StatementBlock(writeZeroValue...))
 
 		return astbuilder.Statements(cacheOriginal, stmt)
 	}

--- a/hack/generator/pkg/conversions/writable_conversion_endpoint.go
+++ b/hack/generator/pkg/conversions/writable_conversion_endpoint.go
@@ -7,7 +7,6 @@ package conversions
 
 import (
 	"fmt"
-	"go/token"
 
 	"github.com/dave/dst"
 
@@ -39,7 +38,6 @@ func MakeWritableConversionEndpointForProperty(
 			return []dst.Stmt{
 				astbuilder.SimpleAssignment(
 					astbuilder.Selector(destination, propertyName),
-					token.ASSIGN,
 					value),
 			}
 		},

--- a/hack/generator/pkg/functions/resource_conversion_function.go
+++ b/hack/generator/pkg/functions/resource_conversion_function.go
@@ -7,7 +7,6 @@ package functions
 
 import (
 	"fmt"
-	"go/token"
 
 	"github.com/dave/dst"
 
@@ -197,9 +196,8 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 		localId, intermediateType.AsType(generationContext), "// intermediate variable for conversion")
 	declareLocal.Decorations().Before = dst.NewLine
 
-	populateLocalFromHub := astbuilder.SimpleAssignment(
+	populateLocalFromHub := astbuilder.SimpleDeclaration(
 		errIdent,
-		token.DEFINE,
 		astbuilder.CallExpr(dst.NewIdent(localId), fn.Name(), dst.NewIdent("hub")))
 	populateLocalFromHub.Decs.Before = dst.EmptyLine
 
@@ -256,9 +254,8 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 		localId, intermediateType.AsType(generationContext), "// intermediate variable for conversion")
 	declareLocal.Decorations().Before = dst.NewLine
 
-	populateLocalFromReceiver := astbuilder.SimpleAssignment(
+	populateLocalFromReceiver := astbuilder.SimpleDeclaration(
 		errIdent,
-		token.DEFINE,
 		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localId))))
 
 	checkForErrorsPopulatingLocal := astbuilder.CheckErrorAndWrap(

--- a/hack/generator/pkg/functions/resource_conversion_function.go
+++ b/hack/generator/pkg/functions/resource_conversion_function.go
@@ -197,7 +197,7 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 	declareLocal.Decorations().Before = dst.NewLine
 
 	populateLocalFromHub := astbuilder.SimpleDeclaration(
-		errIdent,
+		"err",
 		astbuilder.CallExpr(dst.NewIdent(localId), fn.Name(), dst.NewIdent("hub")))
 	populateLocalFromHub.Decs.Before = dst.EmptyLine
 
@@ -255,7 +255,7 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 	declareLocal.Decorations().Before = dst.NewLine
 
 	populateLocalFromReceiver := astbuilder.SimpleDeclaration(
-		errIdent,
+		"err",
 		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localId))))
 
 	checkForErrorsPopulatingLocal := astbuilder.CheckErrorAndWrap(

--- a/hack/generator/pkg/functions/resource_conversion_function.go
+++ b/hack/generator/pkg/functions/resource_conversion_function.go
@@ -209,7 +209,6 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 
 	populateReceiverFromLocal := astbuilder.SimpleAssignment(
 		errIdent,
-		token.ASSIGN,
 		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localId))))
 	populateReceiverFromLocal.Decs.Before = dst.EmptyLine
 
@@ -268,7 +267,6 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 
 	populateHubFromLocal := astbuilder.SimpleAssignment(
 		errIdent,
-		token.ASSIGN,
 		astbuilder.CallExpr(dst.NewIdent(localId), fn.Name(), dst.NewIdent("hub")))
 
 	checkForErrorsPopulatingHub := astbuilder.CheckErrorAndWrap(

--- a/hack/generator/pkg/functions/resource_conversion_function.go
+++ b/hack/generator/pkg/functions/resource_conversion_function.go
@@ -196,7 +196,7 @@ func (fn *ResourceConversionFunction) indirectConversionFromHub(
 		localId, intermediateType.AsType(generationContext), "// intermediate variable for conversion")
 	declareLocal.Decorations().Before = dst.NewLine
 
-	populateLocalFromHub := astbuilder.SimpleDeclaration(
+	populateLocalFromHub := astbuilder.ShortDeclaration(
 		"err",
 		astbuilder.CallExpr(dst.NewIdent(localId), fn.Name(), dst.NewIdent("hub")))
 	populateLocalFromHub.Decs.Before = dst.EmptyLine
@@ -254,7 +254,7 @@ func (fn *ResourceConversionFunction) indirectConversionToHub(
 		localId, intermediateType.AsType(generationContext), "// intermediate variable for conversion")
 	declareLocal.Decorations().Before = dst.NewLine
 
-	populateLocalFromReceiver := astbuilder.SimpleDeclaration(
+	populateLocalFromReceiver := astbuilder.ShortDeclaration(
 		"err",
 		astbuilder.CallExpr(dst.NewIdent(receiverName), fn.propertyFunction.Name(), astbuilder.AddrOf(dst.NewIdent(localId))))
 

--- a/hack/generator/pkg/testcases/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/testcases/object_type_serialization_test_case.go
@@ -179,7 +179,7 @@ func (o ObjectSerializationTestCase) createTestRunner(codegenContext *astmodel.C
 
 	// parameters := gopter.DefaultTestParameters()
 	defineParameters := astbuilder.SimpleDeclaration(
-		dst.NewIdent(parametersLocal),
+		parametersLocal,
 		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"))
 
 	// parameters.MaxSize = 10
@@ -191,7 +191,7 @@ func (o ObjectSerializationTestCase) createTestRunner(codegenContext *astmodel.C
 
 	// properties := gopter.NewProperties(parameters)
 	defineProperties := astbuilder.SimpleDeclaration(
-		dst.NewIdent(propertiesLocal),
+		propertiesLocal,
 		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", dst.NewIdent(parametersLocal)))
 
 	// partial expression: description of the test
@@ -278,7 +278,7 @@ func (o ObjectSerializationTestCase) createTestMethod(codegenContext *astmodel.C
 	// match := cmp.Equal(subject, actual, cmpopts.EquateEmpty())
 	equateEmpty := astbuilder.CallQualifiedFunc(cmpoptsPackage, "EquateEmpty")
 	compare := astbuilder.SimpleDeclaration(
-		dst.NewIdent(matchId),
+		matchId,
 		astbuilder.CallQualifiedFunc(cmpPackage, "Equal",
 			dst.NewIdent(subjectId),
 			dst.NewIdent(actualId),
@@ -293,13 +293,13 @@ func (o ObjectSerializationTestCase) createTestMethod(codegenContext *astmodel.C
 		Body: &dst.BlockStmt{
 			List: []dst.Stmt{
 				astbuilder.SimpleDeclaration(
-					dst.NewIdent(actualFmtId),
+					actualFmtId,
 					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualId))),
 				astbuilder.SimpleDeclaration(
-					dst.NewIdent(subjectFmtId),
+					subjectFmtId,
 					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectId))),
 				astbuilder.SimpleDeclaration(
-					dst.NewIdent(resultId),
+					resultId,
 					astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtId), dst.NewIdent(actualFmtId))),
 				astbuilder.Returns(dst.NewIdent(resultId)),
 			},
@@ -384,7 +384,7 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 		// This serves to terminate any dependency cycles that might occur during creation of a more fully fledged generator
 
 		makeIndependentMap := astbuilder.SimpleDeclaration(
-			dst.NewIdent("independentGenerators"),
+			"independentGenerators",
 			astbuilder.MakeMap(
 				dst.NewIdent("string"),
 				astbuilder.QualifiedTypeName(gopterPackage, "Gen")))
@@ -410,7 +410,7 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 		// if we reuse or modify the map, chaos ensues.
 
 		makeAllMap := astbuilder.SimpleDeclaration(
-			dst.NewIdent("allGenerators"),
+			"allGenerators",
 			astbuilder.MakeMap(
 				dst.NewIdent("string"),
 				astbuilder.QualifiedTypeName(gopterPackage, "Gen")))

--- a/hack/generator/pkg/testcases/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/testcases/object_type_serialization_test_case.go
@@ -265,7 +265,6 @@ func (o ObjectSerializationTestCase) createTestMethod(codegenContext *astmodel.C
 	// err = json.Unmarshal(bin, &actual)
 	deserialize := astbuilder.SimpleAssignment(
 		dst.NewIdent("err"),
-		token.ASSIGN,
 		astbuilder.CallQualifiedFunc(jsonPackage, "Unmarshal",
 			dst.NewIdent(binId),
 			&dst.UnaryExpr{
@@ -403,7 +402,6 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 
 		createIndependentGenerator := astbuilder.SimpleAssignment(
 			dst.NewIdent(o.idOfSubjectGeneratorGlobal()),
-			token.ASSIGN,
 			astbuilder.CallQualifiedFunc(
 				genPackage,
 				"Struct",
@@ -440,7 +438,6 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 
 		createFullGenerator := astbuilder.SimpleAssignment(
 			dst.NewIdent(o.idOfSubjectGeneratorGlobal()),
-			token.ASSIGN,
 			astbuilder.CallQualifiedFunc(
 				genPackage,
 				"Struct",

--- a/hack/generator/pkg/testcases/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/testcases/object_type_serialization_test_case.go
@@ -178,9 +178,8 @@ func (o ObjectSerializationTestCase) createTestRunner(codegenContext *astmodel.C
 	t := dst.NewIdent("t")
 
 	// parameters := gopter.DefaultTestParameters()
-	defineParameters := astbuilder.SimpleAssignment(
+	defineParameters := astbuilder.SimpleDeclaration(
 		dst.NewIdent(parametersLocal),
-		token.DEFINE,
 		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"))
 
 	// parameters.MaxSize = 10
@@ -191,9 +190,8 @@ func (o ObjectSerializationTestCase) createTestRunner(codegenContext *astmodel.C
 		astbuilder.IntLiteral(10))
 
 	// properties := gopter.NewProperties(parameters)
-	defineProperties := astbuilder.SimpleAssignment(
+	defineProperties := astbuilder.SimpleDeclaration(
 		dst.NewIdent(propertiesLocal),
-		token.DEFINE,
 		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", dst.NewIdent(parametersLocal)))
 
 	// partial expression: description of the test
@@ -279,9 +277,8 @@ func (o ObjectSerializationTestCase) createTestMethod(codegenContext *astmodel.C
 
 	// match := cmp.Equal(subject, actual, cmpopts.EquateEmpty())
 	equateEmpty := astbuilder.CallQualifiedFunc(cmpoptsPackage, "EquateEmpty")
-	compare := astbuilder.SimpleAssignment(
+	compare := astbuilder.SimpleDeclaration(
 		dst.NewIdent(matchId),
-		token.DEFINE,
 		astbuilder.CallQualifiedFunc(cmpPackage, "Equal",
 			dst.NewIdent(subjectId),
 			dst.NewIdent(actualId),
@@ -295,17 +292,14 @@ func (o ObjectSerializationTestCase) createTestMethod(codegenContext *astmodel.C
 		},
 		Body: &dst.BlockStmt{
 			List: []dst.Stmt{
-				astbuilder.SimpleAssignment(
+				astbuilder.SimpleDeclaration(
 					dst.NewIdent(actualFmtId),
-					token.DEFINE,
 					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualId))),
-				astbuilder.SimpleAssignment(
+				astbuilder.SimpleDeclaration(
 					dst.NewIdent(subjectFmtId),
-					token.DEFINE,
 					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectId))),
-				astbuilder.SimpleAssignment(
+				astbuilder.SimpleDeclaration(
 					dst.NewIdent(resultId),
-					token.DEFINE,
 					astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtId), dst.NewIdent(actualFmtId))),
 				astbuilder.Returns(dst.NewIdent(resultId)),
 			},
@@ -389,9 +383,8 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 		// Create a simple version of the generator that does not reference generators for related types
 		// This serves to terminate any dependency cycles that might occur during creation of a more fully fledged generator
 
-		makeIndependentMap := astbuilder.SimpleAssignment(
+		makeIndependentMap := astbuilder.SimpleDeclaration(
 			dst.NewIdent("independentGenerators"),
-			token.DEFINE,
 			astbuilder.MakeMap(
 				dst.NewIdent("string"),
 				astbuilder.QualifiedTypeName(gopterPackage, "Gen")))
@@ -416,9 +409,8 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 		// Have to call the factory method twice as the simple generator above has captured the map;
 		// if we reuse or modify the map, chaos ensues.
 
-		makeAllMap := astbuilder.SimpleAssignment(
+		makeAllMap := astbuilder.SimpleDeclaration(
 			dst.NewIdent("allGenerators"),
-			token.DEFINE,
 			astbuilder.MakeMap(
 				dst.NewIdent("string"),
 				astbuilder.QualifiedTypeName(gopterPackage, "Gen")))

--- a/hack/generator/pkg/testcases/object_type_serialization_test_case.go
+++ b/hack/generator/pkg/testcases/object_type_serialization_test_case.go
@@ -178,7 +178,7 @@ func (o ObjectSerializationTestCase) createTestRunner(codegenContext *astmodel.C
 	t := dst.NewIdent("t")
 
 	// parameters := gopter.DefaultTestParameters()
-	defineParameters := astbuilder.SimpleDeclaration(
+	defineParameters := astbuilder.ShortDeclaration(
 		parametersLocal,
 		astbuilder.CallQualifiedFunc(gopterPackage, "DefaultTestParameters"))
 
@@ -190,7 +190,7 @@ func (o ObjectSerializationTestCase) createTestRunner(codegenContext *astmodel.C
 		astbuilder.IntLiteral(10))
 
 	// properties := gopter.NewProperties(parameters)
-	defineProperties := astbuilder.SimpleDeclaration(
+	defineProperties := astbuilder.ShortDeclaration(
 		propertiesLocal,
 		astbuilder.CallQualifiedFunc(gopterPackage, "NewProperties", dst.NewIdent(parametersLocal)))
 
@@ -277,7 +277,7 @@ func (o ObjectSerializationTestCase) createTestMethod(codegenContext *astmodel.C
 
 	// match := cmp.Equal(subject, actual, cmpopts.EquateEmpty())
 	equateEmpty := astbuilder.CallQualifiedFunc(cmpoptsPackage, "EquateEmpty")
-	compare := astbuilder.SimpleDeclaration(
+	compare := astbuilder.ShortDeclaration(
 		matchId,
 		astbuilder.CallQualifiedFunc(cmpPackage, "Equal",
 			dst.NewIdent(subjectId),
@@ -292,13 +292,13 @@ func (o ObjectSerializationTestCase) createTestMethod(codegenContext *astmodel.C
 		},
 		Body: &dst.BlockStmt{
 			List: []dst.Stmt{
-				astbuilder.SimpleDeclaration(
+				astbuilder.ShortDeclaration(
 					actualFmtId,
 					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(actualId))),
-				astbuilder.SimpleDeclaration(
+				astbuilder.ShortDeclaration(
 					subjectFmtId,
 					astbuilder.CallQualifiedFunc(prettyPackage, "Sprint", dst.NewIdent(subjectId))),
-				astbuilder.SimpleDeclaration(
+				astbuilder.ShortDeclaration(
 					resultId,
 					astbuilder.CallQualifiedFunc(diffPackage, "Diff", dst.NewIdent(subjectFmtId), dst.NewIdent(actualFmtId))),
 				astbuilder.Returns(dst.NewIdent(resultId)),
@@ -383,7 +383,7 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 		// Create a simple version of the generator that does not reference generators for related types
 		// This serves to terminate any dependency cycles that might occur during creation of a more fully fledged generator
 
-		makeIndependentMap := astbuilder.SimpleDeclaration(
+		makeIndependentMap := astbuilder.ShortDeclaration(
 			"independentGenerators",
 			astbuilder.MakeMap(
 				dst.NewIdent("string"),
@@ -409,7 +409,7 @@ func (o ObjectSerializationTestCase) createGeneratorMethod(ctx *astmodel.CodeGen
 		// Have to call the factory method twice as the simple generator above has captured the map;
 		// if we reuse or modify the map, chaos ensues.
 
-		makeAllMap := astbuilder.SimpleDeclaration(
+		makeAllMap := astbuilder.ShortDeclaration(
 			"allGenerators",
 			astbuilder.MakeMap(
 				dst.NewIdent("string"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Our `SimpleAssignment()` method has always been brittle because it's so easy to misuse by passing the wrong token value. This also makes it more complex to consume - I've wanted to simplify things for a while.

* `SimpleAssignment()` has been modified so it always does assignment 

* New method `SimpleDeclaration()` uses `:=` to always declare a variable. The first parameter is a string, simplifying all the calling sites.

* New method `SetVariable()` handles the very few remaining cases where the choice between declaration and assignment was dynamic.

The helper `EnsureStatementBlock()` has been subsumed into `StatementBlock()` to simplify usage.

Extends usage of helper functions to simplify code.

Moves some local variable name reservations later, until we know for sure the name is needed. This avoids a handful of cases where we'd reserve a local variable name and not use it, forcing other local variables to use clumsier names in the final output.

I wanted some of this for a WIP branch so I extracted it out into a separate PR.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/SAHwJVnkobiujYogyX/giphy.gif)
