### PR TITLE
Improve recording default timeouts and controller backoff timing

### DIFF
--- a/hack/generated/controllers/suite_test.go
+++ b/hack/generated/controllers/suite_test.go
@@ -26,6 +26,10 @@ var globalTestContext testcommon.KubeGlobalContext
 func setup(options Options) {
 	log.Println("Running test setup")
 
+	// Note: These are set just so we have somewhat reasonable defaults. Almost all
+	// usage of Eventually is done through the testContext wrapper which understands
+	// replay vs record modes and passes a different timeout and polling interval for each,
+	// meaning that there are very few instances where these timeouts are actually used.
 	gomega.SetDefaultEventuallyTimeout(DefaultResourceTimeout)
 	gomega.SetDefaultEventuallyPollingInterval(5 * time.Second)
 

--- a/hack/generated/go.mod
+++ b/hack/generated/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/onsi/gomega v1.14.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
+	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
 	k8s.io/api v0.21.2
 	k8s.io/apiextensions-apiserver v0.21.2
 	k8s.io/apimachinery v0.21.2

--- a/hack/generated/pkg/testcommon/kube_per_test_context.go
+++ b/hack/generated/pkg/testcommon/kube_per_test_context.go
@@ -204,7 +204,7 @@ func (tc KubePerTestContext) CreateTestResourceGroup(rg *resources.ResourceGroup
 		// doesn't stop polling resources in "Deleting" state and so when running recordings
 		// different runs end up polling different numbers of times. Ensuring we reach a state
 		// the controller deems terminal (Deleted) resolves this issue.
-		tc.G.Eventually(rg, tc.DefaultTimeout()).Should(tc.Match.BeDeleted())
+		tc.G.Eventually(rg, tc.DefaultTimeout(), tc.PollingInterval()).Should(tc.Match.BeDeleted())
 	})
 
 	if wait {
@@ -245,6 +245,24 @@ func (tc *KubePerTestContext) DefaultTimeout() time.Duration {
 	return DefaultTimeoutRecording
 }
 
+// PollingIntervalReplaying is the polling interval to use when replaying.
+// TODO: Setting this really low sometimes seems to cause
+// TODO: updating resource: Operation cannot be fulfilled: the object has been modified; please apply your changes to the latest version and try again
+// TODO: I don't know why -- possibly we're starving APIServer of cycles because of fast polling loops which prevents it from processing cache updates or something?
+var PollingIntervalReplaying = 200 * time.Millisecond
+
+// PollingIntervalRecording is the polling interval to use when recording.
+var PollingIntervalRecording = 5 * time.Second
+
+// PollingInterval returns the polling interval to use for Gomega Eventually
+func (tc *KubePerTestContext) PollingInterval() time.Duration {
+	if tc.AzureClientRecorder.Mode() == recorder.ModeReplaying {
+		return PollingIntervalReplaying
+	}
+
+	return PollingIntervalRecording
+}
+
 // RemainingTime returns how long is left until test timeout,
 // and can be used with gomega.Eventually to get better failure behaviour
 //
@@ -269,7 +287,7 @@ func (tc *KubePerTestContext) Eventually(actual interface{}, intervals ...interf
 		return tc.G.Eventually(actual, intervals...)
 	}
 
-	return tc.G.Eventually(actual, tc.RemainingTime())
+	return tc.G.Eventually(actual, tc.RemainingTime(), tc.PollingInterval())
 }
 
 func (tc *KubePerTestContext) CreateNewTestResourceGroupAndWait() *v1alpha1api20200601.ResourceGroup {
@@ -282,7 +300,7 @@ func (tc *KubePerTestContext) CreateNewTestResourceGroupAndWait() *v1alpha1api20
 // change into the Provisioned state.
 func (tc *KubePerTestContext) CreateResourceAndWait(obj client.Object) {
 	tc.G.Expect(tc.KubeClient.Create(tc.Ctx, obj)).To(gomega.Succeed())
-	tc.G.Eventually(obj, tc.RemainingTime()).Should(tc.Match.BeProvisioned())
+	tc.Eventually(obj).Should(tc.Match.BeProvisioned())
 }
 
 // CreateResourcesAndWait creates the resources in K8s and waits for them to
@@ -293,7 +311,7 @@ func (tc *KubePerTestContext) CreateResourcesAndWait(objs ...client.Object) {
 	}
 
 	for _, obj := range objs {
-		tc.G.Eventually(obj, tc.RemainingTime()).Should(tc.Match.BeProvisioned())
+		tc.Eventually(obj).Should(tc.Match.BeProvisioned())
 	}
 }
 
