### PR TITLE
Initial support for 'format' in specs

### DIFF
--- a/hack/generator/pkg/astmodel/kubebuilder_validations.go
+++ b/hack/generator/pkg/astmodel/kubebuilder_validations.go
@@ -12,9 +12,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Azure/azure-service-operator/hack/generator/pkg/astbuilder"
 	"github.com/dave/dst"
 	"k8s.io/klog/v2"
+
+	"github.com/Azure/azure-service-operator/hack/generator/pkg/astbuilder"
 )
 
 // KubeBuilderValidation represents some kind of data validation on a property
@@ -130,7 +131,7 @@ func ValidateMaxLength(length int64) KubeBuilderValidation {
 	return KubeBuilderValidation{MaxLengthValidationName, length}
 }
 
-func ValidatePattern(pattern regexp.Regexp) KubeBuilderValidation {
+func ValidatePattern(pattern *regexp.Regexp) KubeBuilderValidation {
 	return KubeBuilderValidation{PatternValidationName, fmt.Sprintf("%q", pattern.String())}
 }
 

--- a/hack/generator/pkg/interfaces/kubernetes_resource_interface.go
+++ b/hack/generator/pkg/interfaces/kubernetes_resource_interface.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dave/dst"
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/astbuilder"
 	"github.com/Azure/azure-service-operator/hack/generator/pkg/astmodel"
@@ -134,13 +135,14 @@ func getAzureNameFunctionsForType(r **astmodel.ResourceType, spec *astmodel.Obje
 		}
 
 		validations := azureNamePropType.Validations().(astmodel.StringValidations)
-		if validations.Pattern != nil {
-			if validations.Pattern.String() == "^.*/default$" {
+		if len(validations.Patterns) != 0 {
+			if len(validations.Patterns) == 1 &&
+				validations.Patterns[0].String() == "^.*/default$" {
 				*r = (*r).WithSpec(spec.WithoutProperty(astmodel.AzureNameProperty))
 				return fixedValueGetAzureNameFunction("default"), nil, nil // no SetAzureName for this case
 			} else {
 				// ignoring for now:
-				// return nil, errors.Errorf("unable to handle pattern in Name property: %s", validations.Pattern.String())
+				klog.Warningf("unable to handle pattern in Name property: %s", validations.Patterns[0].String())
 				return getStringAzureNameFunction, setStringAzureNameFunction, nil
 			}
 		} else {

--- a/hack/generator/pkg/jsonast/schema_abstraction.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction.go
@@ -38,6 +38,7 @@ type Schema interface {
 	maxLength() *int64
 	minLength() *int64
 	pattern() *regexp.Regexp
+	format() string
 
 	// complex things
 	hasOneOf() bool

--- a/hack/generator/pkg/jsonast/schema_abstraction_gojson.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction_gojson.go
@@ -97,6 +97,10 @@ func (schema GoJSONSchema) minLength() *int64 {
 	return intPointerToInt64Pointer(schema.inner.MinLength)
 }
 
+func (schema GoJSONSchema) format() string {
+	return schema.inner.Format
+}
+
 func intPointerToInt64Pointer(ptr *int) *int64 {
 	if ptr == nil {
 		return nil

--- a/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
+++ b/hack/generator/pkg/jsonast/schema_abstraction_openapi.go
@@ -125,6 +125,10 @@ func (schema *OpenAPISchema) minLength() *int64 {
 	return schema.inner.MinLength
 }
 
+func (schema *OpenAPISchema) format() string {
+	return schema.inner.Format
+}
+
 func (schema *OpenAPISchema) pattern() *regexp.Regexp {
 	p := schema.inner.Pattern
 	if p == "" {


### PR DESCRIPTION
Values of type `string` in JSON/OpenAPI schema can also have `format` which describes the format of the string. Add support for transforming this into a regex validation that Kubebuilder can use.

At the moment this doesn’t have a huge impact (since we are consuming the ARM schemata which are already preprocessed) but if we come to rely on Swagger more then this will be used more.

There are a few interesting formats: potentially `password` could be leveraged to indicate where we should handle secrets Kubernetes-natively.