### PR TITLE
Apply heuristics to add line breaks to complex function calls

### DIFF
--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment__status_arm_types_gen_test.go
@@ -157,7 +157,11 @@ func AddIndependentPropertyGeneratorsForRoleAssignmentPropertiesStatusARM(gens m
 	gens["DelegatedManagedIdentityResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalId"] = gen.AlphaString()
-	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(RoleAssignmentPropertiesStatusPrincipalTypeForeignGroup, RoleAssignmentPropertiesStatusPrincipalTypeGroup, RoleAssignmentPropertiesStatusPrincipalTypeServicePrincipal, RoleAssignmentPropertiesStatusPrincipalTypeUser))
+	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(
+		RoleAssignmentPropertiesStatusPrincipalTypeForeignGroup,
+		RoleAssignmentPropertiesStatusPrincipalTypeGroup,
+		RoleAssignmentPropertiesStatusPrincipalTypeServicePrincipal,
+		RoleAssignmentPropertiesStatusPrincipalTypeUser))
 	gens["RoleDefinitionId"] = gen.AlphaString()
 	gens["Scope"] = gen.PtrOf(gen.AlphaString())
 	gens["UpdatedBy"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen_test.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen_test.go
@@ -222,7 +222,11 @@ func AddIndependentPropertyGeneratorsForRoleAssignmentStatus(gens map[string]gop
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
-	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(RoleAssignmentPropertiesStatusPrincipalTypeForeignGroup, RoleAssignmentPropertiesStatusPrincipalTypeGroup, RoleAssignmentPropertiesStatusPrincipalTypeServicePrincipal, RoleAssignmentPropertiesStatusPrincipalTypeUser))
+	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(
+		RoleAssignmentPropertiesStatusPrincipalTypeForeignGroup,
+		RoleAssignmentPropertiesStatusPrincipalTypeGroup,
+		RoleAssignmentPropertiesStatusPrincipalTypeServicePrincipal,
+		RoleAssignmentPropertiesStatusPrincipalTypeUser))
 	gens["RoleDefinitionId"] = gen.PtrOf(gen.AlphaString())
 	gens["Scope"] = gen.PtrOf(gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
@@ -333,6 +337,10 @@ func AddIndependentPropertyGeneratorsForRoleAssignmentsSpec(gens map[string]gopt
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalId"] = gen.AlphaString()
-	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(RoleAssignmentPropertiesPrincipalTypeForeignGroup, RoleAssignmentPropertiesPrincipalTypeGroup, RoleAssignmentPropertiesPrincipalTypeServicePrincipal, RoleAssignmentPropertiesPrincipalTypeUser))
+	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(
+		RoleAssignmentPropertiesPrincipalTypeForeignGroup,
+		RoleAssignmentPropertiesPrincipalTypeGroup,
+		RoleAssignmentPropertiesPrincipalTypeServicePrincipal,
+		RoleAssignmentPropertiesPrincipalTypeUser))
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 }

--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignments__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignments__spec_arm_types_gen_test.go
@@ -155,6 +155,10 @@ func AddIndependentPropertyGeneratorsForRoleAssignmentPropertiesARM(gens map[str
 	gens["DelegatedManagedIdentityResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["PrincipalId"] = gen.AlphaString()
-	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(RoleAssignmentPropertiesPrincipalTypeForeignGroup, RoleAssignmentPropertiesPrincipalTypeGroup, RoleAssignmentPropertiesPrincipalTypeServicePrincipal, RoleAssignmentPropertiesPrincipalTypeUser))
+	gens["PrincipalType"] = gen.PtrOf(gen.OneConstOf(
+		RoleAssignmentPropertiesPrincipalTypeForeignGroup,
+		RoleAssignmentPropertiesPrincipalTypeGroup,
+		RoleAssignmentPropertiesPrincipalTypeServicePrincipal,
+		RoleAssignmentPropertiesPrincipalTypeUser))
 	gens["RoleDefinitionId"] = gen.AlphaString()
 }

--- a/v2/api/microsoft.batch/v1alpha1api20210101/batch_account__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101/batch_account__status_arm_types_gen_test.go
@@ -245,7 +245,13 @@ func AddIndependentPropertyGeneratorsForBatchAccountPropertiesStatusARM(gens map
 	gens["LowPriorityCoreQuota"] = gen.PtrOf(gen.Int())
 	gens["PoolAllocationMode"] = gen.PtrOf(gen.OneConstOf(PoolAllocationMode_StatusBatchService, PoolAllocationMode_StatusUserSubscription))
 	gens["PoolQuota"] = gen.PtrOf(gen.Int())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(BatchAccountPropertiesStatusProvisioningStateCancelled, BatchAccountPropertiesStatusProvisioningStateCreating, BatchAccountPropertiesStatusProvisioningStateDeleting, BatchAccountPropertiesStatusProvisioningStateFailed, BatchAccountPropertiesStatusProvisioningStateInvalid, BatchAccountPropertiesStatusProvisioningStateSucceeded))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		BatchAccountPropertiesStatusProvisioningStateCancelled,
+		BatchAccountPropertiesStatusProvisioningStateCreating,
+		BatchAccountPropertiesStatusProvisioningStateDeleting,
+		BatchAccountPropertiesStatusProvisioningStateFailed,
+		BatchAccountPropertiesStatusProvisioningStateInvalid,
+		BatchAccountPropertiesStatusProvisioningStateSucceeded))
 	gens["PublicNetworkAccess"] = gen.PtrOf(gen.OneConstOf(PublicNetworkAccessType_StatusDisabled, PublicNetworkAccessType_StatusEnabled))
 }
 
@@ -907,5 +913,9 @@ func PrivateLinkServiceConnectionStateStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForPrivateLinkServiceConnectionStateStatusARM(gens map[string]gopter.Gen) {
 	gens["ActionRequired"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
-	gens["Status"] = gen.OneConstOf(PrivateLinkServiceConnectionStatus_StatusApproved, PrivateLinkServiceConnectionStatus_StatusDisconnected, PrivateLinkServiceConnectionStatus_StatusPending, PrivateLinkServiceConnectionStatus_StatusRejected)
+	gens["Status"] = gen.OneConstOf(
+		PrivateLinkServiceConnectionStatus_StatusApproved,
+		PrivateLinkServiceConnectionStatus_StatusDisconnected,
+		PrivateLinkServiceConnectionStatus_StatusPending,
+		PrivateLinkServiceConnectionStatus_StatusRejected)
 }

--- a/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen_test.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen_test.go
@@ -231,7 +231,13 @@ func AddIndependentPropertyGeneratorsForBatchAccountStatus(gens map[string]gopte
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["PoolAllocationMode"] = gen.PtrOf(gen.OneConstOf(PoolAllocationMode_StatusBatchService, PoolAllocationMode_StatusUserSubscription))
 	gens["PoolQuota"] = gen.PtrOf(gen.Int())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(BatchAccountPropertiesStatusProvisioningStateCancelled, BatchAccountPropertiesStatusProvisioningStateCreating, BatchAccountPropertiesStatusProvisioningStateDeleting, BatchAccountPropertiesStatusProvisioningStateFailed, BatchAccountPropertiesStatusProvisioningStateInvalid, BatchAccountPropertiesStatusProvisioningStateSucceeded))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		BatchAccountPropertiesStatusProvisioningStateCancelled,
+		BatchAccountPropertiesStatusProvisioningStateCreating,
+		BatchAccountPropertiesStatusProvisioningStateDeleting,
+		BatchAccountPropertiesStatusProvisioningStateFailed,
+		BatchAccountPropertiesStatusProvisioningStateInvalid,
+		BatchAccountPropertiesStatusProvisioningStateSucceeded))
 	gens["PublicNetworkAccess"] = gen.PtrOf(gen.OneConstOf(PublicNetworkAccessType_StatusDisabled, PublicNetworkAccessType_StatusEnabled))
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
@@ -1909,5 +1915,9 @@ func PrivateLinkServiceConnectionStateStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForPrivateLinkServiceConnectionStateStatus(gens map[string]gopter.Gen) {
 	gens["ActionRequired"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
-	gens["Status"] = gen.OneConstOf(PrivateLinkServiceConnectionStatus_StatusApproved, PrivateLinkServiceConnectionStatus_StatusDisconnected, PrivateLinkServiceConnectionStatus_StatusPending, PrivateLinkServiceConnectionStatus_StatusRejected)
+	gens["Status"] = gen.OneConstOf(
+		PrivateLinkServiceConnectionStatus_StatusApproved,
+		PrivateLinkServiceConnectionStatus_StatusDisconnected,
+		PrivateLinkServiceConnectionStatus_StatusPending,
+		PrivateLinkServiceConnectionStatus_StatusRejected)
 }

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disk__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disk__status_arm_types_gen_test.go
@@ -173,7 +173,13 @@ func AddIndependentPropertyGeneratorsForDiskPropertiesStatusARM(gens map[string]
 	gens["DiskMBpsReadWrite"] = gen.PtrOf(gen.Int())
 	gens["DiskSizeBytes"] = gen.PtrOf(gen.Int())
 	gens["DiskSizeGB"] = gen.PtrOf(gen.Int())
-	gens["DiskState"] = gen.PtrOf(gen.OneConstOf(DiskState_StatusActiveSAS, DiskState_StatusActiveUpload, DiskState_StatusAttached, DiskState_StatusReadyToUpload, DiskState_StatusReserved, DiskState_StatusUnattached))
+	gens["DiskState"] = gen.PtrOf(gen.OneConstOf(
+		DiskState_StatusActiveSAS,
+		DiskState_StatusActiveUpload,
+		DiskState_StatusAttached,
+		DiskState_StatusReadyToUpload,
+		DiskState_StatusReserved,
+		DiskState_StatusUnattached))
 	gens["HyperVGeneration"] = gen.PtrOf(gen.OneConstOf(DiskPropertiesStatusHyperVGenerationV1, DiskPropertiesStatusHyperVGenerationV2))
 	gens["MaxShares"] = gen.PtrOf(gen.Int())
 	gens["NetworkAccessPolicy"] = gen.PtrOf(gen.OneConstOf(NetworkAccessPolicy_StatusAllowAll, NetworkAccessPolicy_StatusAllowPrivate, NetworkAccessPolicy_StatusDenyAll))
@@ -249,7 +255,11 @@ func DiskSkuStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDiskSkuStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDiskSkuStatusARM(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(DiskSkuStatusNamePremiumLRS, DiskSkuStatusNameStandardLRS, DiskSkuStatusNameStandardSSDLRS, DiskSkuStatusNameUltraSSDLRS))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		DiskSkuStatusNamePremiumLRS,
+		DiskSkuStatusNameStandardLRS,
+		DiskSkuStatusNameStandardSSDLRS,
+		DiskSkuStatusNameUltraSSDLRS))
 	gens["Tier"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -380,7 +390,14 @@ func CreationDataStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForCreationDataStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCreationDataStatusARM(gens map[string]gopter.Gen) {
-	gens["CreateOption"] = gen.OneConstOf(CreationDataStatusCreateOptionAttach, CreationDataStatusCreateOptionCopy, CreationDataStatusCreateOptionEmpty, CreationDataStatusCreateOptionFromImage, CreationDataStatusCreateOptionImport, CreationDataStatusCreateOptionRestore, CreationDataStatusCreateOptionUpload)
+	gens["CreateOption"] = gen.OneConstOf(
+		CreationDataStatusCreateOptionAttach,
+		CreationDataStatusCreateOptionCopy,
+		CreationDataStatusCreateOptionEmpty,
+		CreationDataStatusCreateOptionFromImage,
+		CreationDataStatusCreateOptionImport,
+		CreationDataStatusCreateOptionRestore,
+		CreationDataStatusCreateOptionUpload)
 	gens["LogicalSectorSize"] = gen.PtrOf(gen.Int())
 	gens["SourceResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceUniqueId"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen_test.go
@@ -229,7 +229,13 @@ func AddIndependentPropertyGeneratorsForDiskStatus(gens map[string]gopter.Gen) {
 	gens["DiskMBpsReadWrite"] = gen.PtrOf(gen.Int())
 	gens["DiskSizeBytes"] = gen.PtrOf(gen.Int())
 	gens["DiskSizeGB"] = gen.PtrOf(gen.Int())
-	gens["DiskState"] = gen.PtrOf(gen.OneConstOf(DiskState_StatusActiveSAS, DiskState_StatusActiveUpload, DiskState_StatusAttached, DiskState_StatusReadyToUpload, DiskState_StatusReserved, DiskState_StatusUnattached))
+	gens["DiskState"] = gen.PtrOf(gen.OneConstOf(
+		DiskState_StatusActiveSAS,
+		DiskState_StatusActiveUpload,
+		DiskState_StatusAttached,
+		DiskState_StatusReadyToUpload,
+		DiskState_StatusReserved,
+		DiskState_StatusUnattached))
 	gens["HyperVGeneration"] = gen.PtrOf(gen.OneConstOf(DiskPropertiesStatusHyperVGenerationV1, DiskPropertiesStatusHyperVGenerationV2))
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
@@ -494,7 +500,14 @@ func CreationDataGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForCreationData is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCreationData(gens map[string]gopter.Gen) {
-	gens["CreateOption"] = gen.OneConstOf(CreationDataCreateOptionAttach, CreationDataCreateOptionCopy, CreationDataCreateOptionEmpty, CreationDataCreateOptionFromImage, CreationDataCreateOptionImport, CreationDataCreateOptionRestore, CreationDataCreateOptionUpload)
+	gens["CreateOption"] = gen.OneConstOf(
+		CreationDataCreateOptionAttach,
+		CreationDataCreateOptionCopy,
+		CreationDataCreateOptionEmpty,
+		CreationDataCreateOptionFromImage,
+		CreationDataCreateOptionImport,
+		CreationDataCreateOptionRestore,
+		CreationDataCreateOptionUpload)
 	gens["LogicalSectorSize"] = gen.PtrOf(gen.Int())
 	gens["SourceUri"] = gen.PtrOf(gen.AlphaString())
 	gens["StorageAccountId"] = gen.PtrOf(gen.AlphaString())
@@ -611,7 +624,14 @@ func CreationDataStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForCreationDataStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCreationDataStatus(gens map[string]gopter.Gen) {
-	gens["CreateOption"] = gen.OneConstOf(CreationDataStatusCreateOptionAttach, CreationDataStatusCreateOptionCopy, CreationDataStatusCreateOptionEmpty, CreationDataStatusCreateOptionFromImage, CreationDataStatusCreateOptionImport, CreationDataStatusCreateOptionRestore, CreationDataStatusCreateOptionUpload)
+	gens["CreateOption"] = gen.OneConstOf(
+		CreationDataStatusCreateOptionAttach,
+		CreationDataStatusCreateOptionCopy,
+		CreationDataStatusCreateOptionEmpty,
+		CreationDataStatusCreateOptionFromImage,
+		CreationDataStatusCreateOptionImport,
+		CreationDataStatusCreateOptionRestore,
+		CreationDataStatusCreateOptionUpload)
 	gens["LogicalSectorSize"] = gen.PtrOf(gen.Int())
 	gens["SourceResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceUniqueId"] = gen.PtrOf(gen.AlphaString())
@@ -721,7 +741,11 @@ func DiskSkuGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDiskSku is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDiskSku(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(DiskSkuNamePremiumLRS, DiskSkuNameStandardLRS, DiskSkuNameStandardSSDLRS, DiskSkuNameUltraSSDLRS))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		DiskSkuNamePremiumLRS,
+		DiskSkuNameStandardLRS,
+		DiskSkuNameStandardSSDLRS,
+		DiskSkuNameUltraSSDLRS))
 }
 
 func Test_DiskSku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -819,7 +843,11 @@ func DiskSkuStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDiskSkuStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDiskSkuStatus(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(DiskSkuStatusNamePremiumLRS, DiskSkuStatusNameStandardLRS, DiskSkuStatusNameStandardSSDLRS, DiskSkuStatusNameUltraSSDLRS))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		DiskSkuStatusNamePremiumLRS,
+		DiskSkuStatusNameStandardLRS,
+		DiskSkuStatusNameStandardSSDLRS,
+		DiskSkuStatusNameUltraSSDLRS))
 	gens["Tier"] = gen.PtrOf(gen.AlphaString())
 }
 

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disks__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disks__spec_arm_types_gen_test.go
@@ -238,7 +238,11 @@ func DiskSkuARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDiskSkuARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDiskSkuARM(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(DiskSkuNamePremiumLRS, DiskSkuNameStandardLRS, DiskSkuNameStandardSSDLRS, DiskSkuNameUltraSSDLRS))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		DiskSkuNamePremiumLRS,
+		DiskSkuNameStandardLRS,
+		DiskSkuNameStandardSSDLRS,
+		DiskSkuNameUltraSSDLRS))
 }
 
 func Test_ExtendedLocationARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -367,7 +371,14 @@ func CreationDataARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForCreationDataARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCreationDataARM(gens map[string]gopter.Gen) {
-	gens["CreateOption"] = gen.OneConstOf(CreationDataCreateOptionAttach, CreationDataCreateOptionCopy, CreationDataCreateOptionEmpty, CreationDataCreateOptionFromImage, CreationDataCreateOptionImport, CreationDataCreateOptionRestore, CreationDataCreateOptionUpload)
+	gens["CreateOption"] = gen.OneConstOf(
+		CreationDataCreateOptionAttach,
+		CreationDataCreateOptionCopy,
+		CreationDataCreateOptionEmpty,
+		CreationDataCreateOptionFromImage,
+		CreationDataCreateOptionImport,
+		CreationDataCreateOptionRestore,
+		CreationDataCreateOptionUpload)
 	gens["LogicalSectorSize"] = gen.PtrOf(gen.Int())
 	gens["SourceResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceUri"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set__status_arm_types_gen_test.go
@@ -352,7 +352,11 @@ func VirtualMachineScaleSetIdentityStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetIdentityStatusARM(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(VirtualMachineScaleSetIdentityStatusTypeNone, VirtualMachineScaleSetIdentityStatusTypeSystemAssigned, VirtualMachineScaleSetIdentityStatusTypeSystemAssignedUserAssigned, VirtualMachineScaleSetIdentityStatusTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		VirtualMachineScaleSetIdentityStatusTypeNone,
+		VirtualMachineScaleSetIdentityStatusTypeSystemAssigned,
+		VirtualMachineScaleSetIdentityStatusTypeSystemAssignedUserAssigned,
+		VirtualMachineScaleSetIdentityStatusTypeUserAssigned))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualMachineScaleSetIdentityStatusARM is a factory method for creating gopter generators
@@ -2960,7 +2964,13 @@ func VirtualMachineScaleSetManagedDiskParametersStatusARMGenerator() gopter.Gen 
 
 // AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersStatusARM(gens map[string]gopter.Gen) {
-	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(StorageAccountType_StatusPremiumLRS, StorageAccountType_StatusPremiumZRS, StorageAccountType_StatusStandardLRS, StorageAccountType_StatusStandardSSDLRS, StorageAccountType_StatusStandardSSDZRS, StorageAccountType_StatusUltraSSDLRS))
+	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(
+		StorageAccountType_StatusPremiumLRS,
+		StorageAccountType_StatusPremiumZRS,
+		StorageAccountType_StatusStandardLRS,
+		StorageAccountType_StatusStandardSSDLRS,
+		StorageAccountType_StatusStandardSSDZRS,
+		StorageAccountType_StatusUltraSSDLRS))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersStatusARM is a factory method for creating gopter generators

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen_test.go
@@ -2095,7 +2095,11 @@ func VirtualMachineScaleSetIdentityGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVirtualMachineScaleSetIdentity is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetIdentity(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(VirtualMachineScaleSetIdentityTypeNone, VirtualMachineScaleSetIdentityTypeSystemAssigned, VirtualMachineScaleSetIdentityTypeSystemAssignedUserAssigned, VirtualMachineScaleSetIdentityTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		VirtualMachineScaleSetIdentityTypeNone,
+		VirtualMachineScaleSetIdentityTypeSystemAssigned,
+		VirtualMachineScaleSetIdentityTypeSystemAssignedUserAssigned,
+		VirtualMachineScaleSetIdentityTypeUserAssigned))
 }
 
 func Test_VirtualMachineScaleSetIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2205,7 +2209,11 @@ func VirtualMachineScaleSetIdentityStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetIdentityStatus(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(VirtualMachineScaleSetIdentityStatusTypeNone, VirtualMachineScaleSetIdentityStatusTypeSystemAssigned, VirtualMachineScaleSetIdentityStatusTypeSystemAssignedUserAssigned, VirtualMachineScaleSetIdentityStatusTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		VirtualMachineScaleSetIdentityStatusTypeNone,
+		VirtualMachineScaleSetIdentityStatusTypeSystemAssigned,
+		VirtualMachineScaleSetIdentityStatusTypeSystemAssignedUserAssigned,
+		VirtualMachineScaleSetIdentityStatusTypeUserAssigned))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualMachineScaleSetIdentityStatus is a factory method for creating gopter generators
@@ -8857,7 +8865,13 @@ func VirtualMachineScaleSetManagedDiskParametersGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParameters is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParameters(gens map[string]gopter.Gen) {
-	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumLRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumZRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardLRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDLRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDZRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeUltraSSDLRS))
+	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumLRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumZRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardLRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDLRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDZRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeUltraSSDLRS))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParameters is a factory method for creating gopter generators
@@ -8970,7 +8984,13 @@ func VirtualMachineScaleSetManagedDiskParametersStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersStatus(gens map[string]gopter.Gen) {
-	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(StorageAccountType_StatusPremiumLRS, StorageAccountType_StatusPremiumZRS, StorageAccountType_StatusStandardLRS, StorageAccountType_StatusStandardSSDLRS, StorageAccountType_StatusStandardSSDZRS, StorageAccountType_StatusUltraSSDLRS))
+	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(
+		StorageAccountType_StatusPremiumLRS,
+		StorageAccountType_StatusPremiumZRS,
+		StorageAccountType_StatusStandardLRS,
+		StorageAccountType_StatusStandardSSDLRS,
+		StorageAccountType_StatusStandardSSDZRS,
+		StorageAccountType_StatusUltraSSDLRS))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersStatus is a factory method for creating gopter generators

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_sets__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_sets__spec_arm_types_gen_test.go
@@ -339,7 +339,11 @@ func VirtualMachineScaleSetIdentityARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVirtualMachineScaleSetIdentityARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetIdentityARM(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(VirtualMachineScaleSetIdentityTypeNone, VirtualMachineScaleSetIdentityTypeSystemAssigned, VirtualMachineScaleSetIdentityTypeSystemAssignedUserAssigned, VirtualMachineScaleSetIdentityTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		VirtualMachineScaleSetIdentityTypeNone,
+		VirtualMachineScaleSetIdentityTypeSystemAssigned,
+		VirtualMachineScaleSetIdentityTypeSystemAssignedUserAssigned,
+		VirtualMachineScaleSetIdentityTypeUserAssigned))
 }
 
 func Test_VirtualMachineScaleSets_Spec_PropertiesARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -2864,7 +2868,13 @@ func VirtualMachineScaleSetManagedDiskParametersARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersARM(gens map[string]gopter.Gen) {
-	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumLRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumZRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardLRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDLRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDZRS, VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeUltraSSDLRS))
+	gens["StorageAccountType"] = gen.PtrOf(gen.OneConstOf(
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumLRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypePremiumZRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardLRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDLRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeStandardSSDZRS,
+		VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeUltraSSDLRS))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualMachineScaleSetManagedDiskParametersARM is a factory method for creating gopter generators

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/agent_pool__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/agent_pool__status_arm_types_gen_test.go
@@ -165,7 +165,12 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileProperties
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(GPUInstanceProfile_StatusMIG1G, GPUInstanceProfile_StatusMIG2G, GPUInstanceProfile_StatusMIG3G, GPUInstanceProfile_StatusMIG4G, GPUInstanceProfile_StatusMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		GPUInstanceProfile_StatusMIG1G,
+		GPUInstanceProfile_StatusMIG2G,
+		GPUInstanceProfile_StatusMIG3G,
+		GPUInstanceProfile_StatusMIG4G,
+		GPUInstanceProfile_StatusMIG7G))
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(KubeletDiskType_StatusOS, KubeletDiskType_StatusTemporary))
 	gens["MaxCount"] = gen.PtrOf(gen.Int())
 	gens["MaxPods"] = gen.PtrOf(gen.Int())

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster__status_arm_types_gen_test.go
@@ -752,7 +752,12 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileStatusARM(
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(GPUInstanceProfile_StatusMIG1G, GPUInstanceProfile_StatusMIG2G, GPUInstanceProfile_StatusMIG3G, GPUInstanceProfile_StatusMIG4G, GPUInstanceProfile_StatusMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		GPUInstanceProfile_StatusMIG1G,
+		GPUInstanceProfile_StatusMIG2G,
+		GPUInstanceProfile_StatusMIG3G,
+		GPUInstanceProfile_StatusMIG4G,
+		GPUInstanceProfile_StatusMIG7G))
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(KubeletDiskType_StatusOS, KubeletDiskType_StatusTemporary))
 	gens["MaxCount"] = gen.PtrOf(gen.Int())
 	gens["MaxPods"] = gen.PtrOf(gen.Int())
