### PR TITLE
Add ObservedGeneration to our Conditions

### DIFF
--- a/hack/generated/pkg/genruntime/conditions/conditions_test.go
+++ b/hack/generated/pkg/genruntime/conditions/conditions_test.go
@@ -6,10 +6,12 @@ Licensed under the MIT license.
 package conditions_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/conditions"
 )
@@ -34,7 +36,7 @@ func Test_SetCondition_AddsCondition(t *testing.T) {
 	clock := newMockClock()
 	builder := conditions.NewPositiveConditionBuilder(clock)
 
-	newCondition := builder.MakeTrueCondition(conditions.ConditionTypeReady)
+	newCondition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 0)
 	conditions.SetCondition(o, newCondition)
 	g.Expect(o.Conditions).To(HaveLen(1))
 	g.Expect(o.Conditions[0]).To(Equal(newCondition))
@@ -46,7 +48,7 @@ func Test_SetCondition_ReadyTrueToReadyFalse_UpdatesConditionAndChangesTimestamp
 	clock := newMockClock()
 	builder := conditions.NewPositiveConditionBuilder(clock)
 
-	initialCondition := builder.MakeTrueCondition(conditions.ConditionTypeReady)
+	initialCondition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 0)
 	conditions.SetCondition(o, initialCondition)
 
 	clock.Add(1 * time.Second)
@@ -55,6 +57,7 @@ func Test_SetCondition_ReadyTrueToReadyFalse_UpdatesConditionAndChangesTimestamp
 	updatedCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
+		0,
 		"MyReason",
 		"a message")
 	conditions.SetCondition(o, updatedCondition)
@@ -73,6 +76,7 @@ func Test_SetCondition_ChangeReason_TimestampChanged(t *testing.T) {
 	initialCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
+		0,
 		"MyReason",
 		"a message")
 	conditions.SetCondition(o, initialCondition)
@@ -83,6 +87,7 @@ func Test_SetCondition_ChangeReason_TimestampChanged(t *testing.T) {
 	updatedCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
+		0,
 		"MyNewReason",
 		"a message")
 	conditions.SetCondition(o, updatedCondition)
@@ -101,6 +106,7 @@ func Test_SetCondition_SameConditionTimestampUnchanged(t *testing.T) {
 	initialCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
+		0,
 		"MyReason",
 		"a message")
 	conditions.SetCondition(o, initialCondition)
@@ -111,6 +117,7 @@ func Test_SetCondition_SameConditionTimestampUnchanged(t *testing.T) {
 	updatedCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityError,
+		0,
 		"MyReason",
 		"a message")
 	conditions.SetCondition(o, updatedCondition)
