### PR TITLE
Fix non-deterministic property comments 

### DIFF
--- a/hack/crossplane/apis/microsoft.cache/v1alpha1api20200601/redis_types_gen.go
+++ b/hack/crossplane/apis/microsoft.cache/v1alpha1api20200601/redis_types_gen.go
@@ -50,7 +50,7 @@ type RedisParameters struct {
 	//enabled.
 	EnableNonSslPort *bool `json:"enableNonSslPort,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: The geo-location where the resource lives
 	Location string `json:"location,omitempty"`
 
 	//MinimumTlsVersion: Optional: requires clients to use a specified TLS version (or
@@ -58,7 +58,7 @@ type RedisParameters struct {
 	MinimumTlsVersion *RedisCreatePropertiesMinimumTlsVersion `json:"minimumTlsVersion,omitempty"`
 
 	// +kubebuilder:validation:Required
-	//Name: Name of the resource
+	//Name: The name of the Redis cache.
 	Name string `json:"name"`
 
 	//PublicNetworkAccess: Whether or not public endpoint access is allowed for this

--- a/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/server_types_gen.go
+++ b/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/server_types_gen.go
@@ -134,7 +134,7 @@ type ServersParameters struct {
 	MinimalTlsVersion *string `json:"minimalTlsVersion,omitempty"`
 
 	// +kubebuilder:validation:Required
-	//Name: Name of the resource
+	//Name: The name of the server.
 	Name string `json:"name"`
 
 	//PrimaryUserAssignedIdentityId: The resource id of a user assigned identity to be

--- a/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/servers_database_types_gen.go
+++ b/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/servers_database_types_gen.go
@@ -305,7 +305,7 @@ type ServersDatabasesParameters struct {
 	MinCapacity *float64 `json:"minCapacity,omitempty"`
 
 	// +kubebuilder:validation:Required
-	//Name: Name of the resource
+	//Name: The name of the database.
 	Name string `json:"name"`
 
 	//ReadScale: The state of read-only routing. If enabled, connections that have

--- a/hack/generated/apis/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
+++ b/hack/generated/apis/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
@@ -1003,7 +1003,7 @@ type BatchAccounts_Spec struct {
 	//account.
 	KeyVaultReference *KeyVaultReference `json:"keyVaultReference,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: The region in which to create the account.
 	Location string `json:"location,omitempty"`
 
 	// +kubebuilder:validation:Required
@@ -1019,7 +1019,7 @@ type BatchAccounts_Spec struct {
 	//PublicNetworkAccess: If not specified, the default value is 'enabled'.
 	PublicNetworkAccess *BatchAccountCreatePropertiesPublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
 
-	//Tags: Name-value pairs to add to the resource
+	//Tags: The user-specified tags associated with the account.
 	Tags map[string]string `json:"tags,omitempty"`
 }
 

--- a/hack/generated/apis/microsoft.batch/v1alpha1api20210101/batch_accounts__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.batch/v1alpha1api20210101/batch_accounts__spec_arm_types_gen.go
@@ -15,16 +15,20 @@ type BatchAccounts_SpecARM struct {
 	//configuration.
 	Identity *BatchAccountIdentityARM `json:"identity,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: The region in which to create the account.
 	Location string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: A name for the Batch account which must be unique within the region. Batch
+	//account names must be between 3 and 24 characters in length and must use only
+	//numbers and lowercase letters. This name is used as part of the DNS name that is
+	//used to access the Batch service in the region in which the account is created.
+	//For example: http://accountname.region.batch.azure.com/.
 	Name string `json:"name"`
 
 	//Properties: The properties of a Batch account.
 	Properties BatchAccountCreatePropertiesARM `json:"properties"`
 
-	//Tags: Name-value pairs to add to the resource
+	//Tags: The user-specified tags associated with the account.
 	Tags map[string]string `json:"tags,omitempty"`
 
 	//Type: Resource type

--- a/hack/generated/apis/microsoft.compute/v1alpha1api20200930/disks__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.compute/v1alpha1api20200930/disks__spec_arm_types_gen.go
@@ -16,7 +16,9 @@ type Disks_SpecARM struct {
 	//Location: Location to deploy resource to
 	Location string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: The name of the managed disk that is being created. The name can't be
+	//changed after the disk is created. Supported characters for the name are a-z,
+	//A-Z, 0-9 and _. The maximum name length is 80 characters.
 	Name string `json:"name"`
 
 	//Properties: Disk resource properties.

--- a/hack/generated/apis/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_sets__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_sets__spec_arm_types_gen.go
@@ -22,7 +22,7 @@ type VirtualMachineScaleSets_SpecARM struct {
 	//Location: Location to deploy resource to
 	Location string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: The name of the VM scale set to create or update.
 	Name string `json:"name"`
 
 	//Plan: Specifies information about the marketplace image used to create the

--- a/hack/generated/apis/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
+++ b/hack/generated/apis/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
@@ -1633,7 +1633,7 @@ type DatabaseAccounts_Spec struct {
 	//account creation.
 	Kind *DatabaseAccountsSpecKind `json:"kind,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: The location of the resource group to which the resource belongs.
 	Location *string `json:"location,omitempty"`
 
 	// +kubebuilder:validation:Required
@@ -1654,7 +1654,13 @@ type DatabaseAccounts_Spec struct {
 	//PublicNetworkAccess: Whether requests from Public Network are allowed.
 	PublicNetworkAccess *DatabaseAccountCreateUpdatePropertiesPublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
 
-	//Tags: Name-value pairs to add to the resource
+	//Tags: Tags are a list of key-value pairs that describe the resource. These tags
+	//can be used in viewing and grouping this resource (across resource groups). A
+	//maximum of 15 tags can be provided for a resource. Each tag must have a key no
+	//greater than 128 characters and value no greater than 256 characters. For
+	//example, the default experience for a template type is set with
+	//"defaultExperience": "Cassandra". Current "defaultExperience" values also
+	//include "Table", "Graph", "DocumentDB", and "MongoDB".
 	Tags map[string]string `json:"tags,omitempty"`
 
 	//VirtualNetworkRules: List of Virtual Network ACL rules configured for the Cosmos

--- a/hack/generated/apis/microsoft.documentdb/v1alpha1api20210515/database_accounts__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.documentdb/v1alpha1api20210515/database_accounts__spec_arm_types_gen.go
@@ -20,16 +20,22 @@ type DatabaseAccounts_SpecARM struct {
 	//account creation.
 	Kind *DatabaseAccountsSpecKind `json:"kind,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: The location of the resource group to which the resource belongs.
 	Location *string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: Cosmos DB database account name.
 	Name string `json:"name"`
 
 	//Properties: Properties to create and update Azure Cosmos DB database accounts.
 	Properties DatabaseAccountCreateUpdatePropertiesARM `json:"properties"`
 
-	//Tags: Name-value pairs to add to the resource
+	//Tags: Tags are a list of key-value pairs that describe the resource. These tags
+	//can be used in viewing and grouping this resource (across resource groups). A
+	//maximum of 15 tags can be provided for a resource. Each tag must have a key no
+	//greater than 128 characters and value no greater than 256 characters. For
+	//example, the default experience for a template type is set with
+	//"defaultExperience": "Cassandra". Current "defaultExperience" values also
+	//include "Table", "Graph", "DocumentDB", and "MongoDB".
 	Tags map[string]string `json:"tags,omitempty"`
 
 	//Type: Resource type

--- a/hack/generated/apis/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identities__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identities__spec_arm_types_gen.go
@@ -10,10 +10,10 @@ type UserAssignedIdentities_SpecARM struct {
 	//on the template
 	APIVersion UserAssignedIdentitiesSpecAPIVersion `json:"apiVersion"`
 
-	//Location: Location to deploy resource to
+	//Location: The Azure region where the identity lives.
 	Location string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: The name of the identity resource.
 	Name string `json:"name"`
 
 	//Tags: Name-value pairs to add to the resource

--- a/hack/generated/apis/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
+++ b/hack/generated/apis/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
@@ -565,7 +565,7 @@ type UserAssignedIdentities_Spec struct {
 	//of the resource in Kubernetes but it doesn't have to be.
 	AzureName string `json:"azureName"`
 
-	//Location: Location to deploy resource to
+	//Location: The Azure region where the identity lives.
 	Location string `json:"location,omitempty"`
 
 	// +kubebuilder:validation:Required

--- a/hack/generated/apis/microsoft.network/v1alpha1api20201101/subnet__status__virtual_networks_subnet__sub_resource_embedded_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.network/v1alpha1api20201101/subnet__status__virtual_networks_subnet__sub_resource_embedded_arm_types_gen.go
@@ -181,7 +181,7 @@ type ResourceNavigationLink_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
 
-	//Id: Resource ID.
+	//Id: Resource navigation link identifier.
 	Id *string `json:"id,omitempty"`
 
 	//Name: Name of the resource that is unique within a resource group. This name can

--- a/hack/generated/apis/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
+++ b/hack/generated/apis/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
@@ -2868,7 +2868,7 @@ type ResourceNavigationLink_Status struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
 
-	//Id: Resource ID.
+	//Id: Resource navigation link identifier.
 	Id *string `json:"id,omitempty"`
 
 	//Link: Link to the external resource.

--- a/hack/generated/apis/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
+++ b/hack/generated/apis/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
@@ -240,7 +240,7 @@ type Namespaces_Spec struct {
 	//Keys
 	Identity *Identity `json:"identity,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: The Geo-location where the resource lives
 	Location string `json:"location,omitempty"`
 
 	// +kubebuilder:validation:Required

--- a/hack/generated/apis/microsoft.servicebus/v1alpha1api20210101preview/namespaces__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.servicebus/v1alpha1api20210101preview/namespaces__spec_arm_types_gen.go
@@ -14,7 +14,7 @@ type Namespaces_SpecARM struct {
 	//Keys
 	Identity *IdentityARM `json:"identity,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: The Geo-location where the resource lives
 	Location string `json:"location,omitempty"`
 
 	//Name: Name of the resource

--- a/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
+++ b/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
@@ -1714,7 +1714,11 @@ type StorageAccounts_Spec struct {
 	//disabled once it is enabled.
 	LargeFileSharesState *StorageAccountPropertiesCreateParametersLargeFileSharesState `json:"largeFileSharesState,omitempty"`
 
-	//Location: Location to deploy resource to
+	//Location: Required. Gets or sets the location of the resource. This will be one
+	//of the supported and registered Azure Geo Regions (e.g. West US, East US,
+	//Southeast Asia, etc.). The geo region of a resource cannot be changed once it is
+	//created, but if an identical geo region is specified on update, the request will
+	//succeed.
 	Location string `json:"location,omitempty"`
 
 	//MinimumTlsVersion: Set the minimum TLS version to be permitted on requests to
@@ -1743,7 +1747,11 @@ type StorageAccounts_Spec struct {
 	//to true. The default value is true since API version 2019-04-01.
 	SupportsHttpsTrafficOnly *bool `json:"supportsHttpsTrafficOnly,omitempty"`
 
-	//Tags: Name-value pairs to add to the resource
+	//Tags: Gets or sets a list of key value pairs that describe the resource. These
+	//tags can be used for viewing and grouping this resource (across resource
+	//groups). A maximum of 15 tags can be provided for a resource. Each tag must have
+	//a key with a length no greater than 128 characters and a value with a length no
+	//greater than 256 characters.
 	Tags map[string]string `json:"tags,omitempty"`
 }
 

--- a/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_accounts__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_accounts__spec_arm_types_gen.go
@@ -19,10 +19,16 @@ type StorageAccounts_SpecARM struct {
 	//Kind: Required. Indicates the type of storage account.
 	Kind StorageAccountsSpecKind `json:"kind"`
 
-	//Location: Location to deploy resource to
+	//Location: Required. Gets or sets the location of the resource. This will be one
+	//of the supported and registered Azure Geo Regions (e.g. West US, East US,
+	//Southeast Asia, etc.). The geo region of a resource cannot be changed once it is
+	//created, but if an identical geo region is specified on update, the request will
+	//succeed.
 	Location string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: The name of the storage account within the specified resource group.
+	//Storage account names must be between 3 and 24 characters in length and use
+	//numbers and lower-case letters only.
 	Name string `json:"name"`
 
 	//Properties: The parameters used to create the storage account.
@@ -31,7 +37,11 @@ type StorageAccounts_SpecARM struct {
 	//Sku: The SKU of the storage account.
 	Sku SkuARM `json:"sku"`
 
-	//Tags: Name-value pairs to add to the resource
+	//Tags: Gets or sets a list of key value pairs that describe the resource. These
+	//tags can be used for viewing and grouping this resource (across resource
+	//groups). A maximum of 15 tags can be provided for a resource. Each tag must have
+	//a key with a length no greater than 128 characters and a value with a length no
+	//greater than 256 characters.
 	Tags map[string]string `json:"tags,omitempty"`
 
 	//Type: Resource type

--- a/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services__spec_arm_types_gen.go
@@ -13,7 +13,8 @@ type StorageAccountsBlobServices_SpecARM struct {
 	//Location: Location to deploy resource to
 	Location *string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: The name of the blob Service within the specified storage account. Blob
+	//Service Name must be 'default'
 	Name string `json:"name"`
 
 	//Properties: The properties of a storage account’s Blob service.

--- a/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_containers__spec_arm_types_gen.go
+++ b/hack/generated/apis/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_containers__spec_arm_types_gen.go
@@ -13,7 +13,10 @@ type StorageAccountsBlobServicesContainers_SpecARM struct {
 	//Location: Location to deploy resource to
 	Location *string `json:"location,omitempty"`
 
-	//Name: Name of the resource
+	//Name: The name of the blob container within the specified storage account. Blob
+	//container names must be between 3 and 63 characters in length and use numbers,
+	//lower-case letters and dash (-) only. Every dash (-) character must be
+	//immediately preceded and followed by a letter or number.
 	Name string `json:"name"`
 
 	//Properties: The properties of a container.

--- a/hack/generator/pkg/astmodel/object_type.go
+++ b/hack/generator/pkg/astmodel/object_type.go
@@ -340,7 +340,7 @@ func (objectType *ObjectType) Equals(t Type) bool {
 }
 
 // WithProperty creates a new ObjectType with another property attached to it
-// Properties are unique by name, so this can be used to Add and Replace a property
+// Properties are unique by name, so this can be used to Add and to Replace a property
 func (objectType *ObjectType) WithProperty(property *PropertyDefinition) *ObjectType {
 	// Create a copy of objectType to preserve immutability
 	result := objectType.copy()

--- a/hack/generator/pkg/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -435,6 +435,7 @@ func (s synthesizer) handleObjectObject(leftObj *astmodel.ObjectType, rightObj *
 				// When we merge properties, both of them may have comments, and we need to deterministically choose one
 				// of them to include on the final property. Our simple heuristic is to choose the longer comment, as
 				// that's likely to be more specific.
+				// TODO: Is there a better heuristic? See https://github.com/Azure/azure-service-operator/issues/1768
 				newProp = newProp.WithDescription(p.Description())
 			}
 

--- a/hack/generator/pkg/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/hack/generator/pkg/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -413,11 +413,14 @@ func (s synthesizer) handleArrayArray(leftArray *astmodel.ArrayType, rightArray 
 func (s synthesizer) handleObjectObject(leftObj *astmodel.ObjectType, rightObj *astmodel.ObjectType) (astmodel.Type, error) {
 	mergedProps := make(map[astmodel.PropertyName]*astmodel.PropertyDefinition)
 
-	for _, p := range leftObj.Properties() {
+	leftProperties := leftObj.Properties()
+	rightProperties := rightObj.Properties()
+
+	for _, p := range leftProperties {
 		mergedProps[p.PropertyName()] = p
 	}
 
-	for _, p := range rightObj.Properties() {
+	for _, p := range rightProperties {
 		if existingProp, ok := mergedProps[p.PropertyName()]; ok {
 			newType, err := s.intersectTypes(existingProp.PropertyType(), p.PropertyType())
 			if err != nil {
@@ -427,7 +430,15 @@ func (s synthesizer) handleObjectObject(leftObj *astmodel.ObjectType, rightObj *
 			}
 
 			// TODO: need to handle merging requiredness and tags and...
-			mergedProps[p.PropertyName()] = existingProp.WithType(newType)
+			newProp := existingProp.WithType(newType)
+			if len(p.Description()) > len(newProp.Description()) {
+				// When we merge properties, both of them may have comments, and we need to deterministically choose one
+				// of them to include on the final property. Our simple heuristic is to choose the longer comment, as
+				// that's likely to be more specific.
+				newProp = newProp.WithDescription(p.Description())
+			}
+
+			mergedProps[p.PropertyName()] = newProp
 		} else {
 			mergedProps[p.PropertyName()] = p
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

When merging properties as a part of a one-of or all-of, the comment included on a merged property was non-deterministic, resulting in different results on different runs.

This PR applies a super simple heuristic, selecting the longer (more detailed) comment each time. This works pretty well, but isn't perfect.

Closes #1757 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/k3kqJ2d8cUvSM/giphy.gif)
