### PR TITLE
Fix conversion webhooks in operator bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,6 +399,9 @@ generate-operator-bundle: manifests
 	kustomize build config/operator-bundle | operator-sdk generate bundle --version $(LATEST_TAG) --channels stable --default-channel stable --overwrite --kustomize-dir config/operator-bundle
 	# Building the docker bundle requires a tests/scorecard directory.
 	mkdir -p bundle/tests/scorecard
+	# Remove the webhook service - OLM will create one when installing
+	# the bundle.
+	rm bundle/manifests/azureoperator-webhook-service_v1_service.yaml
 	# Inject the container reference into the bundle.
 	scripts/inject-container-reference.sh "$(PUBLIC_REPO):$(LATEST_TAG)"
 	# Update webhooks to use operator namespace and remove

--- a/Makefile
+++ b/Makefile
@@ -376,16 +376,16 @@ install-tools:
     CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
 
 # Operator-sdk release version
-RELEASE_VERSION ?= v1.0.1
+RELEASE_VERSION ?= v1.11.0
 
 .PHONY: install-operator-sdk
 install-operator-sdk:
 ifeq ($(shell uname -s), Darwin)
-	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
-	chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
+	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_darwin_amd64
+	chmod +x operator-sdk_darwin_amd64 && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk_darwin_amd64 /usr/local/bin/operator-sdk && rm operator-sdk_darwin_amd64
 else
-	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
-	chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+	curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_linux_amd64
+	chmod +x operator-sdk_linux_amd64 && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk_linux_amd64 /usr/local/bin/operator-sdk && rm operator-sdk_linux_amd64
 endif
 
 PREVIOUS_BUNDLE_VERSION ?= 1.0.27207

--- a/config/operator-bundle/bases/azure-service-operator.clusterserviceversion.yaml
+++ b/config/operator-bundle/bases/azure-service-operator.clusterserviceversion.yaml
@@ -307,41 +307,7 @@ spec:
 
     Before you begin, verify you're running the Azure CLI version 2.0.53 or later. Run `az --version` to find the version. If you need to install or upgrade, see [Install Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