@@ -118,4 +125,176 @@ func Test_SetCondition_SameConditionTimestampUnchanged(t *testing.T) {
 	// Set the expected condition to the updated condition
 	g.Expect(o.Conditions).To(HaveLen(1))
 	g.Expect(o.Conditions[0]).To(Equal(initialCondition))
+}
+
+func Test_SetCondition_OverwritesAsExpected(t *testing.T) {
+	clk := newMockClock()
+	builder := conditions.NewPositiveConditionBuilder(clk)
+
+	infoGeneration1Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityInfo,
+		1,
+		"InfoReason",
+		"a message")
+	differentInfoGeneration1Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityInfo,
+		1,
+		"ADifferentInfoReason",
+		"a message")
+	infoGeneration2Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityInfo,
+		2,
+		"InfoOtherReason",
+		"a message")
+	warningGeneration1Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityWarning,
+		1,
+		"WarningReason",
+		"a message")
+	differentWarningGeneration1Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityWarning,
+		1,
+		"ADifferentWarningReason",
+		"a message")
+	warningGeneration2Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityWarning,
+		2,
+		"WarningOtherReason",
+		"a message")
+	errorGeneration1Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityError,
+		1,
+		"MyReason",
+		"a message")
+	differentErrorGeneration1Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityError,
+		1,
+		"ADifferentErrorReason",
+		"a message")
+	errorGeneration2Condition := builder.MakeFalseCondition(
+		conditions.ConditionTypeReady,
+		conditions.ConditionSeverityError,
+		2,
+		"MyOtherReason",
+		"a message")
+	trueGeneration1Condition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 1)
+	trueGeneration2Condition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 2)
+
+	unknownGeneration1Condition := builder.MakeUnknownCondition(
+		conditions.ConditionTypeReady,
+		1,
+		"UnknownReason",
+		"a message")
+	unknownGeneration2Condition := builder.MakeUnknownCondition(
+		conditions.ConditionTypeReady,
+		2,
+		"UnknownOtherReason",
+		"a message")
+
+	gen1List := []conditions.Condition{
+		trueGeneration1Condition,
+		infoGeneration1Condition,
+		warningGeneration1Condition,
+		errorGeneration1Condition,
+		unknownGeneration1Condition,
+	}
+
+	gen2List := []conditions.Condition{
+		trueGeneration2Condition,
+		infoGeneration2Condition,
+		warningGeneration2Condition,
+		errorGeneration2Condition,
+		unknownGeneration2Condition,
+	}
+
+	type testStruct struct {
+		name              string
+		initial           *conditions.Condition
+		new               conditions.Condition
+		expectedOverwrite bool
+	}
+
+	// TODO: Test backwards generation
+	tests := []testStruct{
+		// Something overwrites nothing
+		{name: "True overwrites empty", initial: nil, new: trueGeneration1Condition, expectedOverwrite: true},
+		{name: "Info overwrites empty", initial: nil, new: infoGeneration1Condition, expectedOverwrite: true},
+		{name: "Warning overwrites empty", initial: nil, new: warningGeneration1Condition, expectedOverwrite: true},
+		{name: "Error overwrites empty", initial: nil, new: errorGeneration1Condition, expectedOverwrite: true},
+
+		// Test overwriting within the same generation (positive test cases)
+		{name: "True overwrites same generation Info", initial: &infoGeneration1Condition, new: trueGeneration1Condition, expectedOverwrite: true},
+		{name: "True overwrites same generation Warning", initial: &warningGeneration1Condition, new: trueGeneration1Condition, expectedOverwrite: true},
+		{name: "True overwrites same generation Error", initial: &errorGeneration1Condition, new: trueGeneration1Condition, expectedOverwrite: true},
+		{name: "Info overwrites same generation Info", initial: &infoGeneration1Condition, new: differentInfoGeneration1Condition, expectedOverwrite: true},
+		{name: "Warning overwrites same generation Info", initial: &infoGeneration1Condition, new: warningGeneration1Condition, expectedOverwrite: true},
+		{name: "Warning overwrites same generation Warning", initial: &warningGeneration1Condition, new: differentWarningGeneration1Condition, expectedOverwrite: true},
+		{name: "Warning overwrites same generation Error", initial: &errorGeneration1Condition, new: warningGeneration1Condition, expectedOverwrite: true},
+		{name: "Warning overwrites same generation True", initial: &trueGeneration1Condition, new: warningGeneration1Condition, expectedOverwrite: true},
+		{name: "Error overwrites same generation Info", initial: &infoGeneration1Condition, new: errorGeneration1Condition, expectedOverwrite: true},
+		{name: "Error overwrites same generation Warning", initial: &warningGeneration1Condition, new: errorGeneration1Condition, expectedOverwrite: true},
+		{name: "Error overwrites same generation Error", initial: &errorGeneration1Condition, new: differentErrorGeneration1Condition, expectedOverwrite: true},
+		{name: "Error overwrites same generation True", initial: &trueGeneration1Condition, new: errorGeneration1Condition, expectedOverwrite: true},
+
+		// Test overwriting within the same generation (negative test cases)
+		{name: "Info does NOT overwrite same generation Warning", initial: &warningGeneration1Condition, new: infoGeneration1Condition, expectedOverwrite: false},
+		{name: "Info does NOT overwrite same generation Error", initial: &errorGeneration1Condition, new: infoGeneration1Condition, expectedOverwrite: false},
+		{name: "Info does NOT overwrite same generation True", initial: &trueGeneration1Condition, new: infoGeneration1Condition, expectedOverwrite: false},
+		{name: "Info does NOT overwrite same generation Warning", initial: &warningGeneration1Condition, new: unknownGeneration1Condition, expectedOverwrite: false},
+		{name: "Info does NOT overwrite same generation Error", initial: &errorGeneration1Condition, new: unknownGeneration1Condition, expectedOverwrite: false},
+		{name: "Info does NOT overwrite same generation True", initial: &trueGeneration1Condition, new: unknownGeneration1Condition, expectedOverwrite: false},
+		{name: "Info does NOT overwrite same generation Info", initial: &infoGeneration1Condition, new: unknownGeneration1Condition, expectedOverwrite: false},
+	}
+
+	// Append all the combinations of gen2 overwrites gen1
+	for _, gen1 := range gen1List {
+		gen1 := gen1
+		for _, gen2 := range gen2List {
+			tests = append(
+				tests,
+				testStruct{
+					name:              fmt.Sprintf("Newer %s overwrites older %s", makeFriendlyString(gen2), makeFriendlyString(gen1)),
+					initial:           &gen1,
+					new:               gen2,
+					expectedOverwrite: true,
+				})
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			o := &TestConditioner{}
+			if tt.initial != nil {
+				conditions.SetCondition(o, *tt.initial)
+			}
+
+			conditions.SetCondition(o, tt.new)
+			if tt.expectedOverwrite {
+				g.Expect(o.Conditions[0]).To(Equal(tt.new))
+			} else {
+				g.Expect(o.Conditions[0]).To(Equal(*tt.initial))
+			}
+		})
+	}
+}
+
+func makeFriendlyString(condition conditions.Condition) string {
+	result := string(condition.Severity)
+	if condition.Status == metav1.ConditionTrue {
+		result = "True"
+	} else if condition.Status == metav1.ConditionUnknown {
+		result = "Unknown"
+	}
+
+	return result
 }