@@ -845,7 +850,12 @@ func ManagedClusterAutoUpgradeProfileStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfileStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfileStatusARM(gens map[string]gopter.Gen) {
-	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNodeImage, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNone, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelPatch, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelRapid, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelStable))
+	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNodeImage,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNone,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelPatch,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelRapid,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelStable))
 }
 
 func Test_ManagedClusterHTTPProxyConfig_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -1106,7 +1116,11 @@ func ManagedClusterPropertiesStatusAutoScalerProfileARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForManagedClusterPropertiesStatusAutoScalerProfileARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterPropertiesStatusAutoScalerProfileARM(gens map[string]gopter.Gen) {
 	gens["BalanceSimilarNodeGroups"] = gen.PtrOf(gen.AlphaString())
-	gens["Expander"] = gen.PtrOf(gen.OneConstOf(ManagedClusterPropertiesStatusAutoScalerProfileExpanderLeastWaste, ManagedClusterPropertiesStatusAutoScalerProfileExpanderMostPods, ManagedClusterPropertiesStatusAutoScalerProfileExpanderPriority, ManagedClusterPropertiesStatusAutoScalerProfileExpanderRandom))
+	gens["Expander"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderLeastWaste,
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderMostPods,
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderPriority,
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderRandom))
 	gens["MaxEmptyBulkDelete"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxGracefulTerminationSec"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxNodeProvisionTime"] = gen.PtrOf(gen.AlphaString())
@@ -1582,7 +1596,11 @@ func AddIndependentPropertyGeneratorsForManagedClusterPodIdentityStatusARM(gens 
 	gens["BindingSelector"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.AlphaString()
 	gens["Namespace"] = gen.AlphaString()
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ManagedClusterPodIdentityStatusProvisioningStateAssigned, ManagedClusterPodIdentityStatusProvisioningStateDeleting, ManagedClusterPodIdentityStatusProvisioningStateFailed, ManagedClusterPodIdentityStatusProvisioningStateUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterPodIdentityStatusProvisioningStateAssigned,
+		ManagedClusterPodIdentityStatusProvisioningStateDeleting,
+		ManagedClusterPodIdentityStatusProvisioningStateFailed,
+		ManagedClusterPodIdentityStatusProvisioningStateUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForManagedClusterPodIdentityStatusARM is a factory method for creating gopter generators

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen_test.go
@@ -1794,7 +1794,12 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfile(gens map[
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfileGpuInstanceProfileMIG1G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG2G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG3G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG4G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG1G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG2G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG3G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG4G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG7G))
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfileKubeletDiskTypeOS, ManagedClusterAgentPoolProfileKubeletDiskTypeTemporary))
 	gens["MaxCount"] = gen.PtrOf(gen.Int())
 	gens["MaxPods"] = gen.PtrOf(gen.Int())
@@ -1936,7 +1941,12 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileStatus(gen
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(GPUInstanceProfile_StatusMIG1G, GPUInstanceProfile_StatusMIG2G, GPUInstanceProfile_StatusMIG3G, GPUInstanceProfile_StatusMIG4G, GPUInstanceProfile_StatusMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		GPUInstanceProfile_StatusMIG1G,
+		GPUInstanceProfile_StatusMIG2G,
+		GPUInstanceProfile_StatusMIG3G,
+		GPUInstanceProfile_StatusMIG4G,
+		GPUInstanceProfile_StatusMIG7G))
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(KubeletDiskType_StatusOS, KubeletDiskType_StatusTemporary))
 	gens["MaxCount"] = gen.PtrOf(gen.Int())
 	gens["MaxPods"] = gen.PtrOf(gen.Int())
@@ -2068,7 +2078,12 @@ func ManagedClusterAutoUpgradeProfileGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfile is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfile(gens map[string]gopter.Gen) {
-	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAutoUpgradeProfileUpgradeChannelNodeImage, ManagedClusterAutoUpgradeProfileUpgradeChannelNone, ManagedClusterAutoUpgradeProfileUpgradeChannelPatch, ManagedClusterAutoUpgradeProfileUpgradeChannelRapid, ManagedClusterAutoUpgradeProfileUpgradeChannelStable))
+	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAutoUpgradeProfileUpgradeChannelNodeImage,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelNone,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelPatch,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelRapid,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelStable))
 }
 
 func Test_ManagedClusterAutoUpgradeProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2167,7 +2182,12 @@ func ManagedClusterAutoUpgradeProfileStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfileStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfileStatus(gens map[string]gopter.Gen) {
-	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNodeImage, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNone, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelPatch, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelRapid, ManagedClusterAutoUpgradeProfileStatusUpgradeChannelStable))
+	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNodeImage,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelNone,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelPatch,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelRapid,
+		ManagedClusterAutoUpgradeProfileStatusUpgradeChannelStable))
 }
 
 func Test_ManagedClusterHTTPProxyConfig_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2915,7 +2935,11 @@ func ManagedClusterPropertiesAutoScalerProfileGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForManagedClusterPropertiesAutoScalerProfile is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterPropertiesAutoScalerProfile(gens map[string]gopter.Gen) {
 	gens["BalanceSimilarNodeGroups"] = gen.PtrOf(gen.AlphaString())
-	gens["Expander"] = gen.PtrOf(gen.OneConstOf(ManagedClusterPropertiesAutoScalerProfileExpanderLeastWaste, ManagedClusterPropertiesAutoScalerProfileExpanderMostPods, ManagedClusterPropertiesAutoScalerProfileExpanderPriority, ManagedClusterPropertiesAutoScalerProfileExpanderRandom))
+	gens["Expander"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterPropertiesAutoScalerProfileExpanderLeastWaste,
+		ManagedClusterPropertiesAutoScalerProfileExpanderMostPods,
+		ManagedClusterPropertiesAutoScalerProfileExpanderPriority,
+		ManagedClusterPropertiesAutoScalerProfileExpanderRandom))
 	gens["MaxEmptyBulkDelete"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxGracefulTerminationSec"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxNodeProvisionTime"] = gen.PtrOf(gen.AlphaString())
@@ -3030,7 +3054,11 @@ func ManagedClusterPropertiesStatusAutoScalerProfileGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForManagedClusterPropertiesStatusAutoScalerProfile is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterPropertiesStatusAutoScalerProfile(gens map[string]gopter.Gen) {
 	gens["BalanceSimilarNodeGroups"] = gen.PtrOf(gen.AlphaString())
-	gens["Expander"] = gen.PtrOf(gen.OneConstOf(ManagedClusterPropertiesStatusAutoScalerProfileExpanderLeastWaste, ManagedClusterPropertiesStatusAutoScalerProfileExpanderMostPods, ManagedClusterPropertiesStatusAutoScalerProfileExpanderPriority, ManagedClusterPropertiesStatusAutoScalerProfileExpanderRandom))
+	gens["Expander"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderLeastWaste,
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderMostPods,
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderPriority,
+		ManagedClusterPropertiesStatusAutoScalerProfileExpanderRandom))
 	gens["MaxEmptyBulkDelete"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxGracefulTerminationSec"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxNodeProvisionTime"] = gen.PtrOf(gen.AlphaString())
@@ -4912,7 +4940,11 @@ func AddIndependentPropertyGeneratorsForManagedClusterPodIdentityStatus(gens map
 	gens["BindingSelector"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.AlphaString()
 	gens["Namespace"] = gen.AlphaString()
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ManagedClusterPodIdentityStatusProvisioningStateAssigned, ManagedClusterPodIdentityStatusProvisioningStateDeleting, ManagedClusterPodIdentityStatusProvisioningStateFailed, ManagedClusterPodIdentityStatusProvisioningStateUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterPodIdentityStatusProvisioningStateAssigned,
+		ManagedClusterPodIdentityStatusProvisioningStateDeleting,
+		ManagedClusterPodIdentityStatusProvisioningStateFailed,
+		ManagedClusterPodIdentityStatusProvisioningStateUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForManagedClusterPodIdentityStatus is a factory method for creating gopter generators

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters__spec_arm_types_gen_test.go
@@ -854,7 +854,12 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileARM(gens m
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfileGpuInstanceProfileMIG1G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG2G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG3G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG4G, ManagedClusterAgentPoolProfileGpuInstanceProfileMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG1G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG2G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG3G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG4G,
+		ManagedClusterAgentPoolProfileGpuInstanceProfileMIG7G))
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfileKubeletDiskTypeOS, ManagedClusterAgentPoolProfileKubeletDiskTypeTemporary))
 	gens["MaxCount"] = gen.PtrOf(gen.Int())
 	gens["MaxPods"] = gen.PtrOf(gen.Int())
@@ -944,7 +949,12 @@ func ManagedClusterAutoUpgradeProfileARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfileARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterAutoUpgradeProfileARM(gens map[string]gopter.Gen) {
-	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAutoUpgradeProfileUpgradeChannelNodeImage, ManagedClusterAutoUpgradeProfileUpgradeChannelNone, ManagedClusterAutoUpgradeProfileUpgradeChannelPatch, ManagedClusterAutoUpgradeProfileUpgradeChannelRapid, ManagedClusterAutoUpgradeProfileUpgradeChannelStable))
+	gens["UpgradeChannel"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAutoUpgradeProfileUpgradeChannelNodeImage,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelNone,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelPatch,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelRapid,
+		ManagedClusterAutoUpgradeProfileUpgradeChannelStable))
 }
 
 func Test_ManagedClusterHTTPProxyConfigARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -1144,7 +1154,11 @@ func ManagedClusterPropertiesAutoScalerProfileARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForManagedClusterPropertiesAutoScalerProfileARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedClusterPropertiesAutoScalerProfileARM(gens map[string]gopter.Gen) {
 	gens["BalanceSimilarNodeGroups"] = gen.PtrOf(gen.AlphaString())
-	gens["Expander"] = gen.PtrOf(gen.OneConstOf(ManagedClusterPropertiesAutoScalerProfileExpanderLeastWaste, ManagedClusterPropertiesAutoScalerProfileExpanderMostPods, ManagedClusterPropertiesAutoScalerProfileExpanderPriority, ManagedClusterPropertiesAutoScalerProfileExpanderRandom))
+	gens["Expander"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterPropertiesAutoScalerProfileExpanderLeastWaste,
+		ManagedClusterPropertiesAutoScalerProfileExpanderMostPods,
+		ManagedClusterPropertiesAutoScalerProfileExpanderPriority,
+		ManagedClusterPropertiesAutoScalerProfileExpanderRandom))
 	gens["MaxEmptyBulkDelete"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxGracefulTerminationSec"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxNodeProvisionTime"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen_test.go
@@ -229,7 +229,12 @@ func AddIndependentPropertyGeneratorsForAgentPoolStatus(gens map[string]gopter.G
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(GPUInstanceProfile_StatusMIG1G, GPUInstanceProfile_StatusMIG2G, GPUInstanceProfile_StatusMIG3G, GPUInstanceProfile_StatusMIG4G, GPUInstanceProfile_StatusMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		GPUInstanceProfile_StatusMIG1G,
+		GPUInstanceProfile_StatusMIG2G,
+		GPUInstanceProfile_StatusMIG3G,
+		GPUInstanceProfile_StatusMIG4G,
+		GPUInstanceProfile_StatusMIG7G))
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(KubeletDiskType_StatusOS, KubeletDiskType_StatusTemporary))
 	gens["MaxCount"] = gen.PtrOf(gen.Int())
@@ -380,7 +385,12 @@ func AddIndependentPropertyGeneratorsForManagedClustersAgentPoolsSpec(gens map[s
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG1G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG2G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG3G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG4G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG1G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG2G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG3G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG4G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG7G))
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfilePropertiesKubeletDiskTypeOS, ManagedClusterAgentPoolProfilePropertiesKubeletDiskTypeTemporary))
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["MaxCount"] = gen.PtrOf(gen.Int())

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pools__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pools__spec_arm_types_gen_test.go
@@ -165,7 +165,12 @@ func AddIndependentPropertyGeneratorsForManagedClusterAgentPoolProfileProperties
 	gens["EnableFIPS"] = gen.PtrOf(gen.Bool())
 	gens["EnableNodePublicIP"] = gen.PtrOf(gen.Bool())
 	gens["EnableUltraSSD"] = gen.PtrOf(gen.Bool())
-	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG1G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG2G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG3G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG4G, ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG7G))
+	gens["GpuInstanceProfile"] = gen.PtrOf(gen.OneConstOf(
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG1G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG2G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG3G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG4G,
+		ManagedClusterAgentPoolProfilePropertiesGpuInstanceProfileMIG7G))
 	gens["KubeletDiskType"] = gen.PtrOf(gen.OneConstOf(ManagedClusterAgentPoolProfilePropertiesKubeletDiskTypeOS, ManagedClusterAgentPoolProfilePropertiesKubeletDiskTypeTemporary))
 	gens["MaxCount"] = gen.PtrOf(gen.Int())
 	gens["MaxPods"] = gen.PtrOf(gen.Int())

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/database__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/database__status_arm_types_gen_test.go
@@ -213,8 +213,16 @@ func SystemDataStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSystemDataStatusARM(gens map[string]gopter.Gen) {
 	gens["CreatedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["CreatedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusCreatedByTypeApplication, SystemDataStatusCreatedByTypeKey, SystemDataStatusCreatedByTypeManagedIdentity, SystemDataStatusCreatedByTypeUser))
+	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusCreatedByTypeApplication,
+		SystemDataStatusCreatedByTypeKey,
+		SystemDataStatusCreatedByTypeManagedIdentity,
+		SystemDataStatusCreatedByTypeUser))
 	gens["LastModifiedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["LastModifiedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusLastModifiedByTypeApplication, SystemDataStatusLastModifiedByTypeKey, SystemDataStatusLastModifiedByTypeManagedIdentity, SystemDataStatusLastModifiedByTypeUser))
+	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusLastModifiedByTypeApplication,
+		SystemDataStatusLastModifiedByTypeKey,
+		SystemDataStatusLastModifiedByTypeManagedIdentity,
+		SystemDataStatusLastModifiedByTypeUser))
 }

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen_test.go
@@ -226,7 +226,11 @@ func AddIndependentPropertyGeneratorsForFlexibleServersSpec(gens map[string]gopt
 	gens["AdministratorLoginPassword"] = gen.PtrOf(gen.AlphaString())
 	gens["AvailabilityZone"] = gen.PtrOf(gen.AlphaString())
 	gens["AzureName"] = gen.AlphaString()
-	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesCreateModeCreate, ServerPropertiesCreateModeDefault, ServerPropertiesCreateModePointInTimeRestore, ServerPropertiesCreateModeUpdate))
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(
+		ServerPropertiesCreateModeCreate,
+		ServerPropertiesCreateModeDefault,
+		ServerPropertiesCreateModePointInTimeRestore,
+		ServerPropertiesCreateModeUpdate))
 	gens["Location"] = gen.AlphaString()
 	gens["PointInTimeUTC"] = gen.PtrOf(gen.AlphaString())
 	gens["PropertiesTags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
@@ -351,7 +355,11 @@ func AddIndependentPropertyGeneratorsForServerStatus(gens map[string]gopter.Gen)
 	gens["AdministratorLogin"] = gen.PtrOf(gen.AlphaString())
 	gens["AdministratorLoginPassword"] = gen.PtrOf(gen.AlphaString())
 	gens["AvailabilityZone"] = gen.PtrOf(gen.AlphaString())
-	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesStatusCreateModeCreate, ServerPropertiesStatusCreateModeDefault, ServerPropertiesStatusCreateModePointInTimeRestore, ServerPropertiesStatusCreateModeUpdate))
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(
+		ServerPropertiesStatusCreateModeCreate,
+		ServerPropertiesStatusCreateModeDefault,
+		ServerPropertiesStatusCreateModePointInTimeRestore,
+		ServerPropertiesStatusCreateModeUpdate))
 	gens["FullyQualifiedDomainName"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
@@ -360,7 +368,14 @@ func AddIndependentPropertyGeneratorsForServerStatus(gens map[string]gopter.Gen)
 	gens["PointInTimeUTC"] = gen.PtrOf(gen.AlphaString())
 	gens["PropertiesTags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["SourceServerResourceId"] = gen.PtrOf(gen.AlphaString())
-	gens["State"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesStatusStateDisabled, ServerPropertiesStatusStateDropping, ServerPropertiesStatusStateReady, ServerPropertiesStatusStateStarting, ServerPropertiesStatusStateStopped, ServerPropertiesStatusStateStopping, ServerPropertiesStatusStateUpdating))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		ServerPropertiesStatusStateDisabled,
+		ServerPropertiesStatusStateDropping,
+		ServerPropertiesStatusStateReady,
+		ServerPropertiesStatusStateStarting,
+		ServerPropertiesStatusStateStopped,
+		ServerPropertiesStatusStateStopping,
+		ServerPropertiesStatusStateUpdating))
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 	gens["Version"] = gen.PtrOf(gen.OneConstOf(ServerVersion_Status11, ServerVersion_Status12, ServerVersion_Status13))
@@ -773,7 +788,13 @@ func HighAvailabilityStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForHighAvailabilityStatus(gens map[string]gopter.Gen) {
 	gens["Mode"] = gen.PtrOf(gen.OneConstOf(HighAvailabilityStatusModeDisabled, HighAvailabilityStatusModeZoneRedundant))
 	gens["StandbyAvailabilityZone"] = gen.PtrOf(gen.AlphaString())
-	gens["State"] = gen.PtrOf(gen.OneConstOf(HighAvailabilityStatusStateCreatingStandby, HighAvailabilityStatusStateFailingOver, HighAvailabilityStatusStateHealthy, HighAvailabilityStatusStateNotEnabled, HighAvailabilityStatusStateRemovingStandby, HighAvailabilityStatusStateReplicatingData))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		HighAvailabilityStatusStateCreatingStandby,
+		HighAvailabilityStatusStateFailingOver,
+		HighAvailabilityStatusStateHealthy,
+		HighAvailabilityStatusStateNotEnabled,
+		HighAvailabilityStatusStateRemovingStandby,
+		HighAvailabilityStatusStateReplicatingData))
 }
 
 func Test_MaintenanceWindow_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -1662,8 +1683,16 @@ func SystemDataStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSystemDataStatus(gens map[string]gopter.Gen) {
 	gens["CreatedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["CreatedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusCreatedByTypeApplication, SystemDataStatusCreatedByTypeKey, SystemDataStatusCreatedByTypeManagedIdentity, SystemDataStatusCreatedByTypeUser))
+	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusCreatedByTypeApplication,
+		SystemDataStatusCreatedByTypeKey,
+		SystemDataStatusCreatedByTypeManagedIdentity,
+		SystemDataStatusCreatedByTypeUser))
 	gens["LastModifiedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["LastModifiedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusLastModifiedByTypeApplication, SystemDataStatusLastModifiedByTypeKey, SystemDataStatusLastModifiedByTypeManagedIdentity, SystemDataStatusLastModifiedByTypeUser))
+	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusLastModifiedByTypeApplication,
+		SystemDataStatusLastModifiedByTypeKey,
+		SystemDataStatusLastModifiedByTypeManagedIdentity,
+		SystemDataStatusLastModifiedByTypeUser))
 }

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers__spec_arm_types_gen_test.go
@@ -163,7 +163,11 @@ func AddIndependentPropertyGeneratorsForServerPropertiesARM(gens map[string]gopt
 	gens["AdministratorLogin"] = gen.PtrOf(gen.AlphaString())
 	gens["AdministratorLoginPassword"] = gen.PtrOf(gen.AlphaString())
 	gens["AvailabilityZone"] = gen.PtrOf(gen.AlphaString())
-	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesCreateModeCreate, ServerPropertiesCreateModeDefault, ServerPropertiesCreateModePointInTimeRestore, ServerPropertiesCreateModeUpdate))
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(
+		ServerPropertiesCreateModeCreate,
+		ServerPropertiesCreateModeDefault,
+		ServerPropertiesCreateModePointInTimeRestore,
+		ServerPropertiesCreateModeUpdate))
 	gens["PointInTimeUTC"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceServerResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/server__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/server__status_arm_types_gen_test.go
@@ -165,12 +165,23 @@ func AddIndependentPropertyGeneratorsForServerPropertiesStatusARM(gens map[strin
 	gens["AdministratorLogin"] = gen.PtrOf(gen.AlphaString())
 	gens["AdministratorLoginPassword"] = gen.PtrOf(gen.AlphaString())
 	gens["AvailabilityZone"] = gen.PtrOf(gen.AlphaString())
-	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesStatusCreateModeCreate, ServerPropertiesStatusCreateModeDefault, ServerPropertiesStatusCreateModePointInTimeRestore, ServerPropertiesStatusCreateModeUpdate))
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(
+		ServerPropertiesStatusCreateModeCreate,
+		ServerPropertiesStatusCreateModeDefault,
+		ServerPropertiesStatusCreateModePointInTimeRestore,
+		ServerPropertiesStatusCreateModeUpdate))
 	gens["FullyQualifiedDomainName"] = gen.PtrOf(gen.AlphaString())
 	gens["MinorVersion"] = gen.PtrOf(gen.AlphaString())
 	gens["PointInTimeUTC"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceServerResourceId"] = gen.PtrOf(gen.AlphaString())
-	gens["State"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesStatusStateDisabled, ServerPropertiesStatusStateDropping, ServerPropertiesStatusStateReady, ServerPropertiesStatusStateStarting, ServerPropertiesStatusStateStopped, ServerPropertiesStatusStateStopping, ServerPropertiesStatusStateUpdating))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		ServerPropertiesStatusStateDisabled,
+		ServerPropertiesStatusStateDropping,
+		ServerPropertiesStatusStateReady,
+		ServerPropertiesStatusStateStarting,
+		ServerPropertiesStatusStateStopped,
+		ServerPropertiesStatusStateStopping,
+		ServerPropertiesStatusStateUpdating))
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Version"] = gen.PtrOf(gen.OneConstOf(ServerVersion_Status11, ServerVersion_Status12, ServerVersion_Status13))
 }