-    1. Azure Service Operator requires self-signed certificates for CRD Conversion Webhooks. We can generate these self-signed certificates by installing the [cert-manager](https://cert-manager.io/docs/installation/kubernetes/) project into our cluster by running the following command:
-        ```sh
-        kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.12.0/cert-manager.yaml
-        ```
-        You can use the below command to check if the cert-manager pods are ready. The cert-manager pods should be running before proceeding to the next step.
-        ```sh
-        kubectl rollout status -n cert-manager deploy/cert-manager-webhook
-        ```
-
-    2. After cert-manager has been successfully installed, create the `Issuer` and `Certificate` cert-manager resources:
-
-        ```yaml
-        apiVersion: cert-manager.io/v1alpha2
-        kind: Issuer
-        metadata:
-          name: azureoperator-selfsigned-issuer
-          namespace: operators
-        spec:
-          selfSigned: {}
-        ---
-        apiVersion: cert-manager.io/v1alpha2
-        kind: Certificate
-        metadata:
-          name: azureoperator-serving-cert
-          namespace: operators
-        spec:
-          dnsNames:
-          - azureoperator-webhook-service.operators.svc
-          - azureoperator-webhook-service.operators.svc.cluster.local
-          issuerRef:
-            kind: Issuer
-            name: azureoperator-selfsigned-issuer
-          secretName: webhook-server-cert
-        ```
-    3. Create an Azure Service Principal. You'll need this to grant Azure Service Operator permissions to create resources in your subscription.
+    1. Create an Azure Service Principal. You'll need this to grant Azure Service Operator permissions to create resources in your subscription.
 
         First, set the following environment variables to your Azure Tenant ID and Subscription ID with your values:
         ```yaml
@@ -354,7 +320,7 @@ spec:
         az account show
         ```
 
-    4. Next, we'll create a Service Principal with Contributor permissions for your subscription, so ASO can create resources in your subscription on your behalf. Note that the [ServicePrincipal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli) you pass to the command below needs to have access to create resources in your subscription. If you'd like to use Managed Identity for authorization instead, check out instructions [here](https://github.com/Azure/azure-service-operator/blob/master/docs/v1/howto/managedidentity.md).
+    2. Next, we'll create a Service Principal with Contributor permissions for your subscription, so ASO can create resources in your subscription on your behalf. Note that the [ServicePrincipal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli) you pass to the command below needs to have access to create resources in your subscription. If you'd like to use Managed Identity for authorization instead, check out instructions [here](https://github.com/Azure/azure-service-operator/blob/master/docs/v1/howto/managedidentity.md).
 
         ```sh
         az ad sp create-for-rbac -n "azure-service-operator" --role contributor \
@@ -370,7 +336,7 @@ spec:
         "tenant": "xxxxxxxxxxxxx"
         ```
 
-    5.  Once you have created a Service Principal, gather the following values:
+    3.  Once you have created a Service Principal, gather the following values:
 
         `AZURE_TENANT_ID` is the Tenant ID from Step 1.
 
@@ -382,7 +348,7 @@ spec:
 
         `AZURE_CLOUD_ENV` is the Azure Environment you'd like to use, i.e. AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud.
 
-    6.  Set those values in a `Secret` called `azureoperatorsettings` within the `operators` Namespace:
+    4.  Set those values in a `Secret` called `azureoperatorsettings` within the `operators` Namespace:
         ```yaml
         apiVersion: v1
         kind: Secret
@@ -397,7 +363,7 @@ spec:
           AZURE_CLOUD_ENV: <your-azure-cloud-environment>
         ```
 
-    7. Now you can proceed to install the Azure Service Operator to the `operators` Namespace via the Install button on the top right of this page. After the operator is installed, you will then see the Azure Service Operator pod running in your cluster:
+    5. Now you can proceed to install the Azure Service Operator to the `operators` Namespace via the Install button on the top right of this page. After the operator is installed, you will then see the Azure Service Operator pod running in your cluster:
 
         ```console
         $ kubectl get pods -n operators

--- a/scripts/update-webhook-references-in-operator-bundle.sh
+++ b/scripts/update-webhook-references-in-operator-bundle.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find all of the CRDs that have conversion webhooks defined
+# (filtering out the --- separators yq puts between them).
+query='select(.spec.conversion.webhook.clientConfig.service.namespace == "azureoperator-system") | filename'
+webhook_crds=$(yq eval "$query" bundle/manifests/azure.microsoft.com_*.yaml | grep -v -e "---")
+
+# Update the service details to point at
+# operators/azureoperator-controller-manager-service and remove the
+# cert-manager annotation.
+update='.spec.conversion.webhook.clientConfig.service.namespace = "operators" | .spec.conversion.webhook.clientConfig.service.name = "azureoperator-controller-manager-service" | del(.metadata.annotations["cert-manager.io/inject-ca-from"])'
+for fname in $webhook_crds; do
+    yq -i eval "$update" "$fname"
+done


### PR DESCRIPTION
**What this PR does / why we need it**:
The previously released operator bundle wasn't setting up conversion webhooks properly, so any custom resource with multiple versions would encounter problems reconciling. This updates the bundle generation to use the latest release of operator-sdk, and corrects the webhook config on the multi-version CRDs so that they refer to the webhook service OLM creates, since that's the one that it sets up certificates for.

The azureoperator-webhook-service has been removed. 

Since OLM manages the certificate setup for the webhooks, I've also removed the cert-manager annotations from the CRDs, and removed the cert-manager setup from the installation instructions.

Closes #1718 

**How does this PR make you feel**:
![gif](https://c.tenor.com/tmOwxcWqsbUAAAAd/dance-excited.gif)

**If applicable**:
- [x] this PR contains documentation
