### PR TITLE
Add the ability to rename resources

### DIFF
--- a/v2/internal/generator/astmodel/renaming_visitor.go
+++ b/v2/internal/generator/astmodel/renaming_visitor.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import kerrors "k8s.io/apimachinery/pkg/util/errors"
+
+// RenamingVisitor is a visitor for performing simple TypeName renames
+type RenamingVisitor struct {
+	f func(TypeName) TypeName
+	// renames map[TypeName]TypeName
+	visitor TypeVisitor
+}
+
+// NewRenamingVisitor creates a new visitor which performs the renames specified
+func NewRenamingVisitor(renames map[TypeName]TypeName) *RenamingVisitor {
+	rename := func(name TypeName) TypeName {
+		typeName := name
+		rename, ok := renames[name]
+		if ok {
+			typeName = rename
+		}
+
+		return typeName
+	}
+
+	return NewRenamingVisitorFromLambda(rename)
+}
+
+// NewRenamingVisitorFromLambda creates a new visitor which performs renames using the specified lambda
+func NewRenamingVisitorFromLambda(f func(name TypeName) TypeName) *RenamingVisitor {
+	r := &RenamingVisitor{
+		f: f,
+	}
+
+	rename := func(this *TypeVisitor, it TypeName, ctx interface{}) (Type, error) {
+		newName := f(it)
+		return IdentityVisitOfTypeName(this, newName, ctx)
+	}
+
+	r.visitor = TypeVisitorBuilder{
+		VisitTypeName: rename,
+	}.Build()
+
+	return r
+}
+
+// Rename applies the renames to the Type
+func (r *RenamingVisitor) Rename(t Type) (Type, error) {
+	return r.visitor.Visit(t, nil)
+}
+
+// RenameAll applies the renames to the Types
+func (r *RenamingVisitor) RenameAll(types Types) (Types, error) {
+	result := make(Types)
+	var errs []error
+
+	for _, def := range types {
+		renamed, err := r.visitor.VisitDefinition(def, nil)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		result.Add(renamed)
+	}
+
+	err := kerrors.NewAggregate(errs)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/v2/internal/generator/astmodel/renaming_visitor_test.go
+++ b/v2/internal/generator/astmodel/renaming_visitor_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package astmodel
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRenamingVisitor_RenamesTypeAndReferences(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	badObject := NewTestObject("BadName")
+
+	prop := NewPropertyDefinition("Ref", "ref", badObject.Name())
+	otherObject := NewTestObject("Container", prop)
+
+	types := make(Types)
+	types.Add(badObject)
+	types.Add(otherObject)
+
+	newName := badObject.Name().WithName("GoodName")
+	renames := map[TypeName]TypeName{
+		badObject.Name(): newName,
+	}
+	renamer := NewRenamingVisitor(renames)
+	result, err := renamer.RenameAll(types)
+
+	expectedRenamedTypeName := badObject.Name().WithName("GoodName")
+	expectedOtherObject := otherObject.Type().(*ObjectType).WithProperty(prop.WithType(expectedRenamedTypeName))
+	expectedResult := make(Types)
+
+	expectedResult.Add(badObject.WithName(expectedRenamedTypeName))
+	expectedResult.Add(otherObject.WithType(expectedOtherObject))
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(expectedResult))
+}

--- a/v2/internal/generator/astmodel/type_name.go
+++ b/v2/internal/generator/astmodel/type_name.go
@@ -38,6 +38,11 @@ func (typeName TypeName) Name() string {
 	return typeName.name
 }
 
+// WithName returns a new TypeName in the same package but with a different name
+func (typeName TypeName) WithName(name string) TypeName {
+	return MakeTypeName(typeName.PackageReference, name)
+}
+
 // A TypeName can be used as a Type,
 // it is simply a reference to the name.
 var _ Type = TypeName{}

--- a/v2/internal/generator/config/export_filter.go
+++ b/v2/internal/generator/config/export_filter.go
@@ -5,6 +5,8 @@
 
 package config
 
+import "github.com/pkg/errors"
+
 // ExportFilterAction defines the possible actions that should happen for types matching the filter
 type ExportFilterAction string
 
@@ -23,6 +25,45 @@ const (
 
 // A ExportFilter is used to control which types should be exported by the generator
 type ExportFilter struct {
-	Action      ExportFilterAction
+	Action ExportFilterAction
+	// RenameTo indicates that the type matched by this export filter should be renamed to the
+	// specified name. This may only be used with the include-transitive ExportFilterAction. If
+	// the matcher matches more than a single type, an error is raised as we cannot rename multiple types
+	// to the same name.
+	RenameTo    string `yaml:"renameTo,omitempty"`
 	TypeMatcher `yaml:",inline"`
+}
+
+// Initialize initializes the export filter
+func (f *ExportFilter) Initialize() error {
+	err := f.TypeMatcher.Initialize()
+	if err != nil {
+		return err
+	}
+
+	if f.RenameTo != "" && f.Action != ExportFilterIncludeTransitive {
+		return errors.Errorf(
+			"ExportFilter %s. RenameTo can only be specified on ExportFilters with Action %q",
+			f.TypeMatcher.String(),
+			ExportFilterIncludeTransitive)
+	}
+
+	return nil
+}
+
+// Error returns an error if the filter encountered an error, or nil if there was no error.
+func (f *ExportFilter) Error() error {
+	if !f.MatchedRequiredTypes() {
+		return errors.Errorf("Export filter action: %q, target: %q matched no types", f.Action, f.String())
+	}
+
+	// No need to check that include-transitive is the action as that was already ensured above in Initialize()
+	if f.RenameTo != "" && len(f.matchedTypes) != 1 {
+		return errors.Errorf(
+			"Export filter action: %q, target: %q has RenameTo specified and matched multiple types",
+			f.Action,
+			f.String())
+	}
+
+	return nil
 }

--- a/v2/internal/generator/config/export_filter_test.go
+++ b/v2/internal/generator/config/export_filter_test.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/internal/generator/config"
+)
+
+func Test_ExportFilterWithRenameTo_ErrorWhenNotIncludeTransitive(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	exportFilter := config.ExportFilter{
+		Action: config.ExportFilterInclude,
+		TypeMatcher: config.TypeMatcher{
+			Group:   "foo",
+			Version: "bar",
+			Name:    "baz",
+		},
+		RenameTo: "Test",
+	}
+	err := exportFilter.Initialize()
+	g.Expect(err).To(Not(BeNil()))
+	g.Expect(err.Error()).To(ContainSubstring("RenameTo can only be specified on ExportFilters with Action \"include-transitive\""))
+}

--- a/v2/internal/generator/config/type_transformer.go
+++ b/v2/internal/generator/config/type_transformer.go
@@ -57,7 +57,6 @@ type TypeTransformer struct {
 	matchedProperties map[astmodel.TypeName]string
 }
 
-// TODO: passing this here is a bit icky
 func produceTargetType(target TransformTarget, descriptor string, makeLocalPackageReferenceFunc func(group string, version string) astmodel.LocalPackageReference) (astmodel.Type, error) {
 	if target.Name != "" && target.Map != nil {
 		return nil, errors.Errorf("multiple target types defined")


### PR DESCRIPTION
This is required in order to deal with really long named resources, like: `DatabaseAccountsMongodbDatabasesCollectionsThroughputSettingList`, which are so long they no longer comply with Kubernetes resource naming guidelines (<=63 chars).

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