@@ -364,7 +375,13 @@ func HighAvailabilityStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForHighAvailabilityStatusARM(gens map[string]gopter.Gen) {
 	gens["Mode"] = gen.PtrOf(gen.OneConstOf(HighAvailabilityStatusModeDisabled, HighAvailabilityStatusModeZoneRedundant))
 	gens["StandbyAvailabilityZone"] = gen.PtrOf(gen.AlphaString())
-	gens["State"] = gen.PtrOf(gen.OneConstOf(HighAvailabilityStatusStateCreatingStandby, HighAvailabilityStatusStateFailingOver, HighAvailabilityStatusStateHealthy, HighAvailabilityStatusStateNotEnabled, HighAvailabilityStatusStateRemovingStandby, HighAvailabilityStatusStateReplicatingData))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		HighAvailabilityStatusStateCreatingStandby,
+		HighAvailabilityStatusStateFailingOver,
+		HighAvailabilityStatusStateHealthy,
+		HighAvailabilityStatusStateNotEnabled,
+		HighAvailabilityStatusStateRemovingStandby,
+		HighAvailabilityStatusStateReplicatingData))
 }
 
 func Test_MaintenanceWindow_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_get_results__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_get_results__status_arm_types_gen_test.go
@@ -266,7 +266,11 @@ func ManagedServiceIdentityStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForManagedServiceIdentityStatusARM(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(ManagedServiceIdentityStatusTypeNone, ManagedServiceIdentityStatusTypeSystemAssigned, ManagedServiceIdentityStatusTypeSystemAssignedUserAssigned, ManagedServiceIdentityStatusTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		ManagedServiceIdentityStatusTypeNone,
+		ManagedServiceIdentityStatusTypeSystemAssigned,
+		ManagedServiceIdentityStatusTypeSystemAssignedUserAssigned,
+		ManagedServiceIdentityStatusTypeUserAssigned))
 }
 
 // AddRelatedPropertyGeneratorsForManagedServiceIdentityStatusARM is a factory method for creating gopter generators
@@ -571,7 +575,12 @@ func ConsistencyPolicyStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForConsistencyPolicyStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForConsistencyPolicyStatusARM(gens map[string]gopter.Gen) {
-	gens["DefaultConsistencyLevel"] = gen.OneConstOf(ConsistencyPolicyStatusDefaultConsistencyLevelBoundedStaleness, ConsistencyPolicyStatusDefaultConsistencyLevelConsistentPrefix, ConsistencyPolicyStatusDefaultConsistencyLevelEventual, ConsistencyPolicyStatusDefaultConsistencyLevelSession, ConsistencyPolicyStatusDefaultConsistencyLevelStrong)
+	gens["DefaultConsistencyLevel"] = gen.OneConstOf(
+		ConsistencyPolicyStatusDefaultConsistencyLevelBoundedStaleness,
+		ConsistencyPolicyStatusDefaultConsistencyLevelConsistentPrefix,
+		ConsistencyPolicyStatusDefaultConsistencyLevelEventual,
+		ConsistencyPolicyStatusDefaultConsistencyLevelSession,
+		ConsistencyPolicyStatusDefaultConsistencyLevelStrong)
 	gens["MaxIntervalInSeconds"] = gen.PtrOf(gen.Int())
 	gens["MaxStalenessPrefix"] = gen.PtrOf(gen.Int())
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen_test.go
@@ -1298,7 +1298,12 @@ func ConsistencyPolicyGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForConsistencyPolicy is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForConsistencyPolicy(gens map[string]gopter.Gen) {
-	gens["DefaultConsistencyLevel"] = gen.OneConstOf(ConsistencyPolicyDefaultConsistencyLevelBoundedStaleness, ConsistencyPolicyDefaultConsistencyLevelConsistentPrefix, ConsistencyPolicyDefaultConsistencyLevelEventual, ConsistencyPolicyDefaultConsistencyLevelSession, ConsistencyPolicyDefaultConsistencyLevelStrong)
+	gens["DefaultConsistencyLevel"] = gen.OneConstOf(
+		ConsistencyPolicyDefaultConsistencyLevelBoundedStaleness,
+		ConsistencyPolicyDefaultConsistencyLevelConsistentPrefix,
+		ConsistencyPolicyDefaultConsistencyLevelEventual,
+		ConsistencyPolicyDefaultConsistencyLevelSession,
+		ConsistencyPolicyDefaultConsistencyLevelStrong)
 	gens["MaxIntervalInSeconds"] = gen.PtrOf(gen.Int())
 	gens["MaxStalenessPrefix"] = gen.PtrOf(gen.Int())
 }
@@ -1399,7 +1404,12 @@ func ConsistencyPolicyStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForConsistencyPolicyStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForConsistencyPolicyStatus(gens map[string]gopter.Gen) {
-	gens["DefaultConsistencyLevel"] = gen.OneConstOf(ConsistencyPolicyStatusDefaultConsistencyLevelBoundedStaleness, ConsistencyPolicyStatusDefaultConsistencyLevelConsistentPrefix, ConsistencyPolicyStatusDefaultConsistencyLevelEventual, ConsistencyPolicyStatusDefaultConsistencyLevelSession, ConsistencyPolicyStatusDefaultConsistencyLevelStrong)
+	gens["DefaultConsistencyLevel"] = gen.OneConstOf(
+		ConsistencyPolicyStatusDefaultConsistencyLevelBoundedStaleness,
+		ConsistencyPolicyStatusDefaultConsistencyLevelConsistentPrefix,
+		ConsistencyPolicyStatusDefaultConsistencyLevelEventual,
+		ConsistencyPolicyStatusDefaultConsistencyLevelSession,
+		ConsistencyPolicyStatusDefaultConsistencyLevelStrong)
 	gens["MaxIntervalInSeconds"] = gen.PtrOf(gen.Int())
 	gens["MaxStalenessPrefix"] = gen.PtrOf(gen.Int())
 }
@@ -2205,7 +2215,11 @@ func ManagedServiceIdentityGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForManagedServiceIdentity is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedServiceIdentity(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(ManagedServiceIdentityTypeNone, ManagedServiceIdentityTypeSystemAssigned, ManagedServiceIdentityTypeSystemAssignedUserAssigned, ManagedServiceIdentityTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		ManagedServiceIdentityTypeNone,
+		ManagedServiceIdentityTypeSystemAssigned,
+		ManagedServiceIdentityTypeSystemAssignedUserAssigned,
+		ManagedServiceIdentityTypeUserAssigned))
 }
 
 func Test_ManagedServiceIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2315,7 +2329,11 @@ func ManagedServiceIdentityStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForManagedServiceIdentityStatus(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(ManagedServiceIdentityStatusTypeNone, ManagedServiceIdentityStatusTypeSystemAssigned, ManagedServiceIdentityStatusTypeSystemAssignedUserAssigned, ManagedServiceIdentityStatusTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		ManagedServiceIdentityStatusTypeNone,
+		ManagedServiceIdentityStatusTypeSystemAssigned,
+		ManagedServiceIdentityStatusTypeSystemAssignedUserAssigned,
+		ManagedServiceIdentityStatusTypeUserAssigned))
 }
 
 // AddRelatedPropertyGeneratorsForManagedServiceIdentityStatus is a factory method for creating gopter generators

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_accounts__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_accounts__spec_arm_types_gen_test.go
@@ -247,7 +247,11 @@ func ManagedServiceIdentityARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForManagedServiceIdentityARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForManagedServiceIdentityARM(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(ManagedServiceIdentityTypeNone, ManagedServiceIdentityTypeSystemAssigned, ManagedServiceIdentityTypeSystemAssignedUserAssigned, ManagedServiceIdentityTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		ManagedServiceIdentityTypeNone,
+		ManagedServiceIdentityTypeSystemAssigned,
+		ManagedServiceIdentityTypeSystemAssignedUserAssigned,
+		ManagedServiceIdentityTypeUserAssigned))
 }
 
 func Test_AnalyticalStorageConfigurationARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -557,7 +561,12 @@ func ConsistencyPolicyARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForConsistencyPolicyARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForConsistencyPolicyARM(gens map[string]gopter.Gen) {
-	gens["DefaultConsistencyLevel"] = gen.OneConstOf(ConsistencyPolicyDefaultConsistencyLevelBoundedStaleness, ConsistencyPolicyDefaultConsistencyLevelConsistentPrefix, ConsistencyPolicyDefaultConsistencyLevelEventual, ConsistencyPolicyDefaultConsistencyLevelSession, ConsistencyPolicyDefaultConsistencyLevelStrong)
+	gens["DefaultConsistencyLevel"] = gen.OneConstOf(
+		ConsistencyPolicyDefaultConsistencyLevelBoundedStaleness,
+		ConsistencyPolicyDefaultConsistencyLevelConsistentPrefix,
+		ConsistencyPolicyDefaultConsistencyLevelEventual,
+		ConsistencyPolicyDefaultConsistencyLevelSession,
+		ConsistencyPolicyDefaultConsistencyLevelStrong)
 	gens["MaxIntervalInSeconds"] = gen.PtrOf(gen.Int())
 	gens["MaxStalenessPrefix"] = gen.PtrOf(gen.Int())
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers__spec_arm_types_gen_test.go
@@ -742,7 +742,11 @@ func SpatialSpecARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForSpatialSpecARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSpatialSpecARM(gens map[string]gopter.Gen) {
 	gens["Path"] = gen.PtrOf(gen.AlphaString())
-	gens["Types"] = gen.SliceOf(gen.OneConstOf(SpatialSpecTypesLineString, SpatialSpecTypesMultiPolygon, SpatialSpecTypesPoint, SpatialSpecTypesPolygon))
+	gens["Types"] = gen.SliceOf(gen.OneConstOf(
+		SpatialSpecTypesLineString,
+		SpatialSpecTypesMultiPolygon,
+		SpatialSpecTypesPoint,
+		SpatialSpecTypesPolygon))
 }
 
 func Test_UniqueKeyARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -860,7 +864,13 @@ func IndexesARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIndexesARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIndexesARM(gens map[string]gopter.Gen) {
-	gens["DataType"] = gen.PtrOf(gen.OneConstOf(IndexesDataTypeLineString, IndexesDataTypeMultiPolygon, IndexesDataTypeNumber, IndexesDataTypePoint, IndexesDataTypePolygon, IndexesDataTypeString))
+	gens["DataType"] = gen.PtrOf(gen.OneConstOf(
+		IndexesDataTypeLineString,
+		IndexesDataTypeMultiPolygon,
+		IndexesDataTypeNumber,
+		IndexesDataTypePoint,
+		IndexesDataTypePolygon,
+		IndexesDataTypeString))
 	gens["Kind"] = gen.PtrOf(gen.OneConstOf(IndexesKindHash, IndexesKindRange, IndexesKindSpatial))
 	gens["Precision"] = gen.PtrOf(gen.Int())
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_triggers__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_triggers__spec_arm_types_gen_test.go
@@ -213,6 +213,11 @@ func SqlTriggerResourceARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSqlTriggerResourceARM(gens map[string]gopter.Gen) {
 	gens["Body"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.AlphaString()
-	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(SqlTriggerResourceTriggerOperationAll, SqlTriggerResourceTriggerOperationCreate, SqlTriggerResourceTriggerOperationDelete, SqlTriggerResourceTriggerOperationReplace, SqlTriggerResourceTriggerOperationUpdate))
+	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(
+		SqlTriggerResourceTriggerOperationAll,
+		SqlTriggerResourceTriggerOperationCreate,
+		SqlTriggerResourceTriggerOperationDelete,
+		SqlTriggerResourceTriggerOperationReplace,
+		SqlTriggerResourceTriggerOperationUpdate))
 	gens["TriggerType"] = gen.PtrOf(gen.OneConstOf(SqlTriggerResourceTriggerTypePost, SqlTriggerResourceTriggerTypePre))
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_container_get_results__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_container_get_results__status_arm_types_gen_test.go
@@ -754,7 +754,11 @@ func SpatialSpecStatusARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForSpatialSpecStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSpatialSpecStatusARM(gens map[string]gopter.Gen) {
 	gens["Path"] = gen.PtrOf(gen.AlphaString())
-	gens["Types"] = gen.SliceOf(gen.OneConstOf(SpatialType_StatusLineString, SpatialType_StatusMultiPolygon, SpatialType_StatusPoint, SpatialType_StatusPolygon))
+	gens["Types"] = gen.SliceOf(gen.OneConstOf(
+		SpatialType_StatusLineString,
+		SpatialType_StatusMultiPolygon,
+		SpatialType_StatusPoint,
+		SpatialType_StatusPolygon))
 }
 
 func Test_UniqueKey_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -872,7 +876,13 @@ func IndexesStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIndexesStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIndexesStatusARM(gens map[string]gopter.Gen) {
-	gens["DataType"] = gen.PtrOf(gen.OneConstOf(IndexesStatusDataTypeLineString, IndexesStatusDataTypeMultiPolygon, IndexesStatusDataTypeNumber, IndexesStatusDataTypePoint, IndexesStatusDataTypePolygon, IndexesStatusDataTypeString))
+	gens["DataType"] = gen.PtrOf(gen.OneConstOf(
+		IndexesStatusDataTypeLineString,
+		IndexesStatusDataTypeMultiPolygon,
+		IndexesStatusDataTypeNumber,
+		IndexesStatusDataTypePoint,
+		IndexesStatusDataTypePolygon,
+		IndexesStatusDataTypeString))
 	gens["Kind"] = gen.PtrOf(gen.OneConstOf(IndexesStatusKindHash, IndexesStatusKindRange, IndexesStatusKindSpatial))
 	gens["Precision"] = gen.PtrOf(gen.Int())
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen_test.go
@@ -451,7 +451,12 @@ func AddIndependentPropertyGeneratorsForSqlTriggerGetPropertiesStatusResource(ge
 	gens["Etag"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.AlphaString()
 	gens["Rid"] = gen.PtrOf(gen.AlphaString())
-	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(SqlTriggerGetPropertiesStatusResourceTriggerOperationAll, SqlTriggerGetPropertiesStatusResourceTriggerOperationCreate, SqlTriggerGetPropertiesStatusResourceTriggerOperationDelete, SqlTriggerGetPropertiesStatusResourceTriggerOperationReplace, SqlTriggerGetPropertiesStatusResourceTriggerOperationUpdate))
+	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationAll,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationCreate,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationDelete,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationReplace,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationUpdate))
 	gens["TriggerType"] = gen.PtrOf(gen.OneConstOf(SqlTriggerGetPropertiesStatusResourceTriggerTypePost, SqlTriggerGetPropertiesStatusResourceTriggerTypePre))
 	gens["Ts"] = gen.PtrOf(gen.Float64())
 }
@@ -553,6 +558,11 @@ func SqlTriggerResourceGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSqlTriggerResource(gens map[string]gopter.Gen) {
 	gens["Body"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.AlphaString()
-	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(SqlTriggerResourceTriggerOperationAll, SqlTriggerResourceTriggerOperationCreate, SqlTriggerResourceTriggerOperationDelete, SqlTriggerResourceTriggerOperationReplace, SqlTriggerResourceTriggerOperationUpdate))
+	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(
+		SqlTriggerResourceTriggerOperationAll,
+		SqlTriggerResourceTriggerOperationCreate,
+		SqlTriggerResourceTriggerOperationDelete,
+		SqlTriggerResourceTriggerOperationReplace,
+		SqlTriggerResourceTriggerOperationUpdate))
 	gens["TriggerType"] = gen.PtrOf(gen.OneConstOf(SqlTriggerResourceTriggerTypePost, SqlTriggerResourceTriggerTypePre))
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen_test.go
@@ -2141,7 +2141,11 @@ func SpatialSpecGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForSpatialSpec is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSpatialSpec(gens map[string]gopter.Gen) {
 	gens["Path"] = gen.PtrOf(gen.AlphaString())
-	gens["Types"] = gen.SliceOf(gen.OneConstOf(SpatialSpecTypesLineString, SpatialSpecTypesMultiPolygon, SpatialSpecTypesPoint, SpatialSpecTypesPolygon))
+	gens["Types"] = gen.SliceOf(gen.OneConstOf(
+		SpatialSpecTypesLineString,
+		SpatialSpecTypesMultiPolygon,
+		SpatialSpecTypesPoint,
+		SpatialSpecTypesPolygon))
 }
 
 func Test_SpatialSpec_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2240,7 +2244,11 @@ func SpatialSpecStatusGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForSpatialSpecStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSpatialSpecStatus(gens map[string]gopter.Gen) {
 	gens["Path"] = gen.PtrOf(gen.AlphaString())
-	gens["Types"] = gen.SliceOf(gen.OneConstOf(SpatialType_StatusLineString, SpatialType_StatusMultiPolygon, SpatialType_StatusPoint, SpatialType_StatusPolygon))
+	gens["Types"] = gen.SliceOf(gen.OneConstOf(
+		SpatialType_StatusLineString,
+		SpatialType_StatusMultiPolygon,
+		SpatialType_StatusPoint,
+		SpatialType_StatusPolygon))
 }
 
 func Test_UniqueKey_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2534,7 +2542,13 @@ func IndexesGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIndexes is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIndexes(gens map[string]gopter.Gen) {
-	gens["DataType"] = gen.PtrOf(gen.OneConstOf(IndexesDataTypeLineString, IndexesDataTypeMultiPolygon, IndexesDataTypeNumber, IndexesDataTypePoint, IndexesDataTypePolygon, IndexesDataTypeString))
+	gens["DataType"] = gen.PtrOf(gen.OneConstOf(
+		IndexesDataTypeLineString,
+		IndexesDataTypeMultiPolygon,
+		IndexesDataTypeNumber,
+		IndexesDataTypePoint,
+		IndexesDataTypePolygon,
+		IndexesDataTypeString))
 	gens["Kind"] = gen.PtrOf(gen.OneConstOf(IndexesKindHash, IndexesKindRange, IndexesKindSpatial))
 	gens["Precision"] = gen.PtrOf(gen.Int())
 }
@@ -2634,7 +2648,13 @@ func IndexesStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIndexesStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIndexesStatus(gens map[string]gopter.Gen) {
-	gens["DataType"] = gen.PtrOf(gen.OneConstOf(IndexesStatusDataTypeLineString, IndexesStatusDataTypeMultiPolygon, IndexesStatusDataTypeNumber, IndexesStatusDataTypePoint, IndexesStatusDataTypePolygon, IndexesStatusDataTypeString))
+	gens["DataType"] = gen.PtrOf(gen.OneConstOf(
+		IndexesStatusDataTypeLineString,
+		IndexesStatusDataTypeMultiPolygon,
+		IndexesStatusDataTypeNumber,
+		IndexesStatusDataTypePoint,
+		IndexesStatusDataTypePolygon,
+		IndexesStatusDataTypeString))
 	gens["Kind"] = gen.PtrOf(gen.OneConstOf(IndexesStatusKindHash, IndexesStatusKindRange, IndexesStatusKindSpatial))
 	gens["Precision"] = gen.PtrOf(gen.Int())
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_trigger_get_results__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_trigger_get_results__status_arm_types_gen_test.go
@@ -216,7 +216,12 @@ func AddIndependentPropertyGeneratorsForSqlTriggerGetPropertiesStatusResourceARM
 	gens["Etag"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.AlphaString()
 	gens["Rid"] = gen.PtrOf(gen.AlphaString())
-	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(SqlTriggerGetPropertiesStatusResourceTriggerOperationAll, SqlTriggerGetPropertiesStatusResourceTriggerOperationCreate, SqlTriggerGetPropertiesStatusResourceTriggerOperationDelete, SqlTriggerGetPropertiesStatusResourceTriggerOperationReplace, SqlTriggerGetPropertiesStatusResourceTriggerOperationUpdate))
+	gens["TriggerOperation"] = gen.PtrOf(gen.OneConstOf(
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationAll,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationCreate,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationDelete,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationReplace,
+		SqlTriggerGetPropertiesStatusResourceTriggerOperationUpdate))
 	gens["TriggerType"] = gen.PtrOf(gen.OneConstOf(SqlTriggerGetPropertiesStatusResourceTriggerTypePost, SqlTriggerGetPropertiesStatusResourceTriggerTypePre))
 	gens["Ts"] = gen.PtrOf(gen.Float64())
 }

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic__status_arm_types_gen_test.go
@@ -154,10 +154,18 @@ func SystemDataStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSystemDataStatusARM(gens map[string]gopter.Gen) {
 	gens["CreatedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["CreatedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusCreatedByTypeApplication, SystemDataStatusCreatedByTypeKey, SystemDataStatusCreatedByTypeManagedIdentity, SystemDataStatusCreatedByTypeUser))
+	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusCreatedByTypeApplication,
+		SystemDataStatusCreatedByTypeKey,
+		SystemDataStatusCreatedByTypeManagedIdentity,
+		SystemDataStatusCreatedByTypeUser))
 	gens["LastModifiedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["LastModifiedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusLastModifiedByTypeApplication, SystemDataStatusLastModifiedByTypeKey, SystemDataStatusLastModifiedByTypeManagedIdentity, SystemDataStatusLastModifiedByTypeUser))
