### PR TITLE
Fixes for CI breakage

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,6 +38,11 @@ ENV KIND_CLUSTER_NAME=aso
 
 # install docker, from: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 COPY library-scripts/docker-debian.sh /tmp/library-scripts/
-RUN bash /tmp/library-scripts/docker-debian.sh
+
+# these are all the default values except for the last one (USE_MOBY) which is what we want to set.
+# currently packages.microsoft.com does not have Moby packages for Debian Bullseye, which the 
+# devcontainer image is based on: https://github.com/microsoft/vscode-dev-containers/issues/1008
+RUN bash /tmp/library-scripts/docker-debian.sh true /var/run/docker-host.sock /var/run/docker.sock automatic false
+
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -72,9 +72,10 @@ curl -sL "https://github.com/go-task/task/releases/download/v3.7.0/task_linux_am
 # Install kubebuilder
 os=$(go env GOOS)
 arch=$(go env GOARCH)
-echo "Installing kubebuilder ($os $arch)…"
-curl -L "https://go.kubebuilder.io/dl/2.3.1/${os}/${arch}" | tar -xz -C /tmp/
-mv "/tmp/kubebuilder_2.3.1_${os}_${arch}" "$KUBEBUILDER_DEST"
+kubebuilder_version=2.3.1
+echo "Installing kubebuilder ${kubebuilder_version} ($os $arch)…"
+curl -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${kubebuilder_version}/kubebuilder_${kubebuilder_version}_${os}_${arch}.tar.gz" | tar -xz -C /tmp/
+mv "/tmp/kubebuilder_${kubebuilder_version}_${os}_${arch}" "$KUBEBUILDER_DEST"
 
 echo "Installed tools: $(ls "$TOOL_DEST")"
 


### PR DESCRIPTION

Two fixes:
- Kubebuilder broke their vanity URIs for downloads, switch to Github URIs
- `packages.microsoft.com` is missing Moby packages for Debian Bullseye, switch to use Docker CE (see https://github.com/microsoft/vscode-dev-containers/issues/1008)

