### PR TITLE
Generate DeepCopy() methods for genruntime types

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -195,7 +195,7 @@ tasks:
   controller:test-integration-envtest:
     desc: Run integration tests with envtest using record/replay.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:generate-crds]
+    deps: [controller:generate-kustomize]
     cmds:
     # -race fails at the moment in controller-runtime
     - go test -run '{{default ".*" .TEST_FILTER}}' ./...
@@ -203,7 +203,7 @@ tasks:
   controller:test-integration-envtest-cover:
     desc: Run integration tests with envtest using record/replay and output coverage.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:generate-crds]
+    deps: [controller:generate-kustomize]
     cmds:
     # -race fails at the moment in controller-runtime
     - go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./...
@@ -211,7 +211,7 @@ tasks:
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:generate-crds, cleanup-azure-resources]
+    deps: [controller:generate-kustomize, cleanup-azure-resources]
     cmds:
     # -race fails at the moment in controller-runtime
     - RECORD_REPLAY=0 go test -timeout {{.LIVE_TEST_TIMEOUT}} -covermode atomic -coverprofile=coverage-integration-envtest-live.out -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./...
@@ -242,9 +242,18 @@ tasks:
     vars:
       CRD_OPTIONS: "crd:crdVersions=v1,allowDangerousTypes=true"
 
+  controller:generate-genruntime-deepcopy:
+    desc: Run controller-gen to generate {{.CONTROLLER_APP}} CRD files.
+    dir: "{{.CONTROLLER_ROOT}}"
+    sources:
+      - "pkg/genruntime/**/*.go"
+    cmds:
+      - find ./pkg/genruntime -type f -name "zz_generated.*" -delete
+      - cd pkg/genruntime && controller-gen object:headerFile=../../../boilerplate.go.txt paths="./..." || true
+
   controller:generate-kustomize:
     desc: Run {{.GENERATOR_APP}} to generate the Kustomize file for registering CRDs.
-    deps: [generator:build, controller:generate-crds]
+    deps: [controller:generate-crds, controller:generate-genruntime-deepcopy]
     sources:
       - "{{.GENERATOR_ROOT}}bin/{{.GENERATOR_APP}}"
       - "{{.CONTROLLER_ROOT}}config/crd/bases/**/*.yaml"

--- a/hack/generated/pkg/genruntime/conditions/conditions.go
+++ b/hack/generated/pkg/genruntime/conditions/conditions.go
@@ -75,6 +75,7 @@ const (
 var _ fmt.Stringer = Condition{}
 
 // Condition defines an extension to status (an observation) of a resource
+// +kubebuilder:object:generate=true
 type Condition struct {
 	// Type of condition.
 	// +kubebuilder:validation:Required

--- a/hack/generated/pkg/genruntime/resource_reference.go
+++ b/hack/generated/pkg/genruntime/resource_reference.go
@@ -15,6 +15,7 @@ import (
 )
 
 // KnownResourceReference is a resource reference to a known type.
+// +kubebuilder:object:generate=true
 type KnownResourceReference struct {
 	// This is the name of the Kubernetes resource to reference.
 	Name string `json:"name"`
@@ -29,6 +30,7 @@ type KnownResourceReference struct {
 var _ fmt.Stringer = ResourceReference{}
 
 // ResourceReference represents a resource reference, either to a Kubernetes resource or directly to an Azure resource via ARMID
+// +kubebuilder:object:generate=true
 type ResourceReference struct {
 	// Group is the Kubernetes group of the resource.
 	Group string `json:"group,omitempty"`


### PR DESCRIPTION
Some genruntime types are used by the generated code, while others are used only by the handcrafted controller. Types used
by the generated code need DeepCopy() functionality.