+	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusLastModifiedByTypeApplication,
+		SystemDataStatusLastModifiedByTypeKey,
+		SystemDataStatusLastModifiedByTypeManagedIdentity,
+		SystemDataStatusLastModifiedByTypeUser))
 }
 
 func Test_TopicProperties_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -229,7 +237,13 @@ func AddIndependentPropertyGeneratorsForTopicPropertiesStatusARM(gens map[string
 	gens["Endpoint"] = gen.PtrOf(gen.AlphaString())
 	gens["InputSchema"] = gen.PtrOf(gen.OneConstOf(TopicPropertiesStatusInputSchemaCloudEventSchemaV10, TopicPropertiesStatusInputSchemaCustomEventSchema, TopicPropertiesStatusInputSchemaEventGridSchema))
 	gens["MetricResourceId"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(TopicPropertiesStatusProvisioningStateCanceled, TopicPropertiesStatusProvisioningStateCreating, TopicPropertiesStatusProvisioningStateDeleting, TopicPropertiesStatusProvisioningStateFailed, TopicPropertiesStatusProvisioningStateSucceeded, TopicPropertiesStatusProvisioningStateUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		TopicPropertiesStatusProvisioningStateCanceled,
+		TopicPropertiesStatusProvisioningStateCreating,
+		TopicPropertiesStatusProvisioningStateDeleting,
+		TopicPropertiesStatusProvisioningStateFailed,
+		TopicPropertiesStatusProvisioningStateSucceeded,
+		TopicPropertiesStatusProvisioningStateUpdating))
 	gens["PublicNetworkAccess"] = gen.PtrOf(gen.OneConstOf(TopicPropertiesStatusPublicNetworkAccessDisabled, TopicPropertiesStatusPublicNetworkAccessEnabled))
 }
 

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen_test.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen_test.go
@@ -227,7 +227,13 @@ func AddIndependentPropertyGeneratorsForTopicStatus(gens map[string]gopter.Gen) 
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["MetricResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(TopicPropertiesStatusProvisioningStateCanceled, TopicPropertiesStatusProvisioningStateCreating, TopicPropertiesStatusProvisioningStateDeleting, TopicPropertiesStatusProvisioningStateFailed, TopicPropertiesStatusProvisioningStateSucceeded, TopicPropertiesStatusProvisioningStateUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		TopicPropertiesStatusProvisioningStateCanceled,
+		TopicPropertiesStatusProvisioningStateCreating,
+		TopicPropertiesStatusProvisioningStateDeleting,
+		TopicPropertiesStatusProvisioningStateFailed,
+		TopicPropertiesStatusProvisioningStateSucceeded,
+		TopicPropertiesStatusProvisioningStateUpdating))
 	gens["PublicNetworkAccess"] = gen.PtrOf(gen.OneConstOf(TopicPropertiesStatusPublicNetworkAccessDisabled, TopicPropertiesStatusPublicNetworkAccessEnabled))
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
@@ -736,8 +742,16 @@ func SystemDataStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSystemDataStatus(gens map[string]gopter.Gen) {
 	gens["CreatedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["CreatedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusCreatedByTypeApplication, SystemDataStatusCreatedByTypeKey, SystemDataStatusCreatedByTypeManagedIdentity, SystemDataStatusCreatedByTypeUser))
+	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusCreatedByTypeApplication,
+		SystemDataStatusCreatedByTypeKey,
+		SystemDataStatusCreatedByTypeManagedIdentity,
+		SystemDataStatusCreatedByTypeUser))
 	gens["LastModifiedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["LastModifiedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusLastModifiedByTypeApplication, SystemDataStatusLastModifiedByTypeKey, SystemDataStatusLastModifiedByTypeManagedIdentity, SystemDataStatusLastModifiedByTypeUser))
+	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusLastModifiedByTypeApplication,
+		SystemDataStatusLastModifiedByTypeKey,
+		SystemDataStatusLastModifiedByTypeManagedIdentity,
+		SystemDataStatusLastModifiedByTypeUser))
 }

