### PR TITLE
Update label used to track issues needing triage

### DIFF
--- a/.github/workflows/add-needs-triage-label.yml
+++ b/.github/workflows/add-needs-triage-label.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Label issues
         uses: andymckay/labeler@1825c391d68ade591efa053af2472e5b0e2e2d9e # this is v1.0.3
         with:
-          add-labels: "needs-triage"
+          add-labels: "needs-triage :mag:"


### PR DESCRIPTION
**What this PR does / why we need it**:

I renamed the label from "**needs-triage**" to "**needs-triage :mag:**" and need to update the action to match.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif)
