### PR TITLE
Fix generator module paths and config

### DIFF
--- a/hack/generator/azure-arm.yaml
+++ b/hack/generator/azure-arm.yaml
@@ -3,7 +3,8 @@ schemaUrlRewrite:
   from: 'https://schema.management.azure.com/schemas/'
   to: 'specs/azure-resource-manager-schemas/schemas/'
 destinationGoModuleFile: ../../v2/go.mod
-typesOutputPath: ../../v2/api
+# These two paths are relative to the module path above.
+typesOutputPath: api
 typeRegistrationOutputFile: internal/controller/controllers/controller_resources_gen.go
 pipeline: azure
 typeFilters:

--- a/hack/generator/pkg/astmodel/package_reference.go
+++ b/hack/generator/pkg/astmodel/package_reference.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	genRuntimePathPrefix = "github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	genRuntimePathPrefix = "github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	GroupSuffix          = ".azure.com"
 )
 

--- a/hack/generator/pkg/astmodel/std_references.go
+++ b/hack/generator/pkg/astmodel/std_references.go
@@ -6,7 +6,7 @@
 package astmodel
 
 const (
-	reflectHelpersPath = "github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	reflectHelpersPath = "github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
 )
 
 var (

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_AddStatusConditions/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_AddStatusConditions/microsoft.person-v20200101.golden
@@ -5,7 +5,7 @@
  
 -import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 +import (
-+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/conditions"
++	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 +	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 +)
  

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20200101storage.golden
@@ -4,7 +4,7 @@
 package v20200101storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_CreateStorageTypes/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101.golden
@@ -4,8 +4,8 @@
  package v20200101
  
  import (
- 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
  	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
+ 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
  	"github.com/pkg/errors"
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 +	"sigs.k8s.io/controller-runtime/pkg/conversion"

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
@@ -5,8 +5,8 @@
  
  import (
 +	"fmt"
- 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
  	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+ 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
  	"github.com/pkg/errors"
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 +	"sigs.k8s.io/controller-runtime/pkg/conversion"

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231.golden
@@ -5,8 +5,8 @@
  
  import (
 +	"fmt"
- 	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
  	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+ 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
  	"github.com/pkg/errors"
  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 +	"sigs.k8s.io/controller-runtime/pkg/conversion"

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101.golden
@@ -4,8 +4,8 @@
 package v20200101
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101storage.golden
@@ -5,8 +5,8 @@ package v20200101storage
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231.golden
@@ -5,8 +5,8 @@ package v20211231
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20200101.golden
@@ -4,8 +4,8 @@
 package v20200101
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
@@ -4,8 +4,8 @@
 package v20200101storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20211231.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20211231.golden
@@ -4,8 +4,8 @@
 package v20211231
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleSpecInterface/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,7 +38,7 @@ var _ genruntime.ConvertibleSpec = &Person_Spec{}
 // ConvertSpecFrom populates our Person_Spec from the provided source
 func (personSpec *Person_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == personSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(personSpec)
@@ -47,7 +47,7 @@ func (personSpec *Person_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec
 // ConvertSpecTo populates the provided destination from our Person_Spec
 func (personSpec *Person_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == personSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(personSpec)

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20200101.golden
@@ -4,8 +4,8 @@
 package v20200101
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
@@ -4,8 +4,8 @@
 package v20200101storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20211231.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20211231.golden
@@ -4,8 +4,8 @@
 package v20211231
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectConvertibleStatusInterface/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -44,7 +44,7 @@ var _ genruntime.ConvertibleStatus = &Person_Status{}
 // ConvertStatusFrom populates our Person_Status from the provided source
 func (personStatus *Person_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == personStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(personStatus)
@@ -53,7 +53,7 @@ func (personStatus *Person_Status) ConvertStatusFrom(source genruntime.Convertib
 // ConvertStatusTo populates the provided destination from our Person_Status
 func (personStatus *Person_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == personStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(personStatus)

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20200101.golden
@@ -4,8 +4,8 @@
 package v20200101
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20200101storage.golden
@@ -4,8 +4,8 @@
 package v20200101storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20211231.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20211231.golden
@@ -4,8 +4,8 @@
 package v20211231
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectJsonSerializationTests/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20200101.golden
@@ -4,8 +4,8 @@
 package v20200101
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
@@ -4,8 +4,8 @@
 package v20200101storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20211231.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20211231.golden
@@ -4,8 +4,8 @@
 package v20211231
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentFunctions/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20200101.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20200101.golden
@@ -4,8 +4,8 @@
 package v20200101
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20200101storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
@@ -4,8 +4,8 @@
 package v20200101storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20211231.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20211231.golden
@@ -4,8 +4,8 @@
 package v20211231
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20211231storage.golden
+++ b/hack/generator/pkg/codegen/pipeline/testdata/TestInjectPropertyAssignmentTests/microsoft.person-v20211231storage.golden
@@ -4,7 +4,7 @@
 package v20211231storage
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
@@ -6,8 +6,8 @@ package v1alpha1api20200101
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
+++ b/hack/generator/pkg/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/hack/generator/pkg/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
+++ b/hack/generator/pkg/codegen/testdata/EnumNames/Single_valued_enum_name.golden
@@ -5,8 +5,8 @@ package v1alpha1api20200101
 
 import (
 	"fmt"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/internal/controller/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/hack/generator/pkg/config/configuration.go
+++ b/hack/generator/pkg/config/configuration.go
@@ -57,12 +57,6 @@ type Configuration struct {
 	// after init TypeTransformers is split into property and non-property transformers
 	typeTransformers     []*TypeTransformer
 	propertyTransformers []*TypeTransformer
-
-	// typesOutputModuleSuffix is the suffix to append to GoModulePath to build the actual go import path
-	// to include types with. For example if GoModulePath is "github.com/Azure/azure-service-operator/v2"
-	// and we locally put the generated types into an "api" folder then this suffix would be "api" so that
-	// when joined with GoModulePath the result is github.com/Azure/azure-service-operator/v2/api
-	typesOutputModuleSuffix string
 }
 
 type RewriteRule struct {
@@ -71,7 +65,7 @@ type RewriteRule struct {
 }
 
 func (config *Configuration) LocalPathPrefix() string {
-	return path.Join(config.GoModulePath, config.typesOutputModuleSuffix)
+	return path.Join(config.GoModulePath, config.TypesOutputPath)
 }
 
 func (config *Configuration) FullTypesOutputPath() string {
@@ -131,20 +125,6 @@ func (config *Configuration) GetExportFiltersError() error {
 	}
 
 	return nil
-}
-
-func (config *Configuration) getModuleSuffix() (string, error) {
-	moduleRoot, err := filepath.Abs(filepath.Dir(config.DestinationGoModuleFile))
-	if err != nil {
-		return "", err
-	}
-
-	typesOutputPath, err := filepath.Abs(config.TypesOutputPath)
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Rel(moduleRoot, typesOutputPath)
 }
 
 // NewConfiguration returns a new empty Configuration
@@ -275,11 +255,6 @@ func (config *Configuration) initialize(configPath string) error {
 		errs = append(errs, err)
 	} else {
 		config.GoModulePath = modPath
-	}
-
-	config.typesOutputModuleSuffix, err = config.getModuleSuffix()
-	if err != nil {
-		errs = append(errs, err)
 	}
 
 	for _, filter := range config.ExportFilters {

--- a/hack/generator/pkg/functions/testdata/TestGolden_NewResourceStatusSetterFunction_GeneratesExpectedCode/NewResourceStatusSetterFunction.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_NewResourceStatusSetterFunction_GeneratesExpectedCode/NewResourceStatusSetterFunction.golden
@@ -5,7 +5,7 @@
  
 -import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 +import (
-+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
++	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 +	"github.com/pkg/errors"
 +	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 +)

--- a/hack/generator/pkg/functions/testdata/TestGolden_NewSpecChainedConversionFunction_Conversion_GeneratesExpectedCode/Person.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_NewSpecChainedConversionFunction_Conversion_GeneratesExpectedCode/Person.golden
@@ -4,8 +4,8 @@
  package v20200101
  
 +import (
-+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 +	person "github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231"
++	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 +	"github.com/pkg/errors"
 +)
 +

--- a/hack/generator/pkg/functions/testdata/TestGolden_NewSpecPivotConversionFunction_Conversion_GeneratesExpectedCode/TestGolden_NewSpecPivotConversionFunction_Conversion_GeneratesExpectedCode.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_NewSpecPivotConversionFunction_Conversion_GeneratesExpectedCode/TestGolden_NewSpecPivotConversionFunction_Conversion_GeneratesExpectedCode.golden
@@ -4,7 +4,7 @@
  package v20200101
  
 +import (
-+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
++	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 +	"github.com/pkg/errors"
 +)
 +
@@ -22,7 +22,7 @@
 +// ConvertSpecFrom populates our Person_Spec from the provided source
 +func (personSpec *Person_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 +	if source == personSpec {
-+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
++		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 +	}
 +
 +	return source.ConvertSpecTo(personSpec)
@@ -31,7 +31,7 @@
 +// ConvertSpecTo populates the provided destination from our Person_Spec
 +func (personSpec *Person_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 +	if destination == personSpec {
-+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
++		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 +	}
 +
 +	return destination.ConvertSpecFrom(personSpec)

--- a/hack/generator/pkg/functions/testdata/TestGolden_NewStatusChainedConversionFunction_Conversion_GeneratesExpectedCode/Person.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_NewStatusChainedConversionFunction_Conversion_GeneratesExpectedCode/Person.golden
@@ -4,8 +4,8 @@
  package v20200101
  
 +import (
-+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 +	person "github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231"
++	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 +	"github.com/pkg/errors"
 +)
 +

--- a/hack/generator/pkg/functions/testdata/TestGolden_NewStatusPivotConversionFunction_Conversion_GeneratesExpectedCode/TestGolden_NewStatusPivotConversionFunction_Conversion_GeneratesExpectedCode.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_NewStatusPivotConversionFunction_Conversion_GeneratesExpectedCode/TestGolden_NewStatusPivotConversionFunction_Conversion_GeneratesExpectedCode.golden
@@ -4,7 +4,7 @@
  package v20200101
  
 +import (
-+	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
++	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 +	"github.com/pkg/errors"
 +)
 +
@@ -15,7 +15,7 @@
 +// ConvertStatusFrom populates our Person_Status from the provided source
 +func (personStatus *Person_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 +	if source == personStatus {
-+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
++		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 +	}
 +
 +	return source.ConvertStatusTo(personStatus)
@@ -24,7 +24,7 @@
 +// ConvertStatusTo populates the provided destination from our Person_Status
 +func (personStatus *Person_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 +	if destination == personStatus {
-+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
++		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 +	}
 +
 +	return destination.ConvertStatusFrom(personStatus)

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyKnownReferenceProperty.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyKnownReferenceProperty.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
 type Person struct {

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyMapToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyMapToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalIntToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalIntToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalObjectToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalObjectToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalStringToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalStringToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyReferenceProperty.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyReferenceProperty.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
 type Person struct {

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyRequiredIntToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyRequiredIntToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyRequiredObjectToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyRequiredObjectToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyRequiredStringToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyRequiredStringToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopySliceToPropertyBag.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopySliceToPropertyBag.golden
@@ -4,8 +4,8 @@
 package vCurrent
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/testing/Verification/vNext"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_WhenPropertyBagPresent/PropertyBags.golden
+++ b/hack/generator/pkg/functions/testdata/TestGolden_PropertyAssignmentFunction_WhenPropertyBagPresent/PropertyBags.golden
@@ -4,8 +4,8 @@
 package v20200101
 
 import (
-	"github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime"
 	person "github.com/Azure/azure-service-operator/testing/microsoft.person/v20211231"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/pkg/errors"
 )
 

--- a/v2/api/microsoft.batch/v1alpha1api20210101storage/batch_account_types_gen.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101storage/batch_account_types_gen.go
@@ -139,7 +139,7 @@ var _ genruntime.ConvertibleStatus = &BatchAccount_Status{}
 // ConvertStatusFrom populates our BatchAccount_Status from the provided source
 func (batchAccountStatus *BatchAccount_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == batchAccountStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(batchAccountStatus)
@@ -148,7 +148,7 @@ func (batchAccountStatus *BatchAccount_Status) ConvertStatusFrom(source genrunti
 // ConvertStatusTo populates the provided destination from our BatchAccount_Status
 func (batchAccountStatus *BatchAccount_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == batchAccountStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(batchAccountStatus)
@@ -183,7 +183,7 @@ var _ genruntime.ConvertibleSpec = &BatchAccounts_Spec{}
 // ConvertSpecFrom populates our BatchAccounts_Spec from the provided source
 func (batchAccountsSpec *BatchAccounts_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == batchAccountsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(batchAccountsSpec)
@@ -192,7 +192,7 @@ func (batchAccountsSpec *BatchAccounts_Spec) ConvertSpecFrom(source genruntime.C
 // ConvertSpecTo populates the provided destination from our BatchAccounts_Spec
 func (batchAccountsSpec *BatchAccounts_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == batchAccountsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(batchAccountsSpec)

--- a/v2/api/microsoft.compute/v1alpha1api20200930storage/disk_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930storage/disk_types_gen.go
@@ -152,7 +152,7 @@ var _ genruntime.ConvertibleStatus = &Disk_Status{}
 // ConvertStatusFrom populates our Disk_Status from the provided source
 func (diskStatus *Disk_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == diskStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(diskStatus)
@@ -161,7 +161,7 @@ func (diskStatus *Disk_Status) ConvertStatusFrom(source genruntime.ConvertibleSt
 // ConvertStatusTo populates the provided destination from our Disk_Status
 func (diskStatus *Disk_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == diskStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(diskStatus)
@@ -208,7 +208,7 @@ var _ genruntime.ConvertibleSpec = &Disks_Spec{}
 // ConvertSpecFrom populates our Disks_Spec from the provided source
 func (disksSpec *Disks_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == disksSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(disksSpec)
@@ -217,7 +217,7 @@ func (disksSpec *Disks_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) 
 // ConvertSpecTo populates the provided destination from our Disks_Spec
 func (disksSpec *Disks_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == disksSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(disksSpec)

--- a/v2/api/microsoft.compute/v1alpha1api20201201storage/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201storage/virtual_machine_scale_set_types_gen.go
@@ -145,7 +145,7 @@ var _ genruntime.ConvertibleStatus = &VirtualMachineScaleSet_Status{}
 // ConvertStatusFrom populates our VirtualMachineScaleSet_Status from the provided source
 func (virtualMachineScaleSetStatus *VirtualMachineScaleSet_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == virtualMachineScaleSetStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(virtualMachineScaleSetStatus)
@@ -154,7 +154,7 @@ func (virtualMachineScaleSetStatus *VirtualMachineScaleSet_Status) ConvertStatus
 // ConvertStatusTo populates the provided destination from our VirtualMachineScaleSet_Status
 func (virtualMachineScaleSetStatus *VirtualMachineScaleSet_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == virtualMachineScaleSetStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(virtualMachineScaleSetStatus)
@@ -198,7 +198,7 @@ var _ genruntime.ConvertibleSpec = &VirtualMachineScaleSets_Spec{}
 // ConvertSpecFrom populates our VirtualMachineScaleSets_Spec from the provided source
 func (virtualMachineScaleSetsSpec *VirtualMachineScaleSets_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == virtualMachineScaleSetsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(virtualMachineScaleSetsSpec)
@@ -207,7 +207,7 @@ func (virtualMachineScaleSetsSpec *VirtualMachineScaleSets_Spec) ConvertSpecFrom
 // ConvertSpecTo populates the provided destination from our VirtualMachineScaleSets_Spec
 func (virtualMachineScaleSetsSpec *VirtualMachineScaleSets_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == virtualMachineScaleSetsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(virtualMachineScaleSetsSpec)

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_cluster_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_cluster_types_gen.go
@@ -156,7 +156,7 @@ var _ genruntime.ConvertibleStatus = &ManagedCluster_Status{}
 // ConvertStatusFrom populates our ManagedCluster_Status from the provided source
 func (managedClusterStatus *ManagedCluster_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == managedClusterStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(managedClusterStatus)
@@ -165,7 +165,7 @@ func (managedClusterStatus *ManagedCluster_Status) ConvertStatusFrom(source genr
 // ConvertStatusTo populates the provided destination from our ManagedCluster_Status
 func (managedClusterStatus *ManagedCluster_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == managedClusterStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(managedClusterStatus)
@@ -222,7 +222,7 @@ var _ genruntime.ConvertibleSpec = &ManagedClusters_Spec{}
 // ConvertSpecFrom populates our ManagedClusters_Spec from the provided source
 func (managedClustersSpec *ManagedClusters_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == managedClustersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(managedClustersSpec)
@@ -231,7 +231,7 @@ func (managedClustersSpec *ManagedClusters_Spec) ConvertSpecFrom(source genrunti
 // ConvertSpecTo populates the provided destination from our ManagedClusters_Spec
 func (managedClustersSpec *ManagedClusters_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == managedClustersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(managedClustersSpec)

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_clusters_agent_pool_types_gen.go
@@ -158,7 +158,7 @@ var _ genruntime.ConvertibleStatus = &AgentPool_Status{}
 // ConvertStatusFrom populates our AgentPool_Status from the provided source
 func (agentPoolStatus *AgentPool_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == agentPoolStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(agentPoolStatus)
@@ -167,7 +167,7 @@ func (agentPoolStatus *AgentPool_Status) ConvertStatusFrom(source genruntime.Con
 // ConvertStatusTo populates the provided destination from our AgentPool_Status
 func (agentPoolStatus *AgentPool_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == agentPoolStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(agentPoolStatus)
@@ -237,7 +237,7 @@ var _ genruntime.ConvertibleSpec = &ManagedClustersAgentPools_Spec{}
 // ConvertSpecFrom populates our ManagedClustersAgentPools_Spec from the provided source
 func (managedClustersAgentPoolsSpec *ManagedClustersAgentPools_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == managedClustersAgentPoolsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(managedClustersAgentPoolsSpec)
@@ -246,7 +246,7 @@ func (managedClustersAgentPoolsSpec *ManagedClustersAgentPools_Spec) ConvertSpec
 // ConvertSpecTo populates the provided destination from our ManagedClustersAgentPools_Spec
 func (managedClustersAgentPoolsSpec *ManagedClustersAgentPools_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == managedClustersAgentPoolsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(managedClustersAgentPoolsSpec)

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_server_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_server_types_gen.go
@@ -144,7 +144,7 @@ var _ genruntime.ConvertibleSpec = &FlexibleServers_Spec{}
 // ConvertSpecFrom populates our FlexibleServers_Spec from the provided source
 func (flexibleServersSpec *FlexibleServers_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == flexibleServersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(flexibleServersSpec)
@@ -153,7 +153,7 @@ func (flexibleServersSpec *FlexibleServers_Spec) ConvertSpecFrom(source genrunti
 // ConvertSpecTo populates the provided destination from our FlexibleServers_Spec
 func (flexibleServersSpec *FlexibleServers_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == flexibleServersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(flexibleServersSpec)
@@ -195,7 +195,7 @@ var _ genruntime.ConvertibleStatus = &Server_Status{}
 // ConvertStatusFrom populates our Server_Status from the provided source
 func (serverStatus *Server_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == serverStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(serverStatus)
@@ -204,7 +204,7 @@ func (serverStatus *Server_Status) ConvertStatusFrom(source genruntime.Convertib
 // ConvertStatusTo populates the provided destination from our Server_Status
 func (serverStatus *Server_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == serverStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(serverStatus)

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_database_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_database_types_gen.go
@@ -125,7 +125,7 @@ var _ genruntime.ConvertibleStatus = &Database_Status{}
 // ConvertStatusFrom populates our Database_Status from the provided source
 func (databaseStatus *Database_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == databaseStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(databaseStatus)
@@ -134,7 +134,7 @@ func (databaseStatus *Database_Status) ConvertStatusFrom(source genruntime.Conve
 // ConvertStatusTo populates the provided destination from our Database_Status
 func (databaseStatus *Database_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == databaseStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(databaseStatus)
@@ -161,7 +161,7 @@ var _ genruntime.ConvertibleSpec = &FlexibleServersDatabases_Spec{}
 // ConvertSpecFrom populates our FlexibleServersDatabases_Spec from the provided source
 func (flexibleServersDatabasesSpec *FlexibleServersDatabases_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == flexibleServersDatabasesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(flexibleServersDatabasesSpec)
@@ -170,7 +170,7 @@ func (flexibleServersDatabasesSpec *FlexibleServersDatabases_Spec) ConvertSpecFr
 // ConvertSpecTo populates the provided destination from our FlexibleServersDatabases_Spec
 func (flexibleServersDatabasesSpec *FlexibleServersDatabases_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == flexibleServersDatabasesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(flexibleServersDatabasesSpec)

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_firewall_rule_types_gen.go
@@ -125,7 +125,7 @@ var _ genruntime.ConvertibleStatus = &FirewallRule_Status{}
 // ConvertStatusFrom populates our FirewallRule_Status from the provided source
 func (firewallRuleStatus *FirewallRule_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == firewallRuleStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(firewallRuleStatus)
@@ -134,7 +134,7 @@ func (firewallRuleStatus *FirewallRule_Status) ConvertStatusFrom(source genrunti
 // ConvertStatusTo populates the provided destination from our FirewallRule_Status
 func (firewallRuleStatus *FirewallRule_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == firewallRuleStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(firewallRuleStatus)
@@ -161,7 +161,7 @@ var _ genruntime.ConvertibleSpec = &FlexibleServersFirewallRules_Spec{}
 // ConvertSpecFrom populates our FlexibleServersFirewallRules_Spec from the provided source
 func (flexibleServersFirewallRulesSpec *FlexibleServersFirewallRules_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == flexibleServersFirewallRulesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(flexibleServersFirewallRulesSpec)
@@ -170,7 +170,7 @@ func (flexibleServersFirewallRulesSpec *FlexibleServersFirewallRules_Spec) Conve
 // ConvertSpecTo populates the provided destination from our FlexibleServersFirewallRules_Spec
 func (flexibleServersFirewallRulesSpec *FlexibleServersFirewallRules_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == flexibleServersFirewallRulesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(flexibleServersFirewallRulesSpec)

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/database_account_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/database_account_types_gen.go
@@ -155,7 +155,7 @@ var _ genruntime.ConvertibleStatus = &DatabaseAccountGetResults_Status{}
 // ConvertStatusFrom populates our DatabaseAccountGetResults_Status from the provided source
 func (databaseAccountGetResultsStatus *DatabaseAccountGetResults_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == databaseAccountGetResultsStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(databaseAccountGetResultsStatus)
@@ -164,7 +164,7 @@ func (databaseAccountGetResultsStatus *DatabaseAccountGetResults_Status) Convert
 // ConvertStatusTo populates the provided destination from our DatabaseAccountGetResults_Status
 func (databaseAccountGetResultsStatus *DatabaseAccountGetResults_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == databaseAccountGetResultsStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(databaseAccountGetResultsStatus)
@@ -218,7 +218,7 @@ var _ genruntime.ConvertibleSpec = &DatabaseAccounts_Spec{}
 // ConvertSpecFrom populates our DatabaseAccounts_Spec from the provided source
 func (databaseAccountsSpec *DatabaseAccounts_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == databaseAccountsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(databaseAccountsSpec)
@@ -227,7 +227,7 @@ func (databaseAccountsSpec *DatabaseAccounts_Spec) ConvertSpecFrom(source genrun
 // ConvertSpecTo populates the provided destination from our DatabaseAccounts_Spec
 func (databaseAccountsSpec *DatabaseAccounts_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == databaseAccountsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(databaseAccountsSpec)

--- a/v2/api/microsoft.managedidentity/v1alpha1api20181130storage/user_assigned_identity_types_gen.go
+++ b/v2/api/microsoft.managedidentity/v1alpha1api20181130storage/user_assigned_identity_types_gen.go
@@ -127,7 +127,7 @@ var _ genruntime.ConvertibleStatus = &Identity_Status{}
 // ConvertStatusFrom populates our Identity_Status from the provided source
 func (identityStatus *Identity_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == identityStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(identityStatus)
@@ -136,7 +136,7 @@ func (identityStatus *Identity_Status) ConvertStatusFrom(source genruntime.Conve
 // ConvertStatusTo populates the provided destination from our Identity_Status
 func (identityStatus *Identity_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == identityStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(identityStatus)
@@ -161,7 +161,7 @@ var _ genruntime.ConvertibleSpec = &UserAssignedIdentities_Spec{}
 // ConvertSpecFrom populates our UserAssignedIdentities_Spec from the provided source
 func (userAssignedIdentitiesSpec *UserAssignedIdentities_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == userAssignedIdentitiesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(userAssignedIdentitiesSpec)
@@ -170,7 +170,7 @@ func (userAssignedIdentitiesSpec *UserAssignedIdentities_Spec) ConvertSpecFrom(s
 // ConvertSpecTo populates the provided destination from our UserAssignedIdentities_Spec
 func (userAssignedIdentitiesSpec *UserAssignedIdentities_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == userAssignedIdentitiesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(userAssignedIdentitiesSpec)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/load_balancer_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/load_balancer_types_gen.go
@@ -136,7 +136,7 @@ var _ genruntime.ConvertibleStatus = &LoadBalancer_Status{}
 // ConvertStatusFrom populates our LoadBalancer_Status from the provided source
 func (loadBalancerStatus *LoadBalancer_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == loadBalancerStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(loadBalancerStatus)
@@ -145,7 +145,7 @@ func (loadBalancerStatus *LoadBalancer_Status) ConvertStatusFrom(source genrunti
 // ConvertStatusTo populates the provided destination from our LoadBalancer_Status
 func (loadBalancerStatus *LoadBalancer_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == loadBalancerStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(loadBalancerStatus)
@@ -178,7 +178,7 @@ var _ genruntime.ConvertibleSpec = &LoadBalancers_Spec{}
 // ConvertSpecFrom populates our LoadBalancers_Spec from the provided source
 func (loadBalancersSpec *LoadBalancers_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == loadBalancersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(loadBalancersSpec)
@@ -187,7 +187,7 @@ func (loadBalancersSpec *LoadBalancers_Spec) ConvertSpecFrom(source genruntime.C
 // ConvertSpecTo populates the provided destination from our LoadBalancers_Spec
 func (loadBalancersSpec *LoadBalancers_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == loadBalancersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(loadBalancersSpec)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_group_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_group_types_gen.go
@@ -132,7 +132,7 @@ var _ genruntime.ConvertibleStatus = &NetworkSecurityGroup_Status_NetworkSecurit
 // ConvertStatusFrom populates our NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded from the provided source
 func (networkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded *NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == networkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(networkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded)
@@ -141,7 +141,7 @@ func (networkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded *Network
 // ConvertStatusTo populates the provided destination from our NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded
 func (networkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded *NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == networkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(networkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded)
@@ -166,7 +166,7 @@ var _ genruntime.ConvertibleSpec = &NetworkSecurityGroups_Spec{}
 // ConvertSpecFrom populates our NetworkSecurityGroups_Spec from the provided source
 func (networkSecurityGroupsSpec *NetworkSecurityGroups_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == networkSecurityGroupsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(networkSecurityGroupsSpec)
@@ -175,7 +175,7 @@ func (networkSecurityGroupsSpec *NetworkSecurityGroups_Spec) ConvertSpecFrom(sou
 // ConvertSpecTo populates the provided destination from our NetworkSecurityGroups_Spec
 func (networkSecurityGroupsSpec *NetworkSecurityGroups_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == networkSecurityGroupsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(networkSecurityGroupsSpec)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_groups_security_rule_types_gen.go
@@ -142,7 +142,7 @@ var _ genruntime.ConvertibleSpec = &NetworkSecurityGroupsSecurityRules_Spec{}
 // ConvertSpecFrom populates our NetworkSecurityGroupsSecurityRules_Spec from the provided source
 func (networkSecurityGroupsSecurityRulesSpec *NetworkSecurityGroupsSecurityRules_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == networkSecurityGroupsSecurityRulesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(networkSecurityGroupsSecurityRulesSpec)
@@ -151,7 +151,7 @@ func (networkSecurityGroupsSecurityRulesSpec *NetworkSecurityGroupsSecurityRules
 // ConvertSpecTo populates the provided destination from our NetworkSecurityGroupsSecurityRules_Spec
 func (networkSecurityGroupsSecurityRulesSpec *NetworkSecurityGroupsSecurityRules_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == networkSecurityGroupsSecurityRulesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(networkSecurityGroupsSecurityRulesSpec)
@@ -189,7 +189,7 @@ var _ genruntime.ConvertibleStatus = &SecurityRule_Status_NetworkSecurityGroupsS
 // ConvertStatusFrom populates our SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded from the provided source
 func (securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded *SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded)
@@ -198,7 +198,7 @@ func (securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded *Se
 // ConvertStatusTo populates the provided destination from our SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded
 func (securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded *SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/public_ip_address_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/public_ip_address_types_gen.go
@@ -141,7 +141,7 @@ var _ genruntime.ConvertibleStatus = &PublicIPAddress_Status_PublicIPAddress_Sub
 // ConvertStatusFrom populates our PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded from the provided source
 func (publicIPAddressStatusPublicIPAddressSubResourceEmbedded *PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == publicIPAddressStatusPublicIPAddressSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(publicIPAddressStatusPublicIPAddressSubResourceEmbedded)
@@ -150,7 +150,7 @@ func (publicIPAddressStatusPublicIPAddressSubResourceEmbedded *PublicIPAddress_S
 // ConvertStatusTo populates the provided destination from our PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded
 func (publicIPAddressStatusPublicIPAddressSubResourceEmbedded *PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == publicIPAddressStatusPublicIPAddressSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(publicIPAddressStatusPublicIPAddressSubResourceEmbedded)
@@ -186,7 +186,7 @@ var _ genruntime.ConvertibleSpec = &PublicIPAddresses_Spec{}
 // ConvertSpecFrom populates our PublicIPAddresses_Spec from the provided source
 func (publicIPAddressesSpec *PublicIPAddresses_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == publicIPAddressesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(publicIPAddressesSpec)
@@ -195,7 +195,7 @@ func (publicIPAddressesSpec *PublicIPAddresses_Spec) ConvertSpecFrom(source genr
 // ConvertSpecTo populates the provided destination from our PublicIPAddresses_Spec
 func (publicIPAddressesSpec *PublicIPAddresses_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == publicIPAddressesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(publicIPAddressesSpec)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_gateway_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_gateway_types_gen.go
@@ -143,7 +143,7 @@ var _ genruntime.ConvertibleStatus = &VirtualNetworkGateway_Status{}
 // ConvertStatusFrom populates our VirtualNetworkGateway_Status from the provided source
 func (virtualNetworkGatewayStatus *VirtualNetworkGateway_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == virtualNetworkGatewayStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(virtualNetworkGatewayStatus)
@@ -152,7 +152,7 @@ func (virtualNetworkGatewayStatus *VirtualNetworkGateway_Status) ConvertStatusFr
 // ConvertStatusTo populates the provided destination from our VirtualNetworkGateway_Status
 func (virtualNetworkGatewayStatus *VirtualNetworkGateway_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == virtualNetworkGatewayStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(virtualNetworkGatewayStatus)
@@ -196,7 +196,7 @@ var _ genruntime.ConvertibleSpec = &VirtualNetworkGateways_Spec{}
 // ConvertSpecFrom populates our VirtualNetworkGateways_Spec from the provided source
 func (virtualNetworkGatewaysSpec *VirtualNetworkGateways_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == virtualNetworkGatewaysSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(virtualNetworkGatewaysSpec)
@@ -205,7 +205,7 @@ func (virtualNetworkGatewaysSpec *VirtualNetworkGateways_Spec) ConvertSpecFrom(s
 // ConvertSpecTo populates the provided destination from our VirtualNetworkGateways_Spec
 func (virtualNetworkGatewaysSpec *VirtualNetworkGateways_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == virtualNetworkGatewaysSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(virtualNetworkGatewaysSpec)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_types_gen.go
@@ -137,7 +137,7 @@ var _ genruntime.ConvertibleStatus = &VirtualNetwork_Status{}
 // ConvertStatusFrom populates our VirtualNetwork_Status from the provided source
 func (virtualNetworkStatus *VirtualNetwork_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == virtualNetworkStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(virtualNetworkStatus)
@@ -146,7 +146,7 @@ func (virtualNetworkStatus *VirtualNetwork_Status) ConvertStatusFrom(source genr
 // ConvertStatusTo populates the provided destination from our VirtualNetwork_Status
 func (virtualNetworkStatus *VirtualNetwork_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == virtualNetworkStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(virtualNetworkStatus)
@@ -181,7 +181,7 @@ var _ genruntime.ConvertibleSpec = &VirtualNetworks_Spec{}
 // ConvertSpecFrom populates our VirtualNetworks_Spec from the provided source
 func (virtualNetworksSpec *VirtualNetworks_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == virtualNetworksSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(virtualNetworksSpec)
@@ -190,7 +190,7 @@ func (virtualNetworksSpec *VirtualNetworks_Spec) ConvertSpecFrom(source genrunti
 // ConvertSpecTo populates the provided destination from our VirtualNetworks_Spec
 func (virtualNetworksSpec *VirtualNetworks_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == virtualNetworksSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(virtualNetworksSpec)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_subnet_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_subnet_types_gen.go
@@ -142,7 +142,7 @@ var _ genruntime.ConvertibleStatus = &Subnet_Status_VirtualNetworksSubnet_SubRes
 // ConvertStatusFrom populates our Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded from the provided source
 func (subnetStatusVirtualNetworksSubnetSubResourceEmbedded *Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == subnetStatusVirtualNetworksSubnetSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(subnetStatusVirtualNetworksSubnetSubResourceEmbedded)
@@ -151,7 +151,7 @@ func (subnetStatusVirtualNetworksSubnetSubResourceEmbedded *Subnet_Status_Virtua
 // ConvertStatusTo populates the provided destination from our Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded
 func (subnetStatusVirtualNetworksSubnetSubResourceEmbedded *Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == subnetStatusVirtualNetworksSubnetSubResourceEmbedded {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(subnetStatusVirtualNetworksSubnetSubResourceEmbedded)
@@ -188,7 +188,7 @@ var _ genruntime.ConvertibleSpec = &VirtualNetworksSubnets_Spec{}
 // ConvertSpecFrom populates our VirtualNetworksSubnets_Spec from the provided source
 func (virtualNetworksSubnetsSpec *VirtualNetworksSubnets_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == virtualNetworksSubnetsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(virtualNetworksSubnetsSpec)
@@ -197,7 +197,7 @@ func (virtualNetworksSubnetsSpec *VirtualNetworksSubnets_Spec) ConvertSpecFrom(s
 // ConvertSpecTo populates the provided destination from our VirtualNetworksSubnets_Spec
 func (virtualNetworksSubnetsSpec *VirtualNetworksSubnets_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == virtualNetworksSubnetsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(virtualNetworksSubnetsSpec)

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_virtual_network_peering_types_gen.go
@@ -134,7 +134,7 @@ var _ genruntime.ConvertibleStatus = &VirtualNetworkPeering_Status{}
 // ConvertStatusFrom populates our VirtualNetworkPeering_Status from the provided source
 func (virtualNetworkPeeringStatus *VirtualNetworkPeering_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == virtualNetworkPeeringStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(virtualNetworkPeeringStatus)
@@ -143,7 +143,7 @@ func (virtualNetworkPeeringStatus *VirtualNetworkPeering_Status) ConvertStatusFr
 // ConvertStatusTo populates the provided destination from our VirtualNetworkPeering_Status
 func (virtualNetworkPeeringStatus *VirtualNetworkPeering_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == virtualNetworkPeeringStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(virtualNetworkPeeringStatus)
@@ -177,7 +177,7 @@ var _ genruntime.ConvertibleSpec = &VirtualNetworksVirtualNetworkPeerings_Spec{}
 // ConvertSpecFrom populates our VirtualNetworksVirtualNetworkPeerings_Spec from the provided source
 func (virtualNetworksVirtualNetworkPeeringsSpec *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == virtualNetworksVirtualNetworkPeeringsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(virtualNetworksVirtualNetworkPeeringsSpec)
@@ -186,7 +186,7 @@ func (virtualNetworksVirtualNetworkPeeringsSpec *VirtualNetworksVirtualNetworkPe
 // ConvertSpecTo populates the provided destination from our VirtualNetworksVirtualNetworkPeerings_Spec
 func (virtualNetworksVirtualNetworkPeeringsSpec *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == virtualNetworksVirtualNetworkPeeringsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(virtualNetworksVirtualNetworkPeeringsSpec)

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespace_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespace_types_gen.go
@@ -130,7 +130,7 @@ var _ genruntime.ConvertibleSpec = &Namespaces_Spec{}
 // ConvertSpecFrom populates our Namespaces_Spec from the provided source
 func (namespacesSpec *Namespaces_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == namespacesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(namespacesSpec)
@@ -139,7 +139,7 @@ func (namespacesSpec *Namespaces_Spec) ConvertSpecFrom(source genruntime.Convert
 // ConvertSpecTo populates the provided destination from our Namespaces_Spec
 func (namespacesSpec *Namespaces_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == namespacesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(namespacesSpec)
@@ -174,7 +174,7 @@ var _ genruntime.ConvertibleStatus = &SBNamespace_Status{}
 // ConvertStatusFrom populates our SBNamespace_Status from the provided source
 func (sbNamespaceStatus *SBNamespace_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == sbNamespaceStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(sbNamespaceStatus)
@@ -183,7 +183,7 @@ func (sbNamespaceStatus *SBNamespace_Status) ConvertStatusFrom(source genruntime
 // ConvertStatusTo populates the provided destination from our SBNamespace_Status
 func (sbNamespaceStatus *SBNamespace_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == sbNamespaceStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(sbNamespaceStatus)

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_queue_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_queue_types_gen.go
@@ -142,7 +142,7 @@ var _ genruntime.ConvertibleSpec = &NamespacesQueues_Spec{}
 // ConvertSpecFrom populates our NamespacesQueues_Spec from the provided source
 func (namespacesQueuesSpec *NamespacesQueues_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == namespacesQueuesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(namespacesQueuesSpec)
@@ -151,7 +151,7 @@ func (namespacesQueuesSpec *NamespacesQueues_Spec) ConvertSpecFrom(source genrun
 // ConvertSpecTo populates the provided destination from our NamespacesQueues_Spec
 func (namespacesQueuesSpec *NamespacesQueues_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == namespacesQueuesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(namespacesQueuesSpec)
@@ -194,7 +194,7 @@ var _ genruntime.ConvertibleStatus = &SBQueue_Status{}
 // ConvertStatusFrom populates our SBQueue_Status from the provided source
 func (sbQueueStatus *SBQueue_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == sbQueueStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(sbQueueStatus)
@@ -203,7 +203,7 @@ func (sbQueueStatus *SBQueue_Status) ConvertStatusFrom(source genruntime.Convert
 // ConvertStatusTo populates the provided destination from our SBQueue_Status
 func (sbQueueStatus *SBQueue_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == sbQueueStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(sbQueueStatus)

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_topic_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_topic_types_gen.go
@@ -137,7 +137,7 @@ var _ genruntime.ConvertibleSpec = &NamespacesTopics_Spec{}
 // ConvertSpecFrom populates our NamespacesTopics_Spec from the provided source
 func (namespacesTopicsSpec *NamespacesTopics_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == namespacesTopicsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(namespacesTopicsSpec)
@@ -146,7 +146,7 @@ func (namespacesTopicsSpec *NamespacesTopics_Spec) ConvertSpecFrom(source genrun
 // ConvertSpecTo populates the provided destination from our NamespacesTopics_Spec
 func (namespacesTopicsSpec *NamespacesTopics_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == namespacesTopicsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(namespacesTopicsSpec)
@@ -184,7 +184,7 @@ var _ genruntime.ConvertibleStatus = &SBTopic_Status{}
 // ConvertStatusFrom populates our SBTopic_Status from the provided source
 func (sbTopicStatus *SBTopic_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == sbTopicStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(sbTopicStatus)
@@ -193,7 +193,7 @@ func (sbTopicStatus *SBTopic_Status) ConvertStatusFrom(source genruntime.Convert
 // ConvertStatusTo populates the provided destination from our SBTopic_Status
 func (sbTopicStatus *SBTopic_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == sbTopicStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(sbTopicStatus)

--- a/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_account_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_account_types_gen.go
@@ -158,7 +158,7 @@ var _ genruntime.ConvertibleStatus = &StorageAccount_Status{}
 // ConvertStatusFrom populates our StorageAccount_Status from the provided source
 func (storageAccountStatus *StorageAccount_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == storageAccountStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(storageAccountStatus)
@@ -167,7 +167,7 @@ func (storageAccountStatus *StorageAccount_Status) ConvertStatusFrom(source genr
 // ConvertStatusTo populates the provided destination from our StorageAccount_Status
 func (storageAccountStatus *StorageAccount_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == storageAccountStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(storageAccountStatus)
@@ -215,7 +215,7 @@ var _ genruntime.ConvertibleSpec = &StorageAccounts_Spec{}
 // ConvertSpecFrom populates our StorageAccounts_Spec from the provided source
 func (storageAccountsSpec *StorageAccounts_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == storageAccountsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(storageAccountsSpec)
@@ -224,7 +224,7 @@ func (storageAccountsSpec *StorageAccounts_Spec) ConvertSpecFrom(source genrunti
 // ConvertSpecTo populates the provided destination from our StorageAccounts_Spec
 func (storageAccountsSpec *StorageAccounts_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == storageAccountsSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(storageAccountsSpec)

--- a/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_service_types_gen.go
@@ -132,7 +132,7 @@ var _ genruntime.ConvertibleStatus = &BlobServiceProperties_Status{}
 // ConvertStatusFrom populates our BlobServiceProperties_Status from the provided source
 func (blobServicePropertiesStatus *BlobServiceProperties_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == blobServicePropertiesStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(blobServicePropertiesStatus)
@@ -141,7 +141,7 @@ func (blobServicePropertiesStatus *BlobServiceProperties_Status) ConvertStatusFr
 // ConvertStatusTo populates the provided destination from our BlobServiceProperties_Status
 func (blobServicePropertiesStatus *BlobServiceProperties_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == blobServicePropertiesStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(blobServicePropertiesStatus)
@@ -172,7 +172,7 @@ var _ genruntime.ConvertibleSpec = &StorageAccountsBlobServices_Spec{}
 // ConvertSpecFrom populates our StorageAccountsBlobServices_Spec from the provided source
 func (storageAccountsBlobServicesSpec *StorageAccountsBlobServices_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == storageAccountsBlobServicesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(storageAccountsBlobServicesSpec)
@@ -181,7 +181,7 @@ func (storageAccountsBlobServicesSpec *StorageAccountsBlobServices_Spec) Convert
 // ConvertSpecTo populates the provided destination from our StorageAccountsBlobServices_Spec
 func (storageAccountsBlobServicesSpec *StorageAccountsBlobServices_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == storageAccountsBlobServicesSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(storageAccountsBlobServicesSpec)

--- a/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_services_container_types_gen.go
@@ -140,7 +140,7 @@ var _ genruntime.ConvertibleStatus = &BlobContainer_Status{}
 // ConvertStatusFrom populates our BlobContainer_Status from the provided source
 func (blobContainerStatus *BlobContainer_Status) ConvertStatusFrom(source genruntime.ConvertibleStatus) error {
 	if source == blobContainerStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return source.ConvertStatusTo(blobContainerStatus)
@@ -149,7 +149,7 @@ func (blobContainerStatus *BlobContainer_Status) ConvertStatusFrom(source genrun
 // ConvertStatusTo populates the provided destination from our BlobContainer_Status
 func (blobContainerStatus *BlobContainer_Status) ConvertStatusTo(destination genruntime.ConvertibleStatus) error {
 	if destination == blobContainerStatus {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleStatus")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleStatus")
 	}
 
 	return destination.ConvertStatusFrom(blobContainerStatus)
@@ -181,7 +181,7 @@ var _ genruntime.ConvertibleSpec = &StorageAccountsBlobServicesContainers_Spec{}
 // ConvertSpecFrom populates our StorageAccountsBlobServicesContainers_Spec from the provided source
 func (storageAccountsBlobServicesContainersSpec *StorageAccountsBlobServicesContainers_Spec) ConvertSpecFrom(source genruntime.ConvertibleSpec) error {
 	if source == storageAccountsBlobServicesContainersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return source.ConvertSpecTo(storageAccountsBlobServicesContainersSpec)
@@ -190,7 +190,7 @@ func (storageAccountsBlobServicesContainersSpec *StorageAccountsBlobServicesCont
 // ConvertSpecTo populates the provided destination from our StorageAccountsBlobServicesContainers_Spec
 func (storageAccountsBlobServicesContainersSpec *StorageAccountsBlobServicesContainers_Spec) ConvertSpecTo(destination genruntime.ConvertibleSpec) error {
 	if destination == storageAccountsBlobServicesContainersSpec {
-		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/hack/generated/pkg/genruntime/ConvertibleSpec")
+		return errors.New("attempted conversion between unrelated implementations of github.com/Azure/azure-service-operator/v2/pkg/genruntime/ConvertibleSpec")
 	}
 
 	return destination.ConvertSpecFrom(storageAccountsBlobServicesContainersSpec)


### PR DESCRIPTION
**What this PR does / why we need it**:
After #1844 landed, a misconfiguration meant that the API types were being generated one directory higher than intended, so never overwriting the existing `v2/api` types. It turns out that the generator interprets the `typesOutputPath` relative to the destination `go.mod` location, not the working directory. 

Fixing the config revealed that the new generated types had some library imports still referring to `hack/generated`, but also some pointing at `hack/generator` - it turned out that `Configuration.getModuleSuffix` method was trying to interpret `typesOutputPath` relative to the working dir, but since it actually should just be the same as the `typesOutputPath` config value I removed it. 

We probably also need a test in CI that checks that generating the types actually updates them - I only spotted the problem because I added a new resource to the config but couldn't find the corresponding type in the expected place.