@@ -301,14 +319,14 @@ func (tc *KubePerTestContext) CreateResourcesAndWait(objs ...client.Object) {
 // change into the Failed state.
 func (tc *KubePerTestContext) CreateResourceAndWaitForFailure(obj client.Object) {
 	tc.G.Expect(tc.KubeClient.Create(tc.Ctx, obj)).To(gomega.Succeed())
-	tc.G.Eventually(obj, tc.RemainingTime()).Should(tc.Match.BeFailed())
+	tc.Eventually(obj).Should(tc.Match.BeFailed())
 }
 
 // PatchResourceAndWaitAfter patches the resource in K8s and waits for it to change into
 // the Provisioned state from the provided previousState.
-func (ktc *KubePerTestContext) PatchResourceAndWaitAfter(old client.Object, new client.Object, previousReadyCondition conditions.Condition) {
-	ktc.Patch(old, new)
-	ktc.G.Eventually(new, ktc.RemainingTime()).Should(ktc.Match.BeProvisionedAfter(previousReadyCondition))
+func (tc *KubePerTestContext) PatchResourceAndWaitAfter(old client.Object, new client.Object, previousReadyCondition conditions.Condition) {
+	tc.Patch(old, new)
+	tc.Eventually(new).Should(tc.Match.BeProvisionedAfter(previousReadyCondition))
 }
 
 // GetResource retrieves the current state of the resource from K8s (not from Azure).
@@ -321,15 +339,15 @@ func (tc *KubePerTestContext) UpdateResource(obj client.Object) {
 	tc.G.Expect(tc.KubeClient.Update(tc.Ctx, obj)).To(gomega.Succeed())
 }
 
-func (ktc *KubePerTestContext) Patch(old client.Object, new client.Object) {
-	ktc.Expect(ktc.KubeClient.Patch(ktc.Ctx, new, client.MergeFrom(old))).To(gomega.Succeed())
+func (tc *KubePerTestContext) Patch(old client.Object, new client.Object) {
+	tc.Expect(tc.KubeClient.Patch(tc.Ctx, new, client.MergeFrom(old))).To(gomega.Succeed())
 }
 
 // DeleteResourceAndWait deletes the given resource in K8s and waits for
 // it to update to the Deleted state.
 func (tc *KubePerTestContext) DeleteResourceAndWait(obj client.Object) {
 	tc.G.Expect(tc.KubeClient.Delete(tc.Ctx, obj)).To(gomega.Succeed())
-	tc.G.Eventually(obj, tc.RemainingTime()).Should(tc.Match.BeDeleted())
+	tc.Eventually(obj).Should(tc.Match.BeDeleted())
 }
 
 // DeleteResourcesAndWait deletes the resources in K8s and waits for them to be deleted
@@ -339,7 +357,7 @@ func (tc *KubePerTestContext) DeleteResourcesAndWait(objs ...client.Object) {
 	}
 
 	for _, obj := range objs {
-		tc.G.Eventually(obj, tc.RemainingTime()).Should(tc.Match.BeDeleted())
+		tc.Eventually(obj).Should(tc.Match.BeDeleted())
 	}
 }
 

--- a/hack/generated/pkg/testcommon/kube_test_context_envtest.go
+++ b/hack/generated/pkg/testcommon/kube_test_context_envtest.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/Azure/azure-service-operator/hack/generated/controllers"
@@ -84,6 +85,9 @@ func createEnvtestContext(perTestContext PerTestContext) (*KubeBaseTestContext, 
 				return fmt.Sprintf("k8s_%s", result.String()), nil
 			},
 			RequeueDelay: requeueDelay,
+			Options: controller.Options{
+				RateLimiter: controllers.NewRateLimiter(5*time.Millisecond, 1*time.Minute),
+			},
 		})
 	if err != nil {
 		return nil, errors.Wrapf(err, "registering reconcilers")


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve recording test default timeouts

  * In the abscence of a timeout specified on the cmdline, use recording mode to determine what the timeout should be. When recording, timeout is longer (15m), and when replaying the timeout is shorter (2m).

Improve controller exponential backoff and timing

* Reduced the maximum wait time (it was >15m). Polling speed is now variable based on test mode. In replay mode, polling is fast. In recording mode, polling is slower. 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/d3yxg15kJppJilnW/giphy-downsized-large.gif?cid=ecf05e47fr1z0txelwnmihtx3md571z41chtiff373h7t630&rid=giphy-downsized-large.gif&ct=g)

