### PR TITLE
Reduce test polling speed some to reduce flakiness

### DIFF
--- a/hack/generated/pkg/reconcilers/azure_deployment_reconciler.go
+++ b/hack/generated/pkg/reconcilers/azure_deployment_reconciler.go
@@ -868,6 +868,7 @@ func (r *AzureDeploymentReconciler) CommitUpdate(ctx context.Context) error {
 	// TODO: Do away with this if/when we stop modifying spec.
 	r.obj.SetResourceVersion(clone.GetResourceVersion())
 
+	// TODO: We should stop updating spec at all, see: https://github.com/Azure/azure-service-operator/issues/1744
 	err = r.KubeClient.Client.Update(ctx, r.obj)
 	if err != nil {
 		return errors.Wrap(err, "updating resource")

--- a/hack/generated/pkg/testcommon/kube_per_test_context.go
+++ b/hack/generated/pkg/testcommon/kube_per_test_context.go
@@ -247,9 +247,11 @@ func (tc *KubePerTestContext) DefaultTimeout() time.Duration {
 
 // PollingIntervalReplaying is the polling interval to use when replaying.
 // TODO: Setting this really low sometimes seems to cause
-// TODO: updating resource: Operation cannot be fulfilled: the object has been modified; please apply your changes to the latest version and try again
-// TODO: I don't know why -- possibly we're starving APIServer of cycles because of fast polling loops which prevents it from processing cache updates or something?
-var PollingIntervalReplaying = 200 * time.Millisecond
+// TODO: updating resource: Operation cannot be fulfilled: the object has been modified; please apply your changes to the latest version and try again.
+// TODO: This happens when the test sees a Status update and makes an update to the resource while racing with the Spec update
+// TODO: in azure_deployment_reconciler CommitUpdate. If we fix https://github.com/Azure/azure-service-operator/issues/1744 we can
+// TODO: shorten this interval.
+var PollingIntervalReplaying = 1 * time.Second
 
 // PollingIntervalRecording is the polling interval to use when recording.
 var PollingIntervalRecording = 5 * time.Second


### PR DESCRIPTION
Obivously this isn't the ideal way to do things, but I can't think of another "easy" fix. The real solution is to stop modifying status and spec at the same time, but I believe in order to do that we need to move some fields out of Spec and into Status, which will take some effort. This should unblock us for now.
