### PR TITLE
Add ability to generate scope from resource kind and name

### DIFF
--- a/hack/generated/pkg/genruntime/resource_hierarchy_test.go
+++ b/hack/generated/pkg/genruntime/resource_hierarchy_test.go
@@ -61,3 +61,61 @@ func Test_ResourceHierarchy_ResourceGroup_NestedResource(t *testing.T) {
 	g.Expect(rg).To(Equal(resourceGroupName))
 	g.Expect(hierarchy.FullAzureName()).To(Equal(fmt.Sprintf("%s/%s", hierarchy[1].AzureName(), hierarchy[2].AzureName())))
 }
+
+func Test_ResourceHierarchy_ScopeOnHierarchyWithoutExtensionResourceErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	resourceGroupName := "myrg"
+	name := "myresource"
+
+	a, b := createResourceGroupRootedResource(resourceGroupName, name)
+	hierarchy := genruntime.ResourceHierarchy{a, b}
+
+	_, err := hierarchy.Scope()
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("myresource is not of kind \"extension\""))
+}
+
+func Test_ResourceHierarchy_ExtensionOnResourceGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	resourceGroupName := "myrg"
+	extensionName := "myextension"
+
+	a, b := createExtensionResourceOnResourceGroup(resourceGroupName, extensionName)
+	hierarchy := genruntime.ResourceHierarchy{a, b}
+
+	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
+
+	g.Expect(hierarchy.Scope()).To(Equal(""))
+	g.Expect(hierarchy.FullAzureName()).To(Equal(extensionName))
+}
+
+func Test_ResourceHierarchy_ExtensionOnResourceInResourceGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	resourceGroupName := "myrg"
+	resourceName := "myresource"
+	extensionName := "myextension"
+
+	hierarchy := createExtensionResourceOnResourceInResourceGroup(resourceGroupName, resourceName, extensionName)
+
+	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
+	g.Expect(hierarchy.Scope()).To(Equal(fmt.Sprintf("%s/%s", hierarchy[1].GetType(), resourceName)))
+	g.Expect(hierarchy.FullAzureName()).To(Equal(extensionName))
+}
+
+func Test_ResourceHierarchy_ExtensionOnDeepHierarchy(t *testing.T) {
+	g := NewWithT(t)
+
+	resourceGroupName := "myrg"
+	resourceName := "myresource"
+	childResourceName := "mychildresource"
+	extensionName := "myextension"
+
+	hierarchy := createExtensionResourceOnDeepHierarchyInResourceGroup(resourceGroupName, resourceName, childResourceName, extensionName)
+
+	g.Expect(hierarchy.ResourceGroup()).To(Equal(resourceGroupName))
+	g.Expect(hierarchy.Scope()).To(Equal(fmt.Sprintf("%s/%s/%s/%s", hierarchy[1].GetType(), resourceName, "blobServices", hierarchy[2].AzureName())))
+	g.Expect(hierarchy.FullAzureName()).To(Equal(extensionName))
+}

