### PR TITLE
Update our triage docs for new tag

### DIFF
--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -1,10 +1,9 @@
 # Issue Triage
 
-On a regular basis (target: weekly) the development team will triage issues matching the following [GitHub search](https://github.com/Azure/azure-service-operator/issues?q=is%3Aissue+is%3Aopen+-label%3Atriaged+no%3Amilestone+):
+On a regular basis (target: weekly) the development team will triage issues matching the following [GitHub search](https://github.com/Azure/azure-service-operator/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-triage+):
 
 ```
-is:issue is:open -label:triaged no:milestone 
+is:issue is:open label:needs-triage
 ```
 
-As issues are triaged, the label `triaged` will be added, along with a comment where appropriate.
-
+When new issues are created, our bot will automatically add the `needs-triage` tag so they show up in this list.


### PR DESCRIPTION
**What this PR does / why we need it**:

We're introducing the tag `needs-triage` and a bot to automatically apply it to new issues; this PR updates our docs on what we're looking at when we triage.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/qtnlmKINyEW9G/giphy.gif)

**If applicable**:
- [x] this PR contains documentation

