### PR TITLE
Improve error reporting for gen-kustomize command

### DIFF
--- a/hack/generator/cmd/gen_kustomize.go
+++ b/hack/generator/cmd/gen_kustomize.go
@@ -53,7 +53,7 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 			}
 
 			if len(result.Resources) == 0 {
-				err := errors.Errorf("no files found in %q", basesPath)
+				err = errors.Errorf("no files found in %q", basesPath)
 				return logAndExtractStack("No CRD files found", err)
 			}
 

--- a/hack/generator/cmd/gen_kustomize.go
+++ b/hack/generator/cmd/gen_kustomize.go
@@ -7,9 +7,11 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
@@ -36,7 +38,7 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 
 			files, err := ioutil.ReadDir(basesPath)
 			if err != nil {
-				return err
+				return logAndExtractStack(fmt.Sprintf("Unable to scan folder %q", basesPath), err)
 			}
 
 			result := crdKustomizeFile{
@@ -48,6 +50,11 @@ func NewGenKustomizeCommand() (*cobra.Command, error) {
 					continue
 				}
 				result.Resources = append(result.Resources, filepath.Join(bases, f.Name()))
+			}
+
+			if len(result.Resources) == 0 {
+				err := errors.Errorf("no files found in %q", basesPath)
+				return logAndExtractStack("No CRD files found", err)
 			}
 
 			data, err := yaml.Marshal(result)


### PR DESCRIPTION
**What this PR does / why we need it**:

Trying to run `task ci` locally, I'm getting errors where `generator gen-kustomize` is erroring with an exit code of `1` and no logging. This PR plugs a few gaps in the logging, hoping to make it easier to diagnose future build faults.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/cnv56TUT82sVYKIFlX/giphy.gif)