--- a/hack/generated/pkg/genruntime/sample_resources_test.go
+++ b/hack/generated/pkg/genruntime/sample_resources_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+// TODO: Should this go in its own package?
+
+package genruntime_test
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/conditions"
+)
+
+var SimpleExtensionResourceGroupVersion = schema.GroupVersion{Group: "microsoft.test.azure.com", Version: "v1alpha1apitest"}
+
+type SimpleExtensionResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              SimpleExtensionResourceSpec   `json:"spec,omitempty"`
+	Status            SimpleExtensionResourceStatus `json:"status,omitempty"`
+}
+
+func (r *SimpleExtensionResource) SetStatus(status genruntime.ConvertibleStatus) error {
+	r.Status = status.(SimpleExtensionResourceStatus)
+	return nil
+}
+
+func (r *SimpleExtensionResource) GetSpec() genruntime.ConvertibleSpec {
+	return &r.Spec
+}
+
+func (r *SimpleExtensionResource) GetStatus() genruntime.ConvertibleStatus {
+	return &r.Status
+}
+
+var _ admission.Defaulter = &SimpleExtensionResource{}
+
+// Default defaults the Azure name of the resource to the Kubernetes name
+func (r *SimpleExtensionResource) Default() {
+	if r.Spec.AzureName == "" {
+		r.Spec.AzureName = r.Name
+	}
+}
+
+var _ conditions.Conditioner = &SimpleExtensionResource{}
+
+// GetConditions returns the conditions of the resource
+func (r *SimpleExtensionResource) GetConditions() conditions.Conditions {
+	return r.Status.Conditions
+}
+
+// SetConditions sets the conditions on the resource status
+func (r *SimpleExtensionResource) SetConditions(conditions conditions.Conditions) {
+	r.Status.Conditions = conditions
+}
+
+var _ genruntime.KubernetesResource = &SimpleExtensionResource{}
+
+// AzureName returns the Azure name of the resource
+func (r *SimpleExtensionResource) AzureName() string {
+	return r.Spec.AzureName
+}
+
+// Owner returns the ResourceReference of the owner, or nil if there is no owner
+func (r *SimpleExtensionResource) Owner() *genruntime.ResourceReference {
+	return nil
+}
+
+func (r *SimpleExtensionResource) GetType() string { return "Microsoft.Resources/resourceGroups" }
+
+// GetResourceKind returns the kind of the resource
+func (r *SimpleExtensionResource) GetResourceKind() genruntime.ResourceKind {
+	return genruntime.ResourceKindExtension
+}
+
+type SimpleExtensionResourceSpec struct {
+	AzureName string `json:"azureName,omitempty"`
+
+	Owner genruntime.ResourceReference `json:"owner"`
+}
+
+var _ genruntime.ConvertibleSpec = &SimpleExtensionResourceSpec{}
+
+func (s SimpleExtensionResourceSpec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
+	panic("not expected to be called in this test resource")
+}
+
+func (s SimpleExtensionResourceSpec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
+	panic("not expected to be called in this test resource")
+}
+
+type SimpleExtensionResourceStatus struct {
+	Conditions []conditions.Condition `json:"conditions,omitempty"`
+}
+
+var _ genruntime.ConvertibleStatus = &SimpleExtensionResourceStatus{}
+
+func (s SimpleExtensionResourceStatus) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
+	panic("not expected to be called in this test resource")
+}
+
+func (s SimpleExtensionResourceStatus) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
+	panic("not expected to be called in this test resource")
+}
+
+func (r *SimpleExtensionResource) DeepCopyObject() runtime.Object {
+	// Note: This obviously isn't a copy. We don't care because this is a test resource and we just need this method implemented to satisfy our interface.
+	// We don't want to run controller-gen as it's added overhead for what should be a simple test process.
+	return r
+}

