### PR TITLE
Update JSON schema submodule

### DIFF
--- a/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/server_types_gen.go
+++ b/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/server_types_gen.go
@@ -288,13 +288,14 @@ const (
 	ResourceIdentityStatusTypeUserAssigned   = ResourceIdentityStatusType("UserAssigned")
 )
 
-// +kubebuilder:validation:Enum={"None","SystemAssigned","UserAssigned"}
+// +kubebuilder:validation:Enum={"None","SystemAssigned","SystemAssigned,UserAssigned","UserAssigned"}
 type ResourceIdentityType string
 
 const (
-	ResourceIdentityTypeNone           = ResourceIdentityType("None")
-	ResourceIdentityTypeSystemAssigned = ResourceIdentityType("SystemAssigned")
-	ResourceIdentityTypeUserAssigned   = ResourceIdentityType("UserAssigned")
+	ResourceIdentityTypeNone                       = ResourceIdentityType("None")
+	ResourceIdentityTypeSystemAssigned             = ResourceIdentityType("SystemAssigned")
+	ResourceIdentityTypeSystemAssignedUserAssigned = ResourceIdentityType("SystemAssigned,UserAssigned")
+	ResourceIdentityTypeUserAssigned               = ResourceIdentityType("UserAssigned")
 )
 
 // +kubebuilder:validation:Enum={"ActiveDirectory"}

--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -19,17 +19,12 @@ typeFilters:
     version: '*preview'
     because: preview SDK versions are excluded by default
   - action: prune
-    group: microsoft.web
-    name: SitesAppsettingsChildResource;SitesConnectionstringsChildResource;SitesSlotsConnectionstringsChildResource;SitesSlotsAppsettingsChildResource
-    because: _childResource type which "points" to a resource type that doesn't exist. Need to work with schema owners on why.
-  - action: prune
     group: microsoft.compute
     name: VirtualMachineScaleSetsExtensionsChildResource;VirtualMachinesExtensionsChildResource
     because: _childResource type which "points" to a resource type that doesn't exist. Need to work with schema owners on why.
   - action: prune
     group: microsoft.web
-    version: '*2018*'
-    because: Some types (SitesSlotsConfig) use OneOf in a way we don't currently handle.
+    because: Some types (SitesSlotsConfig) use OneOf in a way we don't currently handle. Exclude the whole set for now.
   - action: prune
     group: microsoft.network
     version: '*api201*'
@@ -91,10 +86,6 @@ exportFilters:
     group: microsoft.machinelearning
     version: v*api20170101
     because: ExampleRequest.Inputs is a map[string][][]map[string]v1.JSON, which controller-gen doesn't know how to handle.
-  - action: exclude
-    group: microsoft.web
-    version: v*api20150801
-    because: ARM conversion is generating bad code for handling SitesSpecResourcesAppsettingsSpec.Name - should be casting to the right type
   - action: exclude
     group: microsoft.datafactory
     version: v*api20180601


### PR DESCRIPTION
There was a bug in the JSON schema generator previously where multiple OpenAPI specifications under the same provider (Microsoft.Authorization for example) would overwrite one another. The ARM JSON schema generator team solved this problem by manufacturing multiple documents named based on the OpenAPI specification file/folder name. We must combine all of
these fabricated documents into a single picture of a single API (as that's what it's actually attempting to represent).

The code to do this is a bit fragile/hacky, although the code that existed prior to this was also a bit fragile...