### PR TITLE
Remove envtest job timeout for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,9 +127,6 @@ jobs:
       displayName: Run envtest tests
       condition: or(eq(variables['check_changes.SOURCE_CODE_CHANGED'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       continueOnError: 'false'
-      # There are some degenerate cases where a test failure means stuff takes super long and ends up timing out.
-      # Setting this to a value smaller than the overall job timeout means that we save some time in those instances.
-      timeoutInMinutes: 45
       env:
         GO111MODULE: on
         AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)

--- a/controllers/azuresql_combined_test.go
+++ b/controllers/azuresql_combined_test.go
@@ -274,7 +274,7 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 					ResourceGroup:                rgName,
 					Server:                       sqlServerName,
 					FailoverPolicy:               v1beta1.FailoverPolicyAutomatic,
-					FailoverGracePeriod:          30,
+					FailoverGracePeriod:          60,
 					SecondaryServer:              sqlServerTwoName,
 					SecondaryServerResourceGroup: rgName,
 					DatabaseList:                 []string{sqlDatabaseName1},

--- a/controllers/azuresql_combined_test.go
+++ b/controllers/azuresql_combined_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	sql "github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,7 +28,7 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 	t.Parallel()
 	defer PanicRecover(t)
 	ctx := context.Background()
-	assert := assert.New(t)
+	require := require.New(t)
 	var err error
 
 	// Add any setup steps that needs to be executed before each test
@@ -114,7 +114,7 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 
 			namespacedName := types.NamespacedName{Name: sqlDatabaseName2, Namespace: "default"}
 			err = tc.k8sClient.Get(ctx, namespacedName, sqlDatabaseInstance2)
-			assert.Equal(nil, err, "get sql database in k8s")
+			require.Equal(nil, err, "get sql database in k8s")
 
 			originalHash := sqlDatabaseInstance2.Status.SpecHash
 
@@ -127,41 +127,41 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 			sqlDatabaseInstance2.Spec.MaxSize = &maxSize
 
 			err = tc.k8sClient.Update(ctx, sqlDatabaseInstance2)
-			assert.Equal(nil, err, "updating sql database in k8s")
+			require.Equal(nil, err, "updating sql database in k8s")
 
-			assert.Eventually(func() bool {
+			require.Eventually(func() bool {
 				db := &v1beta1.AzureSqlDatabase{}
 				err = tc.k8sClient.Get(ctx, namespacedName, db)
-				assert.Equal(nil, err, "err getting DB from k8s")
+				require.Equal(nil, err, "err getting DB from k8s")
 				return originalHash != db.Status.SpecHash
 			}, tc.timeout, tc.retry, "wait for sql database to be updated in k8s")
 
-			assert.Eventually(func() bool {
+			require.Eventually(func() bool {
 				db, err := tc.sqlDbManager.GetDB(ctx, rgName, sqlServerName, sqlDatabaseName2)
-				assert.Equal(nil, err, "err getting DB fromAzure")
+				require.Equal(nil, err, "err getting DB fromAzure")
 				return db.Sku != nil && db.Sku.Name != nil && *db.Sku.Name == "Basic"
 			}, tc.timeout, tc.retry, "wait for sql database Sku.Name to be updated in azure")
 
-			assert.Eventually(func() bool {
+			require.Eventually(func() bool {
 				db, err := tc.sqlDbManager.GetDB(ctx, rgName, sqlServerName, sqlDatabaseName2)
-				assert.Equal(nil, err, "err getting DB fromAzure")
+				require.Equal(nil, err, "err getting DB fromAzure")
 				return db.Sku != nil && db.Sku.Tier != nil && *db.Sku.Tier == "Basic"
 			}, tc.timeout, tc.retry, "wait for sql database Sku.Tier to be updated in azure")
 
-			assert.Eventually(func() bool {
+			require.Eventually(func() bool {
 				db, err := tc.sqlDbManager.GetDB(ctx, rgName, sqlServerName, sqlDatabaseName2)
-				assert.Equal(nil, err, "err getting DB fromAzure")
+				require.Equal(nil, err, "err getting DB fromAzure")
 				return db.MaxSizeBytes != nil && *db.MaxSizeBytes == int64(maxSizeMb)*int64(1024)*int64(1024)
 			}, tc.timeout, tc.retry, "wait for sql database MaxSizeBytes to be updated in azure")
 
 			// At this point the DB should be in a stable state, ensure that the right status is set
 			db := &v1beta1.AzureSqlDatabase{}
 			err = tc.k8sClient.Get(ctx, namespacedName, db)
-			assert.Equal(nil, err, "err getting DB from k8s")
+			require.Equal(nil, err, "err getting DB from k8s")
 
-			assert.Equal(false, db.Status.Provisioning)
-			assert.Equal(false, db.Status.FailedProvisioning)
-			assert.Equal(true, db.Status.Provisioned)
+			require.Equal(false, db.Status.Provisioning)
+			require.Equal(false, db.Status.FailedProvisioning)
+			require.Equal(true, db.Status.Provisioned)
 		})
 
 		// Create a database in the new server
@@ -194,13 +194,13 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 			// Now update with an invalid retention policy
 			sqlDatabaseInstance3.Spec.ShortTermRetentionPolicy.RetentionDays = -1
 			err = tc.k8sClient.Update(ctx, sqlDatabaseInstance3)
-			assert.Equal(nil, err, "updating sql database in k8s")
+			require.Equal(nil, err, "updating sql database in k8s")
 
 			namespacedName := types.NamespacedName{Name: sqlDatabaseName3, Namespace: "default"}
-			assert.Eventually(func() bool {
+			require.Eventually(func() bool {
 				db := &v1beta1.AzureSqlDatabase{}
 				err = tc.k8sClient.Get(ctx, namespacedName, db)
-				assert.Equal(nil, err, "err getting DB from k8s")
+				require.Equal(nil, err, "err getting DB from k8s")
 				return db.Status.Provisioned == false && strings.Contains(db.Status.Message, errhelp.BackupRetentionPolicyInvalid)
 			}, tc.timeout, tc.retry, "wait for sql database to be updated in k8s")
 		})
@@ -284,7 +284,7 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 			EnsureInstance(ctx, t, tc, sqlFailoverGroupInstance)
 
 			// verify secret has been created
-			assert.Eventually(func() bool {
+			require.Eventually(func() bool {
 				key := secrets.SecretKey{Name: sqlFailoverGroupInstance.Name, Namespace: sqlFailoverGroupInstance.Namespace, Kind: "AzureSqlFailoverGroup"}
 				var secrets, err = tc.secretClient.Get(ctx, key)
 
@@ -295,14 +295,14 @@ func TestAzureSqlServerCombinedHappyPath(t *testing.T) {
 			sqlFailoverGroupInstance.Spec.FailoverGracePeriod = 0 // GracePeriod cannot be set when policy is manual
 
 			err = tc.k8sClient.Update(ctx, sqlFailoverGroupInstance)
-			assert.Equal(nil, err, "updating sql failover group in k8s")
+			require.Equal(nil, err, "updating sql failover group in k8s")
 
 			failoverGroupsClient, err := azuresqlshared.GetGoFailoverGroupsClient(config.GlobalCredentials())
-			assert.Equal(nil, err, "getting failovergroup client")
+			require.Equal(nil, err, "getting failovergroup client")
 
-			assert.Eventually(func() bool {
+			require.Eventually(func() bool {
 				fog, err := failoverGroupsClient.Get(ctx, rgName, sqlServerName, sqlFailoverGroupName)
-				assert.Equal(nil, err, "err getting failover group from Azure")
+				require.Equal(nil, err, "err getting failover group from Azure")
 				return fog.ReadWriteEndpoint.FailoverPolicy == sql.Manual
 			}, tc.timeout, tc.retry, "wait for sql failover group failover policy to be updated in Azure")
 		})

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -18,7 +18,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -221,14 +220,14 @@ func EnsureInstance(ctx context.Context, t *testing.T, tc TestContext, instance 
 }
 
 func EnsureInstanceWithResult(ctx context.Context, t *testing.T, tc TestContext, instance client.Object, message string, provisioned bool) {
-	assert := assert.New(t)
+	require := require.New(t)
 	typeOf := fmt.Sprintf("%T", instance)
 
 	err := tc.k8sClient.Create(ctx, instance)
-	assert.Equal(nil, err, fmt.Sprintf("create %s in k8s", typeOf))
+	require.Equal(nil, err, fmt.Sprintf("create %s in k8s", typeOf))
 
 	res, err := meta.Accessor(instance)
-	assert.Equal(nil, err, "not a metav1 object")
+	require.Equal(nil, err, "not a metav1 object")
 
 	names := types.NamespacedName{Name: res.GetName(), Namespace: res.GetNamespace()}
 
@@ -244,7 +243,7 @@ func EnsureInstanceWithResult(ctx context.Context, t *testing.T, tc TestContext,
 		}
 		return nil
 	})
-	assert.Nil(err, "error waiting for %s to have finalizer", typeOf)
+	require.Nil(err, "error waiting for %s to have finalizer", typeOf)
 
 	// wait for provisioned and message to be as expected
 	err = helpers.Retry(tc.timeout, tc.retry, func() error {
@@ -285,24 +284,24 @@ func EnsureInstanceWithResult(ctx context.Context, t *testing.T, tc TestContext,
 		}
 		return nil
 	})
-	assert.Nil(err, "wait for %s to provision", typeOf)
+	require.Nil(err, "wait for %s to provision", typeOf)
 
 }
 
 // EnsureDelete deletes the instance and waits for it to be gone or timeout
 func EnsureDelete(ctx context.Context, t *testing.T, tc TestContext, instance client.Object) {
-	assert := assert.New(t)
+	require := require.New(t)
 	typeOf := fmt.Sprintf("%T", instance)
 
 	err := tc.k8sClient.Delete(ctx, instance)
-	assert.Equal(nil, err, fmt.Sprintf("delete %s in k8s", typeOf))
+	require.Equal(nil, err, fmt.Sprintf("delete %s in k8s", typeOf))
 
 	res, err := meta.Accessor(instance)
-	assert.Equal(nil, err, "not a metav1 object")
+	require.Equal(nil, err, "not a metav1 object")
 
 	names := types.NamespacedName{Name: res.GetName(), Namespace: res.GetNamespace()}
 
-	assert.Eventually(func() bool {
+	require.Eventually(func() bool {
 		err = tc.k8sClient.Get(ctx, names, instance)
 		return apierrors.IsNotFound(err)
 	}, tc.timeout, tc.retry, fmt.Sprintf("wait for %s to be gone from k8s", typeOf))
@@ -310,7 +309,7 @@ func EnsureDelete(ctx context.Context, t *testing.T, tc TestContext, instance cl
 }
 
 func EnsureSecrets(ctx context.Context, t *testing.T, tc TestContext, instance runtime.Object, secretClient secrets.SecretClient, secretKey secrets.SecretKey) {
-	assert := assert.New(t)
+	require := require.New(t)
 	typeOf := fmt.Sprintf("%T", instance)
 
 	// Wait for secret
@@ -319,11 +318,11 @@ func EnsureSecrets(ctx context.Context, t *testing.T, tc TestContext, instance r
 		_, err := secretClient.Get(ctx, secretKey)
 		return err
 	})
-	assert.Nil(err, "error waiting for %s to have secret", typeOf)
+	require.Nil(err, "error waiting for %s to have secret", typeOf)
 
 }
 func EnsureSecretsWithValue(ctx context.Context, t *testing.T, tc TestContext, instance runtime.Object, secretclient secrets.SecretClient, secretKey secrets.SecretKey, secretSubKey string, secretvalue string) {
-	assert := assert.New(t)
+	require := require.New(t)
 	typeOf := fmt.Sprintf("%T", instance)
 
 	// Wait for secret
@@ -339,7 +338,7 @@ func EnsureSecretsWithValue(ctx context.Context, t *testing.T, tc TestContext, i
 
 		return nil
 	})
-	assert.Nil(err, "error waiting for %s to have correct secret", typeOf)
+	require.Nil(err, "error waiting for %s to have correct secret", typeOf)
 }
 
 func RequireInstance(ctx context.Context, t *testing.T, tc TestContext, instance client.Object) {

--- a/pkg/helpers/retry.go
+++ b/pkg/helpers/retry.go
@@ -18,16 +18,19 @@ func (s *StopErr) Error() string {
 }
 
 func Retry(timeout time.Duration, sleep time.Duration, fn func() error) error {
-	if err := fn(); err != nil {
+	started := time.Now()
+	for {
+		err := fn()
+		if err == nil {
+			return nil
+		}
 		// allow early exit
 		if v, ok := err.(*StopErr); ok {
 			return v.Err
 		}
-		if timeout > 0 {
-			time.Sleep(sleep)
-			return Retry(timeout-sleep, sleep, fn)
+		if time.Since(started) >= timeout {
+			return err
 		}
-		return err
+		time.Sleep(sleep)
 	}
-	return nil
 }


### PR DESCRIPTION
It seems like there's a problem in the job that's causing it to be killed by the timeout, but the way the job is killed prevents us from seeing the output which would let us fix the underlying problem in whichever test is failing.

[Example of the job timeout](https://dev.azure.com/azure/azure-service-operator/_build/results?buildId=27948&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=cb33ee24-f492-54d2-727a-ae0a7bb84b2c)

**How does this PR make you feel**:
![gif](https://c.tenor.com/1ojX4_S5a2YAAAAC/batman-batman-intensifies.gif)