--- a/v2/api/microsoft.network/v1alpha1api20201101/load_balancer__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/load_balancer__status_arm_types_gen_test.go
@@ -225,7 +225,11 @@ func LoadBalancerPropertiesFormatStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForLoadBalancerPropertiesFormatStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForLoadBalancerPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -876,7 +880,11 @@ func AddIndependentPropertyGeneratorsForFrontendIPConfigurationPropertiesFormatS
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAddressVersion"] = gen.PtrOf(gen.OneConstOf(IPVersion_StatusIPv4, IPVersion_StatusIPv6))
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForFrontendIPConfigurationPropertiesFormatStatusLoadBalancerSubResourceEmbeddedARM is a factory method for creating gopter generators
@@ -963,7 +971,11 @@ func AddIndependentPropertyGeneratorsForInboundNatPoolPropertiesFormatStatusARM(
 	gens["FrontendPortRangeStart"] = gen.Int()
 	gens["IdleTimeoutInMinutes"] = gen.PtrOf(gen.Int())
 	gens["Protocol"] = gen.OneConstOf(TransportProtocol_StatusAll, TransportProtocol_StatusTcp, TransportProtocol_StatusUdp)
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForInboundNatPoolPropertiesFormatStatusARM is a factory method for creating gopter generators
@@ -1045,7 +1057,11 @@ func AddIndependentPropertyGeneratorsForLoadBalancingRulePropertiesFormatStatusA
 	gens["IdleTimeoutInMinutes"] = gen.PtrOf(gen.Int())
 	gens["LoadDistribution"] = gen.PtrOf(gen.OneConstOf(LoadBalancingRulePropertiesFormatStatusLoadDistributionDefault, LoadBalancingRulePropertiesFormatStatusLoadDistributionSourceIP, LoadBalancingRulePropertiesFormatStatusLoadDistributionSourceIPProtocol))
 	gens["Protocol"] = gen.OneConstOf(TransportProtocol_StatusAll, TransportProtocol_StatusTcp, TransportProtocol_StatusUdp)
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForLoadBalancingRulePropertiesFormatStatusARM is a factory method for creating gopter generators
@@ -1125,7 +1141,11 @@ func AddIndependentPropertyGeneratorsForOutboundRulePropertiesFormatStatusARM(ge
 	gens["EnableTcpReset"] = gen.PtrOf(gen.Bool())
 	gens["IdleTimeoutInMinutes"] = gen.PtrOf(gen.Int())
 	gens["Protocol"] = gen.OneConstOf(OutboundRulePropertiesFormatStatusProtocolAll, OutboundRulePropertiesFormatStatusProtocolTcp, OutboundRulePropertiesFormatStatusProtocolUdp)
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForOutboundRulePropertiesFormatStatusARM is a factory method for creating gopter generators
@@ -1204,7 +1224,11 @@ func AddIndependentPropertyGeneratorsForProbePropertiesFormatStatusARM(gens map[
 	gens["NumberOfProbes"] = gen.PtrOf(gen.Int())
 	gens["Port"] = gen.Int()
 	gens["Protocol"] = gen.OneConstOf(ProbePropertiesFormatStatusProtocolHttp, ProbePropertiesFormatStatusProtocolHttps, ProbePropertiesFormatStatusProtocolTcp)
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["RequestPath"] = gen.PtrOf(gen.AlphaString())
 }
 

--- a/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen_test.go
@@ -225,7 +225,11 @@ func AddIndependentPropertyGeneratorsForLoadBalancerStatus(gens map[string]gopte
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
@@ -774,7 +778,11 @@ func AddIndependentPropertyGeneratorsForFrontendIPConfigurationStatusLoadBalance
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAddressVersion"] = gen.PtrOf(gen.OneConstOf(IPVersion_StatusIPv4, IPVersion_StatusIPv6))
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 	gens["Zones"] = gen.SliceOf(gen.AlphaString())
 }
@@ -905,7 +913,11 @@ func AddIndependentPropertyGeneratorsForInboundNatPoolStatus(gens map[string]gop
 	gens["IdleTimeoutInMinutes"] = gen.PtrOf(gen.Int())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["Protocol"] = gen.PtrOf(gen.OneConstOf(TransportProtocol_StatusAll, TransportProtocol_StatusTcp, TransportProtocol_StatusUdp))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2026,7 +2038,11 @@ func AddIndependentPropertyGeneratorsForLoadBalancingRuleStatus(gens map[string]
 	gens["LoadDistribution"] = gen.PtrOf(gen.OneConstOf(LoadBalancingRulePropertiesFormatStatusLoadDistributionDefault, LoadBalancingRulePropertiesFormatStatusLoadDistributionSourceIP, LoadBalancingRulePropertiesFormatStatusLoadDistributionSourceIPProtocol))
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["Protocol"] = gen.PtrOf(gen.OneConstOf(TransportProtocol_StatusAll, TransportProtocol_StatusTcp, TransportProtocol_StatusUdp))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2148,7 +2164,11 @@ func AddIndependentPropertyGeneratorsForOutboundRuleStatus(gens map[string]gopte
 	gens["IdleTimeoutInMinutes"] = gen.PtrOf(gen.Int())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["Protocol"] = gen.PtrOf(gen.OneConstOf(OutboundRulePropertiesFormatStatusProtocolAll, OutboundRulePropertiesFormatStatusProtocolTcp, OutboundRulePropertiesFormatStatusProtocolUdp))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2269,7 +2289,11 @@ func AddIndependentPropertyGeneratorsForProbeStatus(gens map[string]gopter.Gen) 
 	gens["NumberOfProbes"] = gen.PtrOf(gen.Int())
 	gens["Port"] = gen.PtrOf(gen.Int())
 	gens["Protocol"] = gen.PtrOf(gen.OneConstOf(ProbePropertiesFormatStatusProtocolHttp, ProbePropertiesFormatStatusProtocolHttps, ProbePropertiesFormatStatusProtocolTcp))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["RequestPath"] = gen.PtrOf(gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_group__status__network_security_group__sub_resource_embedded_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_group__status__network_security_group__sub_resource_embedded_arm_types_gen_test.go
@@ -162,7 +162,11 @@ func NetworkSecurityGroupPropertiesFormatStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkSecurityGroupPropertiesFormatStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkSecurityGroupPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 }
 

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen_test.go
@@ -227,7 +227,11 @@ func AddIndependentPropertyGeneratorsForNetworkSecurityGroupStatusNetworkSecurit
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen_test.go
@@ -233,7 +233,13 @@ func AddIndependentPropertyGeneratorsForNetworkSecurityGroupsSecurityRulesSpec(g
 	gens["Direction"] = gen.OneConstOf(SecurityRulePropertiesFormatDirectionInbound, SecurityRulePropertiesFormatDirectionOutbound)
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["Priority"] = gen.Int()
-	gens["Protocol"] = gen.OneConstOf(SecurityRulePropertiesFormatProtocolAh, SecurityRulePropertiesFormatProtocolEsp, SecurityRulePropertiesFormatProtocolIcmp, SecurityRulePropertiesFormatProtocolStar, SecurityRulePropertiesFormatProtocolTcp, SecurityRulePropertiesFormatProtocolUdp)
+	gens["Protocol"] = gen.OneConstOf(
+		SecurityRulePropertiesFormatProtocolAh,
+		SecurityRulePropertiesFormatProtocolEsp,
+		SecurityRulePropertiesFormatProtocolIcmp,
+		SecurityRulePropertiesFormatProtocolStar,
+		SecurityRulePropertiesFormatProtocolTcp,
+		SecurityRulePropertiesFormatProtocolUdp)
 	gens["SourceAddressPrefix"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceAddressPrefixes"] = gen.SliceOf(gen.AlphaString())
 	gens["SourcePortRange"] = gen.PtrOf(gen.AlphaString())
@@ -363,8 +369,18 @@ func AddIndependentPropertyGeneratorsForSecurityRuleStatusNetworkSecurityGroupsS
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["Priority"] = gen.PtrOf(gen.Int())
-	gens["Protocol"] = gen.PtrOf(gen.OneConstOf(SecurityRulePropertiesFormatStatusProtocolAh, SecurityRulePropertiesFormatStatusProtocolEsp, SecurityRulePropertiesFormatStatusProtocolIcmp, SecurityRulePropertiesFormatStatusProtocolStar, SecurityRulePropertiesFormatStatusProtocolTcp, SecurityRulePropertiesFormatStatusProtocolUdp))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["Protocol"] = gen.PtrOf(gen.OneConstOf(
+		SecurityRulePropertiesFormatStatusProtocolAh,
+		SecurityRulePropertiesFormatStatusProtocolEsp,
+		SecurityRulePropertiesFormatStatusProtocolIcmp,
+		SecurityRulePropertiesFormatStatusProtocolStar,
+		SecurityRulePropertiesFormatStatusProtocolTcp,
+		SecurityRulePropertiesFormatStatusProtocolUdp))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["SourceAddressPrefix"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceAddressPrefixes"] = gen.SliceOf(gen.AlphaString())
 	gens["SourcePortRange"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rules__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rules__spec_arm_types_gen_test.go
@@ -167,7 +167,13 @@ func AddIndependentPropertyGeneratorsForSecurityRulePropertiesFormatARM(gens map
 	gens["DestinationPortRanges"] = gen.SliceOf(gen.AlphaString())
 	gens["Direction"] = gen.OneConstOf(SecurityRulePropertiesFormatDirectionInbound, SecurityRulePropertiesFormatDirectionOutbound)
 	gens["Priority"] = gen.Int()
-	gens["Protocol"] = gen.OneConstOf(SecurityRulePropertiesFormatProtocolAh, SecurityRulePropertiesFormatProtocolEsp, SecurityRulePropertiesFormatProtocolIcmp, SecurityRulePropertiesFormatProtocolStar, SecurityRulePropertiesFormatProtocolTcp, SecurityRulePropertiesFormatProtocolUdp)
+	gens["Protocol"] = gen.OneConstOf(
+		SecurityRulePropertiesFormatProtocolAh,
+		SecurityRulePropertiesFormatProtocolEsp,
+		SecurityRulePropertiesFormatProtocolIcmp,
+		SecurityRulePropertiesFormatProtocolStar,
+		SecurityRulePropertiesFormatProtocolTcp,
+		SecurityRulePropertiesFormatProtocolUdp)
 	gens["SourceAddressPrefix"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceAddressPrefixes"] = gen.SliceOf(gen.AlphaString())
 	gens["SourcePortRange"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address__status__public_ip_address__sub_resource_embedded_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address__status__public_ip_address__sub_resource_embedded_arm_types_gen_test.go
@@ -167,8 +167,17 @@ func PublicIPAddressPropertiesFormatStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForPublicIPAddressPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
 	gens["IdleTimeoutInMinutes"] = gen.PtrOf(gen.Int())
 	gens["IpAddress"] = gen.PtrOf(gen.AlphaString())
-	gens["MigrationPhase"] = gen.PtrOf(gen.OneConstOf(PublicIPAddressPropertiesFormatStatusMigrationPhaseAbort, PublicIPAddressPropertiesFormatStatusMigrationPhaseCommit, PublicIPAddressPropertiesFormatStatusMigrationPhaseCommitted, PublicIPAddressPropertiesFormatStatusMigrationPhaseNone, PublicIPAddressPropertiesFormatStatusMigrationPhasePrepare))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["MigrationPhase"] = gen.PtrOf(gen.OneConstOf(
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseAbort,
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseCommit,
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseCommitted,
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseNone,
+		PublicIPAddressPropertiesFormatStatusMigrationPhasePrepare))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["PublicIPAddressVersion"] = gen.PtrOf(gen.OneConstOf(IPVersion_StatusIPv4, IPVersion_StatusIPv6))
 	gens["PublicIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
@@ -721,7 +730,11 @@ func IPConfigurationPropertiesFormatStatusPublicIPAddressSubResourceEmbeddedARMG
 func AddIndependentPropertyGeneratorsForIPConfigurationPropertiesFormatStatusPublicIPAddressSubResourceEmbeddedARM(gens map[string]gopter.Gen) {
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForIPConfigurationPropertiesFormatStatusPublicIPAddressSubResourceEmbeddedARM is a factory method for creating gopter generators

--- a/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen_test.go
@@ -227,9 +227,18 @@ func AddIndependentPropertyGeneratorsForPublicIPAddressStatusPublicIPAddressSubR
 	gens["IdleTimeoutInMinutes"] = gen.PtrOf(gen.Int())
 	gens["IpAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
-	gens["MigrationPhase"] = gen.PtrOf(gen.OneConstOf(PublicIPAddressPropertiesFormatStatusMigrationPhaseAbort, PublicIPAddressPropertiesFormatStatusMigrationPhaseCommit, PublicIPAddressPropertiesFormatStatusMigrationPhaseCommitted, PublicIPAddressPropertiesFormatStatusMigrationPhaseNone, PublicIPAddressPropertiesFormatStatusMigrationPhasePrepare))
+	gens["MigrationPhase"] = gen.PtrOf(gen.OneConstOf(
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseAbort,
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseCommit,
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseCommitted,
+		PublicIPAddressPropertiesFormatStatusMigrationPhaseNone,
+		PublicIPAddressPropertiesFormatStatusMigrationPhasePrepare))
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["PublicIPAddressVersion"] = gen.PtrOf(gen.OneConstOf(IPVersion_StatusIPv4, IPVersion_StatusIPv6))
 	gens["PublicIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
@@ -711,7 +720,11 @@ func AddIndependentPropertyGeneratorsForIPConfigurationStatusPublicIPAddressSubR
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForIPConfigurationStatusPublicIPAddressSubResourceEmbedded is a factory method for creating gopter generators

--- a/v2/api/microsoft.network/v1alpha1api20201101/security_rule__status__network_security_groups_security_rule__sub_resource_embedded_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/security_rule__status__network_security_groups_security_rule__sub_resource_embedded_arm_types_gen_test.go
@@ -168,8 +168,18 @@ func AddIndependentPropertyGeneratorsForSecurityRulePropertiesFormatStatusARM(ge
 	gens["DestinationPortRanges"] = gen.SliceOf(gen.AlphaString())
 	gens["Direction"] = gen.OneConstOf(SecurityRuleDirection_StatusInbound, SecurityRuleDirection_StatusOutbound)
 	gens["Priority"] = gen.PtrOf(gen.Int())
-	gens["Protocol"] = gen.OneConstOf(SecurityRulePropertiesFormatStatusProtocolAh, SecurityRulePropertiesFormatStatusProtocolEsp, SecurityRulePropertiesFormatStatusProtocolIcmp, SecurityRulePropertiesFormatStatusProtocolStar, SecurityRulePropertiesFormatStatusProtocolTcp, SecurityRulePropertiesFormatStatusProtocolUdp)
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["Protocol"] = gen.OneConstOf(
+		SecurityRulePropertiesFormatStatusProtocolAh,
+		SecurityRulePropertiesFormatStatusProtocolEsp,
+		SecurityRulePropertiesFormatStatusProtocolIcmp,
+		SecurityRulePropertiesFormatStatusProtocolStar,
+		SecurityRulePropertiesFormatStatusProtocolTcp,
+		SecurityRulePropertiesFormatStatusProtocolUdp)
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["SourceAddressPrefix"] = gen.PtrOf(gen.AlphaString())
 	gens["SourceAddressPrefixes"] = gen.SliceOf(gen.AlphaString())
 	gens["SourcePortRange"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.network/v1alpha1api20201101/subnet__status__virtual_networks_subnet__sub_resource_embedded_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/subnet__status__virtual_networks_subnet__sub_resource_embedded_arm_types_gen_test.go
@@ -164,7 +164,11 @@ func AddIndependentPropertyGeneratorsForSubnetPropertiesFormatStatusARM(gens map
 	gens["AddressPrefixes"] = gen.SliceOf(gen.AlphaString())
 	gens["PrivateEndpointNetworkPolicies"] = gen.PtrOf(gen.OneConstOf(SubnetPropertiesFormatStatusPrivateEndpointNetworkPoliciesDisabled, SubnetPropertiesFormatStatusPrivateEndpointNetworkPoliciesEnabled))
 	gens["PrivateLinkServiceNetworkPolicies"] = gen.PtrOf(gen.OneConstOf(SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPoliciesDisabled, SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPoliciesEnabled))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Purpose"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -959,7 +963,11 @@ func ServiceEndpointPropertiesFormatStatusARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForServiceEndpointPropertiesFormatStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceEndpointPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
 	gens["Locations"] = gen.SliceOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Service"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -1029,7 +1037,11 @@ func ApplicationGatewayIPConfigurationPropertiesFormatStatusARMGenerator() gopte
 
 // AddIndependentPropertyGeneratorsForApplicationGatewayIPConfigurationPropertiesFormatStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForApplicationGatewayIPConfigurationPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForApplicationGatewayIPConfigurationPropertiesFormatStatusARM is a factory method for creating gopter generators
@@ -1095,7 +1107,11 @@ func IPConfigurationProfilePropertiesFormatStatusVirtualNetworksSubnetSubResourc
 
 // AddIndependentPropertyGeneratorsForIPConfigurationProfilePropertiesFormatStatusVirtualNetworksSubnetSubResourceEmbeddedARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIPConfigurationProfilePropertiesFormatStatusVirtualNetworksSubnetSubResourceEmbeddedARM(gens map[string]gopter.Gen) {
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 func Test_IPConfigurationPropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -1167,7 +1183,11 @@ func IPConfigurationPropertiesFormatStatusVirtualNetworksSubnetSubResourceEmbedd
 func AddIndependentPropertyGeneratorsForIPConfigurationPropertiesFormatStatusVirtualNetworksSubnetSubResourceEmbeddedARM(gens map[string]gopter.Gen) {
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForIPConfigurationPropertiesFormatStatusVirtualNetworksSubnetSubResourceEmbeddedARM is a factory method for creating gopter generators
@@ -1234,7 +1254,11 @@ func ResourceNavigationLinkFormatStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForResourceNavigationLinkFormatStatusARM(gens map[string]gopter.Gen) {
 	gens["Link"] = gen.PtrOf(gen.AlphaString())
 	gens["LinkedResourceType"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 func Test_ServiceAssociationLinkPropertiesFormat_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -1298,7 +1322,11 @@ func AddIndependentPropertyGeneratorsForServiceAssociationLinkPropertiesFormatSt
 	gens["Link"] = gen.PtrOf(gen.AlphaString())
 	gens["LinkedResourceType"] = gen.PtrOf(gen.AlphaString())
 	gens["Locations"] = gen.SliceOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 func Test_ServiceDelegationPropertiesFormat_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -1359,7 +1387,11 @@ func ServiceDelegationPropertiesFormatStatusARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForServiceDelegationPropertiesFormatStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceDelegationPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
 	gens["Actions"] = gen.SliceOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ServiceName"] = gen.PtrOf(gen.AlphaString())
 }
 

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network__status_arm_types_gen_test.go
@@ -165,7 +165,11 @@ func VirtualNetworkPropertiesFormatStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForVirtualNetworkPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
 	gens["EnableDdosProtection"] = gen.PtrOf(gen.Bool())
 	gens["EnableVmProtection"] = gen.PtrOf(gen.Bool())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 }
 

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway__status_arm_types_gen_test.go
@@ -169,7 +169,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkGatewayPropertiesFormatSta
 	gens["EnablePrivateIpAddress"] = gen.PtrOf(gen.Bool())
 	gens["GatewayType"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewayPropertiesFormatStatusGatewayTypeExpressRoute, VirtualNetworkGatewayPropertiesFormatStatusGatewayTypeLocalGateway, VirtualNetworkGatewayPropertiesFormatStatusGatewayTypeVpn))
 	gens["InboundDnsForwardingEndpoint"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 	gens["VNetExtendedLocationResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["VpnGatewayGeneration"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewayPropertiesFormatStatusVpnGatewayGenerationGeneration1, VirtualNetworkGatewayPropertiesFormatStatusVpnGatewayGenerationGeneration2, VirtualNetworkGatewayPropertiesFormatStatusVpnGatewayGenerationNone))
@@ -456,8 +460,42 @@ func VirtualNetworkGatewaySkuStatusARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySkuStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySkuStatusARM(gens map[string]gopter.Gen) {
 	gens["Capacity"] = gen.PtrOf(gen.Int())
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuStatusNameBasic, VirtualNetworkGatewaySkuStatusNameErGw1AZ, VirtualNetworkGatewaySkuStatusNameErGw2AZ, VirtualNetworkGatewaySkuStatusNameErGw3AZ, VirtualNetworkGatewaySkuStatusNameHighPerformance, VirtualNetworkGatewaySkuStatusNameStandard, VirtualNetworkGatewaySkuStatusNameUltraPerformance, VirtualNetworkGatewaySkuStatusNameVpnGw1, VirtualNetworkGatewaySkuStatusNameVpnGw1AZ, VirtualNetworkGatewaySkuStatusNameVpnGw2, VirtualNetworkGatewaySkuStatusNameVpnGw2AZ, VirtualNetworkGatewaySkuStatusNameVpnGw3, VirtualNetworkGatewaySkuStatusNameVpnGw3AZ, VirtualNetworkGatewaySkuStatusNameVpnGw4, VirtualNetworkGatewaySkuStatusNameVpnGw4AZ, VirtualNetworkGatewaySkuStatusNameVpnGw5, VirtualNetworkGatewaySkuStatusNameVpnGw5AZ))
-	gens["Tier"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuStatusTierBasic, VirtualNetworkGatewaySkuStatusTierErGw1AZ, VirtualNetworkGatewaySkuStatusTierErGw2AZ, VirtualNetworkGatewaySkuStatusTierErGw3AZ, VirtualNetworkGatewaySkuStatusTierHighPerformance, VirtualNetworkGatewaySkuStatusTierStandard, VirtualNetworkGatewaySkuStatusTierUltraPerformance, VirtualNetworkGatewaySkuStatusTierVpnGw1, VirtualNetworkGatewaySkuStatusTierVpnGw1AZ, VirtualNetworkGatewaySkuStatusTierVpnGw2, VirtualNetworkGatewaySkuStatusTierVpnGw2AZ, VirtualNetworkGatewaySkuStatusTierVpnGw3, VirtualNetworkGatewaySkuStatusTierVpnGw3AZ, VirtualNetworkGatewaySkuStatusTierVpnGw4, VirtualNetworkGatewaySkuStatusTierVpnGw4AZ, VirtualNetworkGatewaySkuStatusTierVpnGw5, VirtualNetworkGatewaySkuStatusTierVpnGw5AZ))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuStatusNameBasic,
+		VirtualNetworkGatewaySkuStatusNameErGw1AZ,
+		VirtualNetworkGatewaySkuStatusNameErGw2AZ,
+		VirtualNetworkGatewaySkuStatusNameErGw3AZ,
+		VirtualNetworkGatewaySkuStatusNameHighPerformance,
+		VirtualNetworkGatewaySkuStatusNameStandard,
+		VirtualNetworkGatewaySkuStatusNameUltraPerformance,
+		VirtualNetworkGatewaySkuStatusNameVpnGw1,
+		VirtualNetworkGatewaySkuStatusNameVpnGw1AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw2,
+		VirtualNetworkGatewaySkuStatusNameVpnGw2AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw3,
+		VirtualNetworkGatewaySkuStatusNameVpnGw3AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw4,
+		VirtualNetworkGatewaySkuStatusNameVpnGw4AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw5,
+		VirtualNetworkGatewaySkuStatusNameVpnGw5AZ))
+	gens["Tier"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuStatusTierBasic,
+		VirtualNetworkGatewaySkuStatusTierErGw1AZ,
+		VirtualNetworkGatewaySkuStatusTierErGw2AZ,
+		VirtualNetworkGatewaySkuStatusTierErGw3AZ,
+		VirtualNetworkGatewaySkuStatusTierHighPerformance,
+		VirtualNetworkGatewaySkuStatusTierStandard,
+		VirtualNetworkGatewaySkuStatusTierUltraPerformance,
+		VirtualNetworkGatewaySkuStatusTierVpnGw1,
+		VirtualNetworkGatewaySkuStatusTierVpnGw1AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw2,
+		VirtualNetworkGatewaySkuStatusTierVpnGw2AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw3,
+		VirtualNetworkGatewaySkuStatusTierVpnGw3AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw4,
+		VirtualNetworkGatewaySkuStatusTierVpnGw4AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw5,
+		VirtualNetworkGatewaySkuStatusTierVpnGw5AZ))
 }
 
 func Test_VpnClientConfiguration_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -664,12 +702,57 @@ func IpsecPolicyStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIpsecPolicyStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIpsecPolicyStatusARM(gens map[string]gopter.Gen) {
-	gens["DhGroup"] = gen.OneConstOf(DhGroup_StatusDHGroup1, DhGroup_StatusDHGroup14, DhGroup_StatusDHGroup2, DhGroup_StatusDHGroup2048, DhGroup_StatusDHGroup24, DhGroup_StatusECP256, DhGroup_StatusECP384, DhGroup_StatusNone)
-	gens["IkeEncryption"] = gen.OneConstOf(IkeEncryption_StatusAES128, IkeEncryption_StatusAES192, IkeEncryption_StatusAES256, IkeEncryption_StatusDES, IkeEncryption_StatusDES3, IkeEncryption_StatusGCMAES128, IkeEncryption_StatusGCMAES256)
-	gens["IkeIntegrity"] = gen.OneConstOf(IkeIntegrity_StatusGCMAES128, IkeIntegrity_StatusGCMAES256, IkeIntegrity_StatusMD5, IkeIntegrity_StatusSHA1, IkeIntegrity_StatusSHA256, IkeIntegrity_StatusSHA384)
-	gens["IpsecEncryption"] = gen.OneConstOf(IpsecEncryption_StatusAES128, IpsecEncryption_StatusAES192, IpsecEncryption_StatusAES256, IpsecEncryption_StatusDES, IpsecEncryption_StatusDES3, IpsecEncryption_StatusGCMAES128, IpsecEncryption_StatusGCMAES192, IpsecEncryption_StatusGCMAES256, IpsecEncryption_StatusNone)
-	gens["IpsecIntegrity"] = gen.OneConstOf(IpsecIntegrity_StatusGCMAES128, IpsecIntegrity_StatusGCMAES192, IpsecIntegrity_StatusGCMAES256, IpsecIntegrity_StatusMD5, IpsecIntegrity_StatusSHA1, IpsecIntegrity_StatusSHA256)
-	gens["PfsGroup"] = gen.OneConstOf(PfsGroup_StatusECP256, PfsGroup_StatusECP384, PfsGroup_StatusNone, PfsGroup_StatusPFS1, PfsGroup_StatusPFS14, PfsGroup_StatusPFS2, PfsGroup_StatusPFS2048, PfsGroup_StatusPFS24, PfsGroup_StatusPFSMM)
+	gens["DhGroup"] = gen.OneConstOf(
+		DhGroup_StatusDHGroup1,
+		DhGroup_StatusDHGroup14,
+		DhGroup_StatusDHGroup2,
+		DhGroup_StatusDHGroup2048,
+		DhGroup_StatusDHGroup24,
+		DhGroup_StatusECP256,
+		DhGroup_StatusECP384,
+		DhGroup_StatusNone)
+	gens["IkeEncryption"] = gen.OneConstOf(
+		IkeEncryption_StatusAES128,
+		IkeEncryption_StatusAES192,
+		IkeEncryption_StatusAES256,
+		IkeEncryption_StatusDES,
+		IkeEncryption_StatusDES3,
+		IkeEncryption_StatusGCMAES128,
+		IkeEncryption_StatusGCMAES256)
+	gens["IkeIntegrity"] = gen.OneConstOf(
+		IkeIntegrity_StatusGCMAES128,
+		IkeIntegrity_StatusGCMAES256,
+		IkeIntegrity_StatusMD5,
+		IkeIntegrity_StatusSHA1,
+		IkeIntegrity_StatusSHA256,
+		IkeIntegrity_StatusSHA384)
+	gens["IpsecEncryption"] = gen.OneConstOf(
+		IpsecEncryption_StatusAES128,
+		IpsecEncryption_StatusAES192,
+		IpsecEncryption_StatusAES256,
+		IpsecEncryption_StatusDES,
+		IpsecEncryption_StatusDES3,
+		IpsecEncryption_StatusGCMAES128,
+		IpsecEncryption_StatusGCMAES192,
+		IpsecEncryption_StatusGCMAES256,
+		IpsecEncryption_StatusNone)
+	gens["IpsecIntegrity"] = gen.OneConstOf(
+		IpsecIntegrity_StatusGCMAES128,
+		IpsecIntegrity_StatusGCMAES192,
+		IpsecIntegrity_StatusGCMAES256,
+		IpsecIntegrity_StatusMD5,
+		IpsecIntegrity_StatusSHA1,
+		IpsecIntegrity_StatusSHA256)
+	gens["PfsGroup"] = gen.OneConstOf(
+		PfsGroup_StatusECP256,
+		PfsGroup_StatusECP384,
+		PfsGroup_StatusNone,
+		PfsGroup_StatusPFS1,
+		PfsGroup_StatusPFS14,
+		PfsGroup_StatusPFS2,
+		PfsGroup_StatusPFS2048,
+		PfsGroup_StatusPFS24,
+		PfsGroup_StatusPFSMM)
 	gens["SaDataSizeKilobytes"] = gen.Int()
 	gens["SaLifeTimeSeconds"] = gen.Int()
 }
@@ -804,7 +887,11 @@ func VirtualNetworkGatewayIPConfigurationPropertiesFormatStatusARMGenerator() go
 func AddIndependentPropertyGeneratorsForVirtualNetworkGatewayIPConfigurationPropertiesFormatStatusARM(gens map[string]gopter.Gen) {
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualNetworkGatewayIPConfigurationPropertiesFormatStatusARM is a factory method for creating gopter generators
@@ -1022,7 +1109,11 @@ func VpnClientRevokedCertificatePropertiesFormatStatusARMGenerator() gopter.Gen 
 
 // AddIndependentPropertyGeneratorsForVpnClientRevokedCertificatePropertiesFormatStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVpnClientRevokedCertificatePropertiesFormatStatusARM(gens map[string]gopter.Gen) {
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Thumbprint"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -1083,6 +1174,10 @@ func VpnClientRootCertificatePropertiesFormatStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVpnClientRootCertificatePropertiesFormatStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVpnClientRootCertificatePropertiesFormatStatusARM(gens map[string]gopter.Gen) {
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["PublicCertData"] = gen.AlphaString()
 }

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen_test.go
@@ -233,7 +233,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkGatewayStatus(gens map[str
 	gens["InboundDnsForwardingEndpoint"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
@@ -363,7 +367,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkGatewaysSpec(gens map[stri
 	gens["EnableBgp"] = gen.PtrOf(gen.Bool())
 	gens["EnableDnsForwarding"] = gen.PtrOf(gen.Bool())
 	gens["EnablePrivateIpAddress"] = gen.PtrOf(gen.Bool())
-	gens["GatewayType"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaysSpecPropertiesGatewayTypeExpressRoute, VirtualNetworkGatewaysSpecPropertiesGatewayTypeHyperNet, VirtualNetworkGatewaysSpecPropertiesGatewayTypeLocalGateway, VirtualNetworkGatewaysSpecPropertiesGatewayTypeVpn))
+	gens["GatewayType"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeExpressRoute,
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeHyperNet,
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeLocalGateway,
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeVpn))
 	gens["Location"] = gen.AlphaString()
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["VpnGatewayGeneration"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaysSpecPropertiesVpnGatewayGenerationGeneration1, VirtualNetworkGatewaysSpecPropertiesVpnGatewayGenerationGeneration2, VirtualNetworkGatewaysSpecPropertiesVpnGatewayGenerationNone))
@@ -719,7 +727,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkGatewayIPConfigurationStat
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForVirtualNetworkGatewayIPConfigurationStatus is a factory method for creating gopter generators
@@ -824,8 +836,42 @@ func VirtualNetworkGatewaySkuGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySku is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySku(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuNameBasic, VirtualNetworkGatewaySkuNameErGw1AZ, VirtualNetworkGatewaySkuNameErGw2AZ, VirtualNetworkGatewaySkuNameErGw3AZ, VirtualNetworkGatewaySkuNameHighPerformance, VirtualNetworkGatewaySkuNameStandard, VirtualNetworkGatewaySkuNameUltraPerformance, VirtualNetworkGatewaySkuNameVpnGw1, VirtualNetworkGatewaySkuNameVpnGw1AZ, VirtualNetworkGatewaySkuNameVpnGw2, VirtualNetworkGatewaySkuNameVpnGw2AZ, VirtualNetworkGatewaySkuNameVpnGw3, VirtualNetworkGatewaySkuNameVpnGw3AZ, VirtualNetworkGatewaySkuNameVpnGw4, VirtualNetworkGatewaySkuNameVpnGw4AZ, VirtualNetworkGatewaySkuNameVpnGw5, VirtualNetworkGatewaySkuNameVpnGw5AZ))
-	gens["Tier"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuTierBasic, VirtualNetworkGatewaySkuTierErGw1AZ, VirtualNetworkGatewaySkuTierErGw2AZ, VirtualNetworkGatewaySkuTierErGw3AZ, VirtualNetworkGatewaySkuTierHighPerformance, VirtualNetworkGatewaySkuTierStandard, VirtualNetworkGatewaySkuTierUltraPerformance, VirtualNetworkGatewaySkuTierVpnGw1, VirtualNetworkGatewaySkuTierVpnGw1AZ, VirtualNetworkGatewaySkuTierVpnGw2, VirtualNetworkGatewaySkuTierVpnGw2AZ, VirtualNetworkGatewaySkuTierVpnGw3, VirtualNetworkGatewaySkuTierVpnGw3AZ, VirtualNetworkGatewaySkuTierVpnGw4, VirtualNetworkGatewaySkuTierVpnGw4AZ, VirtualNetworkGatewaySkuTierVpnGw5, VirtualNetworkGatewaySkuTierVpnGw5AZ))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuNameBasic,
+		VirtualNetworkGatewaySkuNameErGw1AZ,
+		VirtualNetworkGatewaySkuNameErGw2AZ,
+		VirtualNetworkGatewaySkuNameErGw3AZ,
+		VirtualNetworkGatewaySkuNameHighPerformance,
+		VirtualNetworkGatewaySkuNameStandard,
+		VirtualNetworkGatewaySkuNameUltraPerformance,
+		VirtualNetworkGatewaySkuNameVpnGw1,
+		VirtualNetworkGatewaySkuNameVpnGw1AZ,
+		VirtualNetworkGatewaySkuNameVpnGw2,
+		VirtualNetworkGatewaySkuNameVpnGw2AZ,
+		VirtualNetworkGatewaySkuNameVpnGw3,
+		VirtualNetworkGatewaySkuNameVpnGw3AZ,
+		VirtualNetworkGatewaySkuNameVpnGw4,
+		VirtualNetworkGatewaySkuNameVpnGw4AZ,
+		VirtualNetworkGatewaySkuNameVpnGw5,
+		VirtualNetworkGatewaySkuNameVpnGw5AZ))
+	gens["Tier"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuTierBasic,
+		VirtualNetworkGatewaySkuTierErGw1AZ,
+		VirtualNetworkGatewaySkuTierErGw2AZ,
+		VirtualNetworkGatewaySkuTierErGw3AZ,
+		VirtualNetworkGatewaySkuTierHighPerformance,
+		VirtualNetworkGatewaySkuTierStandard,
+		VirtualNetworkGatewaySkuTierUltraPerformance,
+		VirtualNetworkGatewaySkuTierVpnGw1,
+		VirtualNetworkGatewaySkuTierVpnGw1AZ,
+		VirtualNetworkGatewaySkuTierVpnGw2,
+		VirtualNetworkGatewaySkuTierVpnGw2AZ,
+		VirtualNetworkGatewaySkuTierVpnGw3,
+		VirtualNetworkGatewaySkuTierVpnGw3AZ,
+		VirtualNetworkGatewaySkuTierVpnGw4,
+		VirtualNetworkGatewaySkuTierVpnGw4AZ,
+		VirtualNetworkGatewaySkuTierVpnGw5,
+		VirtualNetworkGatewaySkuTierVpnGw5AZ))
 }
 
 func Test_VirtualNetworkGatewaySku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -925,8 +971,42 @@ func VirtualNetworkGatewaySkuStatusGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySkuStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySkuStatus(gens map[string]gopter.Gen) {
 	gens["Capacity"] = gen.PtrOf(gen.Int())
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuStatusNameBasic, VirtualNetworkGatewaySkuStatusNameErGw1AZ, VirtualNetworkGatewaySkuStatusNameErGw2AZ, VirtualNetworkGatewaySkuStatusNameErGw3AZ, VirtualNetworkGatewaySkuStatusNameHighPerformance, VirtualNetworkGatewaySkuStatusNameStandard, VirtualNetworkGatewaySkuStatusNameUltraPerformance, VirtualNetworkGatewaySkuStatusNameVpnGw1, VirtualNetworkGatewaySkuStatusNameVpnGw1AZ, VirtualNetworkGatewaySkuStatusNameVpnGw2, VirtualNetworkGatewaySkuStatusNameVpnGw2AZ, VirtualNetworkGatewaySkuStatusNameVpnGw3, VirtualNetworkGatewaySkuStatusNameVpnGw3AZ, VirtualNetworkGatewaySkuStatusNameVpnGw4, VirtualNetworkGatewaySkuStatusNameVpnGw4AZ, VirtualNetworkGatewaySkuStatusNameVpnGw5, VirtualNetworkGatewaySkuStatusNameVpnGw5AZ))
-	gens["Tier"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuStatusTierBasic, VirtualNetworkGatewaySkuStatusTierErGw1AZ, VirtualNetworkGatewaySkuStatusTierErGw2AZ, VirtualNetworkGatewaySkuStatusTierErGw3AZ, VirtualNetworkGatewaySkuStatusTierHighPerformance, VirtualNetworkGatewaySkuStatusTierStandard, VirtualNetworkGatewaySkuStatusTierUltraPerformance, VirtualNetworkGatewaySkuStatusTierVpnGw1, VirtualNetworkGatewaySkuStatusTierVpnGw1AZ, VirtualNetworkGatewaySkuStatusTierVpnGw2, VirtualNetworkGatewaySkuStatusTierVpnGw2AZ, VirtualNetworkGatewaySkuStatusTierVpnGw3, VirtualNetworkGatewaySkuStatusTierVpnGw3AZ, VirtualNetworkGatewaySkuStatusTierVpnGw4, VirtualNetworkGatewaySkuStatusTierVpnGw4AZ, VirtualNetworkGatewaySkuStatusTierVpnGw5, VirtualNetworkGatewaySkuStatusTierVpnGw5AZ))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuStatusNameBasic,
+		VirtualNetworkGatewaySkuStatusNameErGw1AZ,
+		VirtualNetworkGatewaySkuStatusNameErGw2AZ,
+		VirtualNetworkGatewaySkuStatusNameErGw3AZ,
+		VirtualNetworkGatewaySkuStatusNameHighPerformance,
+		VirtualNetworkGatewaySkuStatusNameStandard,
+		VirtualNetworkGatewaySkuStatusNameUltraPerformance,
+		VirtualNetworkGatewaySkuStatusNameVpnGw1,
+		VirtualNetworkGatewaySkuStatusNameVpnGw1AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw2,
+		VirtualNetworkGatewaySkuStatusNameVpnGw2AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw3,
+		VirtualNetworkGatewaySkuStatusNameVpnGw3AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw4,
+		VirtualNetworkGatewaySkuStatusNameVpnGw4AZ,
+		VirtualNetworkGatewaySkuStatusNameVpnGw5,
+		VirtualNetworkGatewaySkuStatusNameVpnGw5AZ))
+	gens["Tier"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuStatusTierBasic,
+		VirtualNetworkGatewaySkuStatusTierErGw1AZ,
+		VirtualNetworkGatewaySkuStatusTierErGw2AZ,
+		VirtualNetworkGatewaySkuStatusTierErGw3AZ,
+		VirtualNetworkGatewaySkuStatusTierHighPerformance,
+		VirtualNetworkGatewaySkuStatusTierStandard,
+		VirtualNetworkGatewaySkuStatusTierUltraPerformance,
+		VirtualNetworkGatewaySkuStatusTierVpnGw1,
+		VirtualNetworkGatewaySkuStatusTierVpnGw1AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw2,
+		VirtualNetworkGatewaySkuStatusTierVpnGw2AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw3,
+		VirtualNetworkGatewaySkuStatusTierVpnGw3AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw4,
+		VirtualNetworkGatewaySkuStatusTierVpnGw4AZ,
+		VirtualNetworkGatewaySkuStatusTierVpnGw5,
+		VirtualNetworkGatewaySkuStatusTierVpnGw5AZ))
 }
 
 func Test_VirtualNetworkGateways_Spec_Properties_IpConfigurations_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -1587,12 +1667,57 @@ func IpsecPolicyGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIpsecPolicy is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIpsecPolicy(gens map[string]gopter.Gen) {
-	gens["DhGroup"] = gen.OneConstOf(IpsecPolicyDhGroupDHGroup1, IpsecPolicyDhGroupDHGroup14, IpsecPolicyDhGroupDHGroup2, IpsecPolicyDhGroupDHGroup2048, IpsecPolicyDhGroupDHGroup24, IpsecPolicyDhGroupECP256, IpsecPolicyDhGroupECP384, IpsecPolicyDhGroupNone)
-	gens["IkeEncryption"] = gen.OneConstOf(IpsecPolicyIkeEncryptionAES128, IpsecPolicyIkeEncryptionAES192, IpsecPolicyIkeEncryptionAES256, IpsecPolicyIkeEncryptionDES, IpsecPolicyIkeEncryptionDES3, IpsecPolicyIkeEncryptionGCMAES128, IpsecPolicyIkeEncryptionGCMAES256)
-	gens["IkeIntegrity"] = gen.OneConstOf(IpsecPolicyIkeIntegrityGCMAES128, IpsecPolicyIkeIntegrityGCMAES256, IpsecPolicyIkeIntegrityMD5, IpsecPolicyIkeIntegritySHA1, IpsecPolicyIkeIntegritySHA256, IpsecPolicyIkeIntegritySHA384)
-	gens["IpsecEncryption"] = gen.OneConstOf(IpsecPolicyIpsecEncryptionAES128, IpsecPolicyIpsecEncryptionAES192, IpsecPolicyIpsecEncryptionAES256, IpsecPolicyIpsecEncryptionDES, IpsecPolicyIpsecEncryptionDES3, IpsecPolicyIpsecEncryptionGCMAES128, IpsecPolicyIpsecEncryptionGCMAES192, IpsecPolicyIpsecEncryptionGCMAES256, IpsecPolicyIpsecEncryptionNone)
-	gens["IpsecIntegrity"] = gen.OneConstOf(IpsecPolicyIpsecIntegrityGCMAES128, IpsecPolicyIpsecIntegrityGCMAES192, IpsecPolicyIpsecIntegrityGCMAES256, IpsecPolicyIpsecIntegrityMD5, IpsecPolicyIpsecIntegritySHA1, IpsecPolicyIpsecIntegritySHA256)
-	gens["PfsGroup"] = gen.OneConstOf(IpsecPolicyPfsGroupECP256, IpsecPolicyPfsGroupECP384, IpsecPolicyPfsGroupNone, IpsecPolicyPfsGroupPFS1, IpsecPolicyPfsGroupPFS14, IpsecPolicyPfsGroupPFS2, IpsecPolicyPfsGroupPFS2048, IpsecPolicyPfsGroupPFS24, IpsecPolicyPfsGroupPFSMM)
+	gens["DhGroup"] = gen.OneConstOf(
+		IpsecPolicyDhGroupDHGroup1,
+		IpsecPolicyDhGroupDHGroup14,
+		IpsecPolicyDhGroupDHGroup2,
+		IpsecPolicyDhGroupDHGroup2048,
+		IpsecPolicyDhGroupDHGroup24,
+		IpsecPolicyDhGroupECP256,
+		IpsecPolicyDhGroupECP384,
+		IpsecPolicyDhGroupNone)
+	gens["IkeEncryption"] = gen.OneConstOf(
+		IpsecPolicyIkeEncryptionAES128,
+		IpsecPolicyIkeEncryptionAES192,
+		IpsecPolicyIkeEncryptionAES256,
+		IpsecPolicyIkeEncryptionDES,
+		IpsecPolicyIkeEncryptionDES3,
+		IpsecPolicyIkeEncryptionGCMAES128,
+		IpsecPolicyIkeEncryptionGCMAES256)
+	gens["IkeIntegrity"] = gen.OneConstOf(
+		IpsecPolicyIkeIntegrityGCMAES128,
+		IpsecPolicyIkeIntegrityGCMAES256,
+		IpsecPolicyIkeIntegrityMD5,
+		IpsecPolicyIkeIntegritySHA1,
+		IpsecPolicyIkeIntegritySHA256,
+		IpsecPolicyIkeIntegritySHA384)
+	gens["IpsecEncryption"] = gen.OneConstOf(
+		IpsecPolicyIpsecEncryptionAES128,
+		IpsecPolicyIpsecEncryptionAES192,
+		IpsecPolicyIpsecEncryptionAES256,
+		IpsecPolicyIpsecEncryptionDES,
+		IpsecPolicyIpsecEncryptionDES3,
+		IpsecPolicyIpsecEncryptionGCMAES128,
+		IpsecPolicyIpsecEncryptionGCMAES192,
+		IpsecPolicyIpsecEncryptionGCMAES256,
+		IpsecPolicyIpsecEncryptionNone)
+	gens["IpsecIntegrity"] = gen.OneConstOf(
+		IpsecPolicyIpsecIntegrityGCMAES128,
+		IpsecPolicyIpsecIntegrityGCMAES192,
+		IpsecPolicyIpsecIntegrityGCMAES256,
+		IpsecPolicyIpsecIntegrityMD5,
+		IpsecPolicyIpsecIntegritySHA1,
+		IpsecPolicyIpsecIntegritySHA256)
+	gens["PfsGroup"] = gen.OneConstOf(
+		IpsecPolicyPfsGroupECP256,
+		IpsecPolicyPfsGroupECP384,
+		IpsecPolicyPfsGroupNone,
+		IpsecPolicyPfsGroupPFS1,
+		IpsecPolicyPfsGroupPFS14,
+		IpsecPolicyPfsGroupPFS2,
+		IpsecPolicyPfsGroupPFS2048,
+		IpsecPolicyPfsGroupPFS24,
+		IpsecPolicyPfsGroupPFSMM)
 	gens["SaDataSizeKilobytes"] = gen.Int()
 	gens["SaLifeTimeSeconds"] = gen.Int()
 }
@@ -1692,12 +1817,57 @@ func IpsecPolicyStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIpsecPolicyStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIpsecPolicyStatus(gens map[string]gopter.Gen) {
-	gens["DhGroup"] = gen.OneConstOf(DhGroup_StatusDHGroup1, DhGroup_StatusDHGroup14, DhGroup_StatusDHGroup2, DhGroup_StatusDHGroup2048, DhGroup_StatusDHGroup24, DhGroup_StatusECP256, DhGroup_StatusECP384, DhGroup_StatusNone)
-	gens["IkeEncryption"] = gen.OneConstOf(IkeEncryption_StatusAES128, IkeEncryption_StatusAES192, IkeEncryption_StatusAES256, IkeEncryption_StatusDES, IkeEncryption_StatusDES3, IkeEncryption_StatusGCMAES128, IkeEncryption_StatusGCMAES256)
-	gens["IkeIntegrity"] = gen.OneConstOf(IkeIntegrity_StatusGCMAES128, IkeIntegrity_StatusGCMAES256, IkeIntegrity_StatusMD5, IkeIntegrity_StatusSHA1, IkeIntegrity_StatusSHA256, IkeIntegrity_StatusSHA384)
-	gens["IpsecEncryption"] = gen.OneConstOf(IpsecEncryption_StatusAES128, IpsecEncryption_StatusAES192, IpsecEncryption_StatusAES256, IpsecEncryption_StatusDES, IpsecEncryption_StatusDES3, IpsecEncryption_StatusGCMAES128, IpsecEncryption_StatusGCMAES192, IpsecEncryption_StatusGCMAES256, IpsecEncryption_StatusNone)
-	gens["IpsecIntegrity"] = gen.OneConstOf(IpsecIntegrity_StatusGCMAES128, IpsecIntegrity_StatusGCMAES192, IpsecIntegrity_StatusGCMAES256, IpsecIntegrity_StatusMD5, IpsecIntegrity_StatusSHA1, IpsecIntegrity_StatusSHA256)
-	gens["PfsGroup"] = gen.OneConstOf(PfsGroup_StatusECP256, PfsGroup_StatusECP384, PfsGroup_StatusNone, PfsGroup_StatusPFS1, PfsGroup_StatusPFS14, PfsGroup_StatusPFS2, PfsGroup_StatusPFS2048, PfsGroup_StatusPFS24, PfsGroup_StatusPFSMM)
+	gens["DhGroup"] = gen.OneConstOf(
+		DhGroup_StatusDHGroup1,
+		DhGroup_StatusDHGroup14,
+		DhGroup_StatusDHGroup2,
+		DhGroup_StatusDHGroup2048,
+		DhGroup_StatusDHGroup24,
+		DhGroup_StatusECP256,
+		DhGroup_StatusECP384,
+		DhGroup_StatusNone)
+	gens["IkeEncryption"] = gen.OneConstOf(
+		IkeEncryption_StatusAES128,
+		IkeEncryption_StatusAES192,
+		IkeEncryption_StatusAES256,
+		IkeEncryption_StatusDES,
+		IkeEncryption_StatusDES3,
+		IkeEncryption_StatusGCMAES128,
+		IkeEncryption_StatusGCMAES256)
+	gens["IkeIntegrity"] = gen.OneConstOf(
+		IkeIntegrity_StatusGCMAES128,
+		IkeIntegrity_StatusGCMAES256,
+		IkeIntegrity_StatusMD5,
+		IkeIntegrity_StatusSHA1,
+		IkeIntegrity_StatusSHA256,
+		IkeIntegrity_StatusSHA384)
+	gens["IpsecEncryption"] = gen.OneConstOf(
+		IpsecEncryption_StatusAES128,
+		IpsecEncryption_StatusAES192,
+		IpsecEncryption_StatusAES256,
+		IpsecEncryption_StatusDES,
+		IpsecEncryption_StatusDES3,
+		IpsecEncryption_StatusGCMAES128,
+		IpsecEncryption_StatusGCMAES192,
+		IpsecEncryption_StatusGCMAES256,
+		IpsecEncryption_StatusNone)
+	gens["IpsecIntegrity"] = gen.OneConstOf(
+		IpsecIntegrity_StatusGCMAES128,
+		IpsecIntegrity_StatusGCMAES192,
+		IpsecIntegrity_StatusGCMAES256,
+		IpsecIntegrity_StatusMD5,
+		IpsecIntegrity_StatusSHA1,
+		IpsecIntegrity_StatusSHA256)
+	gens["PfsGroup"] = gen.OneConstOf(
+		PfsGroup_StatusECP256,
+		PfsGroup_StatusECP384,
+		PfsGroup_StatusNone,
+		PfsGroup_StatusPFS1,
+		PfsGroup_StatusPFS14,
+		PfsGroup_StatusPFS2,
+		PfsGroup_StatusPFS2048,
+		PfsGroup_StatusPFS24,
+		PfsGroup_StatusPFSMM)
 	gens["SaDataSizeKilobytes"] = gen.Int()
 	gens["SaLifeTimeSeconds"] = gen.Int()
 }
@@ -2203,7 +2373,11 @@ func AddIndependentPropertyGeneratorsForVpnClientRevokedCertificateStatus(gens m
 	gens["Etag"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Thumbprint"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2306,6 +2480,10 @@ func AddIndependentPropertyGeneratorsForVpnClientRootCertificateStatus(gens map[
 	gens["Etag"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["PublicCertData"] = gen.AlphaString()
 }

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateways__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateways__spec_arm_types_gen_test.go
@@ -163,7 +163,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkGatewaysSpecPropertiesARM(
 	gens["EnableBgp"] = gen.PtrOf(gen.Bool())
 	gens["EnableDnsForwarding"] = gen.PtrOf(gen.Bool())
 	gens["EnablePrivateIpAddress"] = gen.PtrOf(gen.Bool())
-	gens["GatewayType"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaysSpecPropertiesGatewayTypeExpressRoute, VirtualNetworkGatewaysSpecPropertiesGatewayTypeHyperNet, VirtualNetworkGatewaysSpecPropertiesGatewayTypeLocalGateway, VirtualNetworkGatewaysSpecPropertiesGatewayTypeVpn))
+	gens["GatewayType"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeExpressRoute,
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeHyperNet,
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeLocalGateway,
+		VirtualNetworkGatewaysSpecPropertiesGatewayTypeVpn))
 	gens["VNetExtendedLocationResourceId"] = gen.PtrOf(gen.AlphaString())
 	gens["VpnGatewayGeneration"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaysSpecPropertiesVpnGatewayGenerationGeneration1, VirtualNetworkGatewaysSpecPropertiesVpnGatewayGenerationGeneration2, VirtualNetworkGatewaysSpecPropertiesVpnGatewayGenerationNone))
 	gens["VpnType"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaysSpecPropertiesVpnTypePolicyBased, VirtualNetworkGatewaysSpecPropertiesVpnTypeRouteBased))
@@ -371,8 +375,42 @@ func VirtualNetworkGatewaySkuARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySkuARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualNetworkGatewaySkuARM(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuNameBasic, VirtualNetworkGatewaySkuNameErGw1AZ, VirtualNetworkGatewaySkuNameErGw2AZ, VirtualNetworkGatewaySkuNameErGw3AZ, VirtualNetworkGatewaySkuNameHighPerformance, VirtualNetworkGatewaySkuNameStandard, VirtualNetworkGatewaySkuNameUltraPerformance, VirtualNetworkGatewaySkuNameVpnGw1, VirtualNetworkGatewaySkuNameVpnGw1AZ, VirtualNetworkGatewaySkuNameVpnGw2, VirtualNetworkGatewaySkuNameVpnGw2AZ, VirtualNetworkGatewaySkuNameVpnGw3, VirtualNetworkGatewaySkuNameVpnGw3AZ, VirtualNetworkGatewaySkuNameVpnGw4, VirtualNetworkGatewaySkuNameVpnGw4AZ, VirtualNetworkGatewaySkuNameVpnGw5, VirtualNetworkGatewaySkuNameVpnGw5AZ))
-	gens["Tier"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkGatewaySkuTierBasic, VirtualNetworkGatewaySkuTierErGw1AZ, VirtualNetworkGatewaySkuTierErGw2AZ, VirtualNetworkGatewaySkuTierErGw3AZ, VirtualNetworkGatewaySkuTierHighPerformance, VirtualNetworkGatewaySkuTierStandard, VirtualNetworkGatewaySkuTierUltraPerformance, VirtualNetworkGatewaySkuTierVpnGw1, VirtualNetworkGatewaySkuTierVpnGw1AZ, VirtualNetworkGatewaySkuTierVpnGw2, VirtualNetworkGatewaySkuTierVpnGw2AZ, VirtualNetworkGatewaySkuTierVpnGw3, VirtualNetworkGatewaySkuTierVpnGw3AZ, VirtualNetworkGatewaySkuTierVpnGw4, VirtualNetworkGatewaySkuTierVpnGw4AZ, VirtualNetworkGatewaySkuTierVpnGw5, VirtualNetworkGatewaySkuTierVpnGw5AZ))
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuNameBasic,
+		VirtualNetworkGatewaySkuNameErGw1AZ,
+		VirtualNetworkGatewaySkuNameErGw2AZ,
+		VirtualNetworkGatewaySkuNameErGw3AZ,
+		VirtualNetworkGatewaySkuNameHighPerformance,
+		VirtualNetworkGatewaySkuNameStandard,
+		VirtualNetworkGatewaySkuNameUltraPerformance,
+		VirtualNetworkGatewaySkuNameVpnGw1,
+		VirtualNetworkGatewaySkuNameVpnGw1AZ,
+		VirtualNetworkGatewaySkuNameVpnGw2,
+		VirtualNetworkGatewaySkuNameVpnGw2AZ,
+		VirtualNetworkGatewaySkuNameVpnGw3,
+		VirtualNetworkGatewaySkuNameVpnGw3AZ,
+		VirtualNetworkGatewaySkuNameVpnGw4,
+		VirtualNetworkGatewaySkuNameVpnGw4AZ,
+		VirtualNetworkGatewaySkuNameVpnGw5,
+		VirtualNetworkGatewaySkuNameVpnGw5AZ))
+	gens["Tier"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkGatewaySkuTierBasic,
+		VirtualNetworkGatewaySkuTierErGw1AZ,
+		VirtualNetworkGatewaySkuTierErGw2AZ,
+		VirtualNetworkGatewaySkuTierErGw3AZ,
+		VirtualNetworkGatewaySkuTierHighPerformance,
+		VirtualNetworkGatewaySkuTierStandard,
+		VirtualNetworkGatewaySkuTierUltraPerformance,
+		VirtualNetworkGatewaySkuTierVpnGw1,
+		VirtualNetworkGatewaySkuTierVpnGw1AZ,
+		VirtualNetworkGatewaySkuTierVpnGw2,
+		VirtualNetworkGatewaySkuTierVpnGw2AZ,
+		VirtualNetworkGatewaySkuTierVpnGw3,
+		VirtualNetworkGatewaySkuTierVpnGw3AZ,
+		VirtualNetworkGatewaySkuTierVpnGw4,
+		VirtualNetworkGatewaySkuTierVpnGw4AZ,
+		VirtualNetworkGatewaySkuTierVpnGw5,
+		VirtualNetworkGatewaySkuTierVpnGw5AZ))
 }
 
 func Test_VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -650,12 +688,57 @@ func IpsecPolicyARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIpsecPolicyARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIpsecPolicyARM(gens map[string]gopter.Gen) {
-	gens["DhGroup"] = gen.OneConstOf(IpsecPolicyDhGroupDHGroup1, IpsecPolicyDhGroupDHGroup14, IpsecPolicyDhGroupDHGroup2, IpsecPolicyDhGroupDHGroup2048, IpsecPolicyDhGroupDHGroup24, IpsecPolicyDhGroupECP256, IpsecPolicyDhGroupECP384, IpsecPolicyDhGroupNone)
-	gens["IkeEncryption"] = gen.OneConstOf(IpsecPolicyIkeEncryptionAES128, IpsecPolicyIkeEncryptionAES192, IpsecPolicyIkeEncryptionAES256, IpsecPolicyIkeEncryptionDES, IpsecPolicyIkeEncryptionDES3, IpsecPolicyIkeEncryptionGCMAES128, IpsecPolicyIkeEncryptionGCMAES256)
-	gens["IkeIntegrity"] = gen.OneConstOf(IpsecPolicyIkeIntegrityGCMAES128, IpsecPolicyIkeIntegrityGCMAES256, IpsecPolicyIkeIntegrityMD5, IpsecPolicyIkeIntegritySHA1, IpsecPolicyIkeIntegritySHA256, IpsecPolicyIkeIntegritySHA384)
-	gens["IpsecEncryption"] = gen.OneConstOf(IpsecPolicyIpsecEncryptionAES128, IpsecPolicyIpsecEncryptionAES192, IpsecPolicyIpsecEncryptionAES256, IpsecPolicyIpsecEncryptionDES, IpsecPolicyIpsecEncryptionDES3, IpsecPolicyIpsecEncryptionGCMAES128, IpsecPolicyIpsecEncryptionGCMAES192, IpsecPolicyIpsecEncryptionGCMAES256, IpsecPolicyIpsecEncryptionNone)
-	gens["IpsecIntegrity"] = gen.OneConstOf(IpsecPolicyIpsecIntegrityGCMAES128, IpsecPolicyIpsecIntegrityGCMAES192, IpsecPolicyIpsecIntegrityGCMAES256, IpsecPolicyIpsecIntegrityMD5, IpsecPolicyIpsecIntegritySHA1, IpsecPolicyIpsecIntegritySHA256)
-	gens["PfsGroup"] = gen.OneConstOf(IpsecPolicyPfsGroupECP256, IpsecPolicyPfsGroupECP384, IpsecPolicyPfsGroupNone, IpsecPolicyPfsGroupPFS1, IpsecPolicyPfsGroupPFS14, IpsecPolicyPfsGroupPFS2, IpsecPolicyPfsGroupPFS2048, IpsecPolicyPfsGroupPFS24, IpsecPolicyPfsGroupPFSMM)
+	gens["DhGroup"] = gen.OneConstOf(
+		IpsecPolicyDhGroupDHGroup1,
+		IpsecPolicyDhGroupDHGroup14,
+		IpsecPolicyDhGroupDHGroup2,
+		IpsecPolicyDhGroupDHGroup2048,
+		IpsecPolicyDhGroupDHGroup24,
+		IpsecPolicyDhGroupECP256,
+		IpsecPolicyDhGroupECP384,
+		IpsecPolicyDhGroupNone)
+	gens["IkeEncryption"] = gen.OneConstOf(
+		IpsecPolicyIkeEncryptionAES128,
+		IpsecPolicyIkeEncryptionAES192,
+		IpsecPolicyIkeEncryptionAES256,
+		IpsecPolicyIkeEncryptionDES,
+		IpsecPolicyIkeEncryptionDES3,
+		IpsecPolicyIkeEncryptionGCMAES128,
+		IpsecPolicyIkeEncryptionGCMAES256)
+	gens["IkeIntegrity"] = gen.OneConstOf(
+		IpsecPolicyIkeIntegrityGCMAES128,
+		IpsecPolicyIkeIntegrityGCMAES256,
+		IpsecPolicyIkeIntegrityMD5,
+		IpsecPolicyIkeIntegritySHA1,
+		IpsecPolicyIkeIntegritySHA256,
+		IpsecPolicyIkeIntegritySHA384)
+	gens["IpsecEncryption"] = gen.OneConstOf(
+		IpsecPolicyIpsecEncryptionAES128,
+		IpsecPolicyIpsecEncryptionAES192,
+		IpsecPolicyIpsecEncryptionAES256,
+		IpsecPolicyIpsecEncryptionDES,
+		IpsecPolicyIpsecEncryptionDES3,
+		IpsecPolicyIpsecEncryptionGCMAES128,
+		IpsecPolicyIpsecEncryptionGCMAES192,
+		IpsecPolicyIpsecEncryptionGCMAES256,
+		IpsecPolicyIpsecEncryptionNone)
+	gens["IpsecIntegrity"] = gen.OneConstOf(
+		IpsecPolicyIpsecIntegrityGCMAES128,
+		IpsecPolicyIpsecIntegrityGCMAES192,
+		IpsecPolicyIpsecIntegrityGCMAES256,
+		IpsecPolicyIpsecIntegrityMD5,
+		IpsecPolicyIpsecIntegritySHA1,
+		IpsecPolicyIpsecIntegritySHA256)
+	gens["PfsGroup"] = gen.OneConstOf(
+		IpsecPolicyPfsGroupECP256,
+		IpsecPolicyPfsGroupECP384,
+		IpsecPolicyPfsGroupNone,
+		IpsecPolicyPfsGroupPFS1,
+		IpsecPolicyPfsGroupPFS14,
+		IpsecPolicyPfsGroupPFS2,
+		IpsecPolicyPfsGroupPFS2048,
+		IpsecPolicyPfsGroupPFS24,
+		IpsecPolicyPfsGroupPFSMM)
 	gens["SaDataSizeKilobytes"] = gen.Int()
 	gens["SaLifeTimeSeconds"] = gen.Int()
 }

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_peering__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_peering__status_arm_types_gen_test.go
@@ -165,7 +165,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkPeeringPropertiesFormatSta
 	gens["AllowVirtualNetworkAccess"] = gen.PtrOf(gen.Bool())
 	gens["DoNotVerifyRemoteGateways"] = gen.PtrOf(gen.Bool())
 	gens["PeeringState"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkPeeringPropertiesFormatStatusPeeringStateConnected, VirtualNetworkPeeringPropertiesFormatStatusPeeringStateDisconnected, VirtualNetworkPeeringPropertiesFormatStatusPeeringStateInitiated))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 	gens["UseRemoteGateways"] = gen.PtrOf(gen.Bool())
 }

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen_test.go
@@ -228,7 +228,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkStatus(gens map[string]gop
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen_test.go
@@ -230,7 +230,11 @@ func AddIndependentPropertyGeneratorsForSubnetStatusVirtualNetworksSubnetSubReso
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateEndpointNetworkPolicies"] = gen.PtrOf(gen.OneConstOf(SubnetPropertiesFormatStatusPrivateEndpointNetworkPoliciesDisabled, SubnetPropertiesFormatStatusPrivateEndpointNetworkPoliciesEnabled))
 	gens["PrivateLinkServiceNetworkPolicies"] = gen.PtrOf(gen.OneConstOf(SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPoliciesDisabled, SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPoliciesEnabled))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Purpose"] = gen.PtrOf(gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
@@ -485,7 +489,11 @@ func AddIndependentPropertyGeneratorsForApplicationGatewayIPConfigurationStatus(
 	gens["Etag"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -593,7 +601,11 @@ func AddIndependentPropertyGeneratorsForDelegationStatus(gens map[string]gopter.
 	gens["Etag"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ServiceName"] = gen.PtrOf(gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
@@ -697,7 +709,11 @@ func AddIndependentPropertyGeneratorsForIPConfigurationProfileStatusVirtualNetwo
 	gens["Etag"] = gen.PtrOf(gen.AlphaString())
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -811,7 +827,11 @@ func AddIndependentPropertyGeneratorsForIPConfigurationStatusVirtualNetworksSubn
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAddress"] = gen.PtrOf(gen.AlphaString())
 	gens["PrivateIPAllocationMethod"] = gen.PtrOf(gen.OneConstOf(IPAllocationMethod_StatusDynamic, IPAllocationMethod_StatusStatic))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 }
 
 // AddRelatedPropertyGeneratorsForIPConfigurationStatusVirtualNetworksSubnetSubResourceEmbedded is a factory method for creating gopter generators
@@ -1132,7 +1152,11 @@ func AddIndependentPropertyGeneratorsForResourceNavigationLinkStatus(gens map[st
 	gens["Link"] = gen.PtrOf(gen.AlphaString())
 	gens["LinkedResourceType"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -1338,7 +1362,11 @@ func AddIndependentPropertyGeneratorsForServiceAssociationLinkStatus(gens map[st
 	gens["LinkedResourceType"] = gen.PtrOf(gen.AlphaString())
 	gens["Locations"] = gen.SliceOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -1639,7 +1667,11 @@ func ServiceEndpointPropertiesFormatStatusGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForServiceEndpointPropertiesFormatStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceEndpointPropertiesFormatStatus(gens map[string]gopter.Gen) {
 	gens["Locations"] = gen.SliceOf(gen.AlphaString())
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["Service"] = gen.PtrOf(gen.AlphaString())
 }
 

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen_test.go
@@ -231,7 +231,11 @@ func AddIndependentPropertyGeneratorsForVirtualNetworkPeeringStatus(gens map[str
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["PeeringState"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkPeeringPropertiesFormatStatusPeeringStateConnected, VirtualNetworkPeeringPropertiesFormatStatusPeeringStateDisconnected, VirtualNetworkPeeringPropertiesFormatStatusPeeringStateInitiated))
-	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(ProvisioningState_StatusDeleting, ProvisioningState_StatusFailed, ProvisioningState_StatusSucceeded, ProvisioningState_StatusUpdating))
+	gens["ProvisioningState"] = gen.PtrOf(gen.OneConstOf(
+		ProvisioningState_StatusDeleting,
+		ProvisioningState_StatusFailed,
+		ProvisioningState_StatusSucceeded,
+		ProvisioningState_StatusUpdating))
 	gens["ResourceGuid"] = gen.PtrOf(gen.AlphaString())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 	gens["UseRemoteGateways"] = gen.PtrOf(gen.Bool())

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen_test.go
@@ -682,7 +682,11 @@ func IdentityGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIdentity is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIdentity(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(IdentityTypeNone, IdentityTypeSystemAssigned, IdentityTypeSystemAssignedUserAssigned, IdentityTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		IdentityTypeNone,
+		IdentityTypeSystemAssigned,
+		IdentityTypeSystemAssignedUserAssigned,
+		IdentityTypeUserAssigned))
 }
 
 func Test_Identity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -791,7 +795,11 @@ func IdentityStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForIdentityStatus(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(IdentityStatusTypeNone, IdentityStatusTypeSystemAssigned, IdentityStatusTypeSystemAssignedUserAssigned, IdentityStatusTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		IdentityStatusTypeNone,
+		IdentityStatusTypeSystemAssigned,
+		IdentityStatusTypeSystemAssignedUserAssigned,
+		IdentityStatusTypeUserAssigned))
 }
 
 // AddRelatedPropertyGeneratorsForIdentityStatus is a factory method for creating gopter generators
@@ -1209,10 +1217,18 @@ func SystemDataStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSystemDataStatus(gens map[string]gopter.Gen) {
 	gens["CreatedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["CreatedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusCreatedByTypeApplication, SystemDataStatusCreatedByTypeKey, SystemDataStatusCreatedByTypeManagedIdentity, SystemDataStatusCreatedByTypeUser))
+	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusCreatedByTypeApplication,
+		SystemDataStatusCreatedByTypeKey,
+		SystemDataStatusCreatedByTypeManagedIdentity,
+		SystemDataStatusCreatedByTypeUser))
 	gens["LastModifiedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["LastModifiedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusLastModifiedByTypeApplication, SystemDataStatusLastModifiedByTypeKey, SystemDataStatusLastModifiedByTypeManagedIdentity, SystemDataStatusLastModifiedByTypeUser))
+	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusLastModifiedByTypeApplication,
+		SystemDataStatusLastModifiedByTypeKey,
+		SystemDataStatusLastModifiedByTypeManagedIdentity,
+		SystemDataStatusLastModifiedByTypeUser))
 }
 
 func Test_DictionaryValue_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces__spec_arm_types_gen_test.go
@@ -150,7 +150,11 @@ func IdentityARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIdentityARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIdentityARM(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(IdentityTypeNone, IdentityTypeSystemAssigned, IdentityTypeSystemAssignedUserAssigned, IdentityTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		IdentityTypeNone,
+		IdentityTypeSystemAssigned,
+		IdentityTypeSystemAssignedUserAssigned,
+		IdentityTypeUserAssigned))
 }
 
 func Test_Namespaces_Spec_PropertiesARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen_test.go
