### PR TITLE
Don't CommitUpdate twice in a single reconcile loop

### DIFF
--- a/hack/generated/pkg/testcommon/kube_test_context_envtest.go
+++ b/hack/generated/pkg/testcommon/kube_test_context_envtest.go
@@ -65,7 +65,7 @@ func createEnvtestContext(perTestContext PerTestContext) (*KubeBaseTestContext, 
 		return nil, errors.Wrapf(err, "creating controller-runtime manager")
 	}
 
-	var requeueDelay time.Duration // defaults to 5s when zero is passed
+	var requeueDelay time.Duration
 	if perTestContext.AzureClientRecorder.Mode() == recorder.ModeReplaying {
 		perTestContext.T.Log("Minimizing requeue delay")
 		// skip requeue delays when replaying


### PR DESCRIPTION
Multiple updates in a single loop means that there are multiple changes with new resourceVersions floating around. This then leads to races where you might end up reconciling on the resource from after update1 when you really want the change from after update2.

Since the two-updates was just an optimization, removed it.