--- a/hack/generated/pkg/genruntime/conditions/positive_condition_builder.go
+++ b/hack/generated/pkg/genruntime/conditions/positive_condition_builder.go
@@ -17,9 +17,9 @@ const ReasonSucceeded = "Succeeded"
 
 // TODO: name?
 type PositiveConditionBuilderInterface interface {
-	MakeTrueCondition(conditionType ConditionType) Condition
-	MakeFalseCondition(conditionType ConditionType, severity ConditionSeverity, reason string, message string) Condition
-	MakeUnknownCondition(conditionType ConditionType, reason string, message string) Condition
+	MakeTrueCondition(conditionType ConditionType, observedGeneration int64) Condition
+	MakeFalseCondition(conditionType ConditionType, severity ConditionSeverity, observedGeneration int64, reason string, message string) Condition
+	MakeUnknownCondition(conditionType ConditionType, observedGeneration int64, reason string, message string) Condition
 }
 
 var _ PositiveConditionBuilderInterface = &PositiveConditionBuilder{}
@@ -48,23 +48,25 @@ func (b *PositiveConditionBuilder) now() metav1.Time {
 }
 
 // MakeTrueCondition makes a condition whose Status is True
-func (b *PositiveConditionBuilder) MakeTrueCondition(conditionType ConditionType) Condition {
+func (b *PositiveConditionBuilder) MakeTrueCondition(conditionType ConditionType, observedGeneration int64) Condition {
 	return Condition{
 		Type:               conditionType,
 		Status:             metav1.ConditionTrue,
 		Severity:           ConditionSeverityNone,
 		LastTransitionTime: b.now(),
+		ObservedGeneration: observedGeneration,
 		Reason:             ReasonSucceeded,
 	}
 }
 
 // MakeFalseCondition makes a condition whose Status is False. A severity, reason, and message must be provided.
-func (b *PositiveConditionBuilder) MakeFalseCondition(conditionType ConditionType, severity ConditionSeverity, reason string, message string) Condition {
+func (b *PositiveConditionBuilder) MakeFalseCondition(conditionType ConditionType, severity ConditionSeverity, observedGeneration int64, reason string, message string) Condition {
 	return Condition{
 		Type:               conditionType,
 		Status:             metav1.ConditionFalse,
 		Severity:           severity,
 		LastTransitionTime: b.now(),
+		ObservedGeneration: observedGeneration,
 		Reason:             reason,
 		Message:            message,
 	}
@@ -72,12 +74,13 @@ func (b *PositiveConditionBuilder) MakeFalseCondition(conditionType ConditionTyp
 
 // MakeUnknownCondition makes a condition whose Status is Unknown. A reason and message must be provided. No severity
 // is required as conditions in Status Unknown do not have a known severity either.
-func (b *PositiveConditionBuilder) MakeUnknownCondition(conditionType ConditionType, reason string, message string) Condition {
+func (b *PositiveConditionBuilder) MakeUnknownCondition(conditionType ConditionType, observedGeneration int64, reason string, message string) Condition {
 	return Condition{
 		Type:               conditionType,
 		Status:             metav1.ConditionUnknown,
 		Severity:           ConditionSeverityNone,
 		LastTransitionTime: b.now(),
+		ObservedGeneration: observedGeneration,
 		Reason:             reason,
 		Message:            message,
 	}

--- a/hack/generated/pkg/genruntime/conditions/positive_condition_builder_test.go
+++ b/hack/generated/pkg/genruntime/conditions/positive_condition_builder_test.go
@@ -28,12 +28,14 @@ func Test_PositiveConditionBuilder_MakeTrueCondition(t *testing.T) {
 	g := NewWithT(t)
 	clk := newMockClock()
 
+	var observedGeneration int64 = 0
 	builder := conditions.NewPositiveConditionBuilder(clk)
-	condition := builder.MakeTrueCondition(conditions.ConditionTypeReady)
+	condition := builder.MakeTrueCondition(conditions.ConditionTypeReady, observedGeneration)
 
 	g.Expect(condition.Type).To(Equal(conditions.ConditionType("Ready")))
 	g.Expect(condition.Severity).To(Equal(conditions.ConditionSeverity("")))
 	g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(condition.ObservedGeneration).To(Equal(observedGeneration))
 	g.Expect(condition.Reason).To(Equal("Succeeded"))
 	g.Expect(condition.Message).To(Equal(""))
 	g.Expect(condition.LastTransitionTime).To(Equal(metav1.NewTime(clk.Now())))
@@ -45,13 +47,15 @@ func Test_PositiveConditionBuilder_MakeFalseCondition(t *testing.T) {
 
 	builder := conditions.NewPositiveConditionBuilder(clk)
 	reason := "MyReason"
+	var observedGeneration int64 = 0
 	message := fmt.Sprintf("This is a message %s", "yay")
 	severity := conditions.ConditionSeverityError
-	condition := builder.MakeFalseCondition(conditions.ConditionTypeReady, severity, reason, message)
+	condition := builder.MakeFalseCondition(conditions.ConditionTypeReady, severity, observedGeneration, reason, message)
 
 	g.Expect(condition.Type).To(Equal(conditions.ConditionType("Ready")))
 	g.Expect(condition.Severity).To(Equal(conditions.ConditionSeverity("Error")))
 	g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(condition.ObservedGeneration).To(Equal(observedGeneration))
 	g.Expect(condition.Reason).To(Equal(reason))
 	g.Expect(condition.Message).To(Equal(message))
 	g.Expect(condition.LastTransitionTime).To(Equal(metav1.NewTime(clk.Now())))
@@ -63,12 +67,14 @@ func Test_PositiveConditionBuilder_MakeUnknownCondition(t *testing.T) {
 
 	builder := conditions.NewPositiveConditionBuilder(clk)
 	reason := "MyReason"
+	var observedGeneration int64 = 0
 	message := fmt.Sprintf("This is a message %s", "yay")
-	condition := builder.MakeUnknownCondition(conditions.ConditionTypeReady, reason, message)
+	condition := builder.MakeUnknownCondition(conditions.ConditionTypeReady, observedGeneration, reason, message)
 
 	g.Expect(condition.Type).To(Equal(conditions.ConditionType("Ready")))
 	g.Expect(condition.Severity).To(Equal(conditions.ConditionSeverity("")))
 	g.Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(condition.ObservedGeneration).To(Equal(observedGeneration))
 	g.Expect(condition.Reason).To(Equal(reason))
 	g.Expect(condition.Message).To(Equal(message))
 	g.Expect(condition.LastTransitionTime).To(Equal(metav1.NewTime(clk.Now())))

--- a/hack/generated/pkg/genruntime/conditions/ready_condition_builder.go
+++ b/hack/generated/pkg/genruntime/conditions/ready_condition_builder.go
@@ -24,30 +24,33 @@ type ReadyConditionBuilder struct {
 	builder PositiveConditionBuilderInterface
 }
 
-func (b *ReadyConditionBuilder) Reconciling() Condition {
+func (b *ReadyConditionBuilder) Reconciling(observedGeneration int64) Condition {
 	return b.builder.MakeFalseCondition(
 		ConditionTypeReady,
 		ConditionSeverityInfo,
+		observedGeneration,
 		ReasonReconciling,
 		"The resource is in the process of being reconciled by the operator")
 }
 
-func (b *ReadyConditionBuilder) WaitingForOwner(ownerDetails string) Condition {
+func (b *ReadyConditionBuilder) WaitingForOwner(observedGeneration int64, ownerDetails string) Condition {
 	return b.builder.MakeFalseCondition(
 		ConditionTypeReady,
 		ConditionSeverityWarning,
+		observedGeneration,
 		ReasonWaitingForOwner,
 		fmt.Sprintf("Owner %q cannot be found. Progress is blocked until the owner is created.", ownerDetails))
 }
 
-func (b *ReadyConditionBuilder) Deleting() Condition {
+func (b *ReadyConditionBuilder) Deleting(observedGeneration int64) Condition {
 	return b.builder.MakeFalseCondition(
 		ConditionTypeReady,
 		ConditionSeverityInfo,
+		observedGeneration,
 		ReasonDeleting,
 		"The resource is being deleted")
 }
 
-func (b *ReadyConditionBuilder) Succeeded() Condition {
-	return b.builder.MakeTrueCondition(ConditionTypeReady)
+func (b *ReadyConditionBuilder) Succeeded(observedGeneration int64) Condition {
+	return b.builder.MakeTrueCondition(ConditionTypeReady, observedGeneration)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This gives us a way to pick winners when we're updating the same condition multiple times for a single resource "shape". It follows the KEP on conditions, I had originally not included it because I thought we didn't need it but it turns out we probably do.

This solves the problem of a Warning (of the same generation) immediately getting overwritten by the subsequent reconcile, while maintaining that overwrite in the case the resource had a warning _and was updated_ (since now the generation will be larger).

**If applicable**:
- [x] this PR contains tests