@@ -356,7 +356,16 @@ func AddIndependentPropertyGeneratorsForSBQueueStatus(gens map[string]gopter.Gen
 	gens["RequiresDuplicateDetection"] = gen.PtrOf(gen.Bool())
 	gens["RequiresSession"] = gen.PtrOf(gen.Bool())
 	gens["SizeInBytes"] = gen.PtrOf(gen.Int())
-	gens["Status"] = gen.PtrOf(gen.OneConstOf(EntityStatus_StatusActive, EntityStatus_StatusCreating, EntityStatus_StatusDeleting, EntityStatus_StatusDisabled, EntityStatus_StatusReceiveDisabled, EntityStatus_StatusRenaming, EntityStatus_StatusRestoring, EntityStatus_StatusSendDisabled, EntityStatus_StatusUnknown))
+	gens["Status"] = gen.PtrOf(gen.OneConstOf(
+		EntityStatus_StatusActive,
+		EntityStatus_StatusCreating,
+		EntityStatus_StatusDeleting,
+		EntityStatus_StatusDisabled,
+		EntityStatus_StatusReceiveDisabled,
+		EntityStatus_StatusRenaming,
+		EntityStatus_StatusRestoring,
+		EntityStatus_StatusSendDisabled,
+		EntityStatus_StatusUnknown))
 	gens["Type"] = gen.PtrOf(gen.AlphaString())
 	gens["UpdatedAt"] = gen.PtrOf(gen.AlphaString())
 }

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen_test.go
@@ -344,7 +344,16 @@ func AddIndependentPropertyGeneratorsForSBTopicStatus(gens map[string]gopter.Gen
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["RequiresDuplicateDetection"] = gen.PtrOf(gen.Bool())
 	gens["SizeInBytes"] = gen.PtrOf(gen.Int())
-	gens["Status"] = gen.PtrOf(gen.OneConstOf(EntityStatus_StatusActive, EntityStatus_StatusCreating, EntityStatus_StatusDeleting, EntityStatus_StatusDisabled, EntityStatus_StatusReceiveDisabled, EntityStatus_StatusRenaming, EntityStatus_StatusRestoring, EntityStatus_StatusSendDisabled, EntityStatus_StatusUnknown))
+	gens["Status"] = gen.PtrOf(gen.OneConstOf(
+		EntityStatus_StatusActive,
+		EntityStatus_StatusCreating,
+		EntityStatus_StatusDeleting,
+		EntityStatus_StatusDisabled,
+		EntityStatus_StatusReceiveDisabled,
+		EntityStatus_StatusRenaming,
+		EntityStatus_StatusRestoring,
+		EntityStatus_StatusSendDisabled,
+		EntityStatus_StatusUnknown))
 	gens["SubscriptionCount"] = gen.PtrOf(gen.Int())
 	gens["SupportOrdering"] = gen.PtrOf(gen.Bool())
 	gens["Type"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_namespace__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_namespace__status_arm_types_gen_test.go
@@ -165,7 +165,11 @@ func IdentityStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForIdentityStatusARM(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.PtrOf(gen.OneConstOf(IdentityStatusTypeNone, IdentityStatusTypeSystemAssigned, IdentityStatusTypeSystemAssignedUserAssigned, IdentityStatusTypeUserAssigned))
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(
+		IdentityStatusTypeNone,
+		IdentityStatusTypeSystemAssigned,
+		IdentityStatusTypeSystemAssignedUserAssigned,
+		IdentityStatusTypeUserAssigned))
 }
 
 // AddRelatedPropertyGeneratorsForIdentityStatusARM is a factory method for creating gopter generators
@@ -374,10 +378,18 @@ func SystemDataStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForSystemDataStatusARM(gens map[string]gopter.Gen) {
 	gens["CreatedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["CreatedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusCreatedByTypeApplication, SystemDataStatusCreatedByTypeKey, SystemDataStatusCreatedByTypeManagedIdentity, SystemDataStatusCreatedByTypeUser))
+	gens["CreatedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusCreatedByTypeApplication,
+		SystemDataStatusCreatedByTypeKey,
+		SystemDataStatusCreatedByTypeManagedIdentity,
+		SystemDataStatusCreatedByTypeUser))
 	gens["LastModifiedAt"] = gen.PtrOf(gen.AlphaString())
 	gens["LastModifiedBy"] = gen.PtrOf(gen.AlphaString())
