### PR TITLE
operator bundle: Remove the cert volume and mount from the pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,7 +388,7 @@ else
 	chmod +x operator-sdk_linux_amd64 && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk_linux_amd64 /usr/local/bin/operator-sdk && rm operator-sdk_linux_amd64
 endif
 
-PREVIOUS_BUNDLE_VERSION ?= 1.0.27207
+PREVIOUS_BUNDLE_VERSION ?= 1.0.28631
 
 .PHONY: generate-operator-bundle
 generate-operator-bundle: LATEST_TAG := $(shell curl -sL https://api.github.com/repos/Azure/azure-service-operator/releases/latest  | jq '.tag_name' --raw-output )

--- a/scripts/inject-container-reference.sh
+++ b/scripts/inject-container-reference.sh
@@ -11,3 +11,9 @@ sed -i "s!controller:latest!${container_reference}!g" $cluster_version_file
 
 # Insert containerImage and createdAt into metadata.annotations.
 yq eval -i ".metadata.annotations.containerImage = \"${container_reference}\" | .metadata.annotations.createdAt = \"${now}\"" $cluster_version_file
+
+# Remove cert volumes and volume mounts from the CSV deployment - the
+# ones here are for cert-manager, OLM will set its own to get the
+# webhook certificates installed in the pod.
+yq eval -i 'del(.spec.install.spec.deployments[0].spec.template.spec.containers[] | select(.name == "manager").volumeMounts)' $cluster_version_file
+yq eval -i 'del(.spec.install.spec.deployments[0].spec.template.spec.volumes)' $cluster_version_file

--- a/scripts/update-webhook-references-in-operator-bundle.sh
+++ b/scripts/update-webhook-references-in-operator-bundle.sh
@@ -6,10 +6,10 @@ set -euo pipefail
 query='select(.spec.conversion.webhook.clientConfig.service.namespace == "azureoperator-system") | filename'
 webhook_crds=$(yq eval "$query" bundle/manifests/azure.microsoft.com_*.yaml | grep -v -e "---")
 
-# Update the service details to point at
-# operators/azureoperator-controller-manager-service and remove the
-# cert-manager annotation.
-update='.spec.conversion.webhook.clientConfig.service.namespace = "operators" | .spec.conversion.webhook.clientConfig.service.name = "azureoperator-controller-manager-service" | del(.metadata.annotations["cert-manager.io/inject-ca-from"])'
+# Remove the cert-manager annotation and conversion details from CRDs
+# with conversion webhooks - OLM will set up the conversion structure
+# for the webhooks.
+update='del(.spec.conversion) | del(.metadata.annotations["cert-manager.io/inject-ca-from"])'
 for fname in $webhook_crds; do
     yq -i eval "$update" "$fname"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
When the operator bundle is installed OLM will set up a volume containing the webhook server certificate and mount it into the manager container, so the existing ones (to get the cert-manager certificate we use in non-operator-bundle deployments) are unnecessary. The spurious volume was referring to a secret that cert-manager is no longer creating and this was preventing the pod from starting in OpenShift 4.6 (k8s 1.19). So this PR removes them.

It also removes the `conversion:` fields from the CRDs in the bundle - the `webhook.clientConfig.namespace` value they specified was wrong for OpenShift. That wasn't causing a problem because it's hooked up by OLM when the operator is installed, but it's misleading.

**How does this PR make you feel**:
![gif](https://c.tenor.com/5SHddeATZQUAAAAd/plug-life-plugged.gif)
