### PR TITLE
Force top level status properties to be optional

### DIFF
--- a/hack/generated/controllers/crd_disk_test.go
+++ b/hack/generated/controllers/crd_disk_test.go
@@ -41,7 +41,7 @@ func Test_Disk_CRUD(t *testing.T) {
 	}
 	tc.CreateResourceAndWait(disk)
 
-	tc.Expect(disk.Status.Location).To(Equal(tc.AzureRegion))
+	tc.Expect(disk.Status.Location).To(Equal(&tc.AzureRegion))
 	tc.Expect(disk.Status.Sku.Name).To(BeEquivalentTo(&standardSkuName))
 	tc.Expect(*disk.Status.DiskSizeGB).To(BeNumerically(">=", 500))
 	tc.Expect(disk.Status.Id).ToNot(BeNil())

--- a/hack/generated/controllers/crd_storageaccount_test.go
+++ b/hack/generated/controllers/crd_storageaccount_test.go
@@ -43,7 +43,7 @@ func Test_StorageAccount_CRUD(t *testing.T) {
 
 	tc.CreateResourceAndWait(acct)
 
-	tc.Expect(acct.Status.Location).To(Equal(tc.AzureRegion))
+	tc.Expect(acct.Status.Location).To(Equal(&tc.AzureRegion))
 	expectedKind := storage.StorageAccountStatusKindBlobStorage
 	tc.Expect(acct.Status.Kind).To(Equal(&expectedKind))
 	tc.Expect(acct.Status.Id).ToNot(BeNil())

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -300,7 +300,12 @@ func FindSpecTypes(types Types) Types {
 
 		// Add the named spec type to our results
 		if spec, ok := types.TryGet(tn); ok {
-			result.Add(spec)
+			// Use AddAllowDuplicates here because some resources share the same spec
+			// across multiple resources, which can trigger multiple adds of the same type
+			err := result.AddAllowDuplicates(spec)
+			if err != nil {
+				panic(err)
+			}
 		}
 	}
 
@@ -326,7 +331,12 @@ func FindStatusTypes(types Types) Types {
 
 		// Add the named status type to our results
 		if status, ok := types.TryGet(tn); ok {
-			result.Add(status)
+			// Use AddAllowDuplicates here because some resources share the same status
+			// across multiple resources, which can trigger multiple adds of the same type
+			err := result.AddAllowDuplicates(status)
+			if err != nil {
+				panic(err)
+			}
 		}
 	}
 

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -106,6 +106,8 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		pipeline.ApplyPropertyRewrites(configuration).
 			RequiresPrerequisiteStages("nameTypes", "allof-anyof-objects"),
 
+		pipeline.MakeStatusPropertiesOptional(),
+
 		// Figure out resource owners:
 		pipeline.DetermineResourceOwnership(configuration),
 

--- a/hack/generator/pkg/codegen/pipeline/make_status_properties_optional.go
+++ b/hack/generator/pkg/codegen/pipeline/make_status_properties_optional.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"context"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
+)
+
+const MakeStatusPropertiesOptionalStageID = "makeStatusPropertiesOptional"
+
+// MakeStatusPropertiesOptional makes all top level Status properties optional. This is required because Status itself
+// is actually optional (it's not set initially) and if any top level properties are not optional they end up
+// always being returned, which makes for an awkward GET response initially (before the Status has been set). It also
+// has implications for updating or patching the CRD resource as patching something in the spec or changing an annotation
+// will deserialize the response from apiserver into the object passed in. If there are any spurious empty properties in Status
+// included they will end up getting overwritten (possibly before the client.Status().Update() call can be made).
+func MakeStatusPropertiesOptional() Stage {
+	return MakeStage(
+		MakeStatusPropertiesOptionalStageID,
+		"Forces all status properties to be optional",
+		func(ctx context.Context, state *State) (*State, error) {
+
+			statusTypes := astmodel.FindStatusTypes(state.Types())
+			var errs []error
+
+			result := make(astmodel.Types)
+			for _, def := range statusTypes {
+				modifiedType, err := makeStatusPropertiesOptional(def)
+				if err != nil {
+					errs = append(errs, err)
+				}
+
+				result.Add(def.WithType(modifiedType))
+			}
+
+			err := kerrors.NewAggregate(errs)
+			if err != nil {
+				return nil, err
+			}
+
+			remaining := state.Types().Except(result)
+			result.AddTypes(remaining)
+
+			return state.WithTypes(result), nil
+		})
+}
+
+// makeStatusPropertiesOptional makes all properties optional on top level Status types
+func makeStatusPropertiesOptional(statusDef astmodel.TypeDefinition) (astmodel.Type, error) {
+	visitor := astmodel.TypeVisitorBuilder{
+		VisitObjectType: makeObjectPropertiesOptional,
+	}.Build()
+
+	return visitor.Visit(statusDef.Type(), statusDef.Name())
+}
+
+// makeObjectPropertiesOptional makes properties optional for the object
+func makeObjectPropertiesOptional(this *astmodel.TypeVisitor, ot *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
+	typeName := ctx.(astmodel.TypeName)
+	for _, property := range ot.Properties() {
+		if property.HasKubebuilderRequiredValidation() {
+			klog.V(4).Infof("\"%s.%s\" was required, changing it to optional", typeName.String(), property.PropertyName())
+		}
+		ot = ot.WithProperty(property.MakeOptional())
+	}
+
+	return astmodel.IdentityVisitOfObjectType(this, ot, ctx)
+}

--- a/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -8,6 +8,7 @@ augmentSpecWithStatus                                Merges information from Sta
 stripUnreferenced                                    Strip unreferenced types
 nameTypes                                            Name inner types for CRD
 propertyRewrites                                     Modify property types using configured transforms
+makeStatusPropertiesOptional                         Forces all status properties to be optional
 determineResourceOwnership                           Determine ARM resource relationships
 removeAliases                                        Remove type aliases
 collapseCrossGroupReferences                         Finds and removes cross group references

--- a/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -8,6 +8,7 @@ augmentSpecWithStatus                              Merges information from Statu
 stripUnreferenced                                  Strip unreferenced types
 nameTypes                                          Name inner types for CRD
 propertyRewrites                                   Modify property types using configured transforms
+makeStatusPropertiesOptional                       Forces all status properties to be optional
 determineResourceOwnership                         Determine ARM resource relationships
 removeAliases                                      Remove type aliases
 collapseCrossGroupReferences                       Finds and removes cross group references

--- a/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
@@ -8,6 +8,7 @@ augmentSpecWithStatus                                Merges information from Sta
 stripUnused                                          Strip unused types for test
 nameTypes                                            Name inner types for CRD
 propertyRewrites                                     Modify property types using configured transforms
+makeStatusPropertiesOptional                         Forces all status properties to be optional
 determineResourceOwnership                           Determine ARM resource relationships
 removeAliases                                        Remove type aliases
 pluralizeNames                                       Improve resource pluralization


### PR DESCRIPTION
**What this PR does / why we need it**:
There are times when `Status` doesn't exist, such as when an object is first created. There's a bit of an unwritten rule that:
1. `Status` is not a pointer on the resource.
2. All top level status properties have `omitempty` set.

This way when there isn't a status, there's not a bunch of extra `""`'s returned.

This is especially important for some multi-write cases between spec and status, as `""`'s returned can overwrite in-memory data before it has a chance to be sent via a `client.Status().Update()` call

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3o7btNRptqBgLSKR2w/giphy.gif)