-	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(SystemDataStatusLastModifiedByTypeApplication, SystemDataStatusLastModifiedByTypeKey, SystemDataStatusLastModifiedByTypeManagedIdentity, SystemDataStatusLastModifiedByTypeUser))
+	gens["LastModifiedByType"] = gen.PtrOf(gen.OneConstOf(
+		SystemDataStatusLastModifiedByTypeApplication,
+		SystemDataStatusLastModifiedByTypeKey,
+		SystemDataStatusLastModifiedByTypeManagedIdentity,
+		SystemDataStatusLastModifiedByTypeUser))
 }
 
 func Test_DictionaryValue_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_queue__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_queue__status_arm_types_gen_test.go
@@ -177,7 +177,16 @@ func AddIndependentPropertyGeneratorsForSBQueuePropertiesStatusARM(gens map[stri
 	gens["RequiresDuplicateDetection"] = gen.PtrOf(gen.Bool())
 	gens["RequiresSession"] = gen.PtrOf(gen.Bool())
 	gens["SizeInBytes"] = gen.PtrOf(gen.Int())
-	gens["Status"] = gen.PtrOf(gen.OneConstOf(EntityStatus_StatusActive, EntityStatus_StatusCreating, EntityStatus_StatusDeleting, EntityStatus_StatusDisabled, EntityStatus_StatusReceiveDisabled, EntityStatus_StatusRenaming, EntityStatus_StatusRestoring, EntityStatus_StatusSendDisabled, EntityStatus_StatusUnknown))
+	gens["Status"] = gen.PtrOf(gen.OneConstOf(
+		EntityStatus_StatusActive,
+		EntityStatus_StatusCreating,
+		EntityStatus_StatusDeleting,
+		EntityStatus_StatusDisabled,
+		EntityStatus_StatusReceiveDisabled,
+		EntityStatus_StatusRenaming,
+		EntityStatus_StatusRestoring,
+		EntityStatus_StatusSendDisabled,
+		EntityStatus_StatusUnknown))
 	gens["UpdatedAt"] = gen.PtrOf(gen.AlphaString())
 }
 

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_topic__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_topic__status_arm_types_gen_test.go
@@ -170,7 +170,16 @@ func AddIndependentPropertyGeneratorsForSBTopicPropertiesStatusARM(gens map[stri
 	gens["MaxSizeInMegabytes"] = gen.PtrOf(gen.Int())
 	gens["RequiresDuplicateDetection"] = gen.PtrOf(gen.Bool())
 	gens["SizeInBytes"] = gen.PtrOf(gen.Int())
-	gens["Status"] = gen.PtrOf(gen.OneConstOf(EntityStatus_StatusActive, EntityStatus_StatusCreating, EntityStatus_StatusDeleting, EntityStatus_StatusDisabled, EntityStatus_StatusReceiveDisabled, EntityStatus_StatusRenaming, EntityStatus_StatusRestoring, EntityStatus_StatusSendDisabled, EntityStatus_StatusUnknown))
+	gens["Status"] = gen.PtrOf(gen.OneConstOf(
+		EntityStatus_StatusActive,
+		EntityStatus_StatusCreating,
+		EntityStatus_StatusDeleting,
+		EntityStatus_StatusDisabled,
+		EntityStatus_StatusReceiveDisabled,
+		EntityStatus_StatusRenaming,
+		EntityStatus_StatusRestoring,
+		EntityStatus_StatusSendDisabled,
+		EntityStatus_StatusUnknown))
 	gens["SubscriptionCount"] = gen.PtrOf(gen.Int())
 	gens["SupportOrdering"] = gen.PtrOf(gen.Bool())
 	gens["UpdatedAt"] = gen.PtrOf(gen.AlphaString())

--- a/v2/api/microsoft.storage/v1alpha1api20210401/blob_container__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/blob_container__status_arm_types_gen_test.go
@@ -168,7 +168,12 @@ func AddIndependentPropertyGeneratorsForContainerPropertiesStatusARM(gens map[st
 	gens["HasLegalHold"] = gen.PtrOf(gen.Bool())
 	gens["LastModifiedTime"] = gen.PtrOf(gen.AlphaString())
 	gens["LeaseDuration"] = gen.PtrOf(gen.OneConstOf(ContainerPropertiesStatusLeaseDurationFixed, ContainerPropertiesStatusLeaseDurationInfinite))
-	gens["LeaseState"] = gen.PtrOf(gen.OneConstOf(ContainerPropertiesStatusLeaseStateAvailable, ContainerPropertiesStatusLeaseStateBreaking, ContainerPropertiesStatusLeaseStateBroken, ContainerPropertiesStatusLeaseStateExpired, ContainerPropertiesStatusLeaseStateLeased))
+	gens["LeaseState"] = gen.PtrOf(gen.OneConstOf(
+		ContainerPropertiesStatusLeaseStateAvailable,
+		ContainerPropertiesStatusLeaseStateBreaking,
+		ContainerPropertiesStatusLeaseStateBroken,
+		ContainerPropertiesStatusLeaseStateExpired,
+		ContainerPropertiesStatusLeaseStateLeased))
 	gens["LeaseStatus"] = gen.PtrOf(gen.OneConstOf(ContainerPropertiesStatusLeaseStatusLocked, ContainerPropertiesStatusLeaseStatusUnlocked))
 	gens["Metadata"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["PublicAccess"] = gen.PtrOf(gen.OneConstOf(ContainerPropertiesStatusPublicAccessBlob, ContainerPropertiesStatusPublicAccessContainer, ContainerPropertiesStatusPublicAccessNone))

--- a/v2/api/microsoft.storage/v1alpha1api20210401/blob_service_properties__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/blob_service_properties__status_arm_types_gen_test.go
@@ -231,7 +231,15 @@ func SkuStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForSkuStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSkuStatusARM(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(SkuName_StatusPremiumLRS, SkuName_StatusPremiumZRS, SkuName_StatusStandardGRS, SkuName_StatusStandardGZRS, SkuName_StatusStandardLRS, SkuName_StatusStandardRAGRS, SkuName_StatusStandardRAGZRS, SkuName_StatusStandardZRS)
+	gens["Name"] = gen.OneConstOf(
+		SkuName_StatusPremiumLRS,
+		SkuName_StatusPremiumZRS,
+		SkuName_StatusStandardGRS,
+		SkuName_StatusStandardGZRS,
+		SkuName_StatusStandardLRS,
+		SkuName_StatusStandardRAGRS,
+		SkuName_StatusStandardRAGZRS,
+		SkuName_StatusStandardZRS)
 	gens["Tier"] = gen.PtrOf(gen.OneConstOf(Tier_StatusPremium, Tier_StatusStandard))
 }
 
@@ -599,7 +607,14 @@ func CorsRuleStatusARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForCorsRuleStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCorsRuleStatusARM(gens map[string]gopter.Gen) {
 	gens["AllowedHeaders"] = gen.SliceOf(gen.AlphaString())
-	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(CorsRuleStatusAllowedMethodsDELETE, CorsRuleStatusAllowedMethodsGET, CorsRuleStatusAllowedMethodsHEAD, CorsRuleStatusAllowedMethodsMERGE, CorsRuleStatusAllowedMethodsOPTIONS, CorsRuleStatusAllowedMethodsPOST, CorsRuleStatusAllowedMethodsPUT))
+	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(
+		CorsRuleStatusAllowedMethodsDELETE,
+		CorsRuleStatusAllowedMethodsGET,
+		CorsRuleStatusAllowedMethodsHEAD,
+		CorsRuleStatusAllowedMethodsMERGE,
+		CorsRuleStatusAllowedMethodsOPTIONS,
+		CorsRuleStatusAllowedMethodsPOST,
+		CorsRuleStatusAllowedMethodsPUT))
 	gens["AllowedOrigins"] = gen.SliceOf(gen.AlphaString())
 	gens["ExposedHeaders"] = gen.SliceOf(gen.AlphaString())
 	gens["MaxAgeInSeconds"] = gen.Int()

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_account__status_arm_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_account__status_arm_types_gen_test.go
@@ -84,7 +84,12 @@ func StorageAccountStatusARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStorageAccountStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageAccountStatusARM(gens map[string]gopter.Gen) {
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
-	gens["Kind"] = gen.PtrOf(gen.OneConstOf(StorageAccountStatusKindBlobStorage, StorageAccountStatusKindBlockBlobStorage, StorageAccountStatusKindFileStorage, StorageAccountStatusKindStorage, StorageAccountStatusKindStorageV2))
+	gens["Kind"] = gen.PtrOf(gen.OneConstOf(
+		StorageAccountStatusKindBlobStorage,
+		StorageAccountStatusKindBlockBlobStorage,
+		StorageAccountStatusKindFileStorage,
+		StorageAccountStatusKindStorage,
+		StorageAccountStatusKindStorageV2))
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
@@ -227,7 +232,11 @@ func IdentityStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForIdentityStatusARM(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.OneConstOf(IdentityStatusTypeNone, IdentityStatusTypeSystemAssigned, IdentityStatusTypeSystemAssignedUserAssigned, IdentityStatusTypeUserAssigned)
+	gens["Type"] = gen.OneConstOf(
+		IdentityStatusTypeNone,
+		IdentityStatusTypeSystemAssigned,
+		IdentityStatusTypeSystemAssignedUserAssigned,
+		IdentityStatusTypeUserAssigned)
 }
 
 // AddRelatedPropertyGeneratorsForIdentityStatusARM is a factory method for creating gopter generators
@@ -403,7 +412,12 @@ func AzureFilesIdentityBasedAuthenticationStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthenticationStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthenticationStatusARM(gens map[string]gopter.Gen) {
-	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionNone, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareContributor, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareElevatedContributor, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareOwner, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareReader))
+	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionNone,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareContributor,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareElevatedContributor,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareOwner,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareReader))
 	gens["DirectoryServiceOptions"] = gen.OneConstOf(AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptionsAADDS, AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptionsAD, AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptionsNone)
 }
 
@@ -953,7 +967,11 @@ func NetworkRuleSetStatusARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSetStatusARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSetStatusARM(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSetStatusBypassAzureServices, NetworkRuleSetStatusBypassLogging, NetworkRuleSetStatusBypassMetrics, NetworkRuleSetStatusBypassNone))
+	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
+		NetworkRuleSetStatusBypassAzureServices,
+		NetworkRuleSetStatusBypassLogging,
+		NetworkRuleSetStatusBypassMetrics,
+		NetworkRuleSetStatusBypassNone))
 	gens["DefaultAction"] = gen.OneConstOf(NetworkRuleSetStatusDefaultActionAllow, NetworkRuleSetStatusDefaultActionDeny)
 }
 
@@ -1841,7 +1859,12 @@ func VirtualNetworkRuleStatusARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForVirtualNetworkRuleStatusARM(gens map[string]gopter.Gen) {
 	gens["Action"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleStatusActionAllow))
 	gens["Id"] = gen.AlphaString()
-	gens["State"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleStatusStateDeprovisioning, VirtualNetworkRuleStatusStateFailed, VirtualNetworkRuleStatusStateNetworkSourceDeleted, VirtualNetworkRuleStatusStateProvisioning, VirtualNetworkRuleStatusStateSucceeded))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkRuleStatusStateDeprovisioning,
+		VirtualNetworkRuleStatusStateFailed,
+		VirtualNetworkRuleStatusStateNetworkSourceDeleted,
+		VirtualNetworkRuleStatusStateProvisioning,
+		VirtualNetworkRuleStatusStateSucceeded))
 }
 
 func Test_BlobRestoreRange_StatusARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen_test.go
