### PR TITLE
Ensure that ASOv1 and ASOv2 can be deployed side by side

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+**Version of Azure Service Operator**
+<!--- 
+The version of the operator pod. 
+Assuming your ASO is deployed in the default namespace, you can get this version from the container image which the controller is running.
+Use one of the following commands:
+ASO V1: `kubectl get deployment -n azureoperator-system azureoperator-controller-manager -o wide` and share the image being used by the manager container.
+ASO V2: `kubectl get deployment -n azureserviceoperator-system azureserviceoperator-controller-manager -o wide` and share the image being used by the manager container.   
+-->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/docs/hugo/content/docs/create-a-new-release.md
+++ b/docs/hugo/content/docs/create-a-new-release.md
@@ -11,10 +11,10 @@
 1. Download the yaml file from the release page
 2. Create a kind cluster: `task controller:kind-create`
 3. Install cert-manager: `task controller:install-cert-manager`
-4. Create the namespace for the operator: `k create namespace azureoperator-system`
+4. Create the namespace for the operator: `k create namespace azureserviceoperator-system`
 5. Source the SP credentials to use for the secret and then run `./scripts/deploy_testing_secret.sh`
 6. Deploy the operator from MCR: `k apply -f <path-to-downloaded-yaml>`
-7. Wait for it to start: `k get all -n azureoperator-system`
+7. Wait for it to start: `k get all -n azureserviceoperator-system`
 8. Create a resource group: `k apply -f v2/config/samples/microsoft.resources/v1alpha1api20200601_resourcegroup.yaml`
 9. Make sure it deploys successfully, and check in the portal.
 

--- a/scripts/deploy_testing_secret.sh
+++ b/scripts/deploy_testing_secret.sh
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aso-controller-settings
-  namespace: azureoperator-system
+  namespace: azureserviceoperator-system
 stringData:
   AZURE_SUBSCRIPTION_ID: "$AZURE_SUBSCRIPTION_ID"
   AZURE_TENANT_ID: "$AZURE_TENANT_ID"

--- a/v2/README.md
+++ b/v2/README.md
@@ -70,7 +70,7 @@ Sample YAMLs for creating each of these resources can be found in the [samples d
    kind: Secret
    metadata:
      name: aso-controller-settings
-     namespace: azureoperator-system
+     namespace: azureserviceoperator-system
    stringData:
      AZURE_SUBSCRIPTION_ID: "$AZURE_SUBSCRIPTION_ID"
      AZURE_TENANT_ID: "$AZURE_TENANT_ID"
@@ -84,12 +84,12 @@ Sample YAMLs for creating each of these resources can be found in the [samples d
 Once the controller has been installed in your cluster, you should be able to run the following:
 
 ```bash
-$ kubectl get pods -n azureoperator-system
+$ kubectl get pods -n azureserviceoperator-system
 NAME                                                READY   STATUS    RESTARTS   AGE
-azureoperator-controller-manager-5b4bfc59df-lfpqf   2/2     Running   0          24s
+azureserviceoperator-controller-manager-5b4bfc59df-lfpqf   2/2     Running   0          24s
 
 # check out the logs for the running controller
-$ kubectl logs -n azureoperator-system azureoperator-controller-manager-5b4bfc59df-lfpqf manager 
+$ kubectl logs -n azureserviceoperator-system azureserviceoperator-controller-manager-5b4bfc59df-lfpqf manager 
 
 # let's create an Azure ResourceGroup in westcentralus with the name "aso-sample-rg"
 cat <<EOF | kubectl apply -f -

--- a/v2/config/default/kustomization.yaml
+++ b/v2/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: azureoperator-system
+namespace: azureserviceoperator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: azureoperator-
+namePrefix: azureserviceoperator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -11,6 +11,7 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
+    app: azure-service-operator-v2
     control-plane: controller-manager
 spec:
   selector:


### PR DESCRIPTION
Prior to this, because we were sharing the same namespace and the same resource names, the ASOv1 and ASOv2  Deployment, Service, and various webhooks would all collide.

Also update bug template to request users share the version of ASO with us when filing a bug.