### PR TITLE
Remove all status validations

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -64,6 +64,10 @@ typeFilters:
     group: microsoft.resources
     name: DeploymentScript*
     because: Some types use OneOf to model inheritance, which we don't currently support.
+  - action: prune
+    group: microsoft.resources
+    name: Tags
+    because: This type is defined recursively.
   - action: include
     group: microsoft.compute.extensions
     name: GenericExtension

--- a/hack/generator/pkg/astmodel/types.go
+++ b/hack/generator/pkg/astmodel/types.go
@@ -71,6 +71,20 @@ func (types Types) AddTypes(otherTypes Types) {
 	}
 }
 
+// AddTypesAllowDuplicates adds multiple types to the set.
+// Multiple adds of a type with the same shape are allowed, but attempting to add two
+// types with the same name but different shape will trigger an error.
+func (types Types) AddTypesAllowDuplicates(otherTypes Types) error {
+	for _, t := range otherTypes {
+		err := types.AddAllowDuplicates(t)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // AddAllowDuplicates attempts to add the specified definition to the types collection.
 // Multiple adds of a type with the same shape are allowed, but attempting to add two
 // types with the same name but different shape will trigger an error.
@@ -113,6 +127,13 @@ func (types Types) Where(predicate func(definition TypeDefinition) bool) Types {
 	}
 
 	return result
+}
+
+// Intersect returns a new set of types including only those defined in both types and otherTypes.
+func (types Types) Intersect(otherTypes Types) Types {
+	return types.Where(func(def TypeDefinition) bool {
+		return otherTypes.Contains(def.Name())
+	})
 }
 
 // Except returns a new set of types including only those not defined in otherTypes

--- a/hack/generator/pkg/astmodel/types_test.go
+++ b/hack/generator/pkg/astmodel/types_test.go
@@ -144,6 +144,47 @@ func Test_TypesExcept_GivenSubset_ReturnsExpectedSet(t *testing.T) {
 }
 
 /*
+ * Intersect() tests
+ */
+
+func Test_TypesIntersect_GivenEmptySet_ReturnsExpectedSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition)
+	empty := make(Types)
+	set := types.Intersect(empty)
+
+	g.Expect(len(set)).To(Equal(0))
+}
+
+func Test_TypesIntersect_GivenSelf_ReturnsSelf(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition)
+	set := types.Intersect(types)
+
+	g.Expect(len(set)).To(Equal(len(types)))
+	g.Expect(set).To(ContainElement(alphaDefinition))
+	g.Expect(set).To(ContainElement(betaDefinition))
+	g.Expect(set).To(ContainElement(gammaDefinition))
+	g.Expect(set).To(ContainElement(deltaDefinition))
+}
+
+func Test_TypesIntersect_GivenSubset_ReturnsExpectedSet(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	types := createTestTypes(alphaDefinition, betaDefinition, gammaDefinition, deltaDefinition)
+	subset := createTestTypes(alphaDefinition, betaDefinition)
+	set := types.Intersect(subset)
+
+	g.Expect(len(set)).To(Equal(2))
+	g.Expect(set).To(ContainElement(alphaDefinition))
+	g.Expect(set).To(ContainElement(betaDefinition))
+	g.Expect(set).NotTo(ContainElement(gammaDefinition))
+	g.Expect(set).NotTo(ContainElement(deltaDefinition))
+}
+
+/*
  * Overlay() tests
  */
 

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -107,6 +107,7 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 			RequiresPrerequisiteStages("nameTypes", "allof-anyof-objects"),
 
 		pipeline.MakeStatusPropertiesOptional(),
+		pipeline.RemoveStatusValidations(),
 
 		// Figure out resource owners:
 		pipeline.DetermineResourceOwnership(configuration),