@@ -231,7 +231,12 @@ func AddIndependentPropertyGeneratorsForStorageAccountStatus(gens map[string]gop
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["IsHnsEnabled"] = gen.PtrOf(gen.Bool())
 	gens["IsNfsV3Enabled"] = gen.PtrOf(gen.Bool())
-	gens["Kind"] = gen.PtrOf(gen.OneConstOf(StorageAccountStatusKindBlobStorage, StorageAccountStatusKindBlockBlobStorage, StorageAccountStatusKindFileStorage, StorageAccountStatusKindStorage, StorageAccountStatusKindStorageV2))
+	gens["Kind"] = gen.PtrOf(gen.OneConstOf(
+		StorageAccountStatusKindBlobStorage,
+		StorageAccountStatusKindBlockBlobStorage,
+		StorageAccountStatusKindFileStorage,
+		StorageAccountStatusKindStorage,
+		StorageAccountStatusKindStorageV2))
 	gens["LargeFileSharesState"] = gen.PtrOf(gen.OneConstOf(StorageAccountPropertiesStatusLargeFileSharesStateDisabled, StorageAccountPropertiesStatusLargeFileSharesStateEnabled))
 	gens["LastGeoFailoverTime"] = gen.PtrOf(gen.AlphaString())
 	gens["Location"] = gen.PtrOf(gen.AlphaString())
@@ -379,7 +384,12 @@ func AddIndependentPropertyGeneratorsForStorageAccountsSpec(gens map[string]gopt
 	gens["AzureName"] = gen.AlphaString()
 	gens["IsHnsEnabled"] = gen.PtrOf(gen.Bool())
 	gens["IsNfsV3Enabled"] = gen.PtrOf(gen.Bool())
-	gens["Kind"] = gen.OneConstOf(StorageAccountsSpecKindBlobStorage, StorageAccountsSpecKindBlockBlobStorage, StorageAccountsSpecKindFileStorage, StorageAccountsSpecKindStorage, StorageAccountsSpecKindStorageV2)
+	gens["Kind"] = gen.OneConstOf(
+		StorageAccountsSpecKindBlobStorage,
+		StorageAccountsSpecKindBlockBlobStorage,
+		StorageAccountsSpecKindFileStorage,
+		StorageAccountsSpecKindStorage,
+		StorageAccountsSpecKindStorageV2)
 	gens["LargeFileSharesState"] = gen.PtrOf(gen.OneConstOf(StorageAccountPropertiesCreateParametersLargeFileSharesStateDisabled, StorageAccountPropertiesCreateParametersLargeFileSharesStateEnabled))
 	gens["Location"] = gen.AlphaString()
 	gens["MinimumTlsVersion"] = gen.PtrOf(gen.OneConstOf(StorageAccountPropertiesCreateParametersMinimumTlsVersionTLS10, StorageAccountPropertiesCreateParametersMinimumTlsVersionTLS11, StorageAccountPropertiesCreateParametersMinimumTlsVersionTLS12))
@@ -506,7 +516,12 @@ func AzureFilesIdentityBasedAuthenticationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthentication is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthentication(gens map[string]gopter.Gen) {
-	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(AzureFilesIdentityBasedAuthenticationDefaultSharePermissionNone, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareContributor, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareElevatedContributor, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareOwner, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareReader))
+	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionNone,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareContributor,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareElevatedContributor,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareOwner,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareReader))
 	gens["DirectoryServiceOptions"] = gen.OneConstOf(AzureFilesIdentityBasedAuthenticationDirectoryServiceOptionsAADDS, AzureFilesIdentityBasedAuthenticationDirectoryServiceOptionsAD, AzureFilesIdentityBasedAuthenticationDirectoryServiceOptionsNone)
 }
 
@@ -620,7 +635,12 @@ func AzureFilesIdentityBasedAuthenticationStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthenticationStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthenticationStatus(gens map[string]gopter.Gen) {
-	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionNone, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareContributor, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareElevatedContributor, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareOwner, AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareReader))
+	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionNone,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareContributor,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareElevatedContributor,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareOwner,
+		AzureFilesIdentityBasedAuthenticationStatusDefaultSharePermissionStorageFileDataSmbShareReader))
 	gens["DirectoryServiceOptions"] = gen.OneConstOf(AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptionsAADDS, AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptionsAD, AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptionsNone)
 }
 
@@ -1685,7 +1705,11 @@ func IdentityGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIdentity is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIdentity(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(IdentityTypeNone, IdentityTypeSystemAssigned, IdentityTypeSystemAssignedUserAssigned, IdentityTypeUserAssigned)
+	gens["Type"] = gen.OneConstOf(
+		IdentityTypeNone,
+		IdentityTypeSystemAssigned,
+		IdentityTypeSystemAssignedUserAssigned,
+		IdentityTypeUserAssigned)
 }
 
 func Test_Identity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -1794,7 +1818,11 @@ func IdentityStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForIdentityStatus(gens map[string]gopter.Gen) {
 	gens["PrincipalId"] = gen.PtrOf(gen.AlphaString())
 	gens["TenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["Type"] = gen.OneConstOf(IdentityStatusTypeNone, IdentityStatusTypeSystemAssigned, IdentityStatusTypeSystemAssignedUserAssigned, IdentityStatusTypeUserAssigned)
+	gens["Type"] = gen.OneConstOf(
+		IdentityStatusTypeNone,
+		IdentityStatusTypeSystemAssigned,
+		IdentityStatusTypeSystemAssignedUserAssigned,
+		IdentityStatusTypeUserAssigned)
 }
 
 // AddRelatedPropertyGeneratorsForIdentityStatus is a factory method for creating gopter generators
@@ -2202,7 +2230,11 @@ func NetworkRuleSetGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSet is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSet(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSetBypassAzureServices, NetworkRuleSetBypassLogging, NetworkRuleSetBypassMetrics, NetworkRuleSetBypassNone))
+	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
+		NetworkRuleSetBypassAzureServices,
+		NetworkRuleSetBypassLogging,
+		NetworkRuleSetBypassMetrics,
+		NetworkRuleSetBypassNone))
 	gens["DefaultAction"] = gen.OneConstOf(NetworkRuleSetDefaultActionAllow, NetworkRuleSetDefaultActionDeny)
 }
 
@@ -2318,7 +2350,11 @@ func NetworkRuleSetStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSetStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSetStatus(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSetStatusBypassAzureServices, NetworkRuleSetStatusBypassLogging, NetworkRuleSetStatusBypassMetrics, NetworkRuleSetStatusBypassNone))
+	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
+		NetworkRuleSetStatusBypassAzureServices,
+		NetworkRuleSetStatusBypassLogging,
+		NetworkRuleSetStatusBypassMetrics,
+		NetworkRuleSetStatusBypassNone))
 	gens["DefaultAction"] = gen.OneConstOf(NetworkRuleSetStatusDefaultActionAllow, NetworkRuleSetStatusDefaultActionDeny)
 }
 
@@ -2922,7 +2958,15 @@ func SkuGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForSku is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSku(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(SkuNamePremiumLRS, SkuNamePremiumZRS, SkuNameStandardGRS, SkuNameStandardGZRS, SkuNameStandardLRS, SkuNameStandardRAGRS, SkuNameStandardRAGZRS, SkuNameStandardZRS)
+	gens["Name"] = gen.OneConstOf(
+		SkuNamePremiumLRS,
+		SkuNamePremiumZRS,
+		SkuNameStandardGRS,
+		SkuNameStandardGZRS,
+		SkuNameStandardLRS,
+		SkuNameStandardRAGRS,
+		SkuNameStandardRAGZRS,
+		SkuNameStandardZRS)
 	gens["Tier"] = gen.PtrOf(gen.OneConstOf(SkuTierPremium, SkuTierStandard))
 }
 
@@ -3021,7 +3065,15 @@ func SkuStatusGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForSkuStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSkuStatus(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(SkuName_StatusPremiumLRS, SkuName_StatusPremiumZRS, SkuName_StatusStandardGRS, SkuName_StatusStandardGZRS, SkuName_StatusStandardLRS, SkuName_StatusStandardRAGRS, SkuName_StatusStandardRAGZRS, SkuName_StatusStandardZRS)
+	gens["Name"] = gen.OneConstOf(
+		SkuName_StatusPremiumLRS,
+		SkuName_StatusPremiumZRS,
+		SkuName_StatusStandardGRS,
+		SkuName_StatusStandardGZRS,
+		SkuName_StatusStandardLRS,
+		SkuName_StatusStandardRAGRS,
+		SkuName_StatusStandardRAGZRS,
+		SkuName_StatusStandardZRS)
 	gens["Tier"] = gen.PtrOf(gen.OneConstOf(Tier_StatusPremium, Tier_StatusStandard))
 }
 
@@ -4741,7 +4793,12 @@ func VirtualNetworkRuleGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForVirtualNetworkRule is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualNetworkRule(gens map[string]gopter.Gen) {
 	gens["Action"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleActionAllow))
-	gens["State"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleStateDeprovisioning, VirtualNetworkRuleStateFailed, VirtualNetworkRuleStateNetworkSourceDeleted, VirtualNetworkRuleStateProvisioning, VirtualNetworkRuleStateSucceeded))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkRuleStateDeprovisioning,
+		VirtualNetworkRuleStateFailed,
+		VirtualNetworkRuleStateNetworkSourceDeleted,
+		VirtualNetworkRuleStateProvisioning,
+		VirtualNetworkRuleStateSucceeded))
 }
 
 func Test_VirtualNetworkRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -4842,7 +4899,12 @@ func VirtualNetworkRuleStatusGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForVirtualNetworkRuleStatus(gens map[string]gopter.Gen) {
 	gens["Action"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleStatusActionAllow))
 	gens["Id"] = gen.AlphaString()
-	gens["State"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleStatusStateDeprovisioning, VirtualNetworkRuleStatusStateFailed, VirtualNetworkRuleStatusStateNetworkSourceDeleted, VirtualNetworkRuleStatusStateProvisioning, VirtualNetworkRuleStatusStateSucceeded))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkRuleStatusStateDeprovisioning,
+		VirtualNetworkRuleStatusStateFailed,
+		VirtualNetworkRuleStatusStateNetworkSourceDeleted,
+		VirtualNetworkRuleStatusStateProvisioning,
+		VirtualNetworkRuleStatusStateSucceeded))
 }
 
 func Test_BlobRestoreRange_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts__spec_arm_types_gen_test.go
@@ -83,7 +83,12 @@ func StorageAccountsSpecARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForStorageAccountsSpecARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageAccountsSpecARM(gens map[string]gopter.Gen) {
-	gens["Kind"] = gen.OneConstOf(StorageAccountsSpecKindBlobStorage, StorageAccountsSpecKindBlockBlobStorage, StorageAccountsSpecKindFileStorage, StorageAccountsSpecKindStorage, StorageAccountsSpecKindStorageV2)
+	gens["Kind"] = gen.OneConstOf(
+		StorageAccountsSpecKindBlobStorage,
+		StorageAccountsSpecKindBlockBlobStorage,
+		StorageAccountsSpecKindFileStorage,
+		StorageAccountsSpecKindStorage,
+		StorageAccountsSpecKindStorageV2)
 	gens["Location"] = gen.AlphaString()
 	gens["Name"] = gen.AlphaString()
 	gens["Tags"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
@@ -214,7 +219,11 @@ func IdentityARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForIdentityARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForIdentityARM(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(IdentityTypeNone, IdentityTypeSystemAssigned, IdentityTypeSystemAssignedUserAssigned, IdentityTypeUserAssigned)
+	gens["Type"] = gen.OneConstOf(
+		IdentityTypeNone,
+		IdentityTypeSystemAssigned,
+		IdentityTypeSystemAssignedUserAssigned,
+		IdentityTypeUserAssigned)
 }
 
 func Test_SkuARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {
@@ -273,7 +282,15 @@ func SkuARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForSkuARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSkuARM(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(SkuNamePremiumLRS, SkuNamePremiumZRS, SkuNameStandardGRS, SkuNameStandardGZRS, SkuNameStandardLRS, SkuNameStandardRAGRS, SkuNameStandardRAGZRS, SkuNameStandardZRS)
+	gens["Name"] = gen.OneConstOf(
+		SkuNamePremiumLRS,
+		SkuNamePremiumZRS,
+		SkuNameStandardGRS,
+		SkuNameStandardGZRS,
+		SkuNameStandardLRS,
+		SkuNameStandardRAGRS,
+		SkuNameStandardRAGZRS,
+		SkuNameStandardZRS)
 	gens["Tier"] = gen.PtrOf(gen.OneConstOf(SkuTierPremium, SkuTierStandard))
 }
 
@@ -431,7 +448,12 @@ func AzureFilesIdentityBasedAuthenticationARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthenticationARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFilesIdentityBasedAuthenticationARM(gens map[string]gopter.Gen) {
-	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(AzureFilesIdentityBasedAuthenticationDefaultSharePermissionNone, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareContributor, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareElevatedContributor, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareOwner, AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareReader))
+	gens["DefaultSharePermission"] = gen.PtrOf(gen.OneConstOf(
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionNone,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareContributor,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareElevatedContributor,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareOwner,
+		AzureFilesIdentityBasedAuthenticationDefaultSharePermissionStorageFileDataSmbShareReader))
 	gens["DirectoryServiceOptions"] = gen.OneConstOf(AzureFilesIdentityBasedAuthenticationDirectoryServiceOptionsAADDS, AzureFilesIdentityBasedAuthenticationDirectoryServiceOptionsAD, AzureFilesIdentityBasedAuthenticationDirectoryServiceOptionsNone)
 }
 
@@ -700,7 +722,11 @@ func NetworkRuleSetARMGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForNetworkRuleSetARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNetworkRuleSetARM(gens map[string]gopter.Gen) {
-	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(NetworkRuleSetBypassAzureServices, NetworkRuleSetBypassLogging, NetworkRuleSetBypassMetrics, NetworkRuleSetBypassNone))
+	gens["Bypass"] = gen.PtrOf(gen.OneConstOf(
+		NetworkRuleSetBypassAzureServices,
+		NetworkRuleSetBypassLogging,
+		NetworkRuleSetBypassMetrics,
+		NetworkRuleSetBypassNone))
 	gens["DefaultAction"] = gen.OneConstOf(NetworkRuleSetDefaultActionAllow, NetworkRuleSetDefaultActionDeny)
 }
 
@@ -1263,7 +1289,12 @@ func VirtualNetworkRuleARMGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForVirtualNetworkRuleARM(gens map[string]gopter.Gen) {
 	gens["Action"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleActionAllow))
 	gens["Id"] = gen.AlphaString()
-	gens["State"] = gen.PtrOf(gen.OneConstOf(VirtualNetworkRuleStateDeprovisioning, VirtualNetworkRuleStateFailed, VirtualNetworkRuleStateNetworkSourceDeleted, VirtualNetworkRuleStateProvisioning, VirtualNetworkRuleStateSucceeded))
+	gens["State"] = gen.PtrOf(gen.OneConstOf(
+		VirtualNetworkRuleStateDeprovisioning,
+		VirtualNetworkRuleStateFailed,
+		VirtualNetworkRuleStateNetworkSourceDeleted,
+		VirtualNetworkRuleStateProvisioning,
+		VirtualNetworkRuleStateSucceeded))
 }
 
 func Test_EncryptionServiceARM_WhenSerializedToJson_DeserializesAsEqual(t *testing.T) {

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen_test.go
@@ -1460,7 +1460,14 @@ func CorsRuleGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForCorsRule is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCorsRule(gens map[string]gopter.Gen) {
 	gens["AllowedHeaders"] = gen.SliceOf(gen.AlphaString())
-	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(CorsRuleAllowedMethodsDELETE, CorsRuleAllowedMethodsGET, CorsRuleAllowedMethodsHEAD, CorsRuleAllowedMethodsMERGE, CorsRuleAllowedMethodsOPTIONS, CorsRuleAllowedMethodsPOST, CorsRuleAllowedMethodsPUT))
+	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(
+		CorsRuleAllowedMethodsDELETE,
+		CorsRuleAllowedMethodsGET,
+		CorsRuleAllowedMethodsHEAD,
+		CorsRuleAllowedMethodsMERGE,
+		CorsRuleAllowedMethodsOPTIONS,
+		CorsRuleAllowedMethodsPOST,
+		CorsRuleAllowedMethodsPUT))
 	gens["AllowedOrigins"] = gen.SliceOf(gen.AlphaString())
 	gens["ExposedHeaders"] = gen.SliceOf(gen.AlphaString())
 	gens["MaxAgeInSeconds"] = gen.Int()
@@ -1562,7 +1569,14 @@ func CorsRuleStatusGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForCorsRuleStatus is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCorsRuleStatus(gens map[string]gopter.Gen) {
 	gens["AllowedHeaders"] = gen.SliceOf(gen.AlphaString())
-	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(CorsRuleStatusAllowedMethodsDELETE, CorsRuleStatusAllowedMethodsGET, CorsRuleStatusAllowedMethodsHEAD, CorsRuleStatusAllowedMethodsMERGE, CorsRuleStatusAllowedMethodsOPTIONS, CorsRuleStatusAllowedMethodsPOST, CorsRuleStatusAllowedMethodsPUT))
+	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(
+		CorsRuleStatusAllowedMethodsDELETE,
+		CorsRuleStatusAllowedMethodsGET,
+		CorsRuleStatusAllowedMethodsHEAD,
+		CorsRuleStatusAllowedMethodsMERGE,
+		CorsRuleStatusAllowedMethodsOPTIONS,
+		CorsRuleStatusAllowedMethodsPOST,
+		CorsRuleStatusAllowedMethodsPUT))
 	gens["AllowedOrigins"] = gen.SliceOf(gen.AlphaString())
 	gens["ExposedHeaders"] = gen.SliceOf(gen.AlphaString())
 	gens["MaxAgeInSeconds"] = gen.Int()

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services__spec_arm_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services__spec_arm_types_gen_test.go
@@ -535,7 +535,14 @@ func CorsRuleARMGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForCorsRuleARM is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForCorsRuleARM(gens map[string]gopter.Gen) {
 	gens["AllowedHeaders"] = gen.SliceOf(gen.AlphaString())
-	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(CorsRuleAllowedMethodsDELETE, CorsRuleAllowedMethodsGET, CorsRuleAllowedMethodsHEAD, CorsRuleAllowedMethodsMERGE, CorsRuleAllowedMethodsOPTIONS, CorsRuleAllowedMethodsPOST, CorsRuleAllowedMethodsPUT))
+	gens["AllowedMethods"] = gen.SliceOf(gen.OneConstOf(
+		CorsRuleAllowedMethodsDELETE,
+		CorsRuleAllowedMethodsGET,
+		CorsRuleAllowedMethodsHEAD,
+		CorsRuleAllowedMethodsMERGE,
+		CorsRuleAllowedMethodsOPTIONS,
+		CorsRuleAllowedMethodsPOST,
+		CorsRuleAllowedMethodsPUT))
 	gens["AllowedOrigins"] = gen.SliceOf(gen.AlphaString())
 	gens["ExposedHeaders"] = gen.SliceOf(gen.AlphaString())
 	gens["MaxAgeInSeconds"] = gen.Int()

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen_test.go
@@ -233,7 +233,12 @@ func AddIndependentPropertyGeneratorsForBlobContainerStatus(gens map[string]gopt
 	gens["Id"] = gen.PtrOf(gen.AlphaString())
 	gens["LastModifiedTime"] = gen.PtrOf(gen.AlphaString())
 	gens["LeaseDuration"] = gen.PtrOf(gen.OneConstOf(ContainerPropertiesStatusLeaseDurationFixed, ContainerPropertiesStatusLeaseDurationInfinite))
-	gens["LeaseState"] = gen.PtrOf(gen.OneConstOf(ContainerPropertiesStatusLeaseStateAvailable, ContainerPropertiesStatusLeaseStateBreaking, ContainerPropertiesStatusLeaseStateBroken, ContainerPropertiesStatusLeaseStateExpired, ContainerPropertiesStatusLeaseStateLeased))
+	gens["LeaseState"] = gen.PtrOf(gen.OneConstOf(
+		ContainerPropertiesStatusLeaseStateAvailable,
+		ContainerPropertiesStatusLeaseStateBreaking,
+		ContainerPropertiesStatusLeaseStateBroken,
+		ContainerPropertiesStatusLeaseStateExpired,
+		ContainerPropertiesStatusLeaseStateLeased))
 	gens["LeaseStatus"] = gen.PtrOf(gen.OneConstOf(ContainerPropertiesStatusLeaseStatusLocked, ContainerPropertiesStatusLeaseStatusUnlocked))
 	gens["Metadata"] = gen.MapOf(gen.AlphaString(), gen.AlphaString())
 	gens["Name"] = gen.PtrOf(gen.AlphaString())

--- a/v2/tools/generator/internal/astbuilder/calls.go
+++ b/v2/tools/generator/internal/astbuilder/calls.go
@@ -14,10 +14,7 @@ import (
 // <funcName>(<arguments>...)
 //
 func CallFunc(funcName string, arguments ...dst.Expr) *dst.CallExpr {
-	return &dst.CallExpr{
-		Fun:  dst.NewIdent(funcName),
-		Args: Expressions(arguments),
-	}
+	return createCallExpr(dst.NewIdent(funcName), arguments...)
 }
 
 // CallQualifiedFunc creates an expression to call a qualified function with the specified
@@ -26,13 +23,12 @@ func CallFunc(funcName string, arguments ...dst.Expr) *dst.CallExpr {
 // <qualifier>.<funcName>(arguments...)
 //
 func CallQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr) *dst.CallExpr {
-	return &dst.CallExpr{
-		Fun: &dst.SelectorExpr{
+	return createCallExpr(
+		&dst.SelectorExpr{
 			X:   dst.NewIdent(qualifier),
 			Sel: dst.NewIdent(funcName),
 		},
-		Args: Expressions(arguments),
-	}
+		arguments...)
 }
 
 // CallExpr creates an expression to call the named function with the specified arguments
@@ -40,13 +36,40 @@ func CallQualifiedFunc(qualifier string, funcName string, arguments ...dst.Expr)
 // <expr>.<funcName>(arguments...)
 //
 func CallExpr(expr dst.Expr, funcName string, arguments ...dst.Expr) *dst.CallExpr {
-	return &dst.CallExpr{
-		Fun: &dst.SelectorExpr{
+	return createCallExpr(
+		&dst.SelectorExpr{
 			X:   expr,
 			Sel: dst.NewIdent(funcName),
 		},
+		arguments...)
+}
+
+func createCallExpr(expr dst.Expr, arguments ...dst.Expr) *dst.CallExpr {
+	// Check to see howe many of our arguments are nested function calls
+	nestedCalls := 0
+	for _, e := range arguments {
+		if _, ok := e.(*dst.CallExpr); ok {
+			nestedCalls++
+			break
+		}
+	}
+
+	// Create our result expression
+	result := &dst.CallExpr{
+		Fun:  dst.Clone(expr).(dst.Expr),
 		Args: Expressions(arguments),
 	}
+
+	// If we have more than one nested call, break our arguments out onto separate lines
+	// Ditto if we have more than three arguments
+	// (heuristics to try and make some of the complex method calls more readable)
+	if nestedCalls > 1 || len(result.Args) > 3 {
+		for _, e := range result.Args {
+			e.Decorations().Before = dst.NewLine
+		}
+	}
+
+	return result
 }
 
 // InvokeFunc creates a statement to invoke a function with specified arguments

--- a/v2/tools/generator/internal/astbuilder/calls.go
+++ b/v2/tools/generator/internal/astbuilder/calls.go
@@ -45,7 +45,7 @@ func CallExpr(expr dst.Expr, funcName string, arguments ...dst.Expr) *dst.CallEx
 }
 
 func createCallExpr(expr dst.Expr, arguments ...dst.Expr) *dst.CallExpr {
-	// Check to see howe many of our arguments are nested function calls
+	// Check to see how many of our arguments are nested function calls
 	nestedCalls := 0
 	for _, e := range arguments {
 		if _, ok := e.(*dst.CallExpr); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of our generated function calls are difficult to read because of the number of parameters.

This PR adds two heuristics for when arguments to function calls should be broken onto separate lines:
* When the number of arguments is > 3
* When the number of nested function calls is > 1

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/L2kz4V3Mr7QyY/giphy.gif)

