### PR TITLE
Fix to skip containing file

### DIFF
--- a/v2/internal/generator/jsonast/schema_abstraction_openapi.go
+++ b/v2/internal/generator/jsonast/schema_abstraction_openapi.go
@@ -291,7 +291,7 @@ func (schema *OpenAPISchema) refTypeName() (astmodel.TypeName, error) {
 		// we don’t conflict with “sibling” files as well as the pulling-in file
 		otherFiles := schema.loader.knownFiles()
 		for _, otherFile := range otherFiles {
-			if otherFile == absRefPath {
+			if otherFile == filepath.ToSlash(absRefPath) {
 				continue // skip containing file
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes something that wasn't fixed in #1859:

Need to use normalized file path when skipping the containing file.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/gzMzeLJmd44WQ/giphy.gif)
