### PR TITLE
Fix TypeName to make code generation more resilient

### DIFF
--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20200101storage.golden
@@ -5,7 +5,6 @@ package v20200101storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,8 +14,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20200101storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20200101storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -24,7 +23,7 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20200101storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20200101.Person_Spec
@@ -42,5 +41,5 @@ type Person_Status struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&v20200101storage.Person{}, &v20200101storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20211231storage.golden
@@ -5,7 +5,6 @@ package v20211231storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,8 +14,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20211231storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20211231storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -24,17 +23,17 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20211231storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20211231.Person_Spec
 type Person_Spec struct {
-	FamilyName         *string                   `json:"familyName,omitempty"`
-	FullName           *string                   `json:"fullName,omitempty"`
-	KnownAs            *string                   `json:"knownAs,omitempty"`
-	PostalAddress      *v20211231storage.Address `json:"postalAddress,omitempty"`
-	PropertyBag        genruntime.PropertyBag    `json:"$propertyBag,omitempty"`
-	ResidentialAddress *v20211231storage.Address `json:"residentialAddress,omitempty"`
+	FamilyName         *string                `json:"familyName,omitempty"`
+	FullName           *string                `json:"fullName,omitempty"`
+	KnownAs            *string                `json:"knownAs,omitempty"`
+	PostalAddress      *Address               `json:"postalAddress,omitempty"`
+	PropertyBag        genruntime.PropertyBag `json:"$propertyBag,omitempty"`
+	ResidentialAddress *Address               `json:"residentialAddress,omitempty"`
 }
 
 //Storage version of v20211231.Person_Status