--- a/hack/generator/pkg/codegen/pipeline/remove_status_property_validations.go
+++ b/hack/generator/pkg/codegen/pipeline/remove_status_property_validations.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
+)
+
+const RemoveStatusPropertyValidationsStageID = "removeStatusPropertyValidation"
+
+// RemoveStatusValidations removes property validations from all Status types.
+// This is required because Status is retrieved directly from the ARM API, and there are
+// cases where ARM might return something that isn't actually "valid" according to the validation,
+// but makes sense in context. Some examples:
+// 1. Status has a modelAsString enum with 2 values, but in a future API version, a 3rd value is added.
+//    The fact that the enum is modelAsString allows the service to return the new 3rd value even in old API
+//    versions.
+// 2. Status has an int that must be between 10 and 20. In a future API version, that restriction is relaxed and
+//    the same int can now be between 0 and 50.
+// 3. A bug in the services Swagger specification causes the service to accept enums with any case, but always
+//    return the enum all uppercase
+// In the above cases, if we left validation on the Status types, we would be unable to persist the content
+// returned by the service (apiserver will reject it as not matching the OpenAPI schema). This could be a problem
+// in cases where the resource was created via some other means and then imported into
+func RemoveStatusValidations() Stage {
+	return MakeStage(
+		RemoveStatusPropertyValidationsStageID,
+		"Removes validation from all status properties",
+		func(ctx context.Context, state *State) (*State, error) {
+
+			result, err := removeStatusTypeValidations(state.Types())
+			if err != nil {
+				return nil, err
+			}
+
+			err = errorIfSpecStatusOverlap(result, state.Types())
+			if err != nil {
+				return nil, err
+			}
+
+			remaining := state.Types().Except(result)
+			result.AddTypes(remaining)
+
+			return state.WithTypes(result), nil
+		})
+}
+
+func removeStatusTypeValidations(types astmodel.Types) (astmodel.Types, error) {
+	statusTypes := astmodel.FindStatusTypes(types)
+
+	walker := astmodel.NewTypeWalker(
+		types,
+		astmodel.TypeVisitorBuilder{
+			VisitEnumType:      removeEnumValidations,
+			VisitValidatedType: removeValidatedType,
+		}.Build())
+
+	var errs []error
+
+	result := make(astmodel.Types)
+	for _, def := range statusTypes {
+		updatedTypes, err := walker.Walk(def)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed walking types"))
+		}
+
+		err = result.AddTypesAllowDuplicates(updatedTypes)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	err := kerrors.NewAggregate(errs)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, err
+}
+
+func errorIfSpecStatusOverlap(statusTypes astmodel.Types, types astmodel.Types) error {
+	specTypes := astmodel.FindSpecTypes(types)
+
+	// We want to be REALLY careful to not remove validation from a spec type.
+	// This is easy as long as the graph of spec and status types doesn't intersect, but
+	// there's no guarantee that property holds forever, so verify it here
+	walker := astmodel.NewTypeWalker(
+		types,
+		astmodel.TypeVisitorBuilder{}.Build())
+	allSpecTypes := make(astmodel.Types)
+	for _, def := range specTypes {
+		types, err := walker.Walk(def)
+		if err != nil {
+			return errors.Wrapf(err, "failed walking types")
+		}
+
+		err = allSpecTypes.AddTypesAllowDuplicates(types)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Verify that the set of spec types and the set of modified status types is totally disjoint
+	intersection := allSpecTypes.Intersect(statusTypes)
+	if len(intersection) > 0 {
+		var nameStrings []string
+		for name := range intersection {
+			nameStrings = append(nameStrings, name.String())
+		}
+
+		return errors.Errorf("expected 0 overlapping spec/status types but there were %d. Overlapping: %s", len(intersection), strings.Join(nameStrings, ", "))
+	}
+
+	return nil
+}
+
+// removeValidatedType returns the validated types element. This assumes that there aren't deeply nested validations.
+func removeValidatedType(this *astmodel.TypeVisitor, vt *astmodel.ValidatedType, _ interface{}) (astmodel.Type, error) {
+	return vt.ElementType(), nil
+}
+
+func removeEnumValidations(this *astmodel.TypeVisitor, et *astmodel.EnumType, _ interface{}) (astmodel.Type, error) {
+	return et.WithoutValidation(), nil
+}

--- a/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -9,6 +9,7 @@ stripUnreferenced                                    Strip unreferenced types
 nameTypes                                            Name inner types for CRD
 propertyRewrites                                     Modify property types using configured transforms
 makeStatusPropertiesOptional                         Forces all status properties to be optional
+removeStatusPropertyValidation                       Removes validation from all status properties
 determineResourceOwnership                           Determine ARM resource relationships
 removeAliases                                        Remove type aliases
 collapseCrossGroupReferences                         Finds and removes cross group references

--- a/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -9,6 +9,7 @@ stripUnreferenced                                  Strip unreferenced types
 nameTypes                                          Name inner types for CRD
 propertyRewrites                                   Modify property types using configured transforms
 makeStatusPropertiesOptional                       Forces all status properties to be optional
+removeStatusPropertyValidation                     Removes validation from all status properties
 determineResourceOwnership                         Determine ARM resource relationships
 removeAliases                                      Remove type aliases
 collapseCrossGroupReferences                       Finds and removes cross group references

--- a/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
@@ -9,6 +9,7 @@ stripUnused                                          Strip unused types for test
 nameTypes                                            Name inner types for CRD
 propertyRewrites                                     Modify property types using configured transforms
 makeStatusPropertiesOptional                         Forces all status properties to be optional
+removeStatusPropertyValidation                       Removes validation from all status properties
 determineResourceOwnership                           Determine ARM resource relationships
 removeAliases                                        Remove type aliases
 pluralizeNames                                       Improve resource pluralization


### PR DESCRIPTION
Removes validation from status types.

This has the unfortunate impact that we won't be able to share types between spec and status... which is pretty unfortunate. See the long explanation in remove_status_property_validations.go for the reason behind this change.

Note: Testing this is difficult because of our testing gap on status types, but it _is_ covered by the upcoming AKS E2E test (not in PR yet) as without this that test fails.
