### PR TITLE
Fix multiple Test-Request-Attempt headers

### DIFF
--- a/v2/internal/controller/testcommon/counting_roundtripper.go
+++ b/v2/internal/controller/testcommon/counting_roundtripper.go
@@ -40,7 +40,7 @@ func (rt *requestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
 	count := rt.counts[key]
 	rt.counts[key] = count + 1
 	rt.countsMutex.Unlock()
-	req.Header.Add(COUNT_HEADER, fmt.Sprintf("%d", count))
+	req.Header.Set(COUNT_HEADER, fmt.Sprintf("%d", count))
 	return rt.inner.RoundTrip(req)
 }
 


### PR DESCRIPTION
If a single request object is reused for multiple requests we get multiple `Test-Request-Attempt` headers, when we should only ever have one.