@@ -51,5 +50,5 @@ type Address struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&v20211231storage.Person{}, &v20211231storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
@@ -6,7 +6,6 @@
  import (
 +	"fmt"
  	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
- 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
  	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
  	"github.com/pkg/errors"
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,14 +18,14 @@
  type Person struct {
  	metav1.TypeMeta   `json:",inline"`
  	metav1.ObjectMeta `json:"metadata,omitempty"`
- 	Spec              v20200101storage.Person_Spec   `json:"spec,omitempty"`
- 	Status            v20200101storage.Person_Status `json:"status,omitempty"`
+ 	Spec              Person_Spec   `json:"spec,omitempty"`
+ 	Status            Person_Status `json:"status,omitempty"`
  }
  
 +var _ conversion.Convertible = &Person{}
 +
 +// ConvertFrom populates our Person from the provided hub Person
-+func (person *v20200101storage.Person) ConvertFrom(hub conversion.Hub) error {
++func (person *Person) ConvertFrom(hub conversion.Hub) error {
 +	source, ok := hub.(*v20211231storage.Person)
 +	if !ok {
 +		return fmt.Errorf("expected storage:microsoft.person/v20211231storage/Person but received %T instead", hub)
@@ -35,7 +34,7 @@
 +}
 +
 +// ConvertTo populates the provided hub Person from our Person
-+func (person *v20200101storage.Person) ConvertTo(hub conversion.Hub) error {
++func (person *Person) ConvertTo(hub conversion.Hub) error {
 +	destination, ok := hub.(*v20211231storage.Person)
 +	if !ok {
 +		return fmt.Errorf("expected storage:microsoft.person/v20211231storage/Person but received %T instead", hub)
@@ -44,7 +43,7 @@
 +}
 +
  // AssignPropertiesFromPerson populates our Person from the provided source Person
- func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
+ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
  
  	// Spec
  	var spec Person_Spec
@@ -67,7 +66,7 @@
  }
  
  // AssignPropertiesToPerson populates the provided destination Person from our Person
- func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
  
  	// Spec
  	var spec v20211231storage.Person_Spec
@@ -94,7 +93,7 @@
  type PersonList struct {
  	metav1.TypeMeta `json:",inline"`
  	metav1.ListMeta `json:"metadata,omitempty"`
- 	Items           []v20200101storage.Person `json:"items"`
+ 	Items           []Person `json:"items"`
  }
  
  //Storage version of v20200101.Person_Spec
@@ -104,7 +103,7 @@
  }
  
  // AssignPropertiesFromPersonSpec populates our Person_Spec from the provided source Person_Spec
- func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
+ func (personSpec *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
  	// Clone the existing property bag
  	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
  
@@ -124,7 +123,7 @@
  }
  
  // AssignPropertiesToPersonSpec populates the provided destination Person_Spec from our Person_Spec
- func (personSpec *v20200101storage.Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
+ func (personSpec *Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
  	// Clone the existing property bag
  	propertyBag := genruntime.NewPropertyBag(personSpec.PropertyBag)
  
@@ -150,7 +149,7 @@
  }
  
  // AssignPropertiesFromPersonStatus populates our Person_Status from the provided source Person_Status
- func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
+ func (personStatus *Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
  	// Clone the existing property bag
  	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
  
@@ -170,7 +169,7 @@
  }
  
  // AssignPropertiesToPersonStatus populates the provided destination Person_Status from our Person_Status
- func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
+ func (personStatus *Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
  	// Clone the existing property bag
  	propertyBag := genruntime.NewPropertyBag(personStatus.PropertyBag)
  
@@ -190,6 +189,6 @@
  }
  
  func init() {
- 	SchemeBuilder.Register(&v20200101storage.Person{}, &v20200101storage.PersonList{})
+ 	SchemeBuilder.Register(&Person{}, &PersonList{})
  }
  

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231storage.golden
@@ -5,7 +5,6 @@ package v20211231storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,8 +14,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20211231storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20211231storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -24,7 +23,7 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20211231storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20211231.Person_Spec
@@ -40,5 +39,5 @@ type Person_Status struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&v20211231storage.Person{}, &v20211231storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
@@ -5,7 +5,6 @@ package v20200101storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,12 +16,12 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20200101storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20200101storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // AssignPropertiesFromPerson populates our Person from the provided source Person
-func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
 	// Spec
 	var spec Person_Spec
@@ -45,7 +44,7 @@ func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
-func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -72,7 +71,7 @@ func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20200101storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20200101.Person_Spec
@@ -84,7 +83,7 @@ type Person_Spec struct {
 var _ genruntime.ConvertibleSpec = &Person_Spec{}
 
 // ConvertSpecFrom populates our Person_Spec from the provided source
-func (personSpec *v20200101storage.Person_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
+func (personSpec *Person_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	src, ok := source.(*v20211231storage.Person_Spec)
 	if ok {
 		// Populate our instance from source
@@ -108,7 +107,7 @@ func (personSpec *v20200101storage.Person_Spec) ConvertSpecFrom(source genruntim
 }
 
 // ConvertSpecTo populates the provided destination from our Person_Spec
-func (personSpec *v20200101storage.Person_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
+func (personSpec *Person_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	dst, ok := destination.(*v20211231storage.Person_Spec)
 	if ok {
 		// Populate destination from our instance
@@ -132,7 +131,7 @@ func (personSpec *v20200101storage.Person_Spec) ConvertSpecTo(destination genrun
 }
 
 // AssignPropertiesFromPersonSpec populates our Person_Spec from the provided source Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -152,7 +151,7 @@ func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(s
 }
 
 // AssignPropertiesToPersonSpec populates the provided destination Person_Spec from our Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personSpec.PropertyBag)
 
@@ -178,7 +177,7 @@ type Person_Status struct {
 }
 
 // AssignPropertiesFromPersonStatus populates our Person_Status from the provided source Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -198,7 +197,7 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonSt
 }
 
 // AssignPropertiesToPersonStatus populates the provided destination Person_Status from our Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personStatus.PropertyBag)
 
@@ -218,5 +217,5 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStat
 }
 
 func init() {
-	SchemeBuilder.Register(&v20200101storage.Person{}, &v20200101storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20211231storage.golden
@@ -5,7 +5,6 @@ package v20211231storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,8 +15,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20211231storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20211231storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -25,7 +24,7 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20211231storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20211231.Person_Spec
@@ -37,7 +36,7 @@ type Person_Spec struct {
 var _ genruntime.ConvertibleSpec = &Person_Spec{}
 
 // ConvertSpecFrom populates our Person_Spec from the provided source
-func (personSpec *v20211231storage.Person_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
+func (personSpec *Person_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == personSpec {
 		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
 	}
@@ -46,7 +45,7 @@ func (personSpec *v20211231storage.Person_Spec) ConvertSpecFrom(source genruntim
 }
 
 // ConvertSpecTo populates the provided destination from our Person_Spec
-func (personSpec *v20211231storage.Person_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
+func (personSpec *Person_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == personSpec {
 		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
 	}
@@ -61,5 +60,5 @@ type Person_Status struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&v20211231storage.Person{}, &v20211231storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
@@ -5,7 +5,6 @@ package v20200101storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,12 +16,12 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20200101storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20200101storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // AssignPropertiesFromPerson populates our Person from the provided source Person
-func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
 	// Spec
 	var spec Person_Spec
@@ -45,7 +44,7 @@ func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
-func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -72,7 +71,7 @@ func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20200101storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20200101.Person_Spec
@@ -82,7 +81,7 @@ type Person_Spec struct {
 }
 
 // AssignPropertiesFromPersonSpec populates our Person_Spec from the provided source Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -102,7 +101,7 @@ func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(s
 }
 
 // AssignPropertiesToPersonSpec populates the provided destination Person_Spec from our Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personSpec.PropertyBag)
 
@@ -130,7 +129,7 @@ type Person_Status struct {
 var _ genruntime.ConvertibleStatus = &Person_Status{}
 
 // ConvertStatusFrom populates our Person_Status from the provided source
-func (personStatus *v20200101storage.Person_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
+func (personStatus *Person_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	src, ok := source.(*v20211231storage.Person_Status)
 	if ok {
 		// Populate our instance from source
@@ -154,7 +153,7 @@ func (personStatus *v20200101storage.Person_Status) ConvertStatusFrom(source gen
 }
 
 // ConvertStatusTo populates the provided destination from our Person_Status
-func (personStatus *v20200101storage.Person_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
+func (personStatus *Person_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	dst, ok := destination.(*v20211231storage.Person_Status)
 	if ok {
 		// Populate destination from our instance
@@ -178,7 +177,7 @@ func (personStatus *v20200101storage.Person_Status) ConvertStatusTo(destination 
 }
 
 // AssignPropertiesFromPersonStatus populates our Person_Status from the provided source Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -198,7 +197,7 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonSt
 }
 
 // AssignPropertiesToPersonStatus populates the provided destination Person_Status from our Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personStatus.PropertyBag)
 
@@ -218,5 +217,5 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStat
 }
 
 func init() {
-	SchemeBuilder.Register(&v20200101storage.Person{}, &v20200101storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20211231storage.golden
@@ -5,7 +5,6 @@ package v20211231storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,8 +15,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20211231storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20211231storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -25,7 +24,7 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20211231storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20211231.Person_Spec
@@ -43,7 +42,7 @@ type Person_Status struct {
 var _ genruntime.ConvertibleStatus = &Person_Status{}
 
 // ConvertStatusFrom populates our Person_Status from the provided source
-func (personStatus *v20211231storage.Person_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
+func (personStatus *Person_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == personStatus {
 		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
 	}
@@ -52,7 +51,7 @@ func (personStatus *v20211231storage.Person_Status) ConvertStatusFrom(source gen
 }
 
 // ConvertStatusTo populates the provided destination from our Person_Status
-func (personStatus *v20211231storage.Person_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
+func (personStatus *Person_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == personStatus {
 		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
 	}
@@ -61,5 +60,5 @@ func (personStatus *v20211231storage.Person_Status) ConvertStatusTo(destination 
 }
 
 func init() {
-	SchemeBuilder.Register(&v20211231storage.Person{}, &v20211231storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20200101storage.golden
@@ -5,7 +5,6 @@ package v20200101storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,12 +16,12 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20200101storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20200101storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // AssignPropertiesFromPerson populates our Person from the provided source Person
-func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
 	// Spec
 	var spec Person_Spec
@@ -45,7 +44,7 @@ func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
-func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -72,7 +71,7 @@ func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20200101storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20200101.Person_Spec
@@ -84,7 +83,7 @@ type Person_Spec struct {
 }
 
 // AssignPropertiesFromPersonSpec populates our Person_Spec from the provided source Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -130,7 +129,7 @@ func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(s
 }
 
 // AssignPropertiesToPersonSpec populates the provided destination Person_Spec from our Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personSpec.PropertyBag)
 
@@ -198,7 +197,7 @@ type Person_Status struct {
 }
 
 // AssignPropertiesFromPersonStatus populates our Person_Status from the provided source Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -218,7 +217,7 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonSt
 }
 
 // AssignPropertiesToPersonStatus populates the provided destination Person_Status from our Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personStatus.PropertyBag)
 
@@ -238,5 +237,5 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStat
 }
 
 func init() {
-	SchemeBuilder.Register(&v20200101storage.Person{}, &v20200101storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20211231storage.golden
@@ -5,7 +5,6 @@ package v20211231storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,8 +14,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20211231storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20211231storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -24,17 +23,17 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20211231storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20211231.Person_Spec
 type Person_Spec struct {
-	FamilyName         *string                   `json:"familyName,omitempty"`
-	FullName           *string                   `json:"fullName,omitempty"`
-	KnownAs            *string                   `json:"knownAs,omitempty"`
-	PostalAddress      *v20211231storage.Address `json:"postalAddress,omitempty"`
-	PropertyBag        genruntime.PropertyBag    `json:"$propertyBag,omitempty"`
-	ResidentialAddress *v20211231storage.Address `json:"residentialAddress,omitempty"`
+	FamilyName         *string                `json:"familyName,omitempty"`
+	FullName           *string                `json:"fullName,omitempty"`
+	KnownAs            *string                `json:"knownAs,omitempty"`
+	PostalAddress      *Address               `json:"postalAddress,omitempty"`
+	PropertyBag        genruntime.PropertyBag `json:"$propertyBag,omitempty"`
+	ResidentialAddress *Address               `json:"residentialAddress,omitempty"`
 }
 
 //Storage version of v20211231.Person_Status
@@ -51,5 +50,5 @@ type Address struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&v20211231storage.Person{}, &v20211231storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
@@ -5,7 +5,6 @@ package v20200101storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,12 +16,12 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20200101storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20200101storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // AssignPropertiesFromPerson populates our Person from the provided source Person
-func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
 	// Spec
 	var spec Person_Spec
@@ -45,7 +44,7 @@ func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
-func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -72,7 +71,7 @@ func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20200101storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20200101.Person_Spec
@@ -84,7 +83,7 @@ type Person_Spec struct {
 }
 
 // AssignPropertiesFromPersonSpec populates our Person_Spec from the provided source Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -130,7 +129,7 @@ func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(s
 }
 
 // AssignPropertiesToPersonSpec populates the provided destination Person_Spec from our Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personSpec.PropertyBag)
 
@@ -198,7 +197,7 @@ type Person_Status struct {
 }
 
 // AssignPropertiesFromPersonStatus populates our Person_Status from the provided source Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -218,7 +217,7 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonSt
 }
 
 // AssignPropertiesToPersonStatus populates the provided destination Person_Status from our Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personStatus.PropertyBag)
 
@@ -238,5 +237,5 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStat
 }
 
 func init() {
-	SchemeBuilder.Register(&v20200101storage.Person{}, &v20200101storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20211231storage.golden
@@ -5,7 +5,6 @@ package v20211231storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,8 +14,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20211231storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20211231storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -24,17 +23,17 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20211231storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20211231.Person_Spec
 type Person_Spec struct {
-	FamilyName         *string                   `json:"familyName,omitempty"`
-	FullName           *string                   `json:"fullName,omitempty"`
-	KnownAs            *string                   `json:"knownAs,omitempty"`
-	PostalAddress      *v20211231storage.Address `json:"postalAddress,omitempty"`
-	PropertyBag        genruntime.PropertyBag    `json:"$propertyBag,omitempty"`
-	ResidentialAddress *v20211231storage.Address `json:"residentialAddress,omitempty"`
+	FamilyName         *string                `json:"familyName,omitempty"`
+	FullName           *string                `json:"fullName,omitempty"`
+	KnownAs            *string                `json:"knownAs,omitempty"`
+	PostalAddress      *Address               `json:"postalAddress,omitempty"`
+	PropertyBag        genruntime.PropertyBag `json:"$propertyBag,omitempty"`
+	ResidentialAddress *Address               `json:"residentialAddress,omitempty"`
 }
 
 //Storage version of v20211231.Person_Status
@@ -51,5 +50,5 @@ type Address struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&v20211231storage.Person{}, &v20211231storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
@@ -5,7 +5,6 @@ package v20200101storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,12 +16,12 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20200101storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20200101storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // AssignPropertiesFromPerson populates our Person from the provided source Person
-func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
 	// Spec
 	var spec Person_Spec
@@ -45,7 +44,7 @@ func (person *v20200101storage.Person) AssignPropertiesFromPerson(source *v20211
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
-func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -72,7 +71,7 @@ func (person *v20200101storage.Person) AssignPropertiesToPerson(destination *v20
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20200101storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20200101.Person_Spec
@@ -84,7 +83,7 @@ type Person_Spec struct {
 }
 
 // AssignPropertiesFromPersonSpec populates our Person_Spec from the provided source Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -130,7 +129,7 @@ func (personSpec *v20200101storage.Person_Spec) AssignPropertiesFromPersonSpec(s
 }
 
 // AssignPropertiesToPersonSpec populates the provided destination Person_Spec from our Person_Spec
-func (personSpec *v20200101storage.Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
+func (personSpec *Person_Spec) AssignPropertiesToPersonSpec(destination *v20211231storage.Person_Spec) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personSpec.PropertyBag)
 
@@ -198,7 +197,7 @@ type Person_Status struct {
 }
 
 // AssignPropertiesFromPersonStatus populates our Person_Status from the provided source Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesFromPersonStatus(source *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(source.PropertyBag)
 
@@ -218,7 +217,7 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesFromPersonSt
 }
 
 // AssignPropertiesToPersonStatus populates the provided destination Person_Status from our Person_Status
-func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
+func (personStatus *Person_Status) AssignPropertiesToPersonStatus(destination *v20211231storage.Person_Status) error {
 	// Clone the existing property bag
 	propertyBag := genruntime.NewPropertyBag(personStatus.PropertyBag)
 
@@ -238,5 +237,5 @@ func (personStatus *v20200101storage.Person_Status) AssignPropertiesToPersonStat
 }
 
 func init() {
-	SchemeBuilder.Register(&v20200101storage.Person{}, &v20200101storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20211231storage.golden
@@ -5,7 +5,6 @@ package v20211231storage
 
 import (
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,8 +14,8 @@ import (
 type Person struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              v20211231storage.Person_Spec   `json:"spec,omitempty"`
-	Status            v20211231storage.Person_Status `json:"status,omitempty"`
+	Spec              Person_Spec   `json:"spec,omitempty"`
+	Status            Person_Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -24,17 +23,17 @@ type Person struct {
 type PersonList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v20211231storage.Person `json:"items"`
+	Items           []Person `json:"items"`
 }
 
 //Storage version of v20211231.Person_Spec
 type Person_Spec struct {
-	FamilyName         *string                   `json:"familyName,omitempty"`
-	FullName           *string                   `json:"fullName,omitempty"`
-	KnownAs            *string                   `json:"knownAs,omitempty"`
-	PostalAddress      *v20211231storage.Address `json:"postalAddress,omitempty"`
-	PropertyBag        genruntime.PropertyBag    `json:"$propertyBag,omitempty"`
-	ResidentialAddress *v20211231storage.Address `json:"residentialAddress,omitempty"`
+	FamilyName         *string                `json:"familyName,omitempty"`
+	FullName           *string                `json:"fullName,omitempty"`
+	KnownAs            *string                `json:"knownAs,omitempty"`
+	PostalAddress      *Address               `json:"postalAddress,omitempty"`
+	PropertyBag        genruntime.PropertyBag `json:"$propertyBag,omitempty"`
+	ResidentialAddress *Address               `json:"residentialAddress,omitempty"`
 }
 
 //Storage version of v20211231.Person_Status
@@ -51,5 +50,5 @@ type Address struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&v20211231storage.Person{}, &v20211231storage.PersonList{})
+	SchemeBuilder.Register(&Person{}, &PersonList{})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Code generation by `TypeName.AsFunc()` was generating the wrong code if the _current_ package was also present in the list of _imported_ packages - it was triggering an import of the package and incorrectly using a qualified name for the type.

I've inverted the logic - now, if the `TypeName` is within the current package, it emits an unqualified identifier, otherwise it creates a selector.

This impacts on a bunch of golden files - where I really should have noticed earlier the incorrect imports - so I've put this in an isolated PR despite it being a small fix.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/zcqLQ63bqAyre/giphy.gif)

**If applicable**:
- [ ] this PR contains tests
