### PR TITLE
Use 15m timeout for tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,19 +81,19 @@ tasks:
     desc: Run {{.GENERATOR_APP}} unit tests.
     dir: v2
     cmds:
-    - go test ./internal/generator/... -tags=noexit -run '{{default ".*" .TEST_FILTER}}'
+    - go test ./internal/generator/... -tags=noexit -timeout 15m -run '{{default ".*" .TEST_FILTER}}'
 
   generator:unit-tests-cover:
     desc: Run {{.GENERATOR_APP}} unit tests and output coverage.
     dir: v2
     cmds:
-    - go test ./internal/generator/... -tags=noexit -race -covermode atomic -coverprofile=generator-coverage.out -coverpkg=./... -run '{{default ".*" .TEST_FILTER}}'
+    - go test ./internal/generator/... -tags=noexit -timeout 15m -race -covermode atomic -coverprofile=generator-coverage.out -coverpkg=./... -run '{{default ".*" .TEST_FILTER}}'
 
   generator:update-golden-tests:
     desc: Update {{.GENERATOR_APP}} golden test outputs.
     dir: v2
     cmds:
-    - go test ./internal/generator/... -run ^TestGolden -update
+    - go test ./internal/generator/... -run ^TestGolden -update -timeout 15m
 
   generator:lint:
     desc: Run {{.GENERATOR_APP}} fast lint checks.
@@ -170,14 +170,14 @@ tasks:
     dir: "{{.CONTROLLER_ROOT}}"
     deps: [controller:generate-crds]
     cmds:
-    - go test -short -tags=noexit -run '{{default ".*" .TEST_FILTER}}' ./...
+    - go test -short -tags=noexit -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./...
 
   controller:test-cover:
     desc: Run {{.CONTROLLER_APP}} unit tests and output coverage.
     dir: "{{.CONTROLLER_ROOT}}"
     deps: [controller:generate-crds]
     cmds: 
-    - go test -short -tags=noexit -race -covermode atomic -coverprofile=controller-coverage.out -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./...
+    - go test -short -tags=noexit -timeout 15m -race -covermode atomic -coverprofile=controller-coverage.out -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./...
 
   controller:build:
     desc: Generate the {{.CONTROLLER_APP}} binary.
@@ -232,7 +232,7 @@ tasks:
     deps: [controller:generate-kustomize]
     cmds:
     # -race fails at the moment in controller-runtime
-    - go test -run '{{default ".*" .TEST_FILTER}}' ./...
+    - go test -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./...
 
   controller:test-integration-envtest-cover:
     desc: Run integration tests with envtest using record/replay and output coverage.
@@ -240,7 +240,7 @@ tasks:
     deps: [controller:generate-kustomize]
     cmds:
     # -race fails at the moment in controller-runtime
-    - go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -run '{{default ".*" .TEST_FILTER}}' ./...
+    - go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./...
 
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.
@@ -353,13 +353,13 @@ tasks:
 #    desc: Run {{.CROSSPLANE_APP}} unit tests.
 #    dir: "{{.CROSSPLANE_ROOT}}"
 #    cmds:
-#      - go test ./... -tags=noexit
+#      - go test ./... -tags=noexit -timeout 15m
 
 #  crossplane:update-golden-tests:
 #    desc: Update {{.CROSSPLANE_APP}} golden test outputs.
 #    dir: "{{.CROSSPLANE_ROOT}}"
 #    cmds:
-#      - go test ./pkg/codegen -run ^TestGolden$ -update
+#      - go test ./pkg/codegen -run ^TestGolden$ -update -timeout 15m
 
   # TODO: No non-generated code in this directory at the moment
   # crossplane:lint:


### PR DESCRIPTION
**What this PR does / why we need it**:

Our tests are becoming unreliable because they timeout under the standard go test limit of 10m. 

Explicitly changing the timeout to 15m to mitigate. Each use of `go test` is configured separately, so we can easilyi tweak them individually in the future if needed.

PR #1860 will make things faster, but we'll keep the higher headroom.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/F7wOACRm9z6ow/giphy.gif)