--- a/hack/generated/pkg/genruntime/sample_resources_test.go
+++ b/hack/generated/pkg/genruntime/sample_resources_test.go
@@ -3,8 +3,6 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-// TODO: Should this go in its own package?
-
 package genruntime_test
 
 import (

--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -268,13 +268,6 @@ typeTransformers:
     remove: true
     because: It exists on ARMResource but doesn't make sense in the context of a CRD
   - name: "*"
-    property: Scope
-    ifType:
-      name: string
-      optional: true
-    remove: true
-    because: It exists on ARMResource but doesn't make sense in the context of a CRD
-  - name: "*"
     property: Comments
     ifType:
       name: string

--- a/hack/generator/pkg/codegen/code_generator.go
+++ b/hack/generator/pkg/codegen/code_generator.go
@@ -105,6 +105,7 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		// that objects are all expanded
 		pipeline.ApplyPropertyRewrites(configuration).
 			RequiresPrerequisiteStages("nameTypes", "allof-anyof-objects"),
+		pipeline.RemoveResourceScope(),
 
 		pipeline.MakeStatusPropertiesOptional(),
 		pipeline.RemoveStatusValidations(),

--- a/hack/generator/pkg/codegen/pipeline/remove_resource_scope.go
+++ b/hack/generator/pkg/codegen/pipeline/remove_resource_scope.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
+)
+
+const RemoveResourceScopeStageID = "removeResourceScope"
+
+// RemoveResourceScope removes the "Scope" property from resource Specs except for on Extension
+// resources, which support scope.
+func RemoveResourceScope() Stage {
+	return MakeStage(
+		RemoveResourceScopeStageID,
+		"Removes scope from all resources except extension resources",
+		func(ctx context.Context, state *State) (*State, error) {
+
+			newDefs := make(astmodel.Types)
+			scopePropertyRemovalVisitor := makeScopePropertyRemovalVisitor()
+
+			for _, def := range astmodel.FindResourceTypes(state.Types()) {
+				resource, ok := astmodel.AsResourceType(def.Type())
+				if !ok {
+					// panic here because this must be a bug
+					panic("FindResourceTypes returned a type that wasn't a resource")
+				}
+
+				// If the resource is an extension resource, we don't do anything to it
+				if resource.Kind() == astmodel.ResourceKindExtension {
+					continue
+				}
+
+				specDef, err := state.Types().ResolveResourceSpecDefinition(resource)
+				if err != nil {
+					return nil, err
+				}
+
+				updatedDef, err := scopePropertyRemovalVisitor.VisitDefinition(specDef, nil)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to remove scope property from %s", updatedDef.Name())
+				}
+				newDefs.Add(updatedDef)
+			}
+
+			result := state.Types().OverlayWith(newDefs)
+
+			return state.WithTypes(result), nil
+		})
+}
+
+func makeScopePropertyRemovalVisitor() astmodel.TypeVisitor {
+	return astmodel.TypeVisitorBuilder{
+		VisitObjectType: removeScopeProperty,
+	}.Build()
+}
+
+func removeScopeProperty(this *astmodel.TypeVisitor, ot *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
+	ot = ot.WithoutProperty(astmodel.ScopeProperty)
+
+	return astmodel.IdentityVisitOfObjectType(this, ot, ctx)
+}

--- a/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -8,6 +8,7 @@ augmentSpecWithStatus                                Merges information from Sta
 stripUnreferenced                                    Strip unreferenced types
 nameTypes                                            Name inner types for CRD
 propertyRewrites                                     Modify property types using configured transforms
+removeResourceScope                                  Removes scope from all resources except extension resources
 makeStatusPropertiesOptional                         Forces all status properties to be optional
 removeStatusPropertyValidation                       Removes validation from all status properties
 unrollRecursiveTypes                                 Unroll directly recursive types since they are not supported by controller-gen

--- a/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewCrossplaneCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -8,6 +8,7 @@ augmentSpecWithStatus                              Merges information from Statu
 stripUnreferenced                                  Strip unreferenced types
 nameTypes                                          Name inner types for CRD
 propertyRewrites                                   Modify property types using configured transforms
+removeResourceScope                                Removes scope from all resources except extension resources
 makeStatusPropertiesOptional                       Forces all status properties to be optional
 removeStatusPropertyValidation                     Removes validation from all status properties
 unrollRecursiveTypes                               Unroll directly recursive types since they are not supported by controller-gen

--- a/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/hack/generator/pkg/codegen/testdata/TestNewTestCodeGeneratorCreatesRightPipeline.golden
@@ -8,6 +8,7 @@ augmentSpecWithStatus                                Merges information from Sta
 stripUnused                                          Strip unused types for test
 nameTypes                                            Name inner types for CRD
 propertyRewrites                                     Modify property types using configured transforms
+removeResourceScope                                  Removes scope from all resources except extension resources
 makeStatusPropertiesOptional                         Forces all status properties to be optional
 removeStatusPropertyValidation                       Removes validation from all status properties
 unrollRecursiveTypes                                 Unroll directly recursive types since they are not supported by controller-gen


### PR DESCRIPTION
- Add Scope() to ResourceHierarchy for Extension resources
- Remove scope in pipeline stage rather than config
  - This allows us to skip removing that property on extension resources. It also resolves a small possible bug where we would
have blindly removed a more deeply scoped "Scope" property. Now we're limited to just top level properties on the spec.