### PR TITLE
Fix run-kustomize task and reorder steps

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,6 +29,18 @@ jobs:
           docker start "$container_id"
           echo "::set-output name=id::$container_id"
         
+      - name: Run Kustomize 
+        run: |
+          container_id=${{steps.devcontainer.outputs.id}}
+          docker exec "$container_id" task controller:run-kustomize
+
+      - name: Build Docker image
+        run: |
+          container_id=${{steps.devcontainer.outputs.id}}
+          docker exec "$container_id" task controller:docker-build
+
+      # Do this after all user-defined code has been run so that
+      # creds cannot be stolen by Evil Dependencies™?
       - name: Login to registry
         uses: docker/login-action@v1
         with:
@@ -36,12 +48,7 @@ jobs:
           username: ${{ secrets.AZURE_CLIENT_ID }}
           password: ${{ secrets.AZURE_CLIENT_SECRET }}
 
-      - name: Run Kustomize 
-        run: |
-          container_id=${{steps.devcontainer.outputs.id}}
-          docker exec "$container_id" task controller:run-kustomize
-
-      - name: Build & push docker image
+      - name: Push Docker image
         run: |
           container_id=${{steps.devcontainer.outputs.id}}
           docker exec -e DOCKER_PUSH_TARGET "$container_id" task controller:docker-push-remote

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -283,6 +283,7 @@ tasks:
     deps: [controller:generate-kustomize]
     dir: "{{.CONTROLLER_ROOT}}"
     cmds:
+    - mkdir -p bin # in case it doesn’t exist
     - kustomize build config/default | sed -e 's@localhost:5000/azureserviceoperator:latest@{{.PUBLIC_REGISTRY}}{{.CONTROLLER_DOCKER_IMAGE}}@g' > bin/azureserviceoperator_{{.VERSION}}.yaml
 
   controller:kind-delete:


### PR DESCRIPTION
`run-kustomize` would fail if run before `build-docker-image` due to output directory not existing.