### PR TITLE
Use Github Action to add needs-triage label

### DIFF
--- a/.devbots/needs-triage.yml
+++ b/.devbots/needs-triage.yml
@@ -1,2 +1,0 @@
-enabled: true
-label: "needs-triage"

--- a/.github/workflows/add-needs-triage-label.yml
+++ b/.github/workflows/add-needs-triage-label.yml
@@ -13,6 +13,6 @@ jobs:
       issues: write
     steps:
       - name: Label issues
-        uses: andymckay/labeler@1825c391d68ade591efa053af2472e5b0e2e2d9e
+        uses: andymckay/labeler@1825c391d68ade591efa053af2472e5b0e2e2d9e # this is v1.0.3
         with:
           add-labels: "needs-triage"

--- a/.github/workflows/add-needs-triage-label.yml
+++ b/.github/workflows/add-needs-triage-label.yml
@@ -9,7 +9,6 @@ jobs:
   add_label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: needs-triage

--- a/.github/workflows/add-needs-triage-label.yml
+++ b/.github/workflows/add-needs-triage-label.yml
@@ -1,0 +1,15 @@
+name: Add 'needs-triage' label to new issues
+
+on:
+  issues:
+    types: 
+    -  opened
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs-triage

--- a/.github/workflows/add-needs-triage-label.yml
+++ b/.github/workflows/add-needs-triage-label.yml
@@ -2,13 +2,17 @@ name: Add 'needs-triage' label to new issues
 
 on:
   issues:
-    types: 
-    -  opened
-
+    types:
+      - reopened
+      - opened
+      
 jobs:
-  add_label:
+  label_issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1
+      - name: Label issues
+        uses: andymckay/labeler@1825c391d68ade591efa053af2472e5b0e2e2d9e
         with:
-          labels: needs-triage
+          add-labels: "needs-triage"


### PR DESCRIPTION
Bot doesn't seem to be working so let's do this instead. Seems simpler overall as well!