### PR TITLE
Suppress useless comment "Generated from:"

### DIFF
--- a/hack/crossplane/apis/microsoft.cache/v1alpha1api20200601/redis_types_gen.go
+++ b/hack/crossplane/apis/microsoft.cache/v1alpha1api20200601/redis_types_gen.go
@@ -197,7 +197,6 @@ type RedisResourceObservation struct {
 	Zones []string `json:"zones,omitempty"`
 }
 
-//Generated from:
 type PrivateEndpointConnection_Status struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -222,7 +221,6 @@ type PrivateEndpointConnection_Status struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type RedisAccessKeys_Status struct {
 	//PrimaryKey: The current primary key that clients can use to authenticate with
 	//Redis cache.
@@ -293,7 +291,6 @@ const (
 	RedisCreatePropertiesPublicNetworkAccessEnabled  = RedisCreatePropertiesPublicNetworkAccess("Enabled")
 )
 
-//Generated from:
 type RedisInstanceDetails_Status struct {
 	//IsMaster: Specifies whether the instance is a master node.
 	IsMaster *bool `json:"isMaster,omitempty"`
@@ -312,7 +309,6 @@ type RedisInstanceDetails_Status struct {
 	Zone *string `json:"zone,omitempty"`
 }
 
-//Generated from:
 type RedisLinkedServer_Status struct {
 	//Id: Linked server Id.
 	Id *string `json:"id,omitempty"`
@@ -411,7 +407,6 @@ type Sku struct {
 	Name SkuName `json:"name"`
 }
 
-//Generated from:
 type Sku_Status struct {
 	// +kubebuilder:validation:Required
 	//Capacity: The size of the Redis cache to deploy. Valid values: for C
@@ -429,7 +424,6 @@ type Sku_Status struct {
 	Name SkuStatusName `json:"name"`
 }
 
-//Generated from:
 type PrivateEndpointConnectionProvisioningState_Status string
 
 const (
@@ -439,13 +433,11 @@ const (
 	PrivateEndpointConnectionProvisioningState_StatusSucceeded = PrivateEndpointConnectionProvisioningState_Status("Succeeded")
 )
 
-//Generated from:
 type PrivateEndpoint_Status struct {
 	//Id: The ARM identifier for Private Endpoint
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type PrivateLinkServiceConnectionState_Status struct {
 	//ActionsRequired: A message indicating if changes on the service provider require
 	//any updates on the consumer.
@@ -491,7 +483,6 @@ const (
 	SkuStatusNameStandard = SkuStatusName("Standard")
 )
 
-//Generated from:
 type PrivateEndpointServiceConnectionStatus_Status string
 
 const (

--- a/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/server_types_gen.go
+++ b/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/server_types_gen.go
@@ -162,7 +162,6 @@ type ResourceIdentity struct {
 	Type *ResourceIdentityType `json:"type,omitempty"`
 }
 
-//Generated from:
 type ResourceIdentity_Status struct {
 	//PrincipalId: The Azure Active Directory principal id.
 	PrincipalId *string `json:"principalId,omitempty"`
@@ -201,7 +200,6 @@ type ServerExternalAdministrator struct {
 	TenantId *string `json:"tenantId,omitempty"`
 }
 
-//Generated from:
 type ServerExternalAdministrator_Status struct {
 	//AdministratorType: Type of the sever administrator.
 	AdministratorType *ServerExternalAdministratorStatusAdministratorType `json:"administratorType,omitempty"`
@@ -222,7 +220,6 @@ type ServerExternalAdministrator_Status struct {
 	TenantId *string `json:"tenantId,omitempty"`
 }
 
-//Generated from:
 type ServerPrivateEndpointConnection_Status struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -253,7 +250,6 @@ const (
 	ServerPropertiesStatusWorkspaceFeatureDisconnected = ServerPropertiesStatusWorkspaceFeature("Disconnected")
 )
 
-//Generated from:
 type PrivateEndpointConnectionProperties_Status struct {
 	//PrivateEndpoint: Private endpoint which the connection belongs to.
 	PrivateEndpoint *PrivateEndpointProperty_Status `json:"privateEndpoint,omitempty"`
@@ -311,7 +307,6 @@ const (
 	ServerExternalAdministratorStatusPrincipalTypeUser        = ServerExternalAdministratorStatusPrincipalType("User")
 )
 
-//Generated from:
 type UserIdentity_Status struct {
 	//ClientId: The Azure Active Directory client id.
 	ClientId *string `json:"clientId,omitempty"`
@@ -330,13 +325,11 @@ const (
 	PrivateEndpointConnectionPropertiesStatusProvisioningStateRejecting = PrivateEndpointConnectionPropertiesStatusProvisioningState("Rejecting")
 )
 
-//Generated from:
 type PrivateEndpointProperty_Status struct {
 	//Id: Resource id of the private endpoint.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type PrivateLinkServiceConnectionStateProperty_Status struct {
 	//ActionsRequired: The actions required for private link service connection.
 	ActionsRequired *PrivateLinkServiceConnectionStatePropertyStatusActionsRequired `json:"actionsRequired,omitempty"`

--- a/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/servers_database_types_gen.go
+++ b/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/servers_database_types_gen.go
@@ -543,7 +543,6 @@ type Sku struct {
 	Tier *string `json:"tier,omitempty"`
 }
 
-//Generated from:
 type Sku_Status struct {
 	//Capacity: Capacity of the particular SKU.
 	Capacity *int `json:"capacity,omitempty"`

--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment__status_arm_types_gen.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20200801preview
 
-//Generated from:
 type RoleAssignment_StatusARM struct {
 	//Id: The role assignment ID.
 	Id *string `json:"id,omitempty"`
@@ -18,7 +17,6 @@ type RoleAssignment_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type RoleAssignmentProperties_StatusARM struct {
 	//Condition: The conditions on the role assignment. This limits the resources it
 	//can be assigned to. e.g.:

--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
@@ -282,7 +282,6 @@ type RoleAssignmentList struct {
 	Items           []RoleAssignment `json:"items"`
 }
 
-//Generated from:
 type RoleAssignment_Status struct {
 	//Condition: The conditions on the role assignment. This limits the resources it
 	//can be assigned to. e.g.:

--- a/v2/api/microsoft.authorization/v1alpha1api20200801previewstorage/role_assignment_types_gen.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801previewstorage/role_assignment_types_gen.go
@@ -123,7 +123,6 @@ type RoleAssignmentList struct {
 }
 
 //Storage version of v1alpha1api20200801preview.RoleAssignment_Status
-//Generated from:
 type RoleAssignment_Status struct {
 	Condition                          *string                `json:"condition,omitempty"`
 	ConditionVersion                   *string                `json:"conditionVersion,omitempty"`

--- a/v2/api/microsoft.batch/v1alpha1api20210101/batch_account__status_arm_types_gen.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101/batch_account__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210101
 
-//Generated from:
 type BatchAccount_StatusARM struct {
 	//Id: The ID of the resource.
 	Id *string `json:"id,omitempty"`
@@ -27,7 +26,6 @@ type BatchAccount_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type BatchAccountIdentity_StatusARM struct {
 	//PrincipalId: The principal id of the Batch account. This property will only be
 	//provided for a system assigned identity.
@@ -47,7 +45,6 @@ type BatchAccountIdentity_StatusARM struct {
 	UserAssignedIdentities map[string]BatchAccountIdentity_Status_UserAssignedIdentitiesARM `json:"userAssignedIdentities,omitempty"`
 }
 
-//Generated from:
 type BatchAccountProperties_StatusARM struct {
 	//AccountEndpoint: The account endpoint used to interact with the Batch service.
 	AccountEndpoint              *string                          `json:"accountEndpoint,omitempty"`
@@ -99,7 +96,6 @@ type BatchAccountProperties_StatusARM struct {
 	PublicNetworkAccess *PublicNetworkAccessType_Status `json:"publicNetworkAccess,omitempty"`
 }
 
-//Generated from:
 type AutoStorageProperties_StatusARM struct {
 	//LastKeySync: The UTC time at which storage keys were last synchronized with the
 	//Batch account.
@@ -126,7 +122,6 @@ type BatchAccountIdentity_Status_UserAssignedIdentitiesARM struct {
 	PrincipalId *string `json:"principalId,omitempty"`
 }
 
-//Generated from:
 type EncryptionProperties_StatusARM struct {
 	//KeySource: Type of the key source.
 	KeySource *EncryptionPropertiesStatusKeySource `json:"keySource,omitempty"`
@@ -135,7 +130,6 @@ type EncryptionProperties_StatusARM struct {
 	KeyVaultProperties *KeyVaultProperties_StatusARM `json:"keyVaultProperties,omitempty"`
 }
 
-//Generated from:
 type KeyVaultReference_StatusARM struct {
 	//Id: The resource ID of the Azure key vault associated with the Batch account.
 	Id string `json:"id"`
@@ -144,7 +138,6 @@ type KeyVaultReference_StatusARM struct {
 	Url string `json:"url"`
 }
 
-//Generated from:
 type PrivateEndpointConnection_StatusARM struct {
 	//Etag: The ETag of the resource, used for concurrency statements.
 	Etag *string `json:"etag,omitempty"`
@@ -162,7 +155,6 @@ type PrivateEndpointConnection_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineFamilyCoreQuota_StatusARM struct {
 	//CoreQuota: The core quota for the VM family for the Batch account.
 	CoreQuota *int `json:"coreQuota,omitempty"`
@@ -171,7 +163,6 @@ type VirtualMachineFamilyCoreQuota_StatusARM struct {
 	Name *string `json:"name,omitempty"`
 }
 
-//Generated from:
 type KeyVaultProperties_StatusARM struct {
 	//KeyIdentifier: Full path to the versioned secret. Example
 	//https://mykeyvault.vault.azure.net/keys/testkey/6e34a81fef704045975661e297a4c053.
@@ -183,19 +174,16 @@ type KeyVaultProperties_StatusARM struct {
 	KeyIdentifier *string `json:"keyIdentifier,omitempty"`
 }
 
-//Generated from:
 type PrivateEndpointConnectionProperties_StatusARM struct {
 	PrivateEndpoint                   *PrivateEndpoint_StatusARM                                  `json:"privateEndpoint,omitempty"`
 	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState_StatusARM                `json:"privateLinkServiceConnectionState,omitempty"`
 	ProvisioningState                 *PrivateEndpointConnectionPropertiesStatusProvisioningState `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type PrivateEndpoint_StatusARM struct {
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type PrivateLinkServiceConnectionState_StatusARM struct {
 	ActionRequired *string                                   `json:"actionRequired,omitempty"`
 	Description    *string                                   `json:"description,omitempty"`

--- a/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
@@ -283,7 +283,6 @@ type BatchAccountList struct {
 	Items           []BatchAccount `json:"items"`
 }
 
-//Generated from:
 type BatchAccount_Status struct {
 	//AccountEndpoint: The account endpoint used to interact with the Batch service.
 	AccountEndpoint              *string                       `json:"accountEndpoint,omitempty"`
@@ -1466,7 +1465,6 @@ func (autoStorageBaseProperties *AutoStorageBaseProperties) AssignPropertiesToAu
 	return nil
 }
 
-//Generated from:
 type AutoStorageProperties_Status struct {
 	// +kubebuilder:validation:Required
 	//LastKeySync: The UTC time at which storage keys were last synchronized with the
@@ -1630,7 +1628,6 @@ func (batchAccountIdentity *BatchAccountIdentity) AssignPropertiesToBatchAccount
 	return nil
 }
 
-//Generated from:
 type BatchAccountIdentity_Status struct {
 	//PrincipalId: The principal id of the Batch account. This property will only be
 	//provided for a system assigned identity.
@@ -1923,7 +1920,6 @@ func (encryptionProperties *EncryptionProperties) AssignPropertiesToEncryptionPr
 	return nil
 }
 
-//Generated from:
 type EncryptionProperties_Status struct {
 	//KeySource: Type of the key source.
 	KeySource *EncryptionPropertiesStatusKeySource `json:"keySource,omitempty"`
@@ -2120,7 +2116,6 @@ func (keyVaultReference *KeyVaultReference) AssignPropertiesToKeyVaultReference(
 	return nil
 }
 
-//Generated from:
 type KeyVaultReference_Status struct {
 	// +kubebuilder:validation:Required
 	//Id: The resource ID of the Azure key vault associated with the Batch account.
@@ -2192,7 +2187,6 @@ func (keyVaultReferenceStatus *KeyVaultReference_Status) AssignPropertiesToKeyVa
 	return nil
 }
 
-//Generated from:
 type PoolAllocationMode_Status string
 
 const (
@@ -2200,7 +2194,6 @@ const (
 	PoolAllocationMode_StatusUserSubscription = PoolAllocationMode_Status("UserSubscription")
 )
 
-//Generated from:
 type PrivateEndpointConnection_Status struct {
 	//Etag: The ETag of the resource, used for concurrency statements.
 	Etag *string `json:"etag,omitempty"`
@@ -2408,7 +2401,6 @@ func (privateEndpointConnectionStatus *PrivateEndpointConnection_Status) AssignP
 	return nil
 }
 
-//Generated from:
 type PublicNetworkAccessType_Status string
 
 const (
@@ -2416,7 +2408,6 @@ const (
 	PublicNetworkAccessType_StatusEnabled  = PublicNetworkAccessType_Status("Enabled")
 )
 
-//Generated from:
 type VirtualMachineFamilyCoreQuota_Status struct {
 	//CoreQuota: The core quota for the VM family for the Batch account.
 	CoreQuota *int `json:"coreQuota,omitempty"`
@@ -2658,7 +2649,6 @@ func (keyVaultProperties *KeyVaultProperties) AssignPropertiesToKeyVaultProperti
 	return nil
 }
 
-//Generated from:
 type KeyVaultProperties_Status struct {
 	//KeyIdentifier: Full path to the versioned secret. Example
 	//https://mykeyvault.vault.azure.net/keys/testkey/6e34a81fef704045975661e297a4c053.
@@ -2731,7 +2721,6 @@ const (
 	PrivateEndpointConnectionPropertiesStatusProvisioningStateUpdating  = PrivateEndpointConnectionPropertiesStatusProvisioningState("Updating")
 )
 
-//Generated from:
 type PrivateEndpoint_Status struct {
 	Id *string `json:"id,omitempty"`
 }
@@ -2789,7 +2778,6 @@ func (privateEndpointStatus *PrivateEndpoint_Status) AssignPropertiesToPrivateEn
 	return nil
 }
 
-//Generated from:
 type PrivateLinkServiceConnectionState_Status struct {
 	ActionRequired *string `json:"actionRequired,omitempty"`
 	Description    *string `json:"description,omitempty"`
@@ -2877,7 +2865,6 @@ func (privateLinkServiceConnectionStateStatus *PrivateLinkServiceConnectionState
 	return nil
 }
 
-//Generated from:
 type PrivateLinkServiceConnectionStatus_Status string
 
 const (

--- a/v2/api/microsoft.batch/v1alpha1api20210101storage/batch_account_types_gen.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101storage/batch_account_types_gen.go
@@ -124,7 +124,6 @@ type BatchAccountList struct {
 }
 
 //Storage version of v1alpha1api20210101.BatchAccount_Status
-//Generated from:
 type BatchAccount_Status struct {
 	AccountEndpoint                       *string                                `json:"accountEndpoint,omitempty"`
 	ActiveJobAndJobScheduleQuota          *int                                   `json:"activeJobAndJobScheduleQuota,omitempty"`
@@ -226,7 +225,6 @@ type AutoStorageBaseProperties struct {
 }
 
 //Storage version of v1alpha1api20210101.AutoStorageProperties_Status
-//Generated from:
 type AutoStorageProperties_Status struct {
 	LastKeySync      *string                `json:"lastKeySync,omitempty"`
 	PropertyBag      genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -241,7 +239,6 @@ type BatchAccountIdentity struct {
 }
 
 //Storage version of v1alpha1api20210101.BatchAccountIdentity_Status
-//Generated from:
 type BatchAccountIdentity_Status struct {
 	PrincipalId            *string                                                       `json:"principalId,omitempty"`
 	PropertyBag            genruntime.PropertyBag                                        `json:"$propertyBag,omitempty"`
@@ -259,7 +256,6 @@ type EncryptionProperties struct {
 }
 
 //Storage version of v1alpha1api20210101.EncryptionProperties_Status
-//Generated from:
 type EncryptionProperties_Status struct {
 	KeySource          *string                    `json:"keySource,omitempty"`
 	KeyVaultProperties *KeyVaultProperties_Status `json:"keyVaultProperties,omitempty"`
@@ -279,7 +275,6 @@ type KeyVaultReference struct {
 }
 
 //Storage version of v1alpha1api20210101.KeyVaultReference_Status
-//Generated from:
 type KeyVaultReference_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -287,7 +282,6 @@ type KeyVaultReference_Status struct {
 }
 
 //Storage version of v1alpha1api20210101.PrivateEndpointConnection_Status
-//Generated from:
 type PrivateEndpointConnection_Status struct {
 	Etag                              *string                                   `json:"etag,omitempty"`
 	Id                                *string                                   `json:"id,omitempty"`
@@ -300,7 +294,6 @@ type PrivateEndpointConnection_Status struct {
 }
 
 //Storage version of v1alpha1api20210101.VirtualMachineFamilyCoreQuota_Status
-//Generated from:
 type VirtualMachineFamilyCoreQuota_Status struct {
 	CoreQuota   *int                   `json:"coreQuota,omitempty"`
 	Name        *string                `json:"name,omitempty"`
@@ -322,21 +315,18 @@ type KeyVaultProperties struct {
 }
 
 //Storage version of v1alpha1api20210101.KeyVaultProperties_Status
-//Generated from:
 type KeyVaultProperties_Status struct {
 	KeyIdentifier *string                `json:"keyIdentifier,omitempty"`
 	PropertyBag   genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20210101.PrivateEndpoint_Status
-//Generated from:
 type PrivateEndpoint_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20210101.PrivateLinkServiceConnectionState_Status
-//Generated from:
 type PrivateLinkServiceConnectionState_Status struct {
 	ActionRequired *string                `json:"actionRequired,omitempty"`
 	Description    *string                `json:"description,omitempty"`

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disk__status_arm_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disk__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20200930
 
-//Generated from:
 type Disk_StatusARM struct {
 	//ExtendedLocation: The extended location where the disk will be created. Extended
 	//location cannot be changed.
@@ -38,7 +37,6 @@ type Disk_StatusARM struct {
 	Zones []string `json:"zones,omitempty"`
 }
 
-//Generated from:
 type DiskProperties_StatusARM struct {
 	//BurstingEnabled: Set to true to enable bursting beyond the provisioned
 	//performance target of the disk. Bursting is disabled by default. Does not apply
@@ -131,7 +129,6 @@ type DiskProperties_StatusARM struct {
 	UniqueId *string `json:"uniqueId,omitempty"`
 }
 
-//Generated from:
 type DiskSku_StatusARM struct {
 	//Name: The sku name.
 	Name *DiskSkuStatusName `json:"name,omitempty"`
@@ -140,7 +137,6 @@ type DiskSku_StatusARM struct {
 	Tier *string `json:"tier,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocation_StatusARM struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -149,7 +145,6 @@ type ExtendedLocation_StatusARM struct {
 	Type *ExtendedLocationType_Status `json:"type,omitempty"`
 }
 
-//Generated from:
 type CreationData_StatusARM struct {
 	//CreateOption: This enumerates the possible sources of a disk's creation.
 	CreateOption CreationDataStatusCreateOption `json:"createOption"`
@@ -198,7 +193,6 @@ const (
 	DiskSkuStatusNameUltraSSDLRS    = DiskSkuStatusName("UltraSSD_LRS")
 )
 
-//Generated from:
 type EncryptionSettingsCollection_StatusARM struct {
 	//Enabled: Set this flag to true and provide DiskEncryptionKey and optional
 	//KeyEncryptionKey to enable encryption. Set this flag to false and remove
@@ -217,7 +211,6 @@ type EncryptionSettingsCollection_StatusARM struct {
 	EncryptionSettingsVersion *string `json:"encryptionSettingsVersion,omitempty"`
 }
 
-//Generated from:
 type Encryption_StatusARM struct {
 	//DiskEncryptionSetId: ResourceId of the disk encryption set to use for enabling
 	//encryption at rest.
@@ -225,12 +218,10 @@ type Encryption_StatusARM struct {
 	Type                *EncryptionType_Status `json:"type,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocationType_Status string
 
 const ExtendedLocationType_StatusEdgeZone = ExtendedLocationType_Status("EdgeZone")
 
-//Generated from:
 type PurchasePlan_StatusARM struct {
 	//Name: The plan ID.
 	Name string `json:"name"`
@@ -246,13 +237,11 @@ type PurchasePlan_StatusARM struct {
 	Publisher string `json:"publisher"`
 }
 
-//Generated from:
 type ShareInfoElement_StatusARM struct {
 	//VmUri: A relative URI containing the ID of the VM that has the disk attached.
 	VmUri *string `json:"vmUri,omitempty"`
 }
 
-//Generated from:
 type EncryptionSettingsElement_StatusARM struct {
 	//DiskEncryptionKey: Key Vault Secret Url and vault id of the disk encryption key
 	DiskEncryptionKey *KeyVaultAndSecretReference_StatusARM `json:"diskEncryptionKey,omitempty"`
@@ -263,7 +252,6 @@ type EncryptionSettingsElement_StatusARM struct {
 	KeyEncryptionKey *KeyVaultAndKeyReference_StatusARM `json:"keyEncryptionKey,omitempty"`
 }
 
-//Generated from:
 type ImageDiskReference_StatusARM struct {
 	//Id: A relative uri containing either a Platform Image Repository or user image
 	//reference.
@@ -275,7 +263,6 @@ type ImageDiskReference_StatusARM struct {
 	Lun *int `json:"lun,omitempty"`
 }
 
-//Generated from:
 type KeyVaultAndKeyReference_StatusARM struct {
 	//KeyUrl: Url pointing to a key or secret in KeyVault
 	KeyUrl string `json:"keyUrl"`
@@ -284,7 +271,6 @@ type KeyVaultAndKeyReference_StatusARM struct {
 	SourceVault SourceVault_StatusARM `json:"sourceVault"`
 }
 
-//Generated from:
 type KeyVaultAndSecretReference_StatusARM struct {
 	//SecretUrl: Url pointing to a key or secret in KeyVault
 	SecretUrl string `json:"secretUrl"`
@@ -293,7 +279,6 @@ type KeyVaultAndSecretReference_StatusARM struct {
 	SourceVault SourceVault_StatusARM `json:"sourceVault"`
 }
 
-//Generated from:
 type SourceVault_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen.go
@@ -283,7 +283,6 @@ type DiskList struct {
 	Items           []Disk `json:"items"`
 }
 
-//Generated from:
 type Disk_Status struct {
 	//BurstingEnabled: Set to true to enable bursting beyond the provisioned
 	//performance target of the disk. Bursting is disabled by default. Does not apply
@@ -2265,7 +2264,6 @@ func (creationData *CreationData) AssignPropertiesToCreationData(destination *v1
 	return nil
 }
 
-//Generated from:
 type CreationData_Status struct {
 	// +kubebuilder:validation:Required
 	//CreateOption: This enumerates the possible sources of a disk's creation.
@@ -2626,7 +2624,6 @@ func (diskSku *DiskSku) AssignPropertiesToDiskSku(destination *v1alpha1api202009
 	return nil
 }
 
-//Generated from:
 type DiskSku_Status struct {
 	//Name: The sku name.
 	Name *DiskSkuStatusName `json:"name,omitempty"`
@@ -2710,7 +2707,6 @@ func (diskSkuStatus *DiskSku_Status) AssignPropertiesToDiskSkuStatus(destination
 	return nil
 }
 
-//Generated from:
 type DiskState_Status string
 
 const (
@@ -2986,7 +2982,6 @@ func (encryptionSettingsCollection *EncryptionSettingsCollection) AssignProperti
 	return nil
 }
 
-//Generated from:
 type EncryptionSettingsCollection_Status struct {
 	// +kubebuilder:validation:Required
 	//Enabled: Set this flag to true and provide DiskEncryptionKey and optional
@@ -3119,7 +3114,6 @@ func (encryptionSettingsCollectionStatus *EncryptionSettingsCollection_Status) A
 	return nil
 }
 
-//Generated from:
 type Encryption_Status struct {
 	//DiskEncryptionSetId: ResourceId of the disk encryption set to use for enabling
 	//encryption at rest.
@@ -3307,7 +3301,6 @@ func (extendedLocation *ExtendedLocation) AssignPropertiesToExtendedLocation(des
 	return nil
 }
 
-//Generated from:
 type ExtendedLocation_Status struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -3391,7 +3384,6 @@ func (extendedLocationStatus *ExtendedLocation_Status) AssignPropertiesToExtende
 	return nil
 }
 
-//Generated from:
 type NetworkAccessPolicy_Status string
 
 const (
@@ -3526,7 +3518,6 @@ func (purchasePlan *PurchasePlan) AssignPropertiesToPurchasePlan(destination *v1
 	return nil
 }
 
-//Generated from:
 type PurchasePlan_Status struct {
 	// +kubebuilder:validation:Required
 	//Name: The plan ID.
@@ -3628,7 +3619,6 @@ func (purchasePlanStatus *PurchasePlan_Status) AssignPropertiesToPurchasePlanSta
 	return nil
 }
 
-//Generated from:
 type ShareInfoElement_Status struct {
 	//VmUri: A relative URI containing the ID of the VM that has the disk attached.
 	VmUri *string `json:"vmUri,omitempty"`
@@ -3862,7 +3852,6 @@ func (encryptionSettingsElement *EncryptionSettingsElement) AssignPropertiesToEn
 	return nil
 }
 
-//Generated from:
 type EncryptionSettingsElement_Status struct {
 	//DiskEncryptionKey: Key Vault Secret Url and vault id of the disk encryption key
 	DiskEncryptionKey *KeyVaultAndSecretReference_Status `json:"diskEncryptionKey,omitempty"`
@@ -3993,7 +3982,6 @@ const (
 	EncryptionTypeEncryptionAtRestWithPlatformKey             = EncryptionType("EncryptionAtRestWithPlatformKey")
 )
 
-//Generated from:
 type EncryptionType_Status string
 
 const (
@@ -4098,7 +4086,6 @@ func (imageDiskReference *ImageDiskReference) AssignPropertiesToImageDiskReferen
 	return nil
 }
 
-//Generated from:
 type ImageDiskReference_Status struct {
 	// +kubebuilder:validation:Required
 	//Id: A relative uri containing either a Platform Image Repository or user image
@@ -4284,7 +4271,6 @@ func (keyVaultAndKeyReference *KeyVaultAndKeyReference) AssignPropertiesToKeyVau
 	return nil
 }
 
-//Generated from:
 type KeyVaultAndKeyReference_Status struct {
 	// +kubebuilder:validation:Required
 	//KeyUrl: Url pointing to a key or secret in KeyVault
@@ -4484,7 +4470,6 @@ func (keyVaultAndSecretReference *KeyVaultAndSecretReference) AssignPropertiesTo
 	return nil
 }
 
-//Generated from:
 type KeyVaultAndSecretReference_Status struct {
 	// +kubebuilder:validation:Required
 	//SecretUrl: Url pointing to a key or secret in KeyVault
@@ -4658,7 +4643,6 @@ func (sourceVault *SourceVault) AssignPropertiesToSourceVault(destination *v1alp
 	return nil
 }
 
-//Generated from:
 type SourceVault_Status struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.compute/v1alpha1api20200930storage/disk_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930storage/disk_types_gen.go
@@ -125,7 +125,6 @@ type DiskList struct {
 }
 
 //Storage version of v1alpha1api20200930.Disk_Status
-//Generated from:
 type Disk_Status struct {
 	BurstingEnabled              *bool                                `json:"burstingEnabled,omitempty"`
 	Conditions                   []conditions.Condition               `json:"conditions,omitempty"`
@@ -257,7 +256,6 @@ type CreationData struct {
 }
 
 //Storage version of v1alpha1api20200930.CreationData_Status
-//Generated from:
 type CreationData_Status struct {
 	CreateOption          *string                    `json:"createOption,omitempty"`
 	GalleryImageReference *ImageDiskReference_Status `json:"galleryImageReference,omitempty"`
@@ -279,7 +277,6 @@ type DiskSku struct {
 }
 
 //Storage version of v1alpha1api20200930.DiskSku_Status
-//Generated from:
 type DiskSku_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -304,7 +301,6 @@ type EncryptionSettingsCollection struct {
 }
 
 //Storage version of v1alpha1api20200930.EncryptionSettingsCollection_Status
-//Generated from:
 type EncryptionSettingsCollection_Status struct {
 	Enabled                   *bool                              `json:"enabled,omitempty"`
 	EncryptionSettings        []EncryptionSettingsElement_Status `json:"encryptionSettings,omitempty"`
@@ -313,7 +309,6 @@ type EncryptionSettingsCollection_Status struct {
 }
 
 //Storage version of v1alpha1api20200930.Encryption_Status
-//Generated from:
 type Encryption_Status struct {
 	DiskEncryptionSetId *string                `json:"diskEncryptionSetId,omitempty"`
 	PropertyBag         genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -373,7 +368,6 @@ func (extendedLocation *ExtendedLocation) AssignPropertiesToExtendedLocation(des
 }
 
 //Storage version of v1alpha1api20200930.ExtendedLocation_Status
-//Generated from:
 type ExtendedLocation_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -435,7 +429,6 @@ type PurchasePlan struct {
 }
 
 //Storage version of v1alpha1api20200930.PurchasePlan_Status
-//Generated from:
 type PurchasePlan_Status struct {
 	Name          *string                `json:"name,omitempty"`
 	Product       *string                `json:"product,omitempty"`
@@ -445,7 +438,6 @@ type PurchasePlan_Status struct {
 }
 
 //Storage version of v1alpha1api20200930.ShareInfoElement_Status
-//Generated from:
 type ShareInfoElement_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	VmUri       *string                `json:"vmUri,omitempty"`
@@ -460,7 +452,6 @@ type EncryptionSettingsElement struct {
 }
 
 //Storage version of v1alpha1api20200930.EncryptionSettingsElement_Status
-//Generated from:
 type EncryptionSettingsElement_Status struct {
 	DiskEncryptionKey *KeyVaultAndSecretReference_Status `json:"diskEncryptionKey,omitempty"`
 	KeyEncryptionKey  *KeyVaultAndKeyReference_Status    `json:"keyEncryptionKey,omitempty"`
@@ -480,7 +471,6 @@ type ImageDiskReference struct {
 }
 
 //Storage version of v1alpha1api20200930.ImageDiskReference_Status
-//Generated from:
 type ImageDiskReference_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	Lun         *int                   `json:"lun,omitempty"`
@@ -496,7 +486,6 @@ type KeyVaultAndKeyReference struct {
 }
 
 //Storage version of v1alpha1api20200930.KeyVaultAndKeyReference_Status
-//Generated from:
 type KeyVaultAndKeyReference_Status struct {
 	KeyUrl      *string                `json:"keyUrl,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -512,7 +501,6 @@ type KeyVaultAndSecretReference struct {
 }
 
 //Storage version of v1alpha1api20200930.KeyVaultAndSecretReference_Status
-//Generated from:
 type KeyVaultAndSecretReference_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	SecretUrl   *string                `json:"secretUrl,omitempty"`
@@ -529,7 +517,6 @@ type SourceVault struct {
 }
 
 //Storage version of v1alpha1api20200930.SourceVault_Status
-//Generated from:
 type SourceVault_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set__status_arm_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set__status_arm_types_gen.go
@@ -5,7 +5,6 @@ package v1alpha1api20201201
 
 import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
-//Generated from:
 type VirtualMachineScaleSet_StatusARM struct {
 	//ExtendedLocation: The extended location of the Virtual Machine Scale Set.
 	ExtendedLocation *ExtendedLocation_StatusARM `json:"extendedLocation,omitempty"`
@@ -45,7 +44,6 @@ type VirtualMachineScaleSet_StatusARM struct {
 	Zones []string `json:"zones,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocation_StatusARM struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -54,7 +52,6 @@ type ExtendedLocation_StatusARM struct {
 	Type *ExtendedLocationType_Status `json:"type,omitempty"`
 }
 
-//Generated from:
 type Plan_StatusARM struct {
 	//Name: The plan ID.
 	Name *string `json:"name,omitempty"`
@@ -70,7 +67,6 @@ type Plan_StatusARM struct {
 	Publisher *string `json:"publisher,omitempty"`
 }
 
-//Generated from:
 type Sku_StatusARM struct {
 	//Capacity: Specifies the number of virtual machines in the scale set.
 	Capacity *int `json:"capacity,omitempty"`
@@ -85,7 +81,6 @@ type Sku_StatusARM struct {
 	Tier *string `json:"tier,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetIdentity_StatusARM struct {
 	//PrincipalId: The principal id of virtual machine scale set identity. This
 	//property will only be provided for a system assigned identity.
@@ -108,7 +103,6 @@ type VirtualMachineScaleSetIdentity_StatusARM struct {
 	UserAssignedIdentities map[string]VirtualMachineScaleSetIdentity_Status_UserAssignedIdentitiesARM `json:"userAssignedIdentities,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetProperties_StatusARM struct {
 	//AdditionalCapabilities: Specifies additional capabilities enabled or disabled on
 	//the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the
@@ -173,7 +167,6 @@ type VirtualMachineScaleSetProperties_StatusARM struct {
 	ZoneBalance *bool `json:"zoneBalance,omitempty"`
 }
 
-//Generated from:
 type AdditionalCapabilities_StatusARM struct {
 	//UltraSSDEnabled: The flag that enables or disables a capability to have one or
 	//more managed data disks with UltraSSD_LRS storage account type on the VM or
@@ -182,7 +175,6 @@ type AdditionalCapabilities_StatusARM struct {
 	UltraSSDEnabled *bool `json:"ultraSSDEnabled,omitempty"`
 }
 
-//Generated from:
 type AutomaticRepairsPolicy_StatusARM struct {
 	//Enabled: Specifies whether automatic repairs should be enabled on the virtual
 	//machine scale set. The default value is false.
@@ -197,12 +189,10 @@ type AutomaticRepairsPolicy_StatusARM struct {
 	GracePeriod *string `json:"gracePeriod,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocationType_Status string
 
 const ExtendedLocationType_StatusEdgeZone = ExtendedLocationType_Status("EdgeZone")
 
-//Generated from:
 type ScaleInPolicy_StatusARM struct {
 	//Rules: The rules to be followed when scaling-in a virtual machine scale set.
 	//Possible values are:
@@ -224,13 +214,11 @@ type ScaleInPolicy_StatusARM struct {
 	Rules []ScaleInPolicyStatusRules `json:"rules,omitempty"`
 }
 
-//Generated from:
 type SubResource_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type UpgradePolicy_StatusARM struct {
 	//AutomaticOSUpgradePolicy: Configuration parameters used for performing automatic
 	//OS Upgrade.
@@ -266,7 +254,6 @@ type VirtualMachineScaleSetIdentity_Status_UserAssignedIdentitiesARM struct {
 	PrincipalId *string `json:"principalId,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetVMProfile_StatusARM struct {
 	//BillingProfile: Specifies the billing related details of a Azure Spot VMSS.
 	//Minimum api-version: 2019-03-01.
@@ -326,7 +313,6 @@ type VirtualMachineScaleSetVMProfile_StatusARM struct {
 	StorageProfile *VirtualMachineScaleSetStorageProfile_StatusARM `json:"storageProfile,omitempty"`
 }
 
-//Generated from:
 type AutomaticOSUpgradePolicy_StatusARM struct {
 	//DisableAutomaticRollback: Whether OS image rollback feature should be disabled.
 	//Default value is false.
@@ -341,7 +327,6 @@ type AutomaticOSUpgradePolicy_StatusARM struct {
 	EnableAutomaticOSUpgrade *bool `json:"enableAutomaticOSUpgrade,omitempty"`
 }
 
-//Generated from:
 type BillingProfile_StatusARM struct {
 	//MaxPrice: Specifies the maximum price you are willing to pay for a Azure Spot
 	//VM/VMSS. This price is in US Dollars.
@@ -361,7 +346,6 @@ type BillingProfile_StatusARM struct {
 	MaxPrice *float64 `json:"maxPrice,omitempty"`
 }
 
-//Generated from:
 type DiagnosticsProfile_StatusARM struct {
 	//BootDiagnostics: Boot Diagnostics is a debugging feature which allows you to
 	//view Console Output and Screenshot to diagnose VM status.
@@ -370,7 +354,6 @@ type DiagnosticsProfile_StatusARM struct {
 	BootDiagnostics *BootDiagnostics_StatusARM `json:"bootDiagnostics,omitempty"`
 }
 
-//Generated from:
 type RollingUpgradePolicy_StatusARM struct {
 	//EnableCrossZoneUpgrade: Allow VMSS to ignore AZ boundaries when constructing
 	//upgrade batches. Take into consideration the Update Domain and
@@ -407,14 +390,12 @@ type RollingUpgradePolicy_StatusARM struct {
 	PrioritizeUnhealthyInstances *bool `json:"prioritizeUnhealthyInstances,omitempty"`
 }
 
-//Generated from:
 type ScheduledEventsProfile_StatusARM struct {
 	//TerminateNotificationProfile: Specifies Terminate Scheduled Event related
 	//configurations.
 	TerminateNotificationProfile *TerminateNotificationProfile_StatusARM `json:"terminateNotificationProfile,omitempty"`
 }
 
-//Generated from:
 type SecurityProfile_StatusARM struct {
 	//EncryptionAtHost: This property can be used by user in the request to enable or
 	//disable the Host Encryption for the virtual machine or virtual machine scale
@@ -436,7 +417,6 @@ type SecurityProfile_StatusARM struct {
 	UefiSettings *UefiSettings_StatusARM `json:"uefiSettings,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetExtensionProfile_StatusARM struct {
 	//Extensions: The virtual machine scale set child extension resources.
 	Extensions []VirtualMachineScaleSetExtension_StatusARM `json:"extensions,omitempty"`
@@ -449,7 +429,6 @@ type VirtualMachineScaleSetExtensionProfile_StatusARM struct {
 	ExtensionsTimeBudget *string `json:"extensionsTimeBudget,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetNetworkProfile_StatusARM struct {
 	//HealthProbe: A reference to a load balancer probe used to determine the health
 	//of an instance in the virtual machine scale set. The reference will be in the
@@ -461,7 +440,6 @@ type VirtualMachineScaleSetNetworkProfile_StatusARM struct {
 	NetworkInterfaceConfigurations []VirtualMachineScaleSetNetworkConfiguration_StatusARM `json:"networkInterfaceConfigurations,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetOSProfile_StatusARM struct {
 	//AdminPassword: Specifies the password of the administrator account.
 	//Minimum-length (Windows): 8 characters
@@ -531,7 +509,6 @@ type VirtualMachineScaleSetOSProfile_StatusARM struct {
 	WindowsConfiguration *WindowsConfiguration_StatusARM `json:"windowsConfiguration,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetStorageProfile_StatusARM struct {
 	//DataDisks: Specifies the parameters that are used to add data disks to the
 	//virtual machines in the scale set.
@@ -553,14 +530,12 @@ type VirtualMachineScaleSetStorageProfile_StatusARM struct {
 	OsDisk *VirtualMachineScaleSetOSDisk_StatusARM `json:"osDisk,omitempty"`
 }
 
-//Generated from:
 type ApiEntityReference_StatusARM struct {
 	//Id: The ARM resource id in the form of
 	///subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/...
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type BootDiagnostics_StatusARM struct {
 	//Enabled: Whether boot diagnostics should be enabled on the Virtual Machine.
 	Enabled *bool `json:"enabled,omitempty"`
@@ -572,7 +547,6 @@ type BootDiagnostics_StatusARM struct {
 	StorageUri *string `json:"storageUri,omitempty"`
 }
 
-//Generated from:
 type ImageReference_StatusARM struct {
 	//ExactVersion: Specifies in decimal numbers, the version of platform image or
 	//marketplace image used to create the virtual machine. This readonly field
@@ -602,7 +576,6 @@ type ImageReference_StatusARM struct {
 	Version *string `json:"version,omitempty"`
 }
 
-//Generated from:
 type LinuxConfiguration_StatusARM struct {
 	//DisablePasswordAuthentication: Specifies whether password authentication should
 	//be disabled.
@@ -623,7 +596,6 @@ type LinuxConfiguration_StatusARM struct {
 	Ssh *SshConfiguration_StatusARM `json:"ssh,omitempty"`
 }
 
-//Generated from:
 type TerminateNotificationProfile_StatusARM struct {
 	//Enable: Specifies whether the Terminate Scheduled event is enabled or disabled.
 	Enable *bool `json:"enable,omitempty"`
@@ -635,7 +607,6 @@ type TerminateNotificationProfile_StatusARM struct {
 	NotBeforeTimeout *string `json:"notBeforeTimeout,omitempty"`
 }
 
-//Generated from:
 type UefiSettings_StatusARM struct {
 	//SecureBootEnabled: Specifies whether secure boot should be enabled on the
 	//virtual machine.
@@ -647,7 +618,6 @@ type UefiSettings_StatusARM struct {
 	VTpmEnabled *bool `json:"vTpmEnabled,omitempty"`
 }
 
-//Generated from:
 type VaultSecretGroup_StatusARM struct {
 	//SourceVault: The relative URL of the Key Vault containing all of the
 	//certificates in VaultCertificates.
@@ -658,7 +628,6 @@ type VaultSecretGroup_StatusARM struct {
 	VaultCertificates []VaultCertificate_StatusARM `json:"vaultCertificates,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetDataDisk_StatusARM struct {
 	//Caching: Specifies the caching requirements.
 	//Possible values are:
@@ -702,7 +671,6 @@ type VirtualMachineScaleSetDataDisk_StatusARM struct {
 	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetExtension_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -715,7 +683,6 @@ type VirtualMachineScaleSetExtension_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetNetworkConfiguration_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -725,7 +692,6 @@ type VirtualMachineScaleSetNetworkConfiguration_StatusARM struct {
 	Properties *VirtualMachineScaleSetNetworkConfigurationProperties_StatusARM `json:"properties,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetOSDisk_StatusARM struct {
 	//Caching: Specifies the caching requirements.
 	//Possible values are:
@@ -778,7 +744,6 @@ type VirtualMachineScaleSetOSDisk_StatusARM struct {
 	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
 }
 
-//Generated from:
 type WindowsConfiguration_StatusARM struct {
 	//AdditionalUnattendContent: Specifies additional base-64 encoded XML formatted
 	//information that can be included in the Unattend.xml file, which is used by
@@ -815,7 +780,6 @@ type WindowsConfiguration_StatusARM struct {
 	WinRM *WinRMConfiguration_StatusARM `json:"winRM,omitempty"`
 }
 
-//Generated from:
 type AdditionalUnattendContent_StatusARM struct {
 	//ComponentName: The component name. Currently, the only allowable value is
 	//Microsoft-Windows-Shell-Setup.
@@ -834,7 +798,6 @@ type AdditionalUnattendContent_StatusARM struct {
 	SettingName *AdditionalUnattendContentStatusSettingName `json:"settingName,omitempty"`
 }
 
-//Generated from:
 type DiffDiskSettings_StatusARM struct {
 	//Option: Specifies the ephemeral disk settings for operating system disk.
 	Option *DiffDiskOption_Status `json:"option,omitempty"`
@@ -852,7 +815,6 @@ type DiffDiskSettings_StatusARM struct {
 	Placement *DiffDiskPlacement_Status `json:"placement,omitempty"`
 }
 
-//Generated from:
 type LinuxPatchSettings_StatusARM struct {
 	//PatchMode: Specifies the mode of VM Guest Patching to IaaS virtual machine.
 	//Possible values are:
@@ -862,7 +824,6 @@ type LinuxPatchSettings_StatusARM struct {
 	PatchMode *LinuxPatchSettingsStatusPatchMode `json:"patchMode,omitempty"`
 }
 
-//Generated from:
 type PatchSettings_StatusARM struct {
 	//EnableHotpatching: Enables customers to patch their Azure VMs without requiring
 	//a reboot. For enableHotpatching, the 'provisionVMAgent' must be set to true and
@@ -883,14 +844,12 @@ type PatchSettings_StatusARM struct {
 	PatchMode *PatchSettingsStatusPatchMode `json:"patchMode,omitempty"`
 }
 
-//Generated from:
 type SshConfiguration_StatusARM struct {
 	//PublicKeys: The list of SSH public keys used to authenticate with linux based
 	//VMs.
 	PublicKeys []SshPublicKey_StatusARM `json:"publicKeys,omitempty"`
 }
 
-//Generated from:
 type VaultCertificate_StatusARM struct {
 	//CertificateStore: For Windows VMs, specifies the certificate store on the
 	//Virtual Machine to which the certificate should be added. The specified
@@ -915,13 +874,11 @@ type VaultCertificate_StatusARM struct {
 	CertificateUrl *string `json:"certificateUrl,omitempty"`
 }
 
-//Generated from:
 type VirtualHardDisk_StatusARM struct {
 	//Uri: Specifies the virtual hard disk's uri.
 	Uri *string `json:"uri,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetExtensionProperties_StatusARM struct {
 	//AutoUpgradeMinorVersion: Indicates whether the extension should use a newer
 	//minor version if one is available at deployment time. Once deployed, however,
@@ -962,7 +919,6 @@ type VirtualMachineScaleSetExtensionProperties_StatusARM struct {
 	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetManagedDiskParameters_StatusARM struct {
 	//DiskEncryptionSet: Specifies the customer managed disk encryption set resource
 	//id for the managed disk.
@@ -974,7 +930,6 @@ type VirtualMachineScaleSetManagedDiskParameters_StatusARM struct {
 	StorageAccountType *StorageAccountType_Status `json:"storageAccountType,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetNetworkConfigurationProperties_StatusARM struct {
 	//DnsSettings: The dns settings to be applied on the network interfaces.
 	DnsSettings *VirtualMachineScaleSetNetworkConfigurationDnsSettings_StatusARM `json:"dnsSettings,omitempty"`
@@ -1000,13 +955,11 @@ type VirtualMachineScaleSetNetworkConfigurationProperties_StatusARM struct {
 	Primary *bool `json:"primary,omitempty"`
 }
 
-//Generated from:
 type WinRMConfiguration_StatusARM struct {
 	//Listeners: The list of Windows Remote Management listeners
 	Listeners []WinRMListener_StatusARM `json:"listeners,omitempty"`
 }
 
-//Generated from:
 type SshPublicKey_StatusARM struct {
 	//KeyData: SSH public key certificate used to authenticate with the VM through
 	//ssh. The key needs to be at least 2048-bit and in ssh-rsa format.
@@ -1020,7 +973,6 @@ type SshPublicKey_StatusARM struct {
 	Path *string `json:"path,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetIPConfiguration_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -1030,13 +982,11 @@ type VirtualMachineScaleSetIPConfiguration_StatusARM struct {
 	Properties *VirtualMachineScaleSetIPConfigurationProperties_StatusARM `json:"properties,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetNetworkConfigurationDnsSettings_StatusARM struct {
 	//DnsServers: List of DNS servers IP addresses
 	DnsServers []string `json:"dnsServers,omitempty"`
 }
 
-//Generated from:
 type WinRMListener_StatusARM struct {
 	//CertificateUrl: This is the URL of a certificate that has been uploaded to Key
 	//Vault as a secret. For adding a secret to the Key Vault, see [Add a key or
@@ -1058,7 +1008,6 @@ type WinRMListener_StatusARM struct {
 	Protocol *WinRMListenerStatusProtocol `json:"protocol,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetIPConfigurationProperties_StatusARM struct {
 	//ApplicationGatewayBackendAddressPools: Specifies an array of references to
 	//backend address pools of application gateways. A scale set can reference backend
@@ -1098,14 +1047,12 @@ type VirtualMachineScaleSetIPConfigurationProperties_StatusARM struct {
 	Subnet *ApiEntityReference_StatusARM `json:"subnet,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetPublicIPAddressConfiguration_StatusARM struct {
 	//Name: The publicIP address configuration name.
 	Name       string                                                                  `json:"name"`
 	Properties *VirtualMachineScaleSetPublicIPAddressConfigurationProperties_StatusARM `json:"properties,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetPublicIPAddressConfigurationProperties_StatusARM struct {
 	//DnsSettings: The dns settings to be applied on the publicIP addresses .
 	DnsSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_StatusARM `json:"dnsSettings,omitempty"`
@@ -1125,7 +1072,6 @@ type VirtualMachineScaleSetPublicIPAddressConfigurationProperties_StatusARM stru
 	PublicIPPrefix *SubResource_StatusARM `json:"publicIPPrefix,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetIpTag_StatusARM struct {
 	//IpTagType: IP tag type. Example: FirstPartyUsage.
 	IpTagType *string `json:"ipTagType,omitempty"`
@@ -1134,7 +1080,6 @@ type VirtualMachineScaleSetIpTag_StatusARM struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
-//Generated from:
 type VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_StatusARM struct {
 	//DomainNameLabel: The Domain name label.The concatenation of the domain name
 	//label and vm index will be the domain name labels of the PublicIPAddress

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
@@ -286,7 +286,6 @@ type VirtualMachineScaleSetList struct {
 	Items           []VirtualMachineScaleSet `json:"items"`
 }
 
-//Generated from:
 type VirtualMachineScaleSet_Status struct {
 	//AdditionalCapabilities: Specifies additional capabilities enabled or disabled on
 	//the Virtual Machines in the Virtual Machine Scale Set. For instance: whether the
@@ -2144,7 +2143,6 @@ func (additionalCapabilities *AdditionalCapabilities) AssignPropertiesToAddition
 	return nil
 }
 
-//Generated from:
 type AdditionalCapabilities_Status struct {
 	//UltraSSDEnabled: The flag that enables or disables a capability to have one or
 	//more managed data disks with UltraSSD_LRS storage account type on the VM or
@@ -2327,7 +2325,6 @@ func (automaticRepairsPolicy *AutomaticRepairsPolicy) AssignPropertiesToAutomati
 	return nil
 }
 
-//Generated from:
 type AutomaticRepairsPolicy_Status struct {
 	//Enabled: Specifies whether automatic repairs should be enabled on the virtual
 	//machine scale set. The default value is false.
@@ -2522,7 +2519,6 @@ func (extendedLocation *ExtendedLocation) AssignPropertiesToExtendedLocation(des
 	return nil
 }
 
-//Generated from:
 type ExtendedLocation_Status struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -2606,7 +2602,6 @@ func (extendedLocationStatus *ExtendedLocation_Status) AssignPropertiesToExtende
 	return nil
 }
 
-//Generated from:
 type OrchestrationMode_Status string
 
 const (
@@ -2752,7 +2747,6 @@ func (plan *Plan) AssignPropertiesToPlan(destination *v1alpha1api20201201storage
 	return nil
 }
 
-//Generated from:
 type Plan_Status struct {
 	//Name: The plan ID.
 	Name *string `json:"name,omitempty"`
@@ -2965,7 +2959,6 @@ func (scaleInPolicy *ScaleInPolicy) AssignPropertiesToScaleInPolicy(destination 
 	return nil
 }
 
-//Generated from:
 type ScaleInPolicy_Status struct {
 	//Rules: The rules to be followed when scaling-in a virtual machine scale set.
 	//Possible values are:
@@ -3178,7 +3171,6 @@ func (sku *Sku) AssignPropertiesToSku(destination *v1alpha1api20201201storage.Sk
 	return nil
 }
 
-//Generated from:
 type Sku_Status struct {
 	//Capacity: Specifies the number of virtual machines in the scale set.
 	Capacity *int `json:"capacity,omitempty"`
@@ -3354,7 +3346,6 @@ func (subResource *SubResource) AssignPropertiesToSubResource(destination *v1alp
 	return nil
 }
 
-//Generated from:
 type SubResource_Status struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -3600,7 +3591,6 @@ func (upgradePolicy *UpgradePolicy) AssignPropertiesToUpgradePolicy(destination 
 	return nil
 }
 
-//Generated from:
 type UpgradePolicy_Status struct {
 	//AutomaticOSUpgradePolicy: Configuration parameters used for performing automatic
 	//OS Upgrade.
@@ -3839,7 +3829,6 @@ func (virtualMachineScaleSetIdentity *VirtualMachineScaleSetIdentity) AssignProp
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetIdentity_Status struct {
 	//PrincipalId: The principal id of virtual machine scale set identity. This
 	//property will only be provided for a system assigned identity.
@@ -3998,7 +3987,6 @@ func (virtualMachineScaleSetIdentityStatus *VirtualMachineScaleSetIdentity_Statu
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetVMProfile_Status struct {
 	//BillingProfile: Specifies the billing related details of a Azure Spot VMSS.
 	//Minimum api-version: 2019-03-01.
@@ -5102,7 +5090,6 @@ func (automaticOSUpgradePolicy *AutomaticOSUpgradePolicy) AssignPropertiesToAuto
 	return nil
 }
 
-//Generated from:
 type AutomaticOSUpgradePolicy_Status struct {
 	//DisableAutomaticRollback: Whether OS image rollback feature should be disabled.
 	//Default value is false.
@@ -5300,7 +5287,6 @@ func (billingProfile *BillingProfile) AssignPropertiesToBillingProfile(destinati
 	return nil
 }
 
-//Generated from:
 type BillingProfile_Status struct {
 	//MaxPrice: Specifies the maximum price you are willing to pay for a Azure Spot
 	//VM/VMSS. This price is in US Dollars.
@@ -5487,7 +5473,6 @@ func (diagnosticsProfile *DiagnosticsProfile) AssignPropertiesToDiagnosticsProfi
 	return nil
 }
 
-//Generated from:
 type DiagnosticsProfile_Status struct {
 	//BootDiagnostics: Boot Diagnostics is a debugging feature which allows you to
 	//view Console Output and Screenshot to diagnose VM status.
@@ -5572,7 +5557,6 @@ func (diagnosticsProfileStatus *DiagnosticsProfile_Status) AssignPropertiesToDia
 	return nil
 }
 
-//Generated from:
 type EvictionPolicy_Status string
 
 const (
@@ -5580,7 +5564,6 @@ const (
 	EvictionPolicy_StatusDelete     = EvictionPolicy_Status("Delete")
 )
 
-//Generated from:
 type Priority_Status string
 
 const (
@@ -5840,7 +5823,6 @@ func (rollingUpgradePolicy *RollingUpgradePolicy) AssignPropertiesToRollingUpgra
 	return nil
 }
 
-//Generated from:
 type RollingUpgradePolicy_Status struct {
 	//EnableCrossZoneUpgrade: Allow VMSS to ignore AZ boundaries when constructing
 	//upgrade batches. Take into consideration the Update Domain and
@@ -6127,7 +6109,6 @@ func (scheduledEventsProfile *ScheduledEventsProfile) AssignPropertiesToSchedule
 	return nil
 }
 
-//Generated from:
 type ScheduledEventsProfile_Status struct {
 	//TerminateNotificationProfile: Specifies Terminate Scheduled Event related
 	//configurations.
@@ -6383,7 +6364,6 @@ func (securityProfile *SecurityProfile) AssignPropertiesToSecurityProfile(destin
 	return nil
 }
 
-//Generated from:
 type SecurityProfile_Status struct {
 	//EncryptionAtHost: This property can be used by user in the request to enable or
 	//disable the Host Encryption for the virtual machine or virtual machine scale
@@ -6542,7 +6522,6 @@ const (
 	UpgradePolicyStatusModeRolling   = UpgradePolicyStatusMode("Rolling")
 )
 
-//Generated from:
 type VirtualMachineScaleSetExtensionProfile_Status struct {
 	//Extensions: The virtual machine scale set child extension resources.
 	Extensions []VirtualMachineScaleSetExtension_Status `json:"extensions,omitempty"`
@@ -6727,7 +6706,6 @@ func (virtualMachineScaleSetIdentityStatusUserAssignedIdentities *VirtualMachine
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetNetworkProfile_Status struct {
 	//HealthProbe: A reference to a load balancer probe used to determine the health
 	//of an instance in the virtual machine scale set. The reference will be in the
@@ -7198,7 +7176,6 @@ func (virtualMachineScaleSetOSProfile *VirtualMachineScaleSetOSProfile) AssignPr
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetOSProfile_Status struct {
 	//AdminPassword: Specifies the password of the administrator account.
 	//Minimum-length (Windows): 8 characters
@@ -7688,7 +7665,6 @@ func (virtualMachineScaleSetStorageProfile *VirtualMachineScaleSetStorageProfile
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetStorageProfile_Status struct {
 	//DataDisks: Specifies the parameters that are used to add data disks to the
 	//virtual machines in the scale set.
@@ -8262,7 +8238,6 @@ func (apiEntityReference *ApiEntityReference) AssignPropertiesToApiEntityReferen
 	return nil
 }
 
-//Generated from:
 type ApiEntityReference_Status struct {
 	//Id: The ARM resource id in the form of
 	///subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/...
@@ -8430,7 +8405,6 @@ func (bootDiagnostics *BootDiagnostics) AssignPropertiesToBootDiagnostics(destin
 	return nil
 }
 
-//Generated from:
 type BootDiagnostics_Status struct {
 	//Enabled: Whether boot diagnostics should be enabled on the Virtual Machine.
 	Enabled *bool `json:"enabled,omitempty"`
@@ -8691,7 +8665,6 @@ func (imageReference *ImageReference) AssignPropertiesToImageReference(destinati
 	return nil
 }
 
-//Generated from:
 type ImageReference_Status struct {
 	//ExactVersion: Specifies in decimal numbers, the version of platform image or
 	//marketplace image used to create the virtual machine. This readonly field
@@ -9050,7 +9023,6 @@ func (linuxConfiguration *LinuxConfiguration) AssignPropertiesToLinuxConfigurati
 	return nil
 }
 
-//Generated from:
 type LinuxConfiguration_Status struct {
 	//DisablePasswordAuthentication: Specifies whether password authentication should
 	//be disabled.
@@ -9343,7 +9315,6 @@ func (terminateNotificationProfile *TerminateNotificationProfile) AssignProperti
 	return nil
 }
 
-//Generated from:
 type TerminateNotificationProfile_Status struct {
 	//Enable: Specifies whether the Terminate Scheduled event is enabled or disabled.
 	Enable *bool `json:"enable,omitempty"`
@@ -9548,7 +9519,6 @@ func (uefiSettings *UefiSettings) AssignPropertiesToUefiSettings(destination *v1
 	return nil
 }
 
-//Generated from:
 type UefiSettings_Status struct {
 	//SecureBootEnabled: Specifies whether secure boot should be enabled on the
 	//virtual machine.
@@ -9804,7 +9774,6 @@ func (vaultSecretGroup *VaultSecretGroup) AssignPropertiesToVaultSecretGroup(des
 	return nil
 }
 
-//Generated from:
 type VaultSecretGroup_Status struct {
 	//SourceVault: The relative URL of the Key Vault containing all of the
 	//certificates in VaultCertificates.
@@ -10236,7 +10205,6 @@ func (virtualMachineScaleSetDataDisk *VirtualMachineScaleSetDataDisk) AssignProp
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetDataDisk_Status struct {
 	//Caching: Specifies the caching requirements.
 	//Possible values are:
@@ -10474,7 +10442,6 @@ func (virtualMachineScaleSetDataDiskStatus *VirtualMachineScaleSetDataDisk_Statu
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetExtension_Status struct {
 	//AutoUpgradeMinorVersion: Indicates whether the extension should use a newer
 	//minor version if one is available at deployment time. Once deployed, however,
@@ -10815,7 +10782,6 @@ func (virtualMachineScaleSetExtensionStatus *VirtualMachineScaleSetExtension_Sta
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetNetworkConfiguration_Status struct {
 	//DnsSettings: The dns settings to be applied on the network interfaces.
 	DnsSettings *VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status `json:"dnsSettings,omitempty"`
@@ -11528,7 +11494,6 @@ func (virtualMachineScaleSetOSDisk *VirtualMachineScaleSetOSDisk) AssignProperti
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetOSDisk_Status struct {
 	//Caching: Specifies the caching requirements.
 	//Possible values are:
@@ -12739,7 +12704,6 @@ func (windowsConfiguration *WindowsConfiguration) AssignPropertiesToWindowsConfi
 	return nil
 }
 
-//Generated from:
 type WindowsConfiguration_Status struct {
 	//AdditionalUnattendContent: Specifies additional base-64 encoded XML formatted
 	//information that can be included in the Unattend.xml file, which is used by
@@ -13160,7 +13124,6 @@ func (additionalUnattendContent *AdditionalUnattendContent) AssignPropertiesToAd
 	return nil
 }
 
-//Generated from:
 type AdditionalUnattendContent_Status struct {
 	//ComponentName: The component name. Currently, the only allowable value is
 	//Microsoft-Windows-Shell-Setup.
@@ -13298,7 +13261,6 @@ func (additionalUnattendContentStatus *AdditionalUnattendContent_Status) AssignP
 	return nil
 }
 
-//Generated from:
 type Caching_Status string
 
 const (
@@ -13307,7 +13269,6 @@ const (
 	Caching_StatusReadWrite = Caching_Status("ReadWrite")
 )
 
-//Generated from:
 type CreateOption_Status string
 
 const (
@@ -13440,7 +13401,6 @@ func (diffDiskSettings *DiffDiskSettings) AssignPropertiesToDiffDiskSettings(des
 	return nil
 }
 
-//Generated from:
 type DiffDiskSettings_Status struct {
 	//Option: Specifies the ephemeral disk settings for operating system disk.
 	Option *DiffDiskOption_Status `json:"option,omitempty"`
@@ -13631,7 +13591,6 @@ func (linuxPatchSettings *LinuxPatchSettings) AssignPropertiesToLinuxPatchSettin
 	return nil
 }
 
-//Generated from:
 type LinuxPatchSettings_Status struct {
 	//PatchMode: Specifies the mode of VM Guest Patching to IaaS virtual machine.
 	//Possible values are:
@@ -13831,7 +13790,6 @@ func (patchSettings *PatchSettings) AssignPropertiesToPatchSettings(destination 
 	return nil
 }
 
-//Generated from:
 type PatchSettings_Status struct {
 	//EnableHotpatching: Enables customers to patch their Azure VMs without requiring
 	//a reboot. For enableHotpatching, the 'provisionVMAgent' must be set to true and
@@ -14049,7 +14007,6 @@ func (sshConfiguration *SshConfiguration) AssignPropertiesToSshConfiguration(des
 	return nil
 }
 
-//Generated from:
 type SshConfiguration_Status struct {
 	//PublicKeys: The list of SSH public keys used to authenticate with linux based
 	//VMs.
@@ -14254,7 +14211,6 @@ func (vaultCertificate *VaultCertificate) AssignPropertiesToVaultCertificate(des
 	return nil
 }
 
-//Generated from:
 type VaultCertificate_Status struct {
 	//CertificateStore: For Windows VMs, specifies the certificate store on the
 	//Virtual Machine to which the certificate should be added. The specified
@@ -14418,7 +14374,6 @@ func (virtualHardDisk *VirtualHardDisk) AssignPropertiesToVirtualHardDisk(destin
 	return nil
 }
 
-//Generated from:
 type VirtualHardDisk_Status struct {
 	//Uri: Specifies the virtual hard disk's uri.
 	Uri *string `json:"uri,omitempty"`
@@ -14495,7 +14450,6 @@ const (
 	VirtualMachineScaleSetDataDiskCreateOptionFromImage = VirtualMachineScaleSetDataDiskCreateOption("FromImage")
 )
 
-//Generated from:
 type VirtualMachineScaleSetIPConfiguration_Status struct {
 	//ApplicationGatewayBackendAddressPools: Specifies an array of references to
 	//backend address pools of application gateways. A scale set can reference backend
@@ -15064,7 +15018,6 @@ func (virtualMachineScaleSetManagedDiskParameters *VirtualMachineScaleSetManaged
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetManagedDiskParameters_Status struct {
 	//DiskEncryptionSet: Specifies the customer managed disk encryption set resource
 	//id for the managed disk.
@@ -15246,7 +15199,6 @@ func (virtualMachineScaleSetNetworkConfigurationDnsSettings *VirtualMachineScale
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status struct {
 	//DnsServers: List of DNS servers IP addresses
 	DnsServers []string `json:"dnsServers,omitempty"`
@@ -15955,7 +15907,6 @@ func (winRMConfiguration *WinRMConfiguration) AssignPropertiesToWinRMConfigurati
 	return nil
 }
 
-//Generated from:
 type WinRMConfiguration_Status struct {
 	//Listeners: The list of Windows Remote Management listeners
 	Listeners []WinRMListener_Status `json:"listeners,omitempty"`
@@ -16081,12 +16032,10 @@ const (
 	AdditionalUnattendContentStatusSettingNameFirstLogonCommands = AdditionalUnattendContentStatusSettingName("FirstLogonCommands")
 )
 
-//Generated from:
 type DiffDiskOption_Status string
 
 const DiffDiskOption_StatusLocal = DiffDiskOption_Status("Local")
 
-//Generated from:
 type DiffDiskPlacement_Status string
 
 const (
@@ -16323,7 +16272,6 @@ func (sshPublicKey *SshPublicKey) AssignPropertiesToSshPublicKey(destination *v1
 	return nil
 }
 
-//Generated from:
 type SshPublicKey_Status struct {
 	//KeyData: SSH public key certificate used to authenticate with the VM through
 	//ssh. The key needs to be at least 2048-bit and in ssh-rsa format.
@@ -16402,7 +16350,6 @@ func (sshPublicKeyStatus *SshPublicKey_Status) AssignPropertiesToSshPublicKeySta
 	return nil
 }
 
-//Generated from:
 type StorageAccountType_Status string
 
 const (
@@ -16433,7 +16380,6 @@ const (
 	VirtualMachineScaleSetManagedDiskParametersStorageAccountTypeUltraSSDLRS    = VirtualMachineScaleSetManagedDiskParametersStorageAccountType("UltraSSD_LRS")
 )
 
-//Generated from:
 type VirtualMachineScaleSetPublicIPAddressConfiguration_Status struct {
 	//DnsSettings: The dns settings to be applied on the publicIP addresses .
 	DnsSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status `json:"dnsSettings,omitempty"`
@@ -17085,7 +17031,6 @@ func (winRMListener *WinRMListener) AssignPropertiesToWinRMListener(destination 
 	return nil
 }
 
-//Generated from:
 type WinRMListener_Status struct {
 	//CertificateUrl: This is the URL of a certificate that has been uploaded to Key
 	//Vault as a secret. For adding a secret to the Key Vault, see [Add a key or
@@ -17277,7 +17222,6 @@ func (virtualMachineScaleSetIpTag *VirtualMachineScaleSetIpTag) AssignProperties
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetIpTag_Status struct {
 	//IpTagType: IP tag type. Example: FirstPartyUsage.
 	IpTagType *string `json:"ipTagType,omitempty"`
@@ -17423,7 +17367,6 @@ func (virtualMachineScaleSetPublicIPAddressConfigurationDnsSettings *VirtualMach
 	return nil
 }
 
-//Generated from:
 type VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status struct {
 	// +kubebuilder:validation:Required
 	//DomainNameLabel: The Domain name label.The concatenation of the domain name

--- a/v2/api/microsoft.compute/v1alpha1api20201201storage/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201storage/virtual_machine_scale_set_types_gen.go
@@ -125,7 +125,6 @@ type VirtualMachineScaleSetList struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSet_Status
-//Generated from:
 type VirtualMachineScaleSet_Status struct {
 	AdditionalCapabilities                 *AdditionalCapabilities_Status          `json:"additionalCapabilities,omitempty"`
 	AutomaticRepairsPolicy                 *AutomaticRepairsPolicy_Status          `json:"automaticRepairsPolicy,omitempty"`
@@ -237,7 +236,6 @@ type AdditionalCapabilities struct {
 }
 
 //Storage version of v1alpha1api20201201.AdditionalCapabilities_Status
-//Generated from:
 type AdditionalCapabilities_Status struct {
 	PropertyBag     genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	UltraSSDEnabled *bool                  `json:"ultraSSDEnabled,omitempty"`
@@ -252,7 +250,6 @@ type AutomaticRepairsPolicy struct {
 }
 
 //Storage version of v1alpha1api20201201.AutomaticRepairsPolicy_Status
-//Generated from:
 type AutomaticRepairsPolicy_Status struct {
 	Enabled     *bool                  `json:"enabled,omitempty"`
 	GracePeriod *string                `json:"gracePeriod,omitempty"`
@@ -268,7 +265,6 @@ type ExtendedLocation struct {
 }
 
 //Storage version of v1alpha1api20201201.ExtendedLocation_Status
-//Generated from:
 type ExtendedLocation_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -286,7 +282,6 @@ type Plan struct {
 }
 
 //Storage version of v1alpha1api20201201.Plan_Status
-//Generated from:
 type Plan_Status struct {
 	Name          *string                `json:"name,omitempty"`
 	Product       *string                `json:"product,omitempty"`
@@ -303,7 +298,6 @@ type ScaleInPolicy struct {
 }
 
 //Storage version of v1alpha1api20201201.ScaleInPolicy_Status
-//Generated from:
 type ScaleInPolicy_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	Rules       []string               `json:"rules,omitempty"`
@@ -319,7 +313,6 @@ type Sku struct {
 }
 
 //Storage version of v1alpha1api20201201.Sku_Status
-//Generated from:
 type Sku_Status struct {
 	Capacity    *int                   `json:"capacity,omitempty"`
 	Name        *string                `json:"name,omitempty"`
@@ -337,7 +330,6 @@ type SubResource struct {
 }
 
 //Storage version of v1alpha1api20201201.SubResource_Status
-//Generated from:
 type SubResource_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -353,7 +345,6 @@ type UpgradePolicy struct {
 }
 
 //Storage version of v1alpha1api20201201.UpgradePolicy_Status
-//Generated from:
 type UpgradePolicy_Status struct {
 	AutomaticOSUpgradePolicy *AutomaticOSUpgradePolicy_Status `json:"automaticOSUpgradePolicy,omitempty"`
 	Mode                     *string                          `json:"mode,omitempty"`
@@ -369,7 +360,6 @@ type VirtualMachineScaleSetIdentity struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetIdentity_Status
-//Generated from:
 type VirtualMachineScaleSetIdentity_Status struct {
 	PrincipalId            *string                                                                 `json:"principalId,omitempty"`
 	PropertyBag            genruntime.PropertyBag                                                  `json:"$propertyBag,omitempty"`
@@ -379,7 +369,6 @@ type VirtualMachineScaleSetIdentity_Status struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetVMProfile_Status
-//Generated from:
 type VirtualMachineScaleSetVMProfile_Status struct {
 	BillingProfile         *BillingProfile_Status                         `json:"billingProfile,omitempty"`
 	DiagnosticsProfile     *DiagnosticsProfile_Status                     `json:"diagnosticsProfile,omitempty"`
@@ -420,7 +409,6 @@ type AutomaticOSUpgradePolicy struct {
 }
 
 //Storage version of v1alpha1api20201201.AutomaticOSUpgradePolicy_Status
-//Generated from:
 type AutomaticOSUpgradePolicy_Status struct {
 	DisableAutomaticRollback *bool                  `json:"disableAutomaticRollback,omitempty"`
 	EnableAutomaticOSUpgrade *bool                  `json:"enableAutomaticOSUpgrade,omitempty"`
@@ -435,7 +423,6 @@ type BillingProfile struct {
 }
 
 //Storage version of v1alpha1api20201201.BillingProfile_Status
-//Generated from:
 type BillingProfile_Status struct {
 	MaxPrice    *float64               `json:"maxPrice,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -449,7 +436,6 @@ type DiagnosticsProfile struct {
 }
 
 //Storage version of v1alpha1api20201201.DiagnosticsProfile_Status
-//Generated from:
 type DiagnosticsProfile_Status struct {
 	BootDiagnostics *BootDiagnostics_Status `json:"bootDiagnostics,omitempty"`
 	PropertyBag     genruntime.PropertyBag  `json:"$propertyBag,omitempty"`
@@ -468,7 +454,6 @@ type RollingUpgradePolicy struct {
 }
 
 //Storage version of v1alpha1api20201201.RollingUpgradePolicy_Status
-//Generated from:
 type RollingUpgradePolicy_Status struct {
 	EnableCrossZoneUpgrade              *bool                  `json:"enableCrossZoneUpgrade,omitempty"`
 	MaxBatchInstancePercent             *int                   `json:"maxBatchInstancePercent,omitempty"`
@@ -487,7 +472,6 @@ type ScheduledEventsProfile struct {
 }
 
 //Storage version of v1alpha1api20201201.ScheduledEventsProfile_Status
-//Generated from:
 type ScheduledEventsProfile_Status struct {
 	PropertyBag                  genruntime.PropertyBag               `json:"$propertyBag,omitempty"`
 	TerminateNotificationProfile *TerminateNotificationProfile_Status `json:"terminateNotificationProfile,omitempty"`
@@ -503,7 +487,6 @@ type SecurityProfile struct {
 }
 
 //Storage version of v1alpha1api20201201.SecurityProfile_Status
-//Generated from:
 type SecurityProfile_Status struct {
 	EncryptionAtHost *bool                  `json:"encryptionAtHost,omitempty"`
 	PropertyBag      genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -512,7 +495,6 @@ type SecurityProfile_Status struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetExtensionProfile_Status
-//Generated from:
 type VirtualMachineScaleSetExtensionProfile_Status struct {
 	Extensions           []VirtualMachineScaleSetExtension_Status `json:"extensions,omitempty"`
 	ExtensionsTimeBudget *string                                  `json:"extensionsTimeBudget,omitempty"`
@@ -527,7 +509,6 @@ type VirtualMachineScaleSetIdentity_Status_UserAssignedIdentities struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetNetworkProfile_Status
-//Generated from:
 type VirtualMachineScaleSetNetworkProfile_Status struct {
 	HealthProbe                    *ApiEntityReference_Status                          `json:"healthProbe,omitempty"`
 	NetworkInterfaceConfigurations []VirtualMachineScaleSetNetworkConfiguration_Status `json:"networkInterfaceConfigurations,omitempty"`
@@ -548,7 +529,6 @@ type VirtualMachineScaleSetOSProfile struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetOSProfile_Status
-//Generated from:
 type VirtualMachineScaleSetOSProfile_Status struct {
 	AdminPassword        *string                      `json:"adminPassword,omitempty"`
 	AdminUsername        *string                      `json:"adminUsername,omitempty"`
@@ -570,7 +550,6 @@ type VirtualMachineScaleSetStorageProfile struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetStorageProfile_Status
-//Generated from:
 type VirtualMachineScaleSetStorageProfile_Status struct {
 	DataDisks      []VirtualMachineScaleSetDataDisk_Status `json:"dataDisks,omitempty"`
 	ImageReference *ImageReference_Status                  `json:"imageReference,omitempty"`
@@ -603,7 +582,6 @@ type ApiEntityReference struct {
 }
 
 //Storage version of v1alpha1api20201201.ApiEntityReference_Status
-//Generated from:
 type ApiEntityReference_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -618,7 +596,6 @@ type BootDiagnostics struct {
 }
 
 //Storage version of v1alpha1api20201201.BootDiagnostics_Status
-//Generated from:
 type BootDiagnostics_Status struct {
 	Enabled     *bool                  `json:"enabled,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -639,7 +616,6 @@ type ImageReference struct {
 }
 
 //Storage version of v1alpha1api20201201.ImageReference_Status
-//Generated from:
 type ImageReference_Status struct {
 	ExactVersion *string                `json:"exactVersion,omitempty"`
 	Id           *string                `json:"id,omitempty"`
@@ -661,7 +637,6 @@ type LinuxConfiguration struct {
 }
 
 //Storage version of v1alpha1api20201201.LinuxConfiguration_Status
-//Generated from:
 type LinuxConfiguration_Status struct {
 	DisablePasswordAuthentication *bool                      `json:"disablePasswordAuthentication,omitempty"`
 	PatchSettings                 *LinuxPatchSettings_Status `json:"patchSettings,omitempty"`
@@ -679,7 +654,6 @@ type TerminateNotificationProfile struct {
 }
 
 //Storage version of v1alpha1api20201201.TerminateNotificationProfile_Status
-//Generated from:
 type TerminateNotificationProfile_Status struct {
 	Enable           *bool                  `json:"enable,omitempty"`
 	NotBeforeTimeout *string                `json:"notBeforeTimeout,omitempty"`
@@ -695,7 +669,6 @@ type UefiSettings struct {
 }
 
 //Storage version of v1alpha1api20201201.UefiSettings_Status
-//Generated from:
 type UefiSettings_Status struct {
 	PropertyBag       genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	SecureBootEnabled *bool                  `json:"secureBootEnabled,omitempty"`
@@ -711,7 +684,6 @@ type VaultSecretGroup struct {
 }
 
 //Storage version of v1alpha1api20201201.VaultSecretGroup_Status
-//Generated from:
 type VaultSecretGroup_Status struct {
 	PropertyBag       genruntime.PropertyBag    `json:"$propertyBag,omitempty"`
 	SourceVault       *SubResource_Status       `json:"sourceVault,omitempty"`
@@ -734,7 +706,6 @@ type VirtualMachineScaleSetDataDisk struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetDataDisk_Status
-//Generated from:
 type VirtualMachineScaleSetDataDisk_Status struct {
 	Caching                 *string                                             `json:"caching,omitempty"`
 	CreateOption            *string                                             `json:"createOption,omitempty"`
@@ -749,7 +720,6 @@ type VirtualMachineScaleSetDataDisk_Status struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetExtension_Status
-//Generated from:
 type VirtualMachineScaleSetExtension_Status struct {
 	AutoUpgradeMinorVersion  *bool                  `json:"autoUpgradeMinorVersion,omitempty"`
 	EnableAutomaticUpgrade   *bool                  `json:"enableAutomaticUpgrade,omitempty"`
@@ -768,7 +738,6 @@ type VirtualMachineScaleSetExtension_Status struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetNetworkConfiguration_Status
-//Generated from:
 type VirtualMachineScaleSetNetworkConfiguration_Status struct {
 	DnsSettings                 *VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status `json:"dnsSettings,omitempty"`
 	EnableAcceleratedNetworking *bool                                                         `json:"enableAcceleratedNetworking,omitempty"`
@@ -799,7 +768,6 @@ type VirtualMachineScaleSetOSDisk struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetOSDisk_Status
-//Generated from:
 type VirtualMachineScaleSetOSDisk_Status struct {
 	Caching                 *string                                             `json:"caching,omitempty"`
 	CreateOption            *string                                             `json:"createOption,omitempty"`
@@ -851,7 +819,6 @@ type WindowsConfiguration struct {
 }
 
 //Storage version of v1alpha1api20201201.WindowsConfiguration_Status
-//Generated from:
 type WindowsConfiguration_Status struct {
 	AdditionalUnattendContent []AdditionalUnattendContent_Status `json:"additionalUnattendContent,omitempty"`
 	EnableAutomaticUpdates    *bool                              `json:"enableAutomaticUpdates,omitempty"`
@@ -873,7 +840,6 @@ type AdditionalUnattendContent struct {
 }
 
 //Storage version of v1alpha1api20201201.AdditionalUnattendContent_Status
-//Generated from:
 type AdditionalUnattendContent_Status struct {
 	ComponentName *string                `json:"componentName,omitempty"`
 	Content       *string                `json:"content,omitempty"`
@@ -891,7 +857,6 @@ type DiffDiskSettings struct {
 }
 
 //Storage version of v1alpha1api20201201.DiffDiskSettings_Status
-//Generated from:
 type DiffDiskSettings_Status struct {
 	Option      *string                `json:"option,omitempty"`
 	Placement   *string                `json:"placement,omitempty"`
@@ -906,7 +871,6 @@ type LinuxPatchSettings struct {
 }
 
 //Storage version of v1alpha1api20201201.LinuxPatchSettings_Status
-//Generated from:
 type LinuxPatchSettings_Status struct {
 	PatchMode   *string                `json:"patchMode,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -921,7 +885,6 @@ type PatchSettings struct {
 }
 
 //Storage version of v1alpha1api20201201.PatchSettings_Status
-//Generated from:
 type PatchSettings_Status struct {
 	EnableHotpatching *bool                  `json:"enableHotpatching,omitempty"`
 	PatchMode         *string                `json:"patchMode,omitempty"`
@@ -936,7 +899,6 @@ type SshConfiguration struct {
 }
 
 //Storage version of v1alpha1api20201201.SshConfiguration_Status
-//Generated from:
 type SshConfiguration_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	PublicKeys  []SshPublicKey_Status  `json:"publicKeys,omitempty"`
@@ -951,7 +913,6 @@ type VaultCertificate struct {
 }
 
 //Storage version of v1alpha1api20201201.VaultCertificate_Status
-//Generated from:
 type VaultCertificate_Status struct {
 	CertificateStore *string                `json:"certificateStore,omitempty"`
 	CertificateUrl   *string                `json:"certificateUrl,omitempty"`
@@ -966,14 +927,12 @@ type VirtualHardDisk struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualHardDisk_Status
-//Generated from:
 type VirtualHardDisk_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	Uri         *string                `json:"uri,omitempty"`
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetIPConfiguration_Status
-//Generated from:
 type VirtualMachineScaleSetIPConfiguration_Status struct {
 	ApplicationGatewayBackendAddressPools []SubResource_Status                                       `json:"applicationGatewayBackendAddressPools,omitempty"`
 	ApplicationSecurityGroups             []SubResource_Status                                       `json:"applicationSecurityGroups,omitempty"`
@@ -997,7 +956,6 @@ type VirtualMachineScaleSetManagedDiskParameters struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetManagedDiskParameters_Status
-//Generated from:
 type VirtualMachineScaleSetManagedDiskParameters_Status struct {
 	DiskEncryptionSet  *SubResource_Status    `json:"diskEncryptionSet,omitempty"`
 	PropertyBag        genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -1012,7 +970,6 @@ type VirtualMachineScaleSetNetworkConfigurationDnsSettings struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status
-//Generated from:
 type VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status struct {
 	DnsServers  []string               `json:"dnsServers,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -1041,7 +998,6 @@ type WinRMConfiguration struct {
 }
 
 //Storage version of v1alpha1api20201201.WinRMConfiguration_Status
-//Generated from:
 type WinRMConfiguration_Status struct {
 	Listeners   []WinRMListener_Status `json:"listeners,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -1065,7 +1021,6 @@ type SshPublicKey struct {
 }
 
 //Storage version of v1alpha1api20201201.SshPublicKey_Status
-//Generated from:
 type SshPublicKey_Status struct {
 	KeyData     *string                `json:"keyData,omitempty"`
 	Path        *string                `json:"path,omitempty"`
@@ -1073,7 +1028,6 @@ type SshPublicKey_Status struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetPublicIPAddressConfiguration_Status
-//Generated from:
 type VirtualMachineScaleSetPublicIPAddressConfiguration_Status struct {
 	DnsSettings            *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status `json:"dnsSettings,omitempty"`
 	IdleTimeoutInMinutes   *int                                                                  `json:"idleTimeoutInMinutes,omitempty"`
@@ -1105,7 +1059,6 @@ type WinRMListener struct {
 }
 
 //Storage version of v1alpha1api20201201.WinRMListener_Status
-//Generated from:
 type WinRMListener_Status struct {
 	CertificateUrl *string                `json:"certificateUrl,omitempty"`
 	PropertyBag    genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -1121,7 +1074,6 @@ type VirtualMachineScaleSetIpTag struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetIpTag_Status
-//Generated from:
 type VirtualMachineScaleSetIpTag_Status struct {
 	IpTagType   *string                `json:"ipTagType,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -1136,7 +1088,6 @@ type VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings struct {
 }
 
 //Storage version of v1alpha1api20201201.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status
-//Generated from:
 type VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status struct {
 	DomainNameLabel *string                `json:"domainNameLabel,omitempty"`
 	PropertyBag     genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/agent_pool__status_arm_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/agent_pool__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210501
 
-//Generated from:
 type AgentPool_StatusARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -19,7 +18,6 @@ type AgentPool_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterAgentPoolProfileProperties_StatusARM struct {
 	//AvailabilityZones: The list of Availability zones to use for nodes. This can
 	//only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
@@ -150,7 +148,6 @@ type ManagedClusterAgentPoolProfileProperties_StatusARM struct {
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 }
 
-//Generated from:
 type AgentPoolMode_Status string
 
 const (
@@ -158,7 +155,6 @@ const (
 	AgentPoolMode_StatusUser   = AgentPoolMode_Status("User")
 )
 
-//Generated from:
 type AgentPoolType_Status string
 
 const (
@@ -166,7 +162,6 @@ const (
 	AgentPoolType_StatusVirtualMachineScaleSets = AgentPoolType_Status("VirtualMachineScaleSets")
 )
 
-//Generated from:
 type AgentPoolUpgradeSettings_StatusARM struct {
 	//MaxSurge: This can either be set to an integer (e.g. '5') or a percentage (e.g.
 	//'50%'). If a percentage is specified, it is the percentage of the total agent
@@ -177,7 +172,6 @@ type AgentPoolUpgradeSettings_StatusARM struct {
 	MaxSurge *string `json:"maxSurge,omitempty"`
 }
 
-//Generated from:
 type GPUInstanceProfile_Status string
 
 const (
@@ -188,7 +182,6 @@ const (
 	GPUInstanceProfile_StatusMIG7G = GPUInstanceProfile_Status("MIG7g")
 )
 
-//Generated from:
 type KubeletConfig_StatusARM struct {
 	//AllowedUnsafeSysctls: Allowed list of unsafe sysctls or unsafe sysctl patterns
 	//(ending in `*`).
@@ -237,7 +230,6 @@ type KubeletConfig_StatusARM struct {
 	TopologyManagerPolicy *string `json:"topologyManagerPolicy,omitempty"`
 }
 
-//Generated from:
 type KubeletDiskType_Status string
 
 const (
@@ -245,7 +237,6 @@ const (
 	KubeletDiskType_StatusTemporary = KubeletDiskType_Status("Temporary")
 )
 
-//Generated from:
 type LinuxOSConfig_StatusARM struct {
 	//SwapFileSizeMB: The size in MB of a swap file that will be created on each node.
 	SwapFileSizeMB *int `json:"swapFileSizeMB,omitempty"`
@@ -265,7 +256,6 @@ type LinuxOSConfig_StatusARM struct {
 	TransparentHugePageEnabled *string `json:"transparentHugePageEnabled,omitempty"`
 }
 
-//Generated from:
 type OSDiskType_Status string
 
 const (
@@ -273,7 +263,6 @@ const (
 	OSDiskType_StatusManaged   = OSDiskType_Status("Managed")
 )
 
-//Generated from:
 type OSSKU_Status string
 
 const (
@@ -281,7 +270,6 @@ const (
 	OSSKU_StatusUbuntu     = OSSKU_Status("Ubuntu")
 )
 
-//Generated from:
 type OSType_Status string
 
 const (
@@ -289,13 +277,11 @@ const (
 	OSType_StatusWindows = OSType_Status("Windows")
 )
 
-//Generated from:
 type PowerState_StatusARM struct {
 	//Code: Tells whether the cluster is Running or Stopped
 	Code *PowerStateStatusCode `json:"code,omitempty"`
 }
 
-//Generated from:
 type ScaleSetEvictionPolicy_Status string
 
 const (
@@ -303,7 +289,6 @@ const (
 	ScaleSetEvictionPolicy_StatusDelete     = ScaleSetEvictionPolicy_Status("Delete")
 )
 
-//Generated from:
 type ScaleSetPriority_Status string
 
 const (
@@ -318,7 +303,6 @@ const (
 	PowerStateStatusCodeStopped = PowerStateStatusCode("Stopped")
 )
 
-//Generated from:
 type SysctlConfig_StatusARM struct {
 	//FsAioMaxNr: Sysctl setting fs.aio-max-nr.
 	FsAioMaxNr *int `json:"fsAioMaxNr,omitempty"`

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster__status_arm_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster__status_arm_types_gen.go
@@ -5,7 +5,6 @@ package v1alpha1api20210501
 
 import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
-//Generated from:
 type ManagedCluster_StatusARM struct {
 	//ExtendedLocation: The extended location of the Virtual Machine.
 	ExtendedLocation *ExtendedLocation_StatusARM `json:"extendedLocation,omitempty"`
@@ -35,7 +34,6 @@ type ManagedCluster_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocation_StatusARM struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -44,7 +42,6 @@ type ExtendedLocation_StatusARM struct {
 	Type *ExtendedLocationType_Status `json:"type,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterIdentity_StatusARM struct {
 	//PrincipalId: The principal id of the system assigned identity which is used by
 	//master components.
@@ -63,7 +60,6 @@ type ManagedClusterIdentity_StatusARM struct {
 	UserAssignedIdentities map[string]ManagedClusterIdentity_Status_UserAssignedIdentitiesARM `json:"userAssignedIdentities,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterProperties_StatusARM struct {
 	//AadProfile: The Azure Active Directory configuration.
 	AadProfile *ManagedClusterAADProfile_StatusARM `json:"aadProfile,omitempty"`
@@ -169,7 +165,6 @@ type ManagedClusterProperties_StatusARM struct {
 	WindowsProfile *ManagedClusterWindowsProfile_StatusARM `json:"windowsProfile,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterSKU_StatusARM struct {
 	//Name: The name of a managed cluster SKU.
 	Name *ManagedClusterSKUStatusName `json:"name,omitempty"`
@@ -179,7 +174,6 @@ type ManagedClusterSKU_StatusARM struct {
 	Tier *ManagedClusterSKUStatusTier `json:"tier,omitempty"`
 }
 
-//Generated from:
 type ContainerServiceLinuxProfile_StatusARM struct {
 	//AdminUsername: The administrator username to use for Linux VMs.
 	AdminUsername string `json:"adminUsername"`
@@ -188,7 +182,6 @@ type ContainerServiceLinuxProfile_StatusARM struct {
 	Ssh ContainerServiceSshConfiguration_StatusARM `json:"ssh"`
 }
 
-//Generated from:
 type ContainerServiceNetworkProfile_StatusARM struct {
 	//DnsServiceIP: An IP address assigned to the Kubernetes DNS service. It must be
 	//within the Kubernetes service address range specified in serviceCidr.
@@ -231,12 +224,10 @@ type ContainerServiceNetworkProfile_StatusARM struct {
 	ServiceCidr *string `json:"serviceCidr,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocationType_Status string
 
 const ExtendedLocationType_StatusEdgeZone = ExtendedLocationType_Status("EdgeZone")
 
-//Generated from:
 type ManagedClusterAADProfile_StatusARM struct {
 	//AdminGroupObjectIDs: The list of AAD group object IDs that will have admin role
 	//of the cluster.
@@ -262,7 +253,6 @@ type ManagedClusterAADProfile_StatusARM struct {
 	TenantID *string `json:"tenantID,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterAPIServerAccessProfile_StatusARM struct {
 	//AuthorizedIPRanges: IP ranges are specified in CIDR format, e.g.
 	//137.117.106.88/29. This feature is not compatible with clusters that use Public
@@ -286,7 +276,6 @@ type ManagedClusterAPIServerAccessProfile_StatusARM struct {
 	PrivateDNSZone *string `json:"privateDNSZone,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterAgentPoolProfile_StatusARM struct {
 	//AvailabilityZones: The list of Availability zones to use for nodes. This can
 	//only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
@@ -420,14 +409,12 @@ type ManagedClusterAgentPoolProfile_StatusARM struct {
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterAutoUpgradeProfile_StatusARM struct {
 	//UpgradeChannel: For more information see [setting the AKS cluster auto-upgrade
 	//channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel).
 	UpgradeChannel *ManagedClusterAutoUpgradeProfileStatusUpgradeChannel `json:"upgradeChannel,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterHTTPProxyConfig_StatusARM struct {
 	//HttpProxy: The HTTP proxy server endpoint to use.
 	HttpProxy *string `json:"httpProxy,omitempty"`
@@ -458,7 +445,6 @@ type ManagedClusterIdentity_Status_UserAssignedIdentitiesARM struct {
 	PrincipalId *string `json:"principalId,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterPodIdentityProfile_StatusARM struct {
 	//AllowNetworkPluginKubenet: Running in Kubenet is disabled by default due to the
 	//security related nature of AAD Pod Identity and the risks of IP spoofing. See
@@ -554,7 +540,6 @@ const (
 	ManagedClusterSKUStatusTierPaid = ManagedClusterSKUStatusTier("Paid")
 )
 
-//Generated from:
 type ManagedClusterServicePrincipalProfile_StatusARM struct {
 	//ClientId: The ID for the service principal.
 	ClientId string `json:"clientId"`
@@ -563,7 +548,6 @@ type ManagedClusterServicePrincipalProfile_StatusARM struct {
 	Secret *string `json:"secret,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterWindowsProfile_StatusARM struct {
 	//AdminPassword: Specifies the password of the administrator account.
 	//Minimum-length: 8 characters
@@ -598,7 +582,6 @@ type ManagedClusterWindowsProfile_StatusARM struct {
 	LicenseType *ManagedClusterWindowsProfileStatusLicenseType `json:"licenseType,omitempty"`
 }
 
-//Generated from:
 type PrivateLinkResource_StatusARM struct {
 	//GroupId: The group ID of the resource.
 	GroupId *string `json:"groupId,omitempty"`
@@ -620,14 +603,12 @@ type PrivateLinkResource_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ContainerServiceSshConfiguration_StatusARM struct {
 	//PublicKeys: The list of SSH public keys used to authenticate with Linux-based
 	//VMs. A maximum of 1 key may be specified.
 	PublicKeys []ContainerServiceSshPublicKey_StatusARM `json:"publicKeys"`
 }
 
-//Generated from:
 type ManagedClusterLoadBalancerProfile_StatusARM struct {
 	//AllocatedOutboundPorts: The desired number of allocated SNAT ports per VM.
 	//Allowed values are in the range of 0 to 64000 (inclusive). The default value is
@@ -653,7 +634,6 @@ type ManagedClusterLoadBalancerProfile_StatusARM struct {
 	OutboundIPs *ManagedClusterLoadBalancerProfile_Status_OutboundIPsARM `json:"outboundIPs,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterPodIdentityException_StatusARM struct {
 	//Name: The name of the pod identity exception.
 	Name string `json:"name"`
@@ -665,7 +645,6 @@ type ManagedClusterPodIdentityException_StatusARM struct {
 	PodLabels map[string]string `json:"podLabels"`
 }
 
-//Generated from:
 type ManagedClusterPodIdentity_StatusARM struct {
 	//BindingSelector: The binding selector to use for the AzureIdentityBinding
 	//resource.
@@ -685,7 +664,6 @@ type ManagedClusterPodIdentity_StatusARM struct {
 	ProvisioningState *ManagedClusterPodIdentityStatusProvisioningState `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type ContainerServiceSshPublicKey_StatusARM struct {
 	//KeyData: Certificate public key used to authenticate with VMs through SSH. The
 	//certificate must be in PEM format with or without headers.
@@ -714,13 +692,11 @@ type ManagedClusterPodIdentity_Status_ProvisioningInfoARM struct {
 	Error *ManagedClusterPodIdentityProvisioningError_StatusARM `json:"error,omitempty"`
 }
 
-//Generated from:
 type ResourceReference_StatusARM struct {
 	//Id: The fully qualified Azure resource id.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type UserAssignedIdentity_StatusARM struct {
 	//ClientId: The client ID of the user assigned identity.
 	ClientId *string `json:"clientId,omitempty"`
@@ -732,13 +708,11 @@ type UserAssignedIdentity_StatusARM struct {
 	ResourceId *string `json:"resourceId,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterPodIdentityProvisioningError_StatusARM struct {
 	//Error: Details about the error.
 	Error *ManagedClusterPodIdentityProvisioningErrorBody_StatusARM `json:"error,omitempty"`
 }
 
-//Generated from:
 type ManagedClusterPodIdentityProvisioningErrorBody_StatusARM struct {
 	//Code: An identifier for the error. Codes are invariant and are intended to be
 	//consumed programmatically.

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
@@ -284,7 +284,6 @@ type ManagedClusterList struct {
 	Items           []ManagedCluster `json:"items"`
 }
 
-//Generated from:
 type ManagedCluster_Status struct {
 	//AadProfile: The Azure Active Directory configuration.
 	AadProfile *ManagedClusterAADProfile_Status `json:"aadProfile,omitempty"`
@@ -2980,7 +2979,6 @@ func (containerServiceLinuxProfile *ContainerServiceLinuxProfile) AssignProperti
 	return nil
 }
 
-//Generated from:
 type ContainerServiceLinuxProfile_Status struct {
 	// +kubebuilder:validation:Required
 	//AdminUsername: The administrator username to use for Linux VMs.
@@ -3464,7 +3462,6 @@ func (containerServiceNetworkProfile *ContainerServiceNetworkProfile) AssignProp
 	return nil
 }
 
-//Generated from:
 type ContainerServiceNetworkProfile_Status struct {
 	//DnsServiceIP: An IP address assigned to the Kubernetes DNS service. It must be
 	//within the Kubernetes service address range specified in serviceCidr.
@@ -3846,7 +3843,6 @@ func (extendedLocation *ExtendedLocation) AssignPropertiesToExtendedLocation(des
 	return nil
 }
 
-//Generated from:
 type ExtendedLocation_Status struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -4150,7 +4146,6 @@ func (managedClusterAADProfile *ManagedClusterAADProfile) AssignPropertiesToMana
 	return nil
 }
 
-//Generated from:
 type ManagedClusterAADProfile_Status struct {
 	//AdminGroupObjectIDs: The list of AAD group object IDs that will have admin role
 	//of the cluster.
@@ -4484,7 +4479,6 @@ func (managedClusterAPIServerAccessProfile *ManagedClusterAPIServerAccessProfile
 	return nil
 }
 
-//Generated from:
 type ManagedClusterAPIServerAccessProfile_Status struct {
 	//AuthorizedIPRanges: IP ranges are specified in CIDR format, e.g.
 	//137.117.106.88/29. This feature is not compatible with clusters that use Public
@@ -5788,7 +5782,6 @@ func (managedClusterAgentPoolProfile *ManagedClusterAgentPoolProfile) AssignProp
 	return nil
 }
 
-//Generated from:
 type ManagedClusterAgentPoolProfile_Status struct {
 	//AvailabilityZones: The list of Availability zones to use for nodes. This can
 	//only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
@@ -6736,7 +6729,6 @@ func (managedClusterAutoUpgradeProfile *ManagedClusterAutoUpgradeProfile) Assign
 	return nil
 }
 
-//Generated from:
 type ManagedClusterAutoUpgradeProfile_Status struct {
 	//UpgradeChannel: For more information see [setting the AKS cluster auto-upgrade
 	//channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel).
@@ -6941,7 +6933,6 @@ func (managedClusterHTTPProxyConfig *ManagedClusterHTTPProxyConfig) AssignProper
 	return nil
 }
 
-//Generated from:
 type ManagedClusterHTTPProxyConfig_Status struct {
 	//HttpProxy: The HTTP proxy server endpoint to use.
 	HttpProxy *string `json:"httpProxy,omitempty"`
@@ -7175,7 +7166,6 @@ func (managedClusterIdentity *ManagedClusterIdentity) AssignPropertiesToManagedC
 	return nil
 }
 
-//Generated from:
 type ManagedClusterIdentity_Status struct {
 	//PrincipalId: The principal id of the system assigned identity which is used by
 	//master components.
@@ -7565,7 +7555,6 @@ func (managedClusterPodIdentityProfile *ManagedClusterPodIdentityProfile) Assign
 	return nil
 }
 
-//Generated from:
 type ManagedClusterPodIdentityProfile_Status struct {
 	//AllowNetworkPluginKubenet: Running in Kubenet is disabled by default due to the
 	//security related nature of AAD Pod Identity and the risks of IP spoofing. See
@@ -8631,7 +8620,6 @@ func (managedClusterSKU *ManagedClusterSKU) AssignPropertiesToManagedClusterSKU(
 	return nil
 }
 
-//Generated from:
 type ManagedClusterSKU_Status struct {
 	//Name: The name of a managed cluster SKU.
 	Name *ManagedClusterSKUStatusName `json:"name,omitempty"`
@@ -8817,7 +8805,6 @@ func (managedClusterServicePrincipalProfile *ManagedClusterServicePrincipalProfi
 	return nil
 }
 
-//Generated from:
 type ManagedClusterServicePrincipalProfile_Status struct {
 	// +kubebuilder:validation:Required
 	//ClientId: The ID for the service principal.
@@ -9063,7 +9050,6 @@ func (managedClusterWindowsProfile *ManagedClusterWindowsProfile) AssignProperti
 	return nil
 }
 
-//Generated from:
 type ManagedClusterWindowsProfile_Status struct {
 	//AdminPassword: Specifies the password of the administrator account.
 	//Minimum-length: 8 characters
@@ -9206,7 +9192,6 @@ func (managedClusterWindowsProfileStatus *ManagedClusterWindowsProfile_Status) A
 	return nil
 }
 
-//Generated from:
 type PowerState_Status struct {
 	//Code: Tells whether the cluster is Running or Stopped
 	Code *PowerStateStatusCode `json:"code,omitempty"`
@@ -9441,7 +9426,6 @@ func (privateLinkResource *PrivateLinkResource) AssignPropertiesToPrivateLinkRes
 	return nil
 }
 
-//Generated from:
 type PrivateLinkResource_Status struct {
 	//GroupId: The group ID of the resource.
 	GroupId *string `json:"groupId,omitempty"`
@@ -9763,7 +9747,6 @@ func (containerServiceSshConfiguration *ContainerServiceSshConfiguration) Assign
 	return nil
 }
 
-//Generated from:
 type ContainerServiceSshConfiguration_Status struct {
 	// +kubebuilder:validation:Required
 	//PublicKeys: The list of SSH public keys used to authenticate with Linux-based
@@ -10353,7 +10336,6 @@ func (managedClusterLoadBalancerProfile *ManagedClusterLoadBalancerProfile) Assi
 	return nil
 }
 
-//Generated from:
 type ManagedClusterLoadBalancerProfile_Status struct {
 	//AllocatedOutboundPorts: The desired number of allocated SNAT ports per VM.
 	//Allowed values are in the range of 0 to 64000 (inclusive). The default value is
@@ -10856,7 +10838,6 @@ func (managedClusterPodIdentityException *ManagedClusterPodIdentityException) As
 	return nil
 }
 
-//Generated from:
 type ManagedClusterPodIdentityException_Status struct {
 	// +kubebuilder:validation:Required
 	//Name: The name of the pod identity exception.
@@ -10946,7 +10927,6 @@ func (managedClusterPodIdentityExceptionStatus *ManagedClusterPodIdentityExcepti
 	return nil
 }
 
-//Generated from:
 type ManagedClusterPodIdentity_Status struct {
 	//BindingSelector: The binding selector to use for the AzureIdentityBinding
 	//resource.
@@ -11232,7 +11212,6 @@ func (containerServiceSshPublicKey *ContainerServiceSshPublicKey) AssignProperti
 	return nil
 }
 
-//Generated from:
 type ContainerServiceSshPublicKey_Status struct {
 	// +kubebuilder:validation:Required
 	//KeyData: Certificate public key used to authenticate with VMs through SSH. The
@@ -12019,7 +11998,6 @@ func (resourceReference *ResourceReference) AssignPropertiesToResourceReference(
 	return nil
 }
 
-//Generated from:
 type ResourceReference_Status struct {
 	//Id: The fully qualified Azure resource id.
 	Id *string `json:"id,omitempty"`
@@ -12204,7 +12182,6 @@ func (userAssignedIdentity *UserAssignedIdentity) AssignPropertiesToUserAssigned
 	return nil
 }
 
-//Generated from:
 type UserAssignedIdentity_Status struct {
 	//ClientId: The client ID of the user assigned identity.
 	ClientId *string `json:"clientId,omitempty"`
@@ -12293,7 +12270,6 @@ func (userAssignedIdentityStatus *UserAssignedIdentity_Status) AssignPropertiesT
 	return nil
 }
 
-//Generated from:
 type ManagedClusterPodIdentityProvisioningError_Status struct {
 	//Error: Details about the error.
 	Error *ManagedClusterPodIdentityProvisioningErrorBody_Status `json:"error,omitempty"`
@@ -12375,7 +12351,6 @@ func (managedClusterPodIdentityProvisioningErrorStatus *ManagedClusterPodIdentit
 	return nil
 }
 
-//Generated from:
 type ManagedClusterPodIdentityProvisioningErrorBody_Status struct {
 	//Code: An identifier for the error. Codes are invariant and are intended to be
 	//consumed programmatically.

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -285,7 +285,6 @@ type ManagedClustersAgentPoolList struct {
 	Items           []ManagedClustersAgentPool `json:"items"`
 }
 
-//Generated from:
 type AgentPool_Status struct {
 	//AvailabilityZones: The list of Availability zones to use for nodes. This can
 	//only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
@@ -2562,7 +2561,6 @@ func (agentPoolUpgradeSettings *AgentPoolUpgradeSettings) AssignPropertiesToAgen
 	return nil
 }
 
-//Generated from:
 type AgentPoolUpgradeSettings_Status struct {
 	//MaxSurge: This can either be set to an integer (e.g. '5') or a percentage (e.g.
 	//'50%'). If a percentage is specified, it is the percentage of the total agent
@@ -2952,7 +2950,6 @@ func (kubeletConfig *KubeletConfig) AssignPropertiesToKubeletConfig(destination 
 	return nil
 }
 
-//Generated from:
 type KubeletConfig_Status struct {
 	//AllowedUnsafeSysctls: Allowed list of unsafe sysctls or unsafe sysctl patterns
 	//(ending in `*`).
@@ -3362,7 +3359,6 @@ func (linuxOSConfig *LinuxOSConfig) AssignPropertiesToLinuxOSConfig(destination 
 	return nil
 }
 
-//Generated from:
 type LinuxOSConfig_Status struct {
 	//SwapFileSizeMB: The size in MB of a swap file that will be created on each node.
 	SwapFileSizeMB *int `json:"swapFileSizeMB,omitempty"`
@@ -4221,7 +4217,6 @@ func (sysctlConfig *SysctlConfig) AssignPropertiesToSysctlConfig(destination *v1
 	return nil
 }
 
-//Generated from:
 type SysctlConfig_Status struct {
 	//FsAioMaxNr: Sysctl setting fs.aio-max-nr.
 	FsAioMaxNr *int `json:"fsAioMaxNr,omitempty"`

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_cluster_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_cluster_types_gen.go
@@ -125,7 +125,6 @@ type ManagedClusterList struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedCluster_Status
-//Generated from:
 type ManagedCluster_Status struct {
 	AadProfile              *ManagedClusterAADProfile_Status                   `json:"aadProfile,omitempty"`
 	AddonProfiles           *v1.JSON                                           `json:"addonProfiles,omitempty"`
@@ -274,7 +273,6 @@ type ContainerServiceLinuxProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ContainerServiceLinuxProfile_Status
-//Generated from:
 type ContainerServiceLinuxProfile_Status struct {
 	AdminUsername *string                                  `json:"adminUsername,omitempty"`
 	PropertyBag   genruntime.PropertyBag                   `json:"$propertyBag,omitempty"`
@@ -298,7 +296,6 @@ type ContainerServiceNetworkProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ContainerServiceNetworkProfile_Status
-//Generated from:
 type ContainerServiceNetworkProfile_Status struct {
 	DnsServiceIP        *string                                   `json:"dnsServiceIP,omitempty"`
 	DockerBridgeCidr    *string                                   `json:"dockerBridgeCidr,omitempty"`
@@ -322,7 +319,6 @@ type ExtendedLocation struct {
 }
 
 //Storage version of v1alpha1api20210501.ExtendedLocation_Status
-//Generated from:
 type ExtendedLocation_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -343,7 +339,6 @@ type ManagedClusterAADProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterAADProfile_Status
-//Generated from:
 type ManagedClusterAADProfile_Status struct {
 	AdminGroupObjectIDs []string               `json:"adminGroupObjectIDs,omitempty"`
 	ClientAppID         *string                `json:"clientAppID,omitempty"`
@@ -366,7 +361,6 @@ type ManagedClusterAPIServerAccessProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterAPIServerAccessProfile_Status
-//Generated from:
 type ManagedClusterAPIServerAccessProfile_Status struct {
 	AuthorizedIPRanges             []string               `json:"authorizedIPRanges,omitempty"`
 	EnablePrivateCluster           *bool                  `json:"enablePrivateCluster,omitempty"`
@@ -436,7 +430,6 @@ type ManagedClusterAgentPoolProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterAgentPoolProfile_Status
-//Generated from:
 type ManagedClusterAgentPoolProfile_Status struct {
 	AvailabilityZones         []string                         `json:"availabilityZones,omitempty"`
 	Count                     *int                             `json:"count,omitempty"`
@@ -486,7 +479,6 @@ type ManagedClusterAutoUpgradeProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterAutoUpgradeProfile_Status
-//Generated from:
 type ManagedClusterAutoUpgradeProfile_Status struct {
 	PropertyBag    genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	UpgradeChannel *string                `json:"upgradeChannel,omitempty"`
@@ -503,7 +495,6 @@ type ManagedClusterHTTPProxyConfig struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterHTTPProxyConfig_Status
-//Generated from:
 type ManagedClusterHTTPProxyConfig_Status struct {
 	HttpProxy   *string                `json:"httpProxy,omitempty"`
 	HttpsProxy  *string                `json:"httpsProxy,omitempty"`
@@ -521,7 +512,6 @@ type ManagedClusterIdentity struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterIdentity_Status
-//Generated from:
 type ManagedClusterIdentity_Status struct {
 	PrincipalId            *string                                                         `json:"principalId,omitempty"`
 	PropertyBag            genruntime.PropertyBag                                          `json:"$propertyBag,omitempty"`
@@ -541,7 +531,6 @@ type ManagedClusterPodIdentityProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterPodIdentityProfile_Status
-//Generated from:
 type ManagedClusterPodIdentityProfile_Status struct {
 	AllowNetworkPluginKubenet      *bool                                       `json:"allowNetworkPluginKubenet,omitempty"`
 	Enabled                        *bool                                       `json:"enabled,omitempty"`
@@ -604,7 +593,6 @@ type ManagedClusterSKU struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterSKU_Status
-//Generated from:
 type ManagedClusterSKU_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -620,7 +608,6 @@ type ManagedClusterServicePrincipalProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterServicePrincipalProfile_Status
-//Generated from:
 type ManagedClusterServicePrincipalProfile_Status struct {
 	ClientId    *string                `json:"clientId,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -638,7 +625,6 @@ type ManagedClusterWindowsProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterWindowsProfile_Status
-//Generated from:
 type ManagedClusterWindowsProfile_Status struct {
 	AdminPassword  *string                `json:"adminPassword,omitempty"`
 	AdminUsername  *string                `json:"adminUsername,omitempty"`
@@ -648,7 +634,6 @@ type ManagedClusterWindowsProfile_Status struct {
 }
 
 //Storage version of v1alpha1api20210501.PowerState_Status
-//Generated from:
 type PowerState_Status struct {
 	Code        *string                `json:"code,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -668,7 +653,6 @@ type PrivateLinkResource struct {
 }
 
 //Storage version of v1alpha1api20210501.PrivateLinkResource_Status
-//Generated from:
 type PrivateLinkResource_Status struct {
 	GroupId              *string                `json:"groupId,omitempty"`
 	Id                   *string                `json:"id,omitempty"`
@@ -687,7 +671,6 @@ type ContainerServiceSshConfiguration struct {
 }
 
 //Storage version of v1alpha1api20210501.ContainerServiceSshConfiguration_Status
-//Generated from:
 type ContainerServiceSshConfiguration_Status struct {
 	PropertyBag genruntime.PropertyBag                `json:"$propertyBag,omitempty"`
 	PublicKeys  []ContainerServiceSshPublicKey_Status `json:"publicKeys,omitempty"`
@@ -713,7 +696,6 @@ type ManagedClusterLoadBalancerProfile struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterLoadBalancerProfile_Status
-//Generated from:
 type ManagedClusterLoadBalancerProfile_Status struct {
 	AllocatedOutboundPorts *int                                                         `json:"allocatedOutboundPorts,omitempty"`
 	EffectiveOutboundIPs   []ResourceReference_Status                                   `json:"effectiveOutboundIPs,omitempty"`
@@ -744,7 +726,6 @@ type ManagedClusterPodIdentityException struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterPodIdentityException_Status
-//Generated from:
 type ManagedClusterPodIdentityException_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	Namespace   *string                `json:"namespace,omitempty"`
@@ -753,7 +734,6 @@ type ManagedClusterPodIdentityException_Status struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterPodIdentity_Status
-//Generated from:
 type ManagedClusterPodIdentity_Status struct {
 	BindingSelector   *string                                            `json:"bindingSelector,omitempty"`
 	Identity          *UserAssignedIdentity_Status                       `json:"identity,omitempty"`
@@ -772,7 +752,6 @@ type ContainerServiceSshPublicKey struct {
 }
 
 //Storage version of v1alpha1api20210501.ContainerServiceSshPublicKey_Status
-//Generated from:
 type ContainerServiceSshPublicKey_Status struct {
 	KeyData     *string                `json:"keyData,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -833,7 +812,6 @@ type ResourceReference struct {
 }
 
 //Storage version of v1alpha1api20210501.ResourceReference_Status
-//Generated from:
 type ResourceReference_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -851,7 +829,6 @@ type UserAssignedIdentity struct {
 }
 
 //Storage version of v1alpha1api20210501.UserAssignedIdentity_Status
-//Generated from:
 type UserAssignedIdentity_Status struct {
 	ClientId    *string                `json:"clientId,omitempty"`
 	ObjectId    *string                `json:"objectId,omitempty"`
@@ -860,14 +837,12 @@ type UserAssignedIdentity_Status struct {
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterPodIdentityProvisioningError_Status
-//Generated from:
 type ManagedClusterPodIdentityProvisioningError_Status struct {
 	Error       *ManagedClusterPodIdentityProvisioningErrorBody_Status `json:"error,omitempty"`
 	PropertyBag genruntime.PropertyBag                                 `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20210501.ManagedClusterPodIdentityProvisioningErrorBody_Status
-//Generated from:
 type ManagedClusterPodIdentityProvisioningErrorBody_Status struct {
 	Code        *string                                                          `json:"code,omitempty"`
 	Details     []ManagedClusterPodIdentityProvisioningErrorBody_Status_Unrolled `json:"details,omitempty"`

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501storage/managed_clusters_agent_pool_types_gen.go
@@ -124,7 +124,6 @@ type ManagedClustersAgentPoolList struct {
 }
 
 //Storage version of v1alpha1api20210501.AgentPool_Status
-//Generated from:
 type AgentPool_Status struct {
 	AvailabilityZones         []string                         `json:"availabilityZones,omitempty"`
 	Conditions                []conditions.Condition           `json:"conditions,omitempty"`
@@ -276,7 +275,6 @@ type AgentPoolUpgradeSettings struct {
 }
 
 //Storage version of v1alpha1api20210501.AgentPoolUpgradeSettings_Status
-//Generated from:
 type AgentPoolUpgradeSettings_Status struct {
 	MaxSurge    *string                `json:"maxSurge,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -300,7 +298,6 @@ type KubeletConfig struct {
 }
 
 //Storage version of v1alpha1api20210501.KubeletConfig_Status
-//Generated from:
 type KubeletConfig_Status struct {
 	AllowedUnsafeSysctls  []string               `json:"allowedUnsafeSysctls,omitempty"`
 	ContainerLogMaxFiles  *int                   `json:"containerLogMaxFiles,omitempty"`
@@ -327,7 +324,6 @@ type LinuxOSConfig struct {
 }
 
 //Storage version of v1alpha1api20210501.LinuxOSConfig_Status
-//Generated from:
 type LinuxOSConfig_Status struct {
 	PropertyBag                genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	SwapFileSizeMB             *int                   `json:"swapFileSizeMB,omitempty"`
@@ -371,7 +367,6 @@ type SysctlConfig struct {
 }
 
 //Storage version of v1alpha1api20210501.SysctlConfig_Status
-//Generated from:
 type SysctlConfig_Status struct {
 	FsAioMaxNr                     *int                   `json:"fsAioMaxNr,omitempty"`
 	FsFileMax                      *int                   `json:"fsFileMax,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/database__status_arm_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/database__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210601
 
-//Generated from:
 type Database_StatusARM struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -23,7 +22,6 @@ type Database_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type DatabaseProperties_StatusARM struct {
 	//Charset: The charset of the database.
 	Charset *string `json:"charset,omitempty"`
@@ -32,7 +30,6 @@ type DatabaseProperties_StatusARM struct {
 	Collation *string `json:"collation,omitempty"`
 }
 
-//Generated from:
 type SystemData_StatusARM struct {
 	//CreatedAt: The timestamp of resource creation (UTC).
 	CreatedAt *string `json:"createdAt,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/firewall_rule__status_arm_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/firewall_rule__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210601
 
-//Generated from:
 type FirewallRule_StatusARM struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -23,7 +22,6 @@ type FirewallRule_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type FirewallRuleProperties_StatusARM struct {
 	//EndIpAddress: The end IP address of the server firewall rule. Must be IPv4
 	//format.

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
@@ -976,7 +976,6 @@ func (flexibleServersSpec *FlexibleServers_Spec) SetAzureName(azureName string) 
 	flexibleServersSpec.AzureName = azureName
 }
 
-//Generated from:
 type Server_Status struct {
 	//AdministratorLogin: The administrator's login name of a server. Can only be
 	//specified when the server is being created (and is required for creation).
@@ -1781,7 +1780,6 @@ func (backup *Backup) AssignPropertiesToBackup(destination *v1alpha1api20210601s
 	return nil
 }
 
-//Generated from:
 type Backup_Status struct {
 	//BackupRetentionDays: Backup retention days for the server.
 	BackupRetentionDays *int `json:"backupRetentionDays,omitempty"`
@@ -1986,7 +1984,6 @@ func (highAvailability *HighAvailability) AssignPropertiesToHighAvailability(des
 	return nil
 }
 
-//Generated from:
 type HighAvailability_Status struct {
 	//Mode: The HA mode for the server.
 	Mode *HighAvailabilityStatusMode `json:"mode,omitempty"`
@@ -2232,7 +2229,6 @@ func (maintenanceWindow *MaintenanceWindow) AssignPropertiesToMaintenanceWindow(
 	return nil
 }
 
-//Generated from:
 type MaintenanceWindow_Status struct {
 	//CustomWindow: indicates whether custom window is enabled or disabled
 	CustomWindow *string `json:"customWindow,omitempty"`
@@ -2451,7 +2447,6 @@ func (network *Network) AssignPropertiesToNetwork(destination *v1alpha1api202106
 	return nil
 }
 
-//Generated from:
 type Network_Status struct {
 	//DelegatedSubnetResourceId: delegated subnet arm resource id.
 	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
@@ -2590,7 +2585,6 @@ const (
 	ServerPropertiesVersion13 = ServerPropertiesVersion("13")
 )
 
-//Generated from:
 type ServerVersion_Status string
 
 const (
@@ -2691,7 +2685,6 @@ func (sku *Sku) AssignPropertiesToSku(destination *v1alpha1api20210601storage.Sk
 	return nil
 }
 
-//Generated from:
 type Sku_Status struct {
 	// +kubebuilder:validation:Required
 	//Name: The name of the sku, typically, tier + family + cores, e.g.
@@ -2842,7 +2835,6 @@ func (storage *Storage) AssignPropertiesToStorage(destination *v1alpha1api202106
 	return nil
 }
 
-//Generated from:
 type Storage_Status struct {
 	//StorageSizeGB: Max storage allowed for a server.
 	StorageSizeGB *int `json:"storageSizeGB,omitempty"`
@@ -2901,7 +2893,6 @@ func (storageStatus *Storage_Status) AssignPropertiesToStorageStatus(destination
 	return nil
 }
 
-//Generated from:
 type SystemData_Status struct {
 	//CreatedAt: The timestamp of resource creation (UTC).
 	CreatedAt *string `json:"createdAt,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
@@ -285,7 +285,6 @@ type FlexibleServersDatabaseList struct {
 	Items           []FlexibleServersDatabase `json:"items"`
 }
 
-//Generated from:
 type Database_Status struct {
 	//Charset: The charset of the database.
 	Charset *string `json:"charset,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
@@ -285,7 +285,6 @@ type FlexibleServersFirewallRuleList struct {
 	Items           []FlexibleServersFirewallRule `json:"items"`
 }
 
-//Generated from:
 type FirewallRule_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/server__status_arm_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/server__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210601
 
-//Generated from:
 type Server_StatusARM struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -32,7 +31,6 @@ type Server_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ServerProperties_StatusARM struct {
 	//AdministratorLogin: The administrator's login name of a server. Can only be
 	//specified when the server is being created (and is required for creation).
@@ -87,7 +85,6 @@ type ServerProperties_StatusARM struct {
 	Version *ServerVersion_Status `json:"version,omitempty"`
 }
 
-//Generated from:
 type Sku_StatusARM struct {
 	//Name: The name of the sku, typically, tier + family + cores, e.g.
 	//Standard_D4s_v3.
@@ -97,7 +94,6 @@ type Sku_StatusARM struct {
 	Tier SkuStatusTier `json:"tier"`
 }
 
-//Generated from:
 type Backup_StatusARM struct {
 	//BackupRetentionDays: Backup retention days for the server.
 	BackupRetentionDays *int `json:"backupRetentionDays,omitempty"`
@@ -110,7 +106,6 @@ type Backup_StatusARM struct {
 	GeoRedundantBackup *BackupStatusGeoRedundantBackup `json:"geoRedundantBackup,omitempty"`
 }
 
-//Generated from:
 type HighAvailability_StatusARM struct {
 	//Mode: The HA mode for the server.
 	Mode *HighAvailabilityStatusMode `json:"mode,omitempty"`
@@ -122,7 +117,6 @@ type HighAvailability_StatusARM struct {
 	State *HighAvailabilityStatusState `json:"state,omitempty"`
 }
 
-//Generated from:
 type MaintenanceWindow_StatusARM struct {
 	//CustomWindow: indicates whether custom window is enabled or disabled
 	CustomWindow *string `json:"customWindow,omitempty"`
@@ -137,7 +131,6 @@ type MaintenanceWindow_StatusARM struct {
 	StartMinute *int `json:"startMinute,omitempty"`
 }
 
-//Generated from:
 type Network_StatusARM struct {
 	//DelegatedSubnetResourceId: delegated subnet arm resource id.
 	DelegatedSubnetResourceId *string `json:"delegatedSubnetResourceId,omitempty"`
@@ -157,7 +150,6 @@ const (
 	SkuStatusTierMemoryOptimized = SkuStatusTier("MemoryOptimized")
 )
 
-//Generated from:
 type Storage_StatusARM struct {
 	//StorageSizeGB: Max storage allowed for a server.
 	StorageSizeGB *int `json:"storageSizeGB,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_server_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_server_types_gen.go
@@ -176,7 +176,6 @@ func (flexibleServersSpec *FlexibleServers_Spec) ConvertSpecTo(destination genru
 }
 
 //Storage version of v1alpha1api20210601.Server_Status
-//Generated from:
 type Server_Status struct {
 	AdministratorLogin         *string                   `json:"administratorLogin,omitempty"`
 	AdministratorLoginPassword *string                   `json:"administratorLoginPassword,omitempty"`
@@ -234,7 +233,6 @@ type Backup struct {
 }
 
 //Storage version of v1alpha1api20210601.Backup_Status
-//Generated from:
 type Backup_Status struct {
 	BackupRetentionDays *int                   `json:"backupRetentionDays,omitempty"`
 	EarliestRestoreDate *string                `json:"earliestRestoreDate,omitempty"`
@@ -251,7 +249,6 @@ type HighAvailability struct {
 }
 
 //Storage version of v1alpha1api20210601.HighAvailability_Status
-//Generated from:
 type HighAvailability_Status struct {
 	Mode                    *string                `json:"mode,omitempty"`
 	PropertyBag             genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -270,7 +267,6 @@ type MaintenanceWindow struct {
 }
 
 //Storage version of v1alpha1api20210601.MaintenanceWindow_Status
-//Generated from:
 type MaintenanceWindow_Status struct {
 	CustomWindow *string                `json:"customWindow,omitempty"`
 	DayOfWeek    *int                   `json:"dayOfWeek,omitempty"`
@@ -291,7 +287,6 @@ type Network struct {
 }
 
 //Storage version of v1alpha1api20210601.Network_Status
-//Generated from:
 type Network_Status struct {
 	DelegatedSubnetResourceId   *string                `json:"delegatedSubnetResourceId,omitempty"`
 	PrivateDnsZoneArmResourceId *string                `json:"privateDnsZoneArmResourceId,omitempty"`
@@ -308,7 +303,6 @@ type Sku struct {
 }
 
 //Storage version of v1alpha1api20210601.Sku_Status
-//Generated from:
 type Sku_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -323,14 +317,12 @@ type Storage struct {
 }
 
 //Storage version of v1alpha1api20210601.Storage_Status
-//Generated from:
 type Storage_Status struct {
 	PropertyBag   genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	StorageSizeGB *int                   `json:"storageSizeGB,omitempty"`
 }
 
 //Storage version of v1alpha1api20210601.SystemData_Status
-//Generated from:
 type SystemData_Status struct {
 	CreatedAt          *string                `json:"createdAt,omitempty"`
 	CreatedBy          *string                `json:"createdBy,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_database_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_database_types_gen.go
@@ -124,7 +124,6 @@ type FlexibleServersDatabaseList struct {
 }
 
 //Storage version of v1alpha1api20210601.Database_Status
-//Generated from:
 type Database_Status struct {
 	Charset     *string                `json:"charset,omitempty"`
 	Collation   *string                `json:"collation,omitempty"`

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/flexible_servers_firewall_rule_types_gen.go
@@ -124,7 +124,6 @@ type FlexibleServersFirewallRuleList struct {
 }
 
 //Storage version of v1alpha1api20210601.FirewallRule_Status
-//Generated from:
 type FirewallRule_Status struct {
 	Conditions     []conditions.Condition `json:"conditions,omitempty"`
 	EndIpAddress   *string                `json:"endIpAddress,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type DatabaseAccountGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id       *string                           `json:"id,omitempty"`
@@ -25,7 +24,6 @@ type DatabaseAccountGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type DatabaseAccountGetProperties_StatusARM struct {
 	//AnalyticalStorageConfiguration: Analytical storage specific properties.
 	AnalyticalStorageConfiguration *AnalyticalStorageConfiguration_StatusARM `json:"analyticalStorageConfiguration,omitempty"`
@@ -139,7 +137,6 @@ const (
 	DatabaseAccountGetResultsStatusKindParse            = DatabaseAccountGetResultsStatusKind("Parse")
 )
 
-//Generated from:
 type ManagedServiceIdentity_StatusARM struct {
 	//PrincipalId: The principal id of the system assigned identity. This property
 	//will only be provided for a system assigned identity.
@@ -162,30 +159,25 @@ type ManagedServiceIdentity_StatusARM struct {
 	UserAssignedIdentities map[string]ManagedServiceIdentity_Status_UserAssignedIdentitiesARM `json:"userAssignedIdentities,omitempty"`
 }
 
-//Generated from:
 type AnalyticalStorageConfiguration_StatusARM struct {
 	SchemaType *AnalyticalStorageSchemaType_Status `json:"schemaType,omitempty"`
 }
 
-//Generated from:
 type ApiProperties_StatusARM struct {
 	//ServerVersion: Describes the ServerVersion of an a MongoDB account.
 	ServerVersion *ApiPropertiesStatusServerVersion `json:"serverVersion,omitempty"`
 }
 
-//Generated from:
 type BackupPolicy_StatusARM struct {
 	Type BackupPolicyType_Status `json:"type"`
 }
 
-//Generated from:
 type Capability_StatusARM struct {
 	//Name: Name of the Cosmos DB capability. For example, "name": "EnableCassandra".
 	//Current values also include "EnableTable" and "EnableGremlin".
 	Name *string `json:"name,omitempty"`
 }
 
-//Generated from:
 type ConsistencyPolicy_StatusARM struct {
 	//DefaultConsistencyLevel: The default consistency level and configuration
 	//settings of the Cosmos DB account.
@@ -204,7 +196,6 @@ type ConsistencyPolicy_StatusARM struct {
 	MaxStalenessPrefix *int `json:"maxStalenessPrefix,omitempty"`
 }
 
-//Generated from:
 type CorsPolicy_StatusARM struct {
 	//AllowedHeaders: The request headers that the origin domain may specify on the
 	//CORS request.
@@ -227,7 +218,6 @@ type CorsPolicy_StatusARM struct {
 	MaxAgeInSeconds *int `json:"maxAgeInSeconds,omitempty"`
 }
 
-//Generated from:
 type FailoverPolicy_StatusARM struct {
 	//FailoverPriority: The failover priority of the region. A failover priority of 0
 	//indicates a write region. The maximum value for a failover priority = (total
@@ -243,7 +233,6 @@ type FailoverPolicy_StatusARM struct {
 	LocationName *string `json:"locationName,omitempty"`
 }
 
-//Generated from:
 type IpAddressOrRange_StatusARM struct {
 	//IpAddressOrRange: A single IPv4 address or a single IPv4 address range in CIDR
 	//format. Provided IPs must be well-formatted and cannot be contained in one of
@@ -253,7 +242,6 @@ type IpAddressOrRange_StatusARM struct {
 	IpAddressOrRange *string `json:"ipAddressOrRange,omitempty"`
 }
 
-//Generated from:
 type Location_StatusARM struct {
 	//DocumentEndpoint: The connection endpoint for the specific region. Example:
 	//https://&lt;accountName&gt;-&lt;locationName&gt;.documents.azure.com:443/
@@ -295,14 +283,12 @@ type ManagedServiceIdentity_Status_UserAssignedIdentitiesARM struct {
 	PrincipalId *string `json:"principalId,omitempty"`
 }
 
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbeddedARM struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkRule_StatusARM struct {
 	//Id: Resource ID of a subnet, for example:
 	///subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}.

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
@@ -283,7 +283,6 @@ type DatabaseAccountList struct {
 	Items           []DatabaseAccount `json:"items"`
 }
 
-//Generated from:
 type DatabaseAccountGetResults_Status struct {
 	//AnalyticalStorageConfiguration: Analytical storage specific properties.
 	AnalyticalStorageConfiguration *AnalyticalStorageConfiguration_Status `json:"analyticalStorageConfiguration,omitempty"`
@@ -2803,7 +2802,6 @@ func (analyticalStorageConfiguration *AnalyticalStorageConfiguration) AssignProp
 	return nil
 }
 
-//Generated from:
 type AnalyticalStorageConfiguration_Status struct {
 	SchemaType *AnalyticalStorageSchemaType_Status `json:"schemaType,omitempty"`
 }
@@ -2955,7 +2953,6 @@ func (apiProperties *ApiProperties) AssignPropertiesToApiProperties(destination 
 	return nil
 }
 
-//Generated from:
 type ApiProperties_Status struct {
 	//ServerVersion: Describes the ServerVersion of an a MongoDB account.
 	ServerVersion *ApiPropertiesStatusServerVersion `json:"serverVersion,omitempty"`
@@ -3173,7 +3170,6 @@ func (backupPolicy *BackupPolicy) AssignPropertiesToBackupPolicy(destination *v1
 	return nil
 }
 
-//Generated from:
 type BackupPolicy_Status struct {
 	// +kubebuilder:validation:Required
 	Type BackupPolicyType_Status `json:"type"`
@@ -3309,7 +3305,6 @@ func (capability *Capability) AssignPropertiesToCapability(destination *v1alpha1
 	return nil
 }
 
-//Generated from:
 type Capability_Status struct {
 	//Name: Name of the Cosmos DB capability. For example, "name": "EnableCassandra".
 	//Current values also include "EnableTable" and "EnableGremlin".
@@ -3369,7 +3364,6 @@ func (capabilityStatus *Capability_Status) AssignPropertiesToCapabilityStatus(de
 	return nil
 }
 
-//Generated from:
 type ConnectorOffer_Status string
 
 const ConnectorOffer_StatusSmall = ConnectorOffer_Status("Small")
@@ -3521,7 +3515,6 @@ func (consistencyPolicy *ConsistencyPolicy) AssignPropertiesToConsistencyPolicy(
 	return nil
 }
 
-//Generated from:
 type ConsistencyPolicy_Status struct {
 	// +kubebuilder:validation:Required
 	//DefaultConsistencyLevel: The default consistency level and configuration
@@ -3791,7 +3784,6 @@ func (corsPolicy *CorsPolicy) AssignPropertiesToCorsPolicy(destination *v1alpha1
 	return nil
 }
 
-//Generated from:
 type CorsPolicy_Status struct {
 	//AllowedHeaders: The request headers that the origin domain may specify on the
 	//CORS request.
@@ -3940,12 +3932,10 @@ const (
 	DatabaseAccountCreateUpdatePropertiesPublicNetworkAccessEnabled  = DatabaseAccountCreateUpdatePropertiesPublicNetworkAccess("Enabled")
 )
 
-//Generated from:
 type DatabaseAccountOfferType_Status string
 
 const DatabaseAccountOfferType_StatusStandard = DatabaseAccountOfferType_Status("Standard")
 
-//Generated from:
 type FailoverPolicy_Status struct {
 	//FailoverPriority: The failover priority of the region. A failover priority of 0
 	//indicates a write region. The maximum value for a failover priority = (total
@@ -4116,7 +4106,6 @@ func (ipAddressOrRange *IpAddressOrRange) AssignPropertiesToIpAddressOrRange(des
 	return nil
 }
 
-//Generated from:
 type IpAddressOrRange_Status struct {
 	//IpAddressOrRange: A single IPv4 address or a single IPv4 address range in CIDR
 	//format. Provided IPs must be well-formatted and cannot be contained in one of
@@ -4320,7 +4309,6 @@ func (location *Location) AssignPropertiesToLocation(destination *v1alpha1api202
 	return nil
 }
 
-//Generated from:
 type Location_Status struct {
 	//DocumentEndpoint: The connection endpoint for the specific region. Example:
 	//https://&lt;accountName&gt;-&lt;locationName&gt;.documents.azure.com:443/
@@ -4555,7 +4543,6 @@ func (managedServiceIdentity *ManagedServiceIdentity) AssignPropertiesToManagedS
 	return nil
 }
 
-//Generated from:
 type ManagedServiceIdentity_Status struct {
 	//PrincipalId: The principal id of the system assigned identity. This property
 	//will only be provided for a system assigned identity.
@@ -4714,7 +4701,6 @@ func (managedServiceIdentityStatus *ManagedServiceIdentity_Status) AssignPropert
 	return nil
 }
 
-//Generated from:
 type NetworkAclBypass_Status string
 
 const (
@@ -4722,7 +4708,6 @@ const (
 	NetworkAclBypass_StatusNone          = NetworkAclBypass_Status("None")
 )
 
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbedded struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -4782,7 +4767,6 @@ func (privateEndpointConnectionStatusSubResourceEmbedded *PrivateEndpointConnect
 	return nil
 }
 
-//Generated from:
 type PublicNetworkAccess_Status string
 
 const (
@@ -4907,7 +4891,6 @@ func (virtualNetworkRule *VirtualNetworkRule) AssignPropertiesToVirtualNetworkRu
 	return nil
 }
 
-//Generated from:
 type VirtualNetworkRule_Status struct {
 	//Id: Resource ID of a subnet, for example:
 	///subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}.
@@ -5001,7 +4984,6 @@ const (
 	AnalyticalStorageConfigurationSchemaTypeWellDefined  = AnalyticalStorageConfigurationSchemaType("WellDefined")
 )
 
-//Generated from:
 type AnalyticalStorageSchemaType_Status string
 
 const (
@@ -5026,7 +5008,6 @@ const (
 	ApiPropertiesStatusServerVersion40 = ApiPropertiesStatusServerVersion("4.0")
 )
 
-//Generated from:
 type BackupPolicyType_Status string
 
 const (

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongo_db_collection_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongo_db_collection_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type MongoDBCollectionGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type MongoDBCollectionGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type MongoDBCollectionGetProperties_StatusARM struct {
 	Options  *OptionsResource_StatusARM                         `json:"options,omitempty"`
 	Resource *MongoDBCollectionGetProperties_Status_ResourceARM `json:"resource,omitempty"`
@@ -53,7 +51,6 @@ type MongoDBCollectionGetProperties_Status_ResourceARM struct {
 	Ts *float64 `json:"_ts,omitempty"`
 }
 
-//Generated from:
 type OptionsResource_StatusARM struct {
 	//AutoscaleSettings: Specifies the Autoscale settings.
 	AutoscaleSettings *AutoscaleSettings_StatusARM `json:"autoscaleSettings,omitempty"`
@@ -63,13 +60,11 @@ type OptionsResource_StatusARM struct {
 	Throughput *int `json:"throughput,omitempty"`
 }
 
-//Generated from:
 type AutoscaleSettings_StatusARM struct {
 	//MaxThroughput: Represents maximum throughput, the resource can scale up to.
 	MaxThroughput *int `json:"maxThroughput,omitempty"`
 }
 
-//Generated from:
 type MongoIndex_StatusARM struct {
 	//Key: Cosmos DB MongoDB collection index keys
 	Key *MongoIndexKeys_StatusARM `json:"key,omitempty"`
@@ -78,13 +73,11 @@ type MongoIndex_StatusARM struct {
 	Options *MongoIndexOptions_StatusARM `json:"options,omitempty"`
 }
 
-//Generated from:
 type MongoIndexKeys_StatusARM struct {
 	//Keys: List of keys for each MongoDB collection in the Azure Cosmos DB service
 	Keys []string `json:"keys,omitempty"`
 }
 
-//Generated from:
 type MongoIndexOptions_StatusARM struct {
 	//ExpireAfterSeconds: Expire after seconds
 	ExpireAfterSeconds *int `json:"expireAfterSeconds,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongo_db_database_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongo_db_database_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type MongoDBDatabaseGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type MongoDBDatabaseGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type MongoDBDatabaseGetProperties_StatusARM struct {
 	Options  *OptionsResource_StatusARM                       `json:"options,omitempty"`
 	Resource *MongoDBDatabaseGetProperties_Status_ResourceARM `json:"resource,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -502,7 +502,6 @@ func (databaseAccountsMongodbDatabasesCollectionsThroughputSettingsSpec *Databas
 	return GroupVersion.Version
 }
 
-//Generated from:
 type ThroughputSettingsGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -1147,7 +1146,6 @@ func (autoscaleSettingsResource *AutoscaleSettingsResource) AssignPropertiesToAu
 	return nil
 }
 
-//Generated from:
 type AutoscaleSettingsResource_Status struct {
 	//AutoUpgradePolicy: Cosmos DB resource auto-upgrade policy
 	AutoUpgradePolicy *AutoUpgradePolicyResource_Status `json:"autoUpgradePolicy,omitempty"`
@@ -1360,7 +1358,6 @@ func (autoUpgradePolicyResource *AutoUpgradePolicyResource) AssignPropertiesToAu
 	return nil
 }
 
-//Generated from:
 type AutoUpgradePolicyResource_Status struct {
 	//ThroughputPolicy: Represents throughput policy which service must adhere to for
 	//auto-upgrade
@@ -1549,7 +1546,6 @@ func (throughputPolicyResource *ThroughputPolicyResource) AssignPropertiesToThro
 	return nil
 }
 
-//Generated from:
 type ThroughputPolicyResource_Status struct {
 	//IncrementPercent: Represents the percentage by which throughput can increase
 	//every time throughput policy kicks in.

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
@@ -576,7 +576,6 @@ func (databaseAccountsMongodbDatabasesCollectionsSpec *DatabaseAccountsMongodbDa
 	databaseAccountsMongodbDatabasesCollectionsSpec.AzureName = azureName
 }
 
-//Generated from:
 type MongoDBCollectionGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -1353,7 +1352,6 @@ func (mongoIndex *MongoIndex) AssignPropertiesToMongoIndex(destination *v1alpha1
 	return nil
 }
 
-//Generated from:
 type MongoIndex_Status struct {
 	//Key: Cosmos DB MongoDB collection index keys
 	Key *MongoIndexKeys_Status `json:"key,omitempty"`
@@ -1545,7 +1543,6 @@ func (mongoIndexKeys *MongoIndexKeys) AssignPropertiesToMongoIndexKeys(destinati
 	return nil
 }
 
-//Generated from:
 type MongoIndexKeys_Status struct {
 	//Keys: List of keys for each MongoDB collection in the Azure Cosmos DB service
 	Keys []string `json:"keys,omitempty"`
@@ -1708,7 +1705,6 @@ func (mongoIndexOptions *MongoIndexOptions) AssignPropertiesToMongoIndexOptions(
 	return nil
 }
 
-//Generated from:
 type MongoIndexOptions_Status struct {
 	//ExpireAfterSeconds: Expire after seconds
 	ExpireAfterSeconds *int `json:"expireAfterSeconds,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
@@ -574,7 +574,6 @@ func (databaseAccountsMongodbDatabasesSpec *DatabaseAccountsMongodbDatabases_Spe
 	databaseAccountsMongodbDatabasesSpec.AzureName = azureName
 }
 
-//Generated from:
 type MongoDBDatabaseGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -1137,7 +1136,6 @@ func (mongoDBDatabaseResource *MongoDBDatabaseResource) AssignPropertiesToMongoD
 	return nil
 }
 
-//Generated from:
 type OptionsResource_Status struct {
 	//AutoscaleSettings: Specifies the Autoscale settings.
 	AutoscaleSettings *AutoscaleSettings_Status `json:"autoscaleSettings,omitempty"`
@@ -1309,7 +1307,6 @@ func (autoscaleSettings *AutoscaleSettings) AssignPropertiesToAutoscaleSettings(
 	return nil
 }
 
-//Generated from:
 type AutoscaleSettings_Status struct {
 	//MaxThroughput: Represents maximum throughput, the resource can scale up to.
 	MaxThroughput *int `json:"maxThroughput,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_container_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_container_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type SqlContainerGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type SqlContainerGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SqlContainerGetProperties_StatusARM struct {
 	Options  *OptionsResource_StatusARM                    `json:"options,omitempty"`
 	Resource *SqlContainerGetProperties_Status_ResourceARM `json:"resource,omitempty"`
@@ -65,7 +63,6 @@ type SqlContainerGetProperties_Status_ResourceARM struct {
 	UniqueKeyPolicy *UniqueKeyPolicy_StatusARM `json:"uniqueKeyPolicy,omitempty"`
 }
 
-//Generated from:
 type ConflictResolutionPolicy_StatusARM struct {
 	//ConflictResolutionPath: The conflict resolution path in the case of
 	//LastWriterWins mode.
@@ -79,7 +76,6 @@ type ConflictResolutionPolicy_StatusARM struct {
 	Mode *ConflictResolutionPolicyStatusMode `json:"mode,omitempty"`
 }
 
-//Generated from:
 type ContainerPartitionKey_StatusARM struct {
 	//Kind: Indicates the kind of algorithm used for partitioning. For MultiHash,
 	//multiple partition keys (upto three maximum) are supported for container create
@@ -95,7 +91,6 @@ type ContainerPartitionKey_StatusARM struct {
 	Version *int `json:"version,omitempty"`
 }
 
-//Generated from:
 type IndexingPolicy_StatusARM struct {
 	//Automatic: Indicates if the indexing policy is automatic
 	Automatic *bool `json:"automatic,omitempty"`
@@ -116,14 +111,12 @@ type IndexingPolicy_StatusARM struct {
 	SpatialIndexes []SpatialSpec_StatusARM `json:"spatialIndexes,omitempty"`
 }
 
-//Generated from:
 type UniqueKeyPolicy_StatusARM struct {
 	//UniqueKeys: List of unique keys on that enforces uniqueness constraint on
 	//documents in the collection in the Azure Cosmos DB service.
 	UniqueKeys []UniqueKey_StatusARM `json:"uniqueKeys,omitempty"`
 }
 
-//Generated from:
 type CompositePath_StatusARM struct {
 	//Order: Sort order for composite paths.
 	Order *CompositePathStatusOrder `json:"order,omitempty"`
@@ -148,14 +141,12 @@ const (
 	ContainerPartitionKeyStatusKindRange     = ContainerPartitionKeyStatusKind("Range")
 )
 
-//Generated from:
 type ExcludedPath_StatusARM struct {
 	//Path: The path for which the indexing behavior applies to. Index paths typically
 	//start with root and end with wildcard (/path/*)
 	Path *string `json:"path,omitempty"`
 }
 
-//Generated from:
 type IncludedPath_StatusARM struct {
 	//Indexes: List of indexes for this path
 	Indexes []Indexes_StatusARM `json:"indexes,omitempty"`
@@ -173,7 +164,6 @@ const (
 	IndexingPolicyStatusIndexingModeNone       = IndexingPolicyStatusIndexingMode("none")
 )
 
-//Generated from:
 type SpatialSpec_StatusARM struct {
 	//Path: The path for which the indexing behavior applies to. Index paths typically
 	//start with root and end with wildcard (/path/*)
@@ -183,7 +173,6 @@ type SpatialSpec_StatusARM struct {
 	Types []SpatialType_Status `json:"types,omitempty"`
 }
 
-//Generated from:
 type UniqueKey_StatusARM struct {
 	//Paths: List of paths must be unique for each document in the Azure Cosmos DB
 	//service
@@ -197,7 +186,6 @@ const (
 	CompositePathStatusOrderDescending = CompositePathStatusOrder("descending")
 )
 
-//Generated from:
 type Indexes_StatusARM struct {
 	//DataType: The datatype for which the indexing behavior is applied to.
 	DataType *IndexesStatusDataType `json:"dataType,omitempty"`
@@ -209,7 +197,6 @@ type Indexes_StatusARM struct {
 	Precision *int `json:"precision,omitempty"`
 }
 
-//Generated from:
 type SpatialType_Status string
 
 const (

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
@@ -576,7 +576,6 @@ func (databaseAccountsSqlDatabasesContainersStoredProceduresSpec *DatabaseAccoun
 	databaseAccountsSqlDatabasesContainersStoredProceduresSpec.AzureName = azureName
 }
 
-//Generated from:
 type SqlStoredProcedureGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
@@ -576,7 +576,6 @@ func (databaseAccountsSqlDatabasesContainersTriggersSpec *DatabaseAccountsSqlDat
 	databaseAccountsSqlDatabasesContainersTriggersSpec.AzureName = azureName
 }
 
-//Generated from:
 type SqlTriggerGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
@@ -576,7 +576,6 @@ func (databaseAccountsSqlDatabasesContainersSpec *DatabaseAccountsSqlDatabasesCo
 	databaseAccountsSqlDatabasesContainersSpec.AzureName = azureName
 }
 
-//Generated from:
 type SqlContainerGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -1567,7 +1566,6 @@ func (conflictResolutionPolicy *ConflictResolutionPolicy) AssignPropertiesToConf
 	return nil
 }
 
-//Generated from:
 type ConflictResolutionPolicy_Status struct {
 	//ConflictResolutionPath: The conflict resolution path in the case of
 	//LastWriterWins mode.
@@ -1805,7 +1803,6 @@ func (containerPartitionKey *ContainerPartitionKey) AssignPropertiesToContainerP
 	return nil
 }
 
-//Generated from:
 type ContainerPartitionKey_Status struct {
 	//Kind: Indicates the kind of algorithm used for partitioning. For MultiHash,
 	//multiple partition keys (upto three maximum) are supported for container create
@@ -2304,7 +2301,6 @@ func (indexingPolicy *IndexingPolicy) AssignPropertiesToIndexingPolicy(destinati
 	return nil
 }
 
-//Generated from:
 type IndexingPolicy_Status struct {
 	//Automatic: Indicates if the indexing policy is automatic
 	Automatic *bool `json:"automatic,omitempty"`
@@ -2730,7 +2726,6 @@ func (uniqueKeyPolicy *UniqueKeyPolicy) AssignPropertiesToUniqueKeyPolicy(destin
 	return nil
 }
 
-//Generated from:
 type UniqueKeyPolicy_Status struct {
 	//UniqueKeys: List of unique keys on that enforces uniqueness constraint on
 	//documents in the collection in the Azure Cosmos DB service.
@@ -2930,7 +2925,6 @@ func (compositePath *CompositePath) AssignPropertiesToCompositePath(destination 
 	return nil
 }
 
-//Generated from:
 type CompositePath_Status struct {
 	//Order: Sort order for composite paths.
 	Order *CompositePathStatusOrder `json:"order,omitempty"`
@@ -3090,7 +3084,6 @@ func (excludedPath *ExcludedPath) AssignPropertiesToExcludedPath(destination *v1
 	return nil
 }
 
-//Generated from:
 type ExcludedPath_Status struct {
 	//Path: The path for which the indexing behavior applies to. Index paths typically
 	//start with root and end with wildcard (/path/*)
@@ -3283,7 +3276,6 @@ func (includedPath *IncludedPath) AssignPropertiesToIncludedPath(destination *v1
 	return nil
 }
 
-//Generated from:
 type IncludedPath_Status struct {
 	//Indexes: List of indexes for this path
 	Indexes []Indexes_Status `json:"indexes,omitempty"`
@@ -3506,7 +3498,6 @@ func (spatialSpec *SpatialSpec) AssignPropertiesToSpatialSpec(destination *v1alp
 	return nil
 }
 
-//Generated from:
 type SpatialSpec_Status struct {
 	//Path: The path for which the indexing behavior applies to. Index paths typically
 	//start with root and end with wildcard (/path/*)
@@ -3673,7 +3664,6 @@ func (uniqueKey *UniqueKey) AssignPropertiesToUniqueKey(destination *v1alpha1api
 	return nil
 }
 
-//Generated from:
 type UniqueKey_Status struct {
 	//Paths: List of paths must be unique for each document in the Azure Cosmos DB
 	//service
@@ -3868,7 +3858,6 @@ func (indexes *Indexes) AssignPropertiesToIndexes(destination *v1alpha1api202105
 	return nil
 }
 
-//Generated from:
 type Indexes_Status struct {
 	//DataType: The datatype for which the indexing behavior is applied to.
 	DataType *IndexesStatusDataType `json:"dataType,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
@@ -576,7 +576,6 @@ func (databaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec *DatabaseAc
 	databaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec.AzureName = azureName
 }
 
-//Generated from:
 type SqlUserDefinedFunctionGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type SqlDatabaseGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type SqlDatabaseGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SqlDatabaseGetProperties_StatusARM struct {
 	Options  *OptionsResource_StatusARM                   `json:"options,omitempty"`
 	Resource *SqlDatabaseGetProperties_Status_ResourceARM `json:"resource,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen.go
@@ -574,7 +574,6 @@ func (databaseAccountsSqlDatabasesSpec *DatabaseAccountsSqlDatabases_Spec) SetAz
 	databaseAccountsSqlDatabasesSpec.AzureName = azureName
 }
 
-//Generated from:
 type SqlDatabaseGetResults_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_stored_procedure_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_stored_procedure_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type SqlStoredProcedureGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type SqlStoredProcedureGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SqlStoredProcedureGetProperties_StatusARM struct {
 	Resource *SqlStoredProcedureGetProperties_Status_ResourceARM `json:"resource,omitempty"`
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_trigger_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_trigger_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type SqlTriggerGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type SqlTriggerGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SqlTriggerGetProperties_StatusARM struct {
 	Resource *SqlTriggerGetProperties_Status_ResourceARM `json:"resource,omitempty"`
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_user_defined_function_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_user_defined_function_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type SqlUserDefinedFunctionGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type SqlUserDefinedFunctionGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SqlUserDefinedFunctionGetProperties_StatusARM struct {
 	Resource *SqlUserDefinedFunctionGetProperties_Status_ResourceARM `json:"resource,omitempty"`
 }

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/throughput_settings_get_results__status_arm_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/throughput_settings_get_results__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210515
 
-//Generated from:
 type ThroughputSettingsGetResults_StatusARM struct {
 	//Id: The unique resource identifier of the ARM resource.
 	Id *string `json:"id,omitempty"`
@@ -22,7 +21,6 @@ type ThroughputSettingsGetResults_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ThroughputSettingsGetProperties_StatusARM struct {
 	Resource *ThroughputSettingsGetProperties_Status_ResourceARM `json:"resource,omitempty"`
 }
@@ -54,7 +52,6 @@ type ThroughputSettingsGetProperties_Status_ResourceARM struct {
 	Ts *float64 `json:"_ts,omitempty"`
 }
 
-//Generated from:
 type AutoscaleSettingsResource_StatusARM struct {
 	//AutoUpgradePolicy: Cosmos DB resource auto-upgrade policy
 	AutoUpgradePolicy *AutoUpgradePolicyResource_StatusARM `json:"autoUpgradePolicy,omitempty"`
@@ -67,14 +64,12 @@ type AutoscaleSettingsResource_StatusARM struct {
 	TargetMaxThroughput *int `json:"targetMaxThroughput,omitempty"`
 }
 
-//Generated from:
 type AutoUpgradePolicyResource_StatusARM struct {
 	//ThroughputPolicy: Represents throughput policy which service must adhere to for
 	//auto-upgrade
 	ThroughputPolicy *ThroughputPolicyResource_StatusARM `json:"throughputPolicy,omitempty"`
 }
 
-//Generated from:
 type ThroughputPolicyResource_StatusARM struct {
 	//IncrementPercent: Represents the percentage by which throughput can increase
 	//every time throughput policy kicks in.

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/database_account_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/database_account_types_gen.go
@@ -124,7 +124,6 @@ type DatabaseAccountList struct {
 }
 
 //Storage version of v1alpha1api20210515.DatabaseAccountGetResults_Status
-//Generated from:
 type DatabaseAccountGetResults_Status struct {
 	AnalyticalStorageConfiguration     *AnalyticalStorageConfiguration_Status                 `json:"analyticalStorageConfiguration,omitempty"`
 	ApiProperties                      *ApiProperties_Status                                  `json:"apiProperties,omitempty"`
@@ -257,7 +256,6 @@ type AnalyticalStorageConfiguration struct {
 }
 
 //Storage version of v1alpha1api20210515.AnalyticalStorageConfiguration_Status
-//Generated from:
 type AnalyticalStorageConfiguration_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	SchemaType  *string                `json:"schemaType,omitempty"`
@@ -271,7 +269,6 @@ type ApiProperties struct {
 }
 
 //Storage version of v1alpha1api20210515.ApiProperties_Status
-//Generated from:
 type ApiProperties_Status struct {
 	PropertyBag   genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	ServerVersion *string                `json:"serverVersion,omitempty"`
@@ -286,7 +283,6 @@ type BackupPolicy struct {
 }
 
 //Storage version of v1alpha1api20210515.BackupPolicy_Status
-//Generated from:
 type BackupPolicy_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	Type        *string                `json:"type,omitempty"`
@@ -300,7 +296,6 @@ type Capability struct {
 }
 
 //Storage version of v1alpha1api20210515.Capability_Status
-//Generated from:
 type Capability_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -316,7 +311,6 @@ type ConsistencyPolicy struct {
 }
 
 //Storage version of v1alpha1api20210515.ConsistencyPolicy_Status
-//Generated from:
 type ConsistencyPolicy_Status struct {
 	DefaultConsistencyLevel *string                `json:"defaultConsistencyLevel,omitempty"`
 	MaxIntervalInSeconds    *int                   `json:"maxIntervalInSeconds,omitempty"`
@@ -336,7 +330,6 @@ type CorsPolicy struct {
 }
 
 //Storage version of v1alpha1api20210515.CorsPolicy_Status
-//Generated from:
 type CorsPolicy_Status struct {
 	AllowedHeaders  *string                `json:"allowedHeaders,omitempty"`
 	AllowedMethods  *string                `json:"allowedMethods,omitempty"`
@@ -347,7 +340,6 @@ type CorsPolicy_Status struct {
 }
 
 //Storage version of v1alpha1api20210515.FailoverPolicy_Status
-//Generated from:
 type FailoverPolicy_Status struct {
 	FailoverPriority *int                   `json:"failoverPriority,omitempty"`
 	Id               *string                `json:"id,omitempty"`
@@ -363,7 +355,6 @@ type IpAddressOrRange struct {
 }
 
 //Storage version of v1alpha1api20210515.IpAddressOrRange_Status
-//Generated from:
 type IpAddressOrRange_Status struct {
 	IpAddressOrRange *string                `json:"ipAddressOrRange,omitempty"`
 	PropertyBag      genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -379,7 +370,6 @@ type Location struct {
 }
 
 //Storage version of v1alpha1api20210515.Location_Status
-//Generated from:
 type Location_Status struct {
 	DocumentEndpoint  *string                `json:"documentEndpoint,omitempty"`
 	FailoverPriority  *int                   `json:"failoverPriority,omitempty"`
@@ -398,7 +388,6 @@ type ManagedServiceIdentity struct {
 }
 
 //Storage version of v1alpha1api20210515.ManagedServiceIdentity_Status
-//Generated from:
 type ManagedServiceIdentity_Status struct {
 	PrincipalId            *string                                                         `json:"principalId,omitempty"`
 	PropertyBag            genruntime.PropertyBag                                          `json:"$propertyBag,omitempty"`
@@ -408,7 +397,6 @@ type ManagedServiceIdentity_Status struct {
 }
 
 //Storage version of v1alpha1api20210515.PrivateEndpointConnection_Status_SubResourceEmbedded
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -426,7 +414,6 @@ type VirtualNetworkRule struct {
 }
 
 //Storage version of v1alpha1api20210515.VirtualNetworkRule_Status
-//Generated from:
 type VirtualNetworkRule_Status struct {
 	Id                               *string                `json:"id,omitempty"`
 	IgnoreMissingVNetServiceEndpoint *bool                  `json:"ignoreMissingVNetServiceEndpoint,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/mongodb_database_collection_throughput_setting_types_gen.go
@@ -156,7 +156,6 @@ func (databaseAccountsMongodbDatabasesCollectionsThroughputSettingsSpec *Databas
 }
 
 //Storage version of v1alpha1api20210515.ThroughputSettingsGetResults_Status
-//Generated from:
 type ThroughputSettingsGetResults_Status struct {
 	Conditions  []conditions.Condition                           `json:"conditions,omitempty"`
 	Id          *string                                          `json:"id,omitempty"`
@@ -217,7 +216,6 @@ type AutoscaleSettingsResource struct {
 }
 
 //Storage version of v1alpha1api20210515.AutoscaleSettingsResource_Status
-//Generated from:
 type AutoscaleSettingsResource_Status struct {
 	AutoUpgradePolicy   *AutoUpgradePolicyResource_Status `json:"autoUpgradePolicy,omitempty"`
 	MaxThroughput       *int                              `json:"maxThroughput,omitempty"`
@@ -233,7 +231,6 @@ type AutoUpgradePolicyResource struct {
 }
 
 //Storage version of v1alpha1api20210515.AutoUpgradePolicyResource_Status
-//Generated from:
 type AutoUpgradePolicyResource_Status struct {
 	PropertyBag      genruntime.PropertyBag           `json:"$propertyBag,omitempty"`
 	ThroughputPolicy *ThroughputPolicyResource_Status `json:"throughputPolicy,omitempty"`
@@ -248,7 +245,6 @@ type ThroughputPolicyResource struct {
 }
 
 //Storage version of v1alpha1api20210515.ThroughputPolicyResource_Status
-//Generated from:
 type ThroughputPolicyResource_Status struct {
 	IncrementPercent *int                   `json:"incrementPercent,omitempty"`
 	IsEnabled        *bool                  `json:"isEnabled,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/mongodb_database_collection_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/mongodb_database_collection_types_gen.go
@@ -160,7 +160,6 @@ func (databaseAccountsMongodbDatabasesCollectionsSpec *DatabaseAccountsMongodbDa
 }
 
 //Storage version of v1alpha1api20210515.MongoDBCollectionGetResults_Status
-//Generated from:
 type MongoDBCollectionGetResults_Status struct {
 	Conditions  []conditions.Condition                          `json:"conditions,omitempty"`
 	Id          *string                                         `json:"id,omitempty"`
@@ -224,7 +223,6 @@ type MongoIndex struct {
 }
 
 //Storage version of v1alpha1api20210515.MongoIndex_Status
-//Generated from:
 type MongoIndex_Status struct {
 	Key         *MongoIndexKeys_Status    `json:"key,omitempty"`
 	Options     *MongoIndexOptions_Status `json:"options,omitempty"`
@@ -239,7 +237,6 @@ type MongoIndexKeys struct {
 }
 
 //Storage version of v1alpha1api20210515.MongoIndexKeys_Status
-//Generated from:
 type MongoIndexKeys_Status struct {
 	Keys        []string               `json:"keys,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -254,7 +251,6 @@ type MongoIndexOptions struct {
 }
 
 //Storage version of v1alpha1api20210515.MongoIndexOptions_Status
-//Generated from:
 type MongoIndexOptions_Status struct {
 	ExpireAfterSeconds *int                   `json:"expireAfterSeconds,omitempty"`
 	PropertyBag        genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/mongodb_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/mongodb_database_types_gen.go
@@ -160,7 +160,6 @@ func (databaseAccountsMongodbDatabasesSpec *DatabaseAccountsMongodbDatabases_Spe
 }
 
 //Storage version of v1alpha1api20210515.MongoDBDatabaseGetResults_Status
-//Generated from:
 type MongoDBDatabaseGetResults_Status struct {
 	Conditions  []conditions.Condition                        `json:"conditions,omitempty"`
 	Id          *string                                       `json:"id,omitempty"`
@@ -218,7 +217,6 @@ type MongoDBDatabaseResource struct {
 }
 
 //Storage version of v1alpha1api20210515.OptionsResource_Status
-//Generated from:
 type OptionsResource_Status struct {
 	AutoscaleSettings *AutoscaleSettings_Status `json:"autoscaleSettings,omitempty"`
 	PropertyBag       genruntime.PropertyBag    `json:"$propertyBag,omitempty"`
@@ -233,7 +231,6 @@ type AutoscaleSettings struct {
 }
 
 //Storage version of v1alpha1api20210515.AutoscaleSettings_Status
-//Generated from:
 type AutoscaleSettings_Status struct {
 	MaxThroughput *int                   `json:"maxThroughput,omitempty"`
 	PropertyBag   genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_stored_procedure_types_gen.go
@@ -160,7 +160,6 @@ func (databaseAccountsSqlDatabasesContainersStoredProceduresSpec *DatabaseAccoun
 }
 
 //Storage version of v1alpha1api20210515.SqlStoredProcedureGetResults_Status
-//Generated from:
 type SqlStoredProcedureGetResults_Status struct {
 	Conditions  []conditions.Condition                           `json:"conditions,omitempty"`
 	Id          *string                                          `json:"id,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_trigger_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_trigger_types_gen.go
@@ -160,7 +160,6 @@ func (databaseAccountsSqlDatabasesContainersTriggersSpec *DatabaseAccountsSqlDat
 }
 
 //Storage version of v1alpha1api20210515.SqlTriggerGetResults_Status
-//Generated from:
 type SqlTriggerGetResults_Status struct {
 	Conditions  []conditions.Condition                   `json:"conditions,omitempty"`
 	Id          *string                                  `json:"id,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_types_gen.go
@@ -160,7 +160,6 @@ func (databaseAccountsSqlDatabasesContainersSpec *DatabaseAccountsSqlDatabasesCo
 }
 
 //Storage version of v1alpha1api20210515.SqlContainerGetResults_Status
-//Generated from:
 type SqlContainerGetResults_Status struct {
 	Conditions  []conditions.Condition                     `json:"conditions,omitempty"`
 	Id          *string                                    `json:"id,omitempty"`
@@ -231,7 +230,6 @@ type ConflictResolutionPolicy struct {
 }
 
 //Storage version of v1alpha1api20210515.ConflictResolutionPolicy_Status
-//Generated from:
 type ConflictResolutionPolicy_Status struct {
 	ConflictResolutionPath      *string                `json:"conflictResolutionPath,omitempty"`
 	ConflictResolutionProcedure *string                `json:"conflictResolutionProcedure,omitempty"`
@@ -249,7 +247,6 @@ type ContainerPartitionKey struct {
 }
 
 //Storage version of v1alpha1api20210515.ContainerPartitionKey_Status
-//Generated from:
 type ContainerPartitionKey_Status struct {
 	Kind        *string                `json:"kind,omitempty"`
 	Paths       []string               `json:"paths,omitempty"`
@@ -271,7 +268,6 @@ type IndexingPolicy struct {
 }
 
 //Storage version of v1alpha1api20210515.IndexingPolicy_Status
-//Generated from:
 type IndexingPolicy_Status struct {
 	Automatic        *bool                    `json:"automatic,omitempty"`
 	CompositeIndexes [][]CompositePath_Status `json:"compositeIndexes,omitempty"`
@@ -290,7 +286,6 @@ type UniqueKeyPolicy struct {
 }
 
 //Storage version of v1alpha1api20210515.UniqueKeyPolicy_Status
-//Generated from:
 type UniqueKeyPolicy_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	UniqueKeys  []UniqueKey_Status     `json:"uniqueKeys,omitempty"`
@@ -305,7 +300,6 @@ type CompositePath struct {
 }
 
 //Storage version of v1alpha1api20210515.CompositePath_Status
-//Generated from:
 type CompositePath_Status struct {
 	Order       *string                `json:"order,omitempty"`
 	Path        *string                `json:"path,omitempty"`
@@ -320,7 +314,6 @@ type ExcludedPath struct {
 }
 
 //Storage version of v1alpha1api20210515.ExcludedPath_Status
-//Generated from:
 type ExcludedPath_Status struct {
 	Path        *string                `json:"path,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -335,7 +328,6 @@ type IncludedPath struct {
 }
 
 //Storage version of v1alpha1api20210515.IncludedPath_Status
-//Generated from:
 type IncludedPath_Status struct {
 	Indexes     []Indexes_Status       `json:"indexes,omitempty"`
 	Path        *string                `json:"path,omitempty"`
@@ -351,7 +343,6 @@ type SpatialSpec struct {
 }
 
 //Storage version of v1alpha1api20210515.SpatialSpec_Status
-//Generated from:
 type SpatialSpec_Status struct {
 	Path        *string                `json:"path,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -366,7 +357,6 @@ type UniqueKey struct {
 }
 
 //Storage version of v1alpha1api20210515.UniqueKey_Status
-//Generated from:
 type UniqueKey_Status struct {
 	Paths       []string               `json:"paths,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -382,7 +372,6 @@ type Indexes struct {
 }
 
 //Storage version of v1alpha1api20210515.Indexes_Status
-//Generated from:
 type Indexes_Status struct {
 	DataType    *string                `json:"dataType,omitempty"`
 	Kind        *string                `json:"kind,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_container_user_defined_function_types_gen.go
@@ -160,7 +160,6 @@ func (databaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec *DatabaseAc
 }
 
 //Storage version of v1alpha1api20210515.SqlUserDefinedFunctionGetResults_Status
-//Generated from:
 type SqlUserDefinedFunctionGetResults_Status struct {
 	Conditions  []conditions.Condition                               `json:"conditions,omitempty"`
 	Id          *string                                              `json:"id,omitempty"`

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515storage/sql_database_types_gen.go
@@ -160,7 +160,6 @@ func (databaseAccountsSqlDatabasesSpec *DatabaseAccountsSqlDatabases_Spec) Conve
 }
 
 //Storage version of v1alpha1api20210515.SqlDatabaseGetResults_Status
-//Generated from:
 type SqlDatabaseGetResults_Status struct {
 	Conditions  []conditions.Condition                    `json:"conditions,omitempty"`
 	Id          *string                                   `json:"id,omitempty"`

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic__status_arm_types_gen.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20200601
 
-//Generated from:
 type Topic_StatusARM struct {
 	//Id: Fully qualified identifier of the resource.
 	Id *string `json:"id,omitempty"`
@@ -27,7 +26,6 @@ type Topic_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SystemData_StatusARM struct {
 	//CreatedAt: The timestamp of resource creation (UTC).
 	CreatedAt *string `json:"createdAt,omitempty"`
@@ -48,7 +46,6 @@ type SystemData_StatusARM struct {
 	LastModifiedByType *SystemDataStatusLastModifiedByType `json:"lastModifiedByType,omitempty"`
 }
 
-//Generated from:
 type TopicProperties_StatusARM struct {
 	//Endpoint: Endpoint for the topic.
 	Endpoint *string `json:"endpoint,omitempty"`
@@ -81,7 +78,6 @@ type TopicProperties_StatusARM struct {
 	PublicNetworkAccess *TopicPropertiesStatusPublicNetworkAccess `json:"publicNetworkAccess,omitempty"`
 }
 
-//Generated from:
 type InboundIpRule_StatusARM struct {
 	//Action: Action to perform based on the match or no match of the IpMask.
 	Action *InboundIpRuleStatusAction `json:"action,omitempty"`
@@ -90,13 +86,11 @@ type InboundIpRule_StatusARM struct {
 	IpMask *string `json:"ipMask,omitempty"`
 }
 
-//Generated from:
 type InputSchemaMapping_StatusARM struct {
 	//InputSchemaMappingType: Type of the custom mapping
 	InputSchemaMappingType InputSchemaMappingStatusInputSchemaMappingType `json:"inputSchemaMappingType"`
 }
 
-//Generated from:
 type PrivateEndpointConnection_Status_Topic_SubResourceEmbeddedARM struct {
 	//Id: Fully qualified identifier of the resource.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen.go
@@ -283,7 +283,6 @@ type TopicList struct {
 	Items           []Topic `json:"items"`
 }
 
-//Generated from:
 type Topic_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -963,7 +962,6 @@ func (topicsSpec *Topics_Spec) OriginalVersion() string {
 // SetAzureName sets the Azure name of the resource
 func (topicsSpec *Topics_Spec) SetAzureName(azureName string) { topicsSpec.AzureName = azureName }
 
-//Generated from:
 type InboundIpRule_Status struct {
 	//Action: Action to perform based on the match or no match of the IpMask.
 	Action *InboundIpRuleStatusAction `json:"action,omitempty"`
@@ -1047,7 +1045,6 @@ func (inboundIpRuleStatus *InboundIpRule_Status) AssignPropertiesToInboundIpRule
 	return nil
 }
 
-//Generated from:
 type InputSchemaMapping_Status struct {
 	// +kubebuilder:validation:Required
 	//InputSchemaMappingType: Type of the custom mapping
@@ -1109,7 +1106,6 @@ func (inputSchemaMappingStatus *InputSchemaMapping_Status) AssignPropertiesToInp
 	return nil
 }
 
-//Generated from:
 type PrivateEndpointConnection_Status_Topic_SubResourceEmbedded struct {
 	//Id: Fully qualified identifier of the resource.
 	Id *string `json:"id,omitempty"`
@@ -1168,7 +1164,6 @@ func (privateEndpointConnectionStatusTopicSubResourceEmbedded *PrivateEndpointCo
 	return nil
 }
 
-//Generated from:
 type SystemData_Status struct {
 	//CreatedAt: The timestamp of resource creation (UTC).
 	CreatedAt *string `json:"createdAt,omitempty"`

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601storage/topic_types_gen.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601storage/topic_types_gen.go
@@ -124,7 +124,6 @@ type TopicList struct {
 }
 
 //Storage version of v1alpha1api20200601.Topic_Status
-//Generated from:
 type Topic_Status struct {
 	Conditions                 []conditions.Condition                                       `json:"conditions,omitempty"`
 	Endpoint                   *string                                                      `json:"endpoint,omitempty"`
@@ -199,7 +198,6 @@ func (topicsSpec *Topics_Spec) ConvertSpecTo(destination genruntime.ConvertibleS
 }
 
 //Storage version of v1alpha1api20200601.InboundIpRule_Status
-//Generated from:
 type InboundIpRule_Status struct {
 	Action      *string                `json:"action,omitempty"`
 	IpMask      *string                `json:"ipMask,omitempty"`
@@ -207,21 +205,18 @@ type InboundIpRule_Status struct {
 }
 
 //Storage version of v1alpha1api20200601.InputSchemaMapping_Status
-//Generated from:
 type InputSchemaMapping_Status struct {
 	InputSchemaMappingType *string                `json:"inputSchemaMappingType,omitempty"`
 	PropertyBag            genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20200601.PrivateEndpointConnection_Status_Topic_SubResourceEmbedded
-//Generated from:
 type PrivateEndpointConnection_Status_Topic_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20200601.SystemData_Status
-//Generated from:
 type SystemData_Status struct {
 	CreatedAt          *string                `json:"createdAt,omitempty"`
 	CreatedBy          *string                `json:"createdBy,omitempty"`

--- a/v2/api/microsoft.managedidentity/v1alpha1api20181130/identity__status_arm_types_gen.go
+++ b/v2/api/microsoft.managedidentity/v1alpha1api20181130/identity__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20181130
 
-//Generated from:
 type Identity_StatusARM struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -26,7 +25,6 @@ type Identity_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type UserAssignedIdentityProperties_StatusARM struct {
 	//ClientId: The id of the app associated with the identity. This is a random
 	//generated UUID by MSI.

--- a/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
@@ -285,7 +285,6 @@ type UserAssignedIdentityList struct {
 	Items           []UserAssignedIdentity `json:"items"`
 }
 
-//Generated from:
 type Identity_Status struct {
 	//ClientId: The id of the app associated with the identity. This is a random
 	//generated UUID by MSI.

--- a/v2/api/microsoft.managedidentity/v1alpha1api20181130storage/user_assigned_identity_types_gen.go
+++ b/v2/api/microsoft.managedidentity/v1alpha1api20181130storage/user_assigned_identity_types_gen.go
@@ -124,7 +124,6 @@ type UserAssignedIdentityList struct {
 }
 
 //Storage version of v1alpha1api20181130.Identity_Status
-//Generated from:
 type Identity_Status struct {
 	ClientId    *string                `json:"clientId,omitempty"`
 	Conditions  []conditions.Condition `json:"conditions,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/load_balancer__status_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/load_balancer__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type LoadBalancer_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -33,7 +32,6 @@ type LoadBalancer_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocation_StatusARM struct {
 	//Name: The name of the extended location.
 	Name string `json:"name"`
@@ -42,7 +40,6 @@ type ExtendedLocation_StatusARM struct {
 	Type ExtendedLocationType_Status `json:"type"`
 }
 
-//Generated from:
 type LoadBalancerPropertiesFormat_StatusARM struct {
 	//BackendAddressPools: Collection of backend address pools used by a load balancer.
 	BackendAddressPools []BackendAddressPool_Status_LoadBalancer_SubResourceEmbeddedARM `json:"backendAddressPools,omitempty"`
@@ -86,7 +83,6 @@ type LoadBalancerPropertiesFormat_StatusARM struct {
 	ResourceGuid *string `json:"resourceGuid,omitempty"`
 }
 
-//Generated from:
 type LoadBalancerSku_StatusARM struct {
 	//Name: Name of a load balancer SKU.
 	Name *LoadBalancerSkuStatusName `json:"name,omitempty"`
@@ -95,18 +91,15 @@ type LoadBalancerSku_StatusARM struct {
 	Tier *LoadBalancerSkuStatusTier `json:"tier,omitempty"`
 }
 
-//Generated from:
 type BackendAddressPool_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocationType_Status string
 
 const ExtendedLocationType_StatusEdgeZone = ExtendedLocationType_Status("EdgeZone")
 
-//Generated from:
 type FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -130,7 +123,6 @@ type FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	Zones []string `json:"zones,omitempty"`
 }
 
-//Generated from:
 type InboundNatPool_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -149,7 +141,6 @@ type InboundNatPool_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type InboundNatRule_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -169,7 +160,6 @@ const (
 	LoadBalancerSkuStatusTierRegional = LoadBalancerSkuStatusTier("Regional")
 )
 
-//Generated from:
 type LoadBalancingRule_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -188,7 +178,6 @@ type LoadBalancingRule_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type OutboundRule_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -207,7 +196,6 @@ type OutboundRule_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type Probe_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -226,7 +214,6 @@ type Probe_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type FrontendIPConfigurationPropertiesFormat_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	//InboundNatPools: An array of references to inbound pools that use this frontend
 	//IP.
@@ -268,7 +255,6 @@ type FrontendIPConfigurationPropertiesFormat_Status_LoadBalancer_SubResourceEmbe
 	Subnet *Subnet_Status_LoadBalancer_SubResourceEmbeddedARM `json:"subnet,omitempty"`
 }
 
-//Generated from:
 type InboundNatPoolPropertiesFormat_StatusARM struct {
 	//BackendPort: The port used for internal connections on the endpoint. Acceptable
 	//values are between 1 and 65535.
@@ -310,7 +296,6 @@ type InboundNatPoolPropertiesFormat_StatusARM struct {
 	ProvisioningState *ProvisioningState_Status `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type LoadBalancingRulePropertiesFormat_StatusARM struct {
 	//BackendAddressPool: A reference to a pool of DIPs. Inbound traffic is randomly
 	//load balanced across IPs in the backend IPs.
@@ -362,7 +347,6 @@ type LoadBalancingRulePropertiesFormat_StatusARM struct {
 	ProvisioningState *ProvisioningState_Status `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type OutboundRulePropertiesFormat_StatusARM struct {
 	//AllocatedOutboundPorts: The number of outbound ports to be used for NAT.
 	AllocatedOutboundPorts *int `json:"allocatedOutboundPorts,omitempty"`
@@ -389,7 +373,6 @@ type OutboundRulePropertiesFormat_StatusARM struct {
 	ProvisioningState *ProvisioningState_Status `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type ProbePropertiesFormat_StatusARM struct {
 	//IntervalInSeconds: The interval, in seconds, for how frequently to probe the
 	//endpoint for health status. Typically, the interval is slightly less than half
@@ -426,7 +409,6 @@ type ProbePropertiesFormat_StatusARM struct {
 	RequestPath *string `json:"requestPath,omitempty"`
 }
 
-//Generated from:
 type PublicIPAddress_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	//ExtendedLocation: The extended location of the public ip address.
 	ExtendedLocation *ExtendedLocation_StatusARM `json:"extendedLocation,omitempty"`
@@ -442,7 +424,6 @@ type PublicIPAddress_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	Zones []string `json:"zones,omitempty"`
 }
 
-//Generated from:
 type Subnet_Status_LoadBalancer_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen.go
@@ -283,7 +283,6 @@ type LoadBalancerList struct {
 	Items           []LoadBalancer `json:"items"`
 }
 
-//Generated from:
 type LoadBalancer_Status struct {
 	//BackendAddressPools: Collection of backend address pools used by a load balancer.
 	BackendAddressPools []BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded `json:"backendAddressPools,omitempty"`
@@ -1620,7 +1619,6 @@ func (loadBalancersSpec *LoadBalancers_Spec) SetAzureName(azureName string) {
 	loadBalancersSpec.AzureName = azureName
 }
 
-//Generated from:
 type BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -1770,7 +1768,6 @@ func (extendedLocation *ExtendedLocation) AssignPropertiesToExtendedLocation(des
 	return nil
 }
 
-//Generated from:
 type ExtendedLocation_Status struct {
 	// +kubebuilder:validation:Required
 	//Name: The name of the extended location.
@@ -1846,7 +1843,6 @@ func (extendedLocationStatus *ExtendedLocation_Status) AssignPropertiesToExtende
 	return nil
 }
 
-//Generated from:
 type FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -2406,7 +2402,6 @@ func (frontendIPConfigurationStatusLoadBalancerSubResourceEmbedded *FrontendIPCo
 	return nil
 }
 
-//Generated from:
 type InboundNatPool_Status struct {
 	//BackendPort: The port used for internal connections on the endpoint. Acceptable
 	//values are between 1 and 65535.
@@ -2736,7 +2731,6 @@ func (inboundNatPoolStatus *InboundNatPool_Status) AssignPropertiesToInboundNatP
 	return nil
 }
 
-//Generated from:
 type InboundNatRule_Status_LoadBalancer_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -2910,7 +2904,6 @@ func (loadBalancerSku *LoadBalancerSku) AssignPropertiesToLoadBalancerSku(destin
 	return nil
 }
 
-//Generated from:
 type LoadBalancerSku_Status struct {
 	//Name: Name of a load balancer SKU.
 	Name *LoadBalancerSkuStatusName `json:"name,omitempty"`
@@ -4727,7 +4720,6 @@ func (loadBalancersSpecPropertiesProbes *LoadBalancers_Spec_Properties_Probes) A
 	return nil
 }
 
-//Generated from:
 type LoadBalancingRule_Status struct {
 	//BackendAddressPool: A reference to a pool of DIPs. Inbound traffic is randomly
 	//load balanced across IPs in the backend IPs.
@@ -5184,7 +5176,6 @@ func (loadBalancingRuleStatus *LoadBalancingRule_Status) AssignPropertiesToLoadB
 	return nil
 }
 
-//Generated from:
 type OutboundRule_Status struct {
 	//AllocatedOutboundPorts: The number of outbound ports to be used for NAT.
 	AllocatedOutboundPorts *int `json:"allocatedOutboundPorts,omitempty"`
@@ -5501,7 +5492,6 @@ func (outboundRuleStatus *OutboundRule_Status) AssignPropertiesToOutboundRuleSta
 	return nil
 }
 
-//Generated from:
 type Probe_Status struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -5793,7 +5783,6 @@ func (probeStatus *Probe_Status) AssignPropertiesToProbeStatus(destination *v1al
 	return nil
 }
 
-//Generated from:
 type ProvisioningState_Status string
 
 const (
@@ -6136,7 +6125,6 @@ const (
 	ProbePropertiesFormatStatusProtocolTcp   = ProbePropertiesFormatStatusProtocol("Tcp")
 )
 
-//Generated from:
 type PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded struct {
 	//ExtendedLocation: The extended location of the public ip address.
 	ExtendedLocation *ExtendedLocation_Status `json:"extendedLocation,omitempty"`
@@ -6286,7 +6274,6 @@ func (publicIPAddressStatusLoadBalancerSubResourceEmbedded *PublicIPAddress_Stat
 	return nil
 }
 
-//Generated from:
 type Subnet_Status_LoadBalancer_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -6345,7 +6332,6 @@ func (subnetStatusLoadBalancerSubResourceEmbedded *Subnet_Status_LoadBalancer_Su
 	return nil
 }
 
-//Generated from:
 type TransportProtocol_Status string
 
 const (

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_group__status__network_security_group__sub_resource_embedded_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_group__status__network_security_group__sub_resource_embedded_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -27,7 +26,6 @@ type NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbeddedARM str
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type NetworkSecurityGroupPropertiesFormat_StatusARM struct {
 	//DefaultSecurityRules: The default security rules of network security group.
 	DefaultSecurityRules []SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbeddedARM `json:"defaultSecurityRules,omitempty"`
@@ -51,13 +49,11 @@ type NetworkSecurityGroupPropertiesFormat_StatusARM struct {
 	Subnets []Subnet_Status_NetworkSecurityGroup_SubResourceEmbeddedARM `json:"subnets,omitempty"`
 }
 
-//Generated from:
 type FlowLog_Status_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbeddedARM struct {
 	//ExtendedLocation: The extended location of the network interface.
 	ExtendedLocation *ExtendedLocation_StatusARM `json:"extendedLocation,omitempty"`
@@ -66,13 +62,11 @@ type NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbeddedARM struct 
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type Subnet_Status_NetworkSecurityGroup_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen.go
@@ -285,7 +285,6 @@ type NetworkSecurityGroupList struct {
 	Items           []NetworkSecurityGroup `json:"items"`
 }
 
-//Generated from:
 type NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -979,7 +978,6 @@ func (networkSecurityGroupsSpec *NetworkSecurityGroups_Spec) SetAzureName(azureN
 	networkSecurityGroupsSpec.AzureName = azureName
 }
 
-//Generated from:
 type FlowLog_Status_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -1038,7 +1036,6 @@ func (flowLogStatusSubResourceEmbedded *FlowLog_Status_SubResourceEmbedded) Assi
 	return nil
 }
 
-//Generated from:
 type NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	//ExtendedLocation: The extended location of the network interface.
 	ExtendedLocation *ExtendedLocation_Status `json:"extendedLocation,omitempty"`
@@ -1135,7 +1132,6 @@ func (networkInterfaceStatusNetworkSecurityGroupSubResourceEmbedded *NetworkInte
 	return nil
 }
 
-//Generated from:
 type SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -1194,7 +1190,6 @@ func (securityRuleStatusNetworkSecurityGroupSubResourceEmbedded *SecurityRule_St
 	return nil
 }
 
-//Generated from:
 type Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
@@ -858,7 +858,6 @@ func (networkSecurityGroupsSecurityRulesSpec *NetworkSecurityGroupsSecurityRules
 	networkSecurityGroupsSecurityRulesSpec.AzureName = azureName
 }
 
-//Generated from:
 type SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded struct {
 	//Access: The network traffic is allowed or denied.
 	Access *SecurityRuleAccess_Status `json:"access,omitempty"`
@@ -1420,7 +1419,6 @@ func (securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded *Se
 	return nil
 }
 
-//Generated from:
 type ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -1479,7 +1477,6 @@ func (applicationSecurityGroupStatusNetworkSecurityGroupsSecurityRuleSubResource
 	return nil
 }
 
-//Generated from:
 type SecurityRuleAccess_Status string
 
 const (
@@ -1487,7 +1484,6 @@ const (
 	SecurityRuleAccess_StatusDeny  = SecurityRuleAccess_Status("Deny")
 )
 
-//Generated from:
 type SecurityRuleDirection_Status string
 
 const (

--- a/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address__status__public_ip_address__sub_resource_embedded_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address__status__public_ip_address__sub_resource_embedded_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type PublicIPAddress_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -37,7 +36,6 @@ type PublicIPAddress_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	Zones []string `json:"zones,omitempty"`
 }
 
-//Generated from:
 type PublicIPAddressPropertiesFormat_StatusARM struct {
 	//DdosSettings: The DDoS protection custom policy associated with the public IP
 	//address.
@@ -81,7 +79,6 @@ type PublicIPAddressPropertiesFormat_StatusARM struct {
 	ResourceGuid *string `json:"resourceGuid,omitempty"`
 }
 
-//Generated from:
 type PublicIPAddressSku_StatusARM struct {
 	//Name: Name of a public IP address SKU.
 	Name *PublicIPAddressSkuStatusName `json:"name,omitempty"`
@@ -90,7 +87,6 @@ type PublicIPAddressSku_StatusARM struct {
 	Tier *PublicIPAddressSkuStatusTier `json:"tier,omitempty"`
 }
 
-//Generated from:
 type DdosSettings_StatusARM struct {
 	//DdosCustomPolicy: The DDoS custom policy associated with the public IP.
 	DdosCustomPolicy *SubResource_StatusARM `json:"ddosCustomPolicy,omitempty"`
@@ -103,7 +99,6 @@ type DdosSettings_StatusARM struct {
 	ProtectionCoverage *DdosSettingsStatusProtectionCoverage `json:"protectionCoverage,omitempty"`
 }
 
-//Generated from:
 type IPConfiguration_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -119,7 +114,6 @@ type IPConfiguration_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	Properties *IPConfigurationPropertiesFormat_Status_PublicIPAddress_SubResourceEmbeddedARM `json:"properties,omitempty"`
 }
 
-//Generated from:
 type IpTag_StatusARM struct {
 	//IpTagType: The IP tag type. Example: FirstPartyUsage.
 	IpTagType *string `json:"ipTagType,omitempty"`
@@ -128,7 +122,6 @@ type IpTag_StatusARM struct {
 	Tag *string `json:"tag,omitempty"`
 }
 
-//Generated from:
 type NatGateway_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -141,7 +134,6 @@ type NatGateway_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	Zones []string `json:"zones,omitempty"`
 }
 
-//Generated from:
 type PublicIPAddressDnsSettings_StatusARM struct {
 	//DomainNameLabel: The domain name label. The concatenation of the domain name
 	//label and the regionalized DNS zone make up the fully qualified domain name
@@ -175,13 +167,11 @@ const (
 	PublicIPAddressSkuStatusTierRegional = PublicIPAddressSkuStatusTier("Regional")
 )
 
-//Generated from:
 type SubResource_StatusARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type IPConfigurationPropertiesFormat_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	//PrivateIPAddress: The private IP address of the IP configuration.
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
@@ -196,13 +186,11 @@ type IPConfigurationPropertiesFormat_Status_PublicIPAddress_SubResourceEmbeddedA
 	Subnet *Subnet_Status_PublicIPAddress_SubResourceEmbeddedARM `json:"subnet,omitempty"`
 }
 
-//Generated from:
 type NatGatewaySku_StatusARM struct {
 	//Name: Name of Nat Gateway SKU.
 	Name *NatGatewaySkuStatusName `json:"name,omitempty"`
 }
 
-//Generated from:
 type Subnet_Status_PublicIPAddress_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen.go
@@ -283,7 +283,6 @@ type PublicIPAddressList struct {
 	Items           []PublicIPAddress `json:"items"`
 }
 
-//Generated from:
 type PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -1759,7 +1758,6 @@ func (ddosSettings *DdosSettings) AssignPropertiesToDdosSettings(destination *v1
 	return nil
 }
 
-//Generated from:
 type DdosSettings_Status struct {
 	//DdosCustomPolicy: The DDoS custom policy associated with the public IP.
 	DdosCustomPolicy *SubResource_Status `json:"ddosCustomPolicy,omitempty"`
@@ -1892,7 +1890,6 @@ func (ddosSettingsStatus *DdosSettings_Status) AssignPropertiesToDdosSettingsSta
 	return nil
 }
 
-//Generated from:
 type IPAllocationMethod_Status string
 
 const (
@@ -1900,7 +1897,6 @@ const (
 	IPAllocationMethod_StatusStatic  = IPAllocationMethod_Status("Static")
 )
 
-//Generated from:
 type IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -2105,7 +2101,6 @@ func (ipConfigurationStatusPublicIPAddressSubResourceEmbedded *IPConfiguration_S
 	return nil
 }
 
-//Generated from:
 type IPVersion_Status string
 
 const (
@@ -2208,7 +2203,6 @@ func (ipTag *IpTag) AssignPropertiesToIpTag(destination *v1alpha1api20201101stor
 	return nil
 }
 
-//Generated from:
 type IpTag_Status struct {
 	//IpTagType: The IP tag type. Example: FirstPartyUsage.
 	IpTagType *string `json:"ipTagType,omitempty"`
@@ -2282,7 +2276,6 @@ func (ipTagStatus *IpTag_Status) AssignPropertiesToIpTagStatus(destination *v1al
 	return nil
 }
 
-//Generated from:
 type NatGateway_Status_PublicIPAddress_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -2514,7 +2507,6 @@ func (publicIPAddressDnsSettings *PublicIPAddressDnsSettings) AssignPropertiesTo
 	return nil
 }
 
-//Generated from:
 type PublicIPAddressDnsSettings_Status struct {
 	//DomainNameLabel: The domain name label. The concatenation of the domain name
 	//label and the regionalized DNS zone make up the fully qualified domain name
@@ -2752,7 +2744,6 @@ func (publicIPAddressSku *PublicIPAddressSku) AssignPropertiesToPublicIPAddressS
 	return nil
 }
 
-//Generated from:
 type PublicIPAddressSku_Status struct {
 	//Name: Name of a public IP address SKU.
 	Name *PublicIPAddressSkuStatusName `json:"name,omitempty"`
@@ -2846,7 +2837,6 @@ func (publicIPAddressSkuStatus *PublicIPAddressSku_Status) AssignPropertiesToPub
 	return nil
 }
 
-//Generated from:
 type SubResource_Status struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -2920,7 +2910,6 @@ const (
 	DdosSettingsStatusProtectionCoverageStandard = DdosSettingsStatusProtectionCoverage("Standard")
 )
 
-//Generated from:
 type NatGatewaySku_Status struct {
 	//Name: Name of Nat Gateway SKU.
 	Name *NatGatewaySkuStatusName `json:"name,omitempty"`
@@ -2989,7 +2978,6 @@ func (natGatewaySkuStatus *NatGatewaySku_Status) AssignPropertiesToNatGatewaySku
 	return nil
 }
 
-//Generated from:
 type Subnet_Status_PublicIPAddress_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/security_rule__status__network_security_groups_security_rule__sub_resource_embedded_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/security_rule__status__network_security_groups_security_rule__sub_resource_embedded_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -22,7 +21,6 @@ type SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbeddedAR
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SecurityRulePropertiesFormat_StatusARM struct {
 	//Access: The network traffic is allowed or denied.
 	Access SecurityRuleAccess_Status `json:"access"`
@@ -86,7 +84,6 @@ type SecurityRulePropertiesFormat_StatusARM struct {
 	SourcePortRanges []string `json:"sourcePortRanges,omitempty"`
 }
 
-//Generated from:
 type ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/subnet__status__virtual_networks_subnet__sub_resource_embedded_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/subnet__status__virtual_networks_subnet__sub_resource_embedded_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type Subnet_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -22,7 +21,6 @@ type Subnet_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SubnetPropertiesFormat_StatusARM struct {
 	//AddressPrefix: The address prefix for the subnet.
 	AddressPrefix *string `json:"addressPrefix,omitempty"`
@@ -90,7 +88,6 @@ type SubnetPropertiesFormat_StatusARM struct {
 	ServiceEndpoints []ServiceEndpointPropertiesFormat_StatusARM `json:"serviceEndpoints,omitempty"`
 }
 
-//Generated from:
 type ApplicationGatewayIPConfiguration_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -108,7 +105,6 @@ type ApplicationGatewayIPConfiguration_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type Delegation_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -127,7 +123,6 @@ type Delegation_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -145,7 +140,6 @@ type IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM 
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -161,13 +155,11 @@ type IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct 
 	Properties *IPConfigurationPropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM `json:"properties,omitempty"`
 }
 
-//Generated from:
 type NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//ExtendedLocation: The extended location of the load balancer.
 	ExtendedLocation *ExtendedLocation_StatusARM `json:"extendedLocation,omitempty"`
@@ -176,7 +168,6 @@ type PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct 
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type ResourceNavigationLink_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -195,13 +186,11 @@ type ResourceNavigationLink_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type ServiceAssociationLink_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -220,7 +209,6 @@ type ServiceAssociationLink_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -230,7 +218,6 @@ type ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM s
 	Kind *string `json:"kind,omitempty"`
 }
 
-//Generated from:
 type ServiceEndpointPropertiesFormat_StatusARM struct {
 	//Locations: A list of locations.
 	Locations []string `json:"locations,omitempty"`
@@ -256,7 +243,6 @@ const (
 	SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPoliciesEnabled  = SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPolicies("Enabled")
 )
 
-//Generated from:
 type ApplicationGatewayIPConfigurationPropertiesFormat_StatusARM struct {
 	//ProvisioningState: The provisioning state of the application gateway IP
 	//configuration resource.
@@ -267,14 +253,12 @@ type ApplicationGatewayIPConfigurationPropertiesFormat_StatusARM struct {
 	Subnet *SubResource_StatusARM `json:"subnet,omitempty"`
 }
 
-//Generated from:
 type IPConfigurationProfilePropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//ProvisioningState: The provisioning state of the IP configuration profile
 	//resource.
 	ProvisioningState *ProvisioningState_Status `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type IPConfigurationPropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//PrivateIPAddress: The private IP address of the IP configuration.
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
@@ -289,7 +273,6 @@ type IPConfigurationPropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmb
 	PublicIPAddress *PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM `json:"publicIPAddress,omitempty"`
 }
 
-//Generated from:
 type ResourceNavigationLinkFormat_StatusARM struct {
 	//Link: Link to the external resource.
 	Link *string `json:"link,omitempty"`
@@ -302,7 +285,6 @@ type ResourceNavigationLinkFormat_StatusARM struct {
 	ProvisioningState *ProvisioningState_Status `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type ServiceAssociationLinkPropertiesFormat_StatusARM struct {
 	//AllowDelete: If true, the resource can be deleted.
 	AllowDelete *bool `json:"allowDelete,omitempty"`
@@ -321,7 +303,6 @@ type ServiceAssociationLinkPropertiesFormat_StatusARM struct {
 	ProvisioningState *ProvisioningState_Status `json:"provisioningState,omitempty"`
 }
 
-//Generated from:
 type ServiceDelegationPropertiesFormat_StatusARM struct {
 	//Actions: The actions permitted to the service upon delegation.
 	Actions []string `json:"actions,omitempty"`
@@ -334,7 +315,6 @@ type ServiceDelegationPropertiesFormat_StatusARM struct {
 	ServiceName *string `json:"serviceName,omitempty"`
 }
 
-//Generated from:
 type PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbeddedARM struct {
 	//ExtendedLocation: The extended location of the public ip address.
 	ExtendedLocation *ExtendedLocation_StatusARM `json:"extendedLocation,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network__status_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type VirtualNetwork_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -30,7 +29,6 @@ type VirtualNetwork_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkPropertiesFormat_StatusARM struct {
 	//AddressSpace: The AddressSpace that contains an array of IP address ranges that
 	//can be used by subnets.
@@ -72,19 +70,16 @@ type VirtualNetworkPropertiesFormat_StatusARM struct {
 	VirtualNetworkPeerings []VirtualNetworkPeering_Status_SubResourceEmbeddedARM `json:"virtualNetworkPeerings,omitempty"`
 }
 
-//Generated from:
 type DhcpOptions_StatusARM struct {
 	//DnsServers: The list of DNS servers IP addresses.
 	DnsServers []string `json:"dnsServers,omitempty"`
 }
 
-//Generated from:
 type Subnet_Status_VirtualNetwork_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkPeering_Status_SubResourceEmbeddedARM struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway__status_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type VirtualNetworkGateway_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -30,7 +29,6 @@ type VirtualNetworkGateway_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkGatewayPropertiesFormat_StatusARM struct {
 	//ActiveActive: ActiveActive flag.
 	ActiveActive *bool `json:"activeActive,omitempty"`
@@ -95,14 +93,12 @@ type VirtualNetworkGatewayPropertiesFormat_StatusARM struct {
 	VpnType *VirtualNetworkGatewayPropertiesFormatStatusVpnType `json:"vpnType,omitempty"`
 }
 
-//Generated from:
 type AddressSpace_StatusARM struct {
 	//AddressPrefixes: A list of address blocks reserved for this virtual network in
 	//CIDR notation.
 	AddressPrefixes []string `json:"addressPrefixes,omitempty"`
 }
 
-//Generated from:
 type BgpSettings_StatusARM struct {
 	//Asn: The BGP speaker's ASN.
 	Asn *uint32 `json:"asn,omitempty"`
@@ -119,7 +115,6 @@ type BgpSettings_StatusARM struct {
 	PeerWeight *int `json:"peerWeight,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkGatewayIPConfiguration_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -135,7 +130,6 @@ type VirtualNetworkGatewayIPConfiguration_StatusARM struct {
 	Properties *VirtualNetworkGatewayIPConfigurationPropertiesFormat_StatusARM `json:"properties,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkGatewaySku_StatusARM struct {
 	//Capacity: The capacity.
 	Capacity *int `json:"capacity,omitempty"`
@@ -147,7 +141,6 @@ type VirtualNetworkGatewaySku_StatusARM struct {
 	Tier *VirtualNetworkGatewaySkuStatusTier `json:"tier,omitempty"`
 }
 
-//Generated from:
 type VpnClientConfiguration_StatusARM struct {
 	//AadAudience: The AADAudience property of the VirtualNetworkGateway resource for
 	//vpn client connection used for AAD authentication.
@@ -196,7 +189,6 @@ type VpnClientConfiguration_StatusARM struct {
 	VpnClientRootCertificates []VpnClientRootCertificate_StatusARM `json:"vpnClientRootCertificates,omitempty"`
 }
 
-//Generated from:
 type IPConfigurationBgpPeeringAddress_StatusARM struct {
 	//CustomBgpIpAddresses: The list of custom BGP peering addresses which belong to
 	//IP configuration.
@@ -214,7 +206,6 @@ type IPConfigurationBgpPeeringAddress_StatusARM struct {
 	TunnelIpAddresses []string `json:"tunnelIpAddresses,omitempty"`
 }
 
-//Generated from:
 type IpsecPolicy_StatusARM struct {
 	//DhGroup: The DH Group used in IKE Phase 1 for initial SA.
 	DhGroup DhGroup_Status `json:"dhGroup"`
@@ -243,7 +234,6 @@ type IpsecPolicy_StatusARM struct {
 	SaLifeTimeSeconds int `json:"saLifeTimeSeconds"`
 }
 
-//Generated from:
 type RadiusServer_StatusARM struct {
 	//RadiusServerAddress: The address of this radius server.
 	RadiusServerAddress string `json:"radiusServerAddress"`
@@ -255,7 +245,6 @@ type RadiusServer_StatusARM struct {
 	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkGatewayIPConfigurationPropertiesFormat_StatusARM struct {
 	//PrivateIPAddress: Private IP Address for this gateway.
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
@@ -274,7 +263,6 @@ type VirtualNetworkGatewayIPConfigurationPropertiesFormat_StatusARM struct {
 	Subnet *SubResource_StatusARM `json:"subnet,omitempty"`
 }
 
-//Generated from:
 type VpnClientRevokedCertificate_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -290,7 +278,6 @@ type VpnClientRevokedCertificate_StatusARM struct {
 	Properties *VpnClientRevokedCertificatePropertiesFormat_StatusARM `json:"properties,omitempty"`
 }
 
-//Generated from:
 type VpnClientRootCertificate_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -306,7 +293,6 @@ type VpnClientRootCertificate_StatusARM struct {
 	Properties VpnClientRootCertificatePropertiesFormat_StatusARM `json:"properties"`
 }
 
-//Generated from:
 type VpnClientRevokedCertificatePropertiesFormat_StatusARM struct {
 	//ProvisioningState: The provisioning state of the VPN client revoked certificate
 	//resource.
@@ -316,7 +302,6 @@ type VpnClientRevokedCertificatePropertiesFormat_StatusARM struct {
 	Thumbprint *string `json:"thumbprint,omitempty"`
 }
 
-//Generated from:
 type VpnClientRootCertificatePropertiesFormat_StatusARM struct {
 	//ProvisioningState: The provisioning state of the VPN client root certificate
 	//resource.

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
@@ -285,7 +285,6 @@ type VirtualNetworkGatewayList struct {
 	Items           []VirtualNetworkGateway `json:"items"`
 }
 
-//Generated from:
 type VirtualNetworkGateway_Status struct {
 	//ActiveActive: ActiveActive flag.
 	ActiveActive *bool `json:"activeActive,omitempty"`
@@ -2033,7 +2032,6 @@ func (bgpSettings *BgpSettings) AssignPropertiesToBgpSettings(destination *v1alp
 	return nil
 }
 
-//Generated from:
 type BgpSettings_Status struct {
 	//Asn: The BGP speaker's ASN.
 	Asn *uint32 `json:"asn,omitempty"`
@@ -2183,7 +2181,6 @@ func (bgpSettingsStatus *BgpSettings_Status) AssignPropertiesToBgpSettingsStatus
 	return nil
 }
 
-//Generated from:
 type VirtualNetworkGatewayIPConfiguration_Status struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -2568,7 +2565,6 @@ func (virtualNetworkGatewaySku *VirtualNetworkGatewaySku) AssignPropertiesToVirt
 	return nil
 }
 
-//Generated from:
 type VirtualNetworkGatewaySku_Status struct {
 	//Capacity: The capacity.
 	Capacity *int `json:"capacity,omitempty"`
@@ -3438,7 +3434,6 @@ func (virtualNetworkGatewaysSpecPropertiesVpnClientConfiguration *VirtualNetwork
 	return nil
 }
 
-//Generated from:
 type VpnClientConfiguration_Status struct {
 	//AadAudience: The AADAudience property of the VirtualNetworkGateway resource for
 	//vpn client connection used for AAD authentication.
@@ -3963,7 +3958,6 @@ func (ipConfigurationBgpPeeringAddress *IPConfigurationBgpPeeringAddress) Assign
 	return nil
 }
 
-//Generated from:
 type IPConfigurationBgpPeeringAddress_Status struct {
 	//CustomBgpIpAddresses: The list of custom BGP peering addresses which belong to
 	//IP configuration.
@@ -4282,7 +4276,6 @@ func (ipsecPolicy *IpsecPolicy) AssignPropertiesToIpsecPolicy(destination *v1alp
 	return nil
 }
 
-//Generated from:
 type IpsecPolicy_Status struct {
 	// +kubebuilder:validation:Required
 	//DhGroup: The DH Group used in IKE Phase 1 for initial SA.
@@ -4576,7 +4569,6 @@ func (radiusServer *RadiusServer) AssignPropertiesToRadiusServer(destination *v1
 	return nil
 }
 
-//Generated from:
 type RadiusServer_Status struct {
 	// +kubebuilder:validation:Required
 	//RadiusServerAddress: The address of this radius server.
@@ -4989,7 +4981,6 @@ const (
 	VpnClientConfigurationStatusVpnClientProtocolsSSTP    = VpnClientConfigurationStatusVpnClientProtocols("SSTP")
 )
 
-//Generated from:
 type VpnClientRevokedCertificate_Status struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -5126,7 +5117,6 @@ func (vpnClientRevokedCertificateStatus *VpnClientRevokedCertificate_Status) Ass
 	return nil
 }
 
-//Generated from:
 type VpnClientRootCertificate_Status struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -5258,7 +5248,6 @@ func (vpnClientRootCertificateStatus *VpnClientRootCertificate_Status) AssignPro
 	return nil
 }
 
-//Generated from:
 type DhGroup_Status string
 
 const (
@@ -5272,7 +5261,6 @@ const (
 	DhGroup_StatusNone        = DhGroup_Status("None")
 )
 
-//Generated from:
 type IkeEncryption_Status string
 
 const (
@@ -5285,7 +5273,6 @@ const (
 	IkeEncryption_StatusGCMAES256 = IkeEncryption_Status("GCMAES256")
 )
 
-//Generated from:
 type IkeIntegrity_Status string
 
 const (
@@ -5297,7 +5284,6 @@ const (
 	IkeIntegrity_StatusSHA384    = IkeIntegrity_Status("SHA384")
 )
 
-//Generated from:
 type IpsecEncryption_Status string
 
 const (
@@ -5312,7 +5298,6 @@ const (
 	IpsecEncryption_StatusNone      = IpsecEncryption_Status("None")
 )
 
-//Generated from:
 type IpsecIntegrity_Status string
 
 const (
@@ -5405,7 +5390,6 @@ const (
 	IpsecPolicyPfsGroupPFSMM   = IpsecPolicyPfsGroup("PFSMM")
 )
 
-//Generated from:
 type PfsGroup_Status string
 
 const (

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_peering__status_arm_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_peering__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20201101
 
-//Generated from:
 type VirtualNetworkPeering_StatusARM struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -22,7 +21,6 @@ type VirtualNetworkPeering_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkPeeringPropertiesFormat_StatusARM struct {
 	//AllowForwardedTraffic: Whether the forwarded traffic from the VMs in the local
 	//virtual network will be allowed/disallowed in remote virtual network.
@@ -71,7 +69,6 @@ type VirtualNetworkPeeringPropertiesFormat_StatusARM struct {
 	UseRemoteGateways *bool `json:"useRemoteGateways,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkBgpCommunities_StatusARM struct {
 	//RegionalCommunity: The BGP community associated with the region of the virtual
 	//network.

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen.go
@@ -283,7 +283,6 @@ type VirtualNetworkList struct {
 	Items           []VirtualNetwork `json:"items"`
 }
 
-//Generated from:
 type VirtualNetwork_Status struct {
 	//AddressSpace: The AddressSpace that contains an array of IP address ranges that
 	//can be used by subnets.
@@ -1620,7 +1619,6 @@ func (addressSpace *AddressSpace) AssignPropertiesToAddressSpace(destination *v1
 	return nil
 }
 
-//Generated from:
 type AddressSpace_Status struct {
 	//AddressPrefixes: A list of address blocks reserved for this virtual network in
 	//CIDR notation.
@@ -1752,7 +1750,6 @@ func (dhcpOptions *DhcpOptions) AssignPropertiesToDhcpOptions(destination *v1alp
 	return nil
 }
 
-//Generated from:
 type DhcpOptions_Status struct {
 	//DnsServers: The list of DNS servers IP addresses.
 	DnsServers []string `json:"dnsServers,omitempty"`
@@ -1810,7 +1807,6 @@ func (dhcpOptionsStatus *DhcpOptions_Status) AssignPropertiesToDhcpOptionsStatus
 	return nil
 }
 
-//Generated from:
 type Subnet_Status_VirtualNetwork_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -1939,7 +1935,6 @@ func (virtualNetworkBgpCommunities *VirtualNetworkBgpCommunities) AssignProperti
 	return nil
 }
 
-//Generated from:
 type VirtualNetworkBgpCommunities_Status struct {
 	//RegionalCommunity: The BGP community associated with the region of the virtual
 	//network.
@@ -2013,7 +2008,6 @@ func (virtualNetworkBgpCommunitiesStatus *VirtualNetworkBgpCommunities_Status) A
 	return nil
 }
 
-//Generated from:
 type VirtualNetworkPeering_Status_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
@@ -285,7 +285,6 @@ type VirtualNetworksSubnetList struct {
 	Items           []VirtualNetworksSubnet `json:"items"`
 }
 
-//Generated from:
 type Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//AddressPrefix: The address prefix for the subnet.
 	AddressPrefix *string `json:"addressPrefix,omitempty"`
@@ -1882,7 +1881,6 @@ func (virtualNetworksSubnetsSpec *VirtualNetworksSubnets_Spec) SetAzureName(azur
 	virtualNetworksSubnetsSpec.AzureName = azureName
 }
 
-//Generated from:
 type ApplicationGatewayIPConfiguration_Status struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -2057,7 +2055,6 @@ func (applicationGatewayIPConfigurationStatus *ApplicationGatewayIPConfiguration
 	return nil
 }
 
-//Generated from:
 type Delegation_Status struct {
 	//Actions: The actions permitted to the service upon delegation.
 	Actions []string `json:"actions,omitempty"`
@@ -2226,7 +2223,6 @@ func (delegationStatus *Delegation_Status) AssignPropertiesToDelegationStatus(de
 	return nil
 }
 
-//Generated from:
 type IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -2359,7 +2355,6 @@ func (ipConfigurationProfileStatusVirtualNetworksSubnetSubResourceEmbedded *IPCo
 	return nil
 }
 
-//Generated from:
 type IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -2564,7 +2559,6 @@ func (ipConfigurationStatusVirtualNetworksSubnetSubResourceEmbedded *IPConfigura
 	return nil
 }
 
-//Generated from:
 type NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -2623,7 +2617,6 @@ func (networkSecurityGroupStatusVirtualNetworksSubnetSubResourceEmbedded *Networ
 	return nil
 }
 
-//Generated from:
 type PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//ExtendedLocation: The extended location of the load balancer.
 	ExtendedLocation *ExtendedLocation_Status `json:"extendedLocation,omitempty"`
@@ -2720,7 +2713,6 @@ func (privateEndpointStatusVirtualNetworksSubnetSubResourceEmbedded *PrivateEndp
 	return nil
 }
 
-//Generated from:
 type ResourceNavigationLink_Status struct {
 	//Etag: A unique read-only string that changes whenever the resource is updated.
 	Etag *string `json:"etag,omitempty"`
@@ -2890,7 +2882,6 @@ func (resourceNavigationLinkStatus *ResourceNavigationLink_Status) AssignPropert
 	return nil
 }
 
-//Generated from:
 type RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -2949,7 +2940,6 @@ func (routeTableStatusVirtualNetworksSubnetSubResourceEmbedded *RouteTable_Statu
 	return nil
 }
 
-//Generated from:
 type ServiceAssociationLink_Status struct {
 	//AllowDelete: If true, the resource can be deleted.
 	AllowDelete *bool `json:"allowDelete,omitempty"`
@@ -3164,7 +3154,6 @@ func (serviceAssociationLinkStatus *ServiceAssociationLink_Status) AssignPropert
 	return nil
 }
 
-//Generated from:
 type ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//Id: Resource ID.
 	Id *string `json:"id,omitempty"`
@@ -3332,7 +3321,6 @@ func (serviceEndpointPropertiesFormat *ServiceEndpointPropertiesFormat) AssignPr
 	return nil
 }
 
-//Generated from:
 type ServiceEndpointPropertiesFormat_Status struct {
 	//Locations: A list of locations.
 	Locations []string `json:"locations,omitempty"`
@@ -3528,7 +3516,6 @@ func (virtualNetworksSubnetsSpecPropertiesDelegations *VirtualNetworksSubnets_Sp
 	return nil
 }
 
-//Generated from:
 type PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	//ExtendedLocation: The extended location of the public ip address.
 	ExtendedLocation *ExtendedLocation_Status `json:"extendedLocation,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -285,7 +285,6 @@ type VirtualNetworksVirtualNetworkPeeringList struct {
 	Items           []VirtualNetworksVirtualNetworkPeering `json:"items"`
 }
 
-//Generated from:
 type VirtualNetworkPeering_Status struct {
 	//AllowForwardedTraffic: Whether the forwarded traffic from the VMs in the local
 	//virtual network will be allowed/disallowed in remote virtual network.

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/load_balancer_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/load_balancer_types_gen.go
@@ -124,7 +124,6 @@ type LoadBalancerList struct {
 }
 
 //Storage version of v1alpha1api20201101.LoadBalancer_Status
-//Generated from:
 type LoadBalancer_Status struct {
 	BackendAddressPools      []BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded      `json:"backendAddressPools,omitempty"`
 	Conditions               []conditions.Condition                                            `json:"conditions,omitempty"`
@@ -210,7 +209,6 @@ func (loadBalancersSpec *LoadBalancers_Spec) ConvertSpecTo(destination genruntim
 }
 
 //Storage version of v1alpha1api20201101.BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded
-//Generated from:
 type BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -225,7 +223,6 @@ type ExtendedLocation struct {
 }
 
 //Storage version of v1alpha1api20201101.ExtendedLocation_Status
-//Generated from:
 type ExtendedLocation_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -233,7 +230,6 @@ type ExtendedLocation_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded
-//Generated from:
 type FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded struct {
 	Etag                      *string                                                  `json:"etag,omitempty"`
 	Id                        *string                                                  `json:"id,omitempty"`
@@ -255,7 +251,6 @@ type FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded struct {
 }
 
 //Storage version of v1alpha1api20201101.InboundNatPool_Status
-//Generated from:
 type InboundNatPool_Status struct {
 	BackendPort             *int                   `json:"backendPort,omitempty"`
 	EnableFloatingIP        *bool                  `json:"enableFloatingIP,omitempty"`
@@ -274,7 +269,6 @@ type InboundNatPool_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.InboundNatRule_Status_LoadBalancer_SubResourceEmbedded
-//Generated from:
 type InboundNatRule_Status_LoadBalancer_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -289,7 +283,6 @@ type LoadBalancerSku struct {
 }
 
 //Storage version of v1alpha1api20201101.LoadBalancerSku_Status
-//Generated from:
 type LoadBalancerSku_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -372,7 +365,6 @@ type LoadBalancers_Spec_Properties_Probes struct {
 }
 
 //Storage version of v1alpha1api20201101.LoadBalancingRule_Status
-//Generated from:
 type LoadBalancingRule_Status struct {
 	BackendAddressPool      *SubResource_Status    `json:"backendAddressPool,omitempty"`
 	BackendPort             *int                   `json:"backendPort,omitempty"`
@@ -394,7 +386,6 @@ type LoadBalancingRule_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.OutboundRule_Status
-//Generated from:
 type OutboundRule_Status struct {
 	AllocatedOutboundPorts   *int                   `json:"allocatedOutboundPorts,omitempty"`
 	BackendAddressPool       *SubResource_Status    `json:"backendAddressPool,omitempty"`
@@ -411,7 +402,6 @@ type OutboundRule_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.Probe_Status
-//Generated from:
 type Probe_Status struct {
 	Etag               *string                `json:"etag,omitempty"`
 	Id                 *string                `json:"id,omitempty"`
@@ -438,7 +428,6 @@ type LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBa
 }
 
 //Storage version of v1alpha1api20201101.PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded
-//Generated from:
 type PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded struct {
 	ExtendedLocation *ExtendedLocation_Status   `json:"extendedLocation,omitempty"`
 	Id               *string                    `json:"id,omitempty"`
@@ -448,7 +437,6 @@ type PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded struct {
 }
 
 //Storage version of v1alpha1api20201101.Subnet_Status_LoadBalancer_SubResourceEmbedded
-//Generated from:
 type Subnet_Status_LoadBalancer_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_group_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_group_types_gen.go
@@ -124,7 +124,6 @@ type NetworkSecurityGroupList struct {
 }
 
 //Storage version of v1alpha1api20201101.NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded
-//Generated from:
 type NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	Conditions           []conditions.Condition                                             `json:"conditions,omitempty"`
 	DefaultSecurityRules []SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded     `json:"defaultSecurityRules,omitempty"`
@@ -198,14 +197,12 @@ func (networkSecurityGroupsSpec *NetworkSecurityGroups_Spec) ConvertSpecTo(desti
 }
 
 //Storage version of v1alpha1api20201101.FlowLog_Status_SubResourceEmbedded
-//Generated from:
 type FlowLog_Status_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20201101.NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded
-//Generated from:
 type NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	ExtendedLocation *ExtendedLocation_Status `json:"extendedLocation,omitempty"`
 	Id               *string                  `json:"id,omitempty"`
@@ -213,14 +210,12 @@ type NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 }
 
 //Storage version of v1alpha1api20201101.SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded
-//Generated from:
 type SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20201101.Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded
-//Generated from:
 type Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/network_security_groups_security_rule_types_gen.go
@@ -174,7 +174,6 @@ func (networkSecurityGroupsSecurityRulesSpec *NetworkSecurityGroupsSecurityRules
 }
 
 //Storage version of v1alpha1api20201101.SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded
-//Generated from:
 type SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded struct {
 	Access                               *string                                                                                 `json:"access,omitempty"`
 	Conditions                           []conditions.Condition                                                                  `json:"conditions,omitempty"`
@@ -221,7 +220,6 @@ func (securityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded *Se
 }
 
 //Storage version of v1alpha1api20201101.ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded
-//Generated from:
 type ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/public_ip_address_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/public_ip_address_types_gen.go
@@ -124,7 +124,6 @@ type PublicIPAddressList struct {
 }
 
 //Storage version of v1alpha1api20201101.PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded
-//Generated from:
 type PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded struct {
 	Conditions               []conditions.Condition                                      `json:"conditions,omitempty"`
 	DdosSettings             *DdosSettings_Status                                        `json:"ddosSettings,omitempty"`
@@ -227,7 +226,6 @@ type DdosSettings struct {
 }
 
 //Storage version of v1alpha1api20201101.DdosSettings_Status
-//Generated from:
 type DdosSettings_Status struct {
 	DdosCustomPolicy   *SubResource_Status    `json:"ddosCustomPolicy,omitempty"`
 	PropertyBag        genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -236,7 +234,6 @@ type DdosSettings_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded
-//Generated from:
 type IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded struct {
 	Etag                      *string                                            `json:"etag,omitempty"`
 	Id                        *string                                            `json:"id,omitempty"`
@@ -257,7 +254,6 @@ type IpTag struct {
 }
 
 //Storage version of v1alpha1api20201101.IpTag_Status
-//Generated from:
 type IpTag_Status struct {
 	IpTagType   *string                `json:"ipTagType,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -265,7 +261,6 @@ type IpTag_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.NatGateway_Status_PublicIPAddress_SubResourceEmbedded
-//Generated from:
 type NatGateway_Status_PublicIPAddress_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -283,7 +278,6 @@ type PublicIPAddressDnsSettings struct {
 }
 
 //Storage version of v1alpha1api20201101.PublicIPAddressDnsSettings_Status
-//Generated from:
 type PublicIPAddressDnsSettings_Status struct {
 	DomainNameLabel *string                `json:"domainNameLabel,omitempty"`
 	Fqdn            *string                `json:"fqdn,omitempty"`
@@ -300,7 +294,6 @@ type PublicIPAddressSku struct {
 }
 
 //Storage version of v1alpha1api20201101.PublicIPAddressSku_Status
-//Generated from:
 type PublicIPAddressSku_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -308,21 +301,18 @@ type PublicIPAddressSku_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.SubResource_Status
-//Generated from:
 type SubResource_Status struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20201101.NatGatewaySku_Status
-//Generated from:
 type NatGatewaySku_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20201101.Subnet_Status_PublicIPAddress_SubResourceEmbedded
-//Generated from:
 type Subnet_Status_PublicIPAddress_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_gateway_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_gateway_types_gen.go
@@ -124,7 +124,6 @@ type VirtualNetworkGatewayList struct {
 }
 
 //Storage version of v1alpha1api20201101.VirtualNetworkGateway_Status
-//Generated from:
 type VirtualNetworkGateway_Status struct {
 	ActiveActive                   *bool                                         `json:"activeActive,omitempty"`
 	BgpSettings                    *BgpSettings_Status                           `json:"bgpSettings,omitempty"`
@@ -238,7 +237,6 @@ type BgpSettings struct {
 }
 
 //Storage version of v1alpha1api20201101.BgpSettings_Status
-//Generated from:
 type BgpSettings_Status struct {
 	Asn                 *uint32                                   `json:"asn,omitempty"`
 	BgpPeeringAddress   *string                                   `json:"bgpPeeringAddress,omitempty"`
@@ -248,7 +246,6 @@ type BgpSettings_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.VirtualNetworkGatewayIPConfiguration_Status
-//Generated from:
 type VirtualNetworkGatewayIPConfiguration_Status struct {
 	Etag                      *string                `json:"etag,omitempty"`
 	Id                        *string                `json:"id,omitempty"`
@@ -270,7 +267,6 @@ type VirtualNetworkGatewaySku struct {
 }
 
 //Storage version of v1alpha1api20201101.VirtualNetworkGatewaySku_Status
-//Generated from:
 type VirtualNetworkGatewaySku_Status struct {
 	Capacity    *int                   `json:"capacity,omitempty"`
 	Name        *string                `json:"name,omitempty"`
@@ -305,7 +301,6 @@ type VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration struct {
 }
 
 //Storage version of v1alpha1api20201101.VpnClientConfiguration_Status
-//Generated from:
 type VpnClientConfiguration_Status struct {
 	AadAudience                  *string                              `json:"aadAudience,omitempty"`
 	AadIssuer                    *string                              `json:"aadIssuer,omitempty"`
@@ -331,7 +326,6 @@ type IPConfigurationBgpPeeringAddress struct {
 }
 
 //Storage version of v1alpha1api20201101.IPConfigurationBgpPeeringAddress_Status
-//Generated from:
 type IPConfigurationBgpPeeringAddress_Status struct {
 	CustomBgpIpAddresses  []string               `json:"customBgpIpAddresses,omitempty"`
 	DefaultBgpIpAddresses []string               `json:"defaultBgpIpAddresses,omitempty"`
@@ -355,7 +349,6 @@ type IpsecPolicy struct {
 }
 
 //Storage version of v1alpha1api20201101.IpsecPolicy_Status
-//Generated from:
 type IpsecPolicy_Status struct {
 	DhGroup             *string                `json:"dhGroup,omitempty"`
 	IkeEncryption       *string                `json:"ikeEncryption,omitempty"`
@@ -378,7 +371,6 @@ type RadiusServer struct {
 }
 
 //Storage version of v1alpha1api20201101.RadiusServer_Status
-//Generated from:
 type RadiusServer_Status struct {
 	PropertyBag         genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	RadiusServerAddress *string                `json:"radiusServerAddress,omitempty"`
@@ -401,7 +393,6 @@ type VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRoot
 }
 
 //Storage version of v1alpha1api20201101.VpnClientRevokedCertificate_Status
-//Generated from:
 type VpnClientRevokedCertificate_Status struct {
 	Etag              *string                `json:"etag,omitempty"`
 	Id                *string                `json:"id,omitempty"`
@@ -412,7 +403,6 @@ type VpnClientRevokedCertificate_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.VpnClientRootCertificate_Status
-//Generated from:
 type VpnClientRootCertificate_Status struct {
 	Etag              *string                `json:"etag,omitempty"`
 	Id                *string                `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_network_types_gen.go
@@ -124,7 +124,6 @@ type VirtualNetworkList struct {
 }
 
 //Storage version of v1alpha1api20201101.VirtualNetwork_Status
-//Generated from:
 type VirtualNetwork_Status struct {
 	AddressSpace           *AddressSpace_Status                               `json:"addressSpace,omitempty"`
 	BgpCommunities         *VirtualNetworkBgpCommunities_Status               `json:"bgpCommunities,omitempty"`
@@ -220,7 +219,6 @@ type AddressSpace struct {
 }
 
 //Storage version of v1alpha1api20201101.AddressSpace_Status
-//Generated from:
 type AddressSpace_Status struct {
 	AddressPrefixes []string               `json:"addressPrefixes,omitempty"`
 	PropertyBag     genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -234,14 +232,12 @@ type DhcpOptions struct {
 }
 
 //Storage version of v1alpha1api20201101.DhcpOptions_Status
-//Generated from:
 type DhcpOptions_Status struct {
 	DnsServers  []string               `json:"dnsServers,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20201101.Subnet_Status_VirtualNetwork_SubResourceEmbedded
-//Generated from:
 type Subnet_Status_VirtualNetwork_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -255,7 +251,6 @@ type VirtualNetworkBgpCommunities struct {
 }
 
 //Storage version of v1alpha1api20201101.VirtualNetworkBgpCommunities_Status
-//Generated from:
 type VirtualNetworkBgpCommunities_Status struct {
 	PropertyBag             genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	RegionalCommunity       *string                `json:"regionalCommunity,omitempty"`
@@ -263,7 +258,6 @@ type VirtualNetworkBgpCommunities_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.VirtualNetworkPeering_Status_SubResourceEmbedded
-//Generated from:
 type VirtualNetworkPeering_Status_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_subnet_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_subnet_types_gen.go
@@ -124,7 +124,6 @@ type VirtualNetworksSubnetList struct {
 }
 
 //Storage version of v1alpha1api20201101.Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	AddressPrefix                      *string                                                                   `json:"addressPrefix,omitempty"`
 	AddressPrefixes                    []string                                                                  `json:"addressPrefixes,omitempty"`
@@ -220,7 +219,6 @@ func (virtualNetworksSubnetsSpec *VirtualNetworksSubnets_Spec) ConvertSpecTo(des
 }
 
 //Storage version of v1alpha1api20201101.ApplicationGatewayIPConfiguration_Status
-//Generated from:
 type ApplicationGatewayIPConfiguration_Status struct {
 	Etag              *string                `json:"etag,omitempty"`
 	Id                *string                `json:"id,omitempty"`
@@ -232,7 +230,6 @@ type ApplicationGatewayIPConfiguration_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.Delegation_Status
-//Generated from:
 type Delegation_Status struct {
 	Actions           []string               `json:"actions,omitempty"`
 	Etag              *string                `json:"etag,omitempty"`
@@ -245,7 +242,6 @@ type Delegation_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	Etag              *string                `json:"etag,omitempty"`
 	Id                *string                `json:"id,omitempty"`
@@ -256,7 +252,6 @@ type IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded str
 }
 
 //Storage version of v1alpha1api20201101.IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	Etag                      *string                                                           `json:"etag,omitempty"`
 	Id                        *string                                                           `json:"id,omitempty"`
@@ -269,14 +264,12 @@ type IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 }
 
 //Storage version of v1alpha1api20201101.NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20201101.PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	ExtendedLocation *ExtendedLocation_Status `json:"extendedLocation,omitempty"`
 	Id               *string                  `json:"id,omitempty"`
@@ -284,7 +277,6 @@ type PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 }
 
 //Storage version of v1alpha1api20201101.ResourceNavigationLink_Status
-//Generated from:
 type ResourceNavigationLink_Status struct {
 	Etag               *string                `json:"etag,omitempty"`
 	Id                 *string                `json:"id,omitempty"`
@@ -297,14 +289,12 @@ type ResourceNavigationLink_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 }
 
 //Storage version of v1alpha1api20201101.ServiceAssociationLink_Status
-//Generated from:
 type ServiceAssociationLink_Status struct {
 	AllowDelete        *bool                  `json:"allowDelete,omitempty"`
 	Etag               *string                `json:"etag,omitempty"`
@@ -319,7 +309,6 @@ type ServiceAssociationLink_Status struct {
 }
 
 //Storage version of v1alpha1api20201101.ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	Kind        *string                `json:"kind,omitempty"`
@@ -335,7 +324,6 @@ type ServiceEndpointPropertiesFormat struct {
 }
 
 //Storage version of v1alpha1api20201101.ServiceEndpointPropertiesFormat_Status
-//Generated from:
 type ServiceEndpointPropertiesFormat_Status struct {
 	Locations         []string               `json:"locations,omitempty"`
 	PropertyBag       genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -351,7 +339,6 @@ type VirtualNetworksSubnets_Spec_Properties_Delegations struct {
 }
 
 //Storage version of v1alpha1api20201101.PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded
-//Generated from:
 type PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded struct {
 	ExtendedLocation *ExtendedLocation_Status   `json:"extendedLocation,omitempty"`
 	Id               *string                    `json:"id,omitempty"`

--- a/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101storage/virtual_networks_virtual_network_peering_types_gen.go
@@ -124,7 +124,6 @@ type VirtualNetworksVirtualNetworkPeeringList struct {
 }
 
 //Storage version of v1alpha1api20201101.VirtualNetworkPeering_Status
-//Generated from:
 type VirtualNetworkPeering_Status struct {
 	AllowForwardedTraffic     *bool                                `json:"allowForwardedTraffic,omitempty"`
 	AllowGatewayTransit       *bool                                `json:"allowGatewayTransit,omitempty"`

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
@@ -651,7 +651,6 @@ func (namespacesSpec *Namespaces_Spec) SetAzureName(azureName string) {
 	namespacesSpec.AzureName = azureName
 }
 
-//Generated from:
 type SBNamespace_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -1351,7 +1350,6 @@ func (encryption *Encryption) AssignPropertiesToEncryption(destination *v1alpha1
 	return nil
 }
 
-//Generated from:
 type Encryption_Status struct {
 	//KeySource: Enumerates the possible value of keySource for Encryption
 	KeySource *EncryptionStatusKeySource `json:"keySource,omitempty"`
@@ -1579,7 +1577,6 @@ func (identity *Identity) AssignPropertiesToIdentity(destination *v1alpha1api202
 	return nil
 }
 
-//Generated from:
 type Identity_Status struct {
 	//PrincipalId: ObjectId from the KeyVault
 	PrincipalId *string `json:"principalId,omitempty"`
@@ -1730,7 +1727,6 @@ func (identityStatus *Identity_Status) AssignPropertiesToIdentityStatus(destinat
 	return nil
 }
 
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbedded struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -1954,7 +1950,6 @@ func (sbSku *SBSku) AssignPropertiesToSBSku(destination *v1alpha1api20210101prev
 	return nil
 }
 
-//Generated from:
 type SBSku_Status struct {
 	//Capacity: The specified messaging units for the tier. For Premium tier, capacity
 	//are 1,2 and 4.
@@ -2057,7 +2052,6 @@ func (sbSkuStatus *SBSku_Status) AssignPropertiesToSBSkuStatus(destination *v1al
 	return nil
 }
 
-//Generated from:
 type SystemData_Status struct {
 	//CreatedAt: The timestamp of resource creation (UTC).
 	CreatedAt *string `json:"createdAt,omitempty"`
@@ -2211,7 +2205,6 @@ func (systemDataStatus *SystemData_Status) AssignPropertiesToSystemDataStatus(de
 	return nil
 }
 
-//Generated from:
 type DictionaryValue_Status struct {
 	//ClientId: Client Id of user assigned identity
 	ClientId *string `json:"clientId,omitempty"`
@@ -2457,7 +2450,6 @@ func (keyVaultProperties *KeyVaultProperties) AssignPropertiesToKeyVaultProperti
 	return nil
 }
 
-//Generated from:
 type KeyVaultProperties_Status struct {
 	Identity *UserAssignedIdentityProperties_Status `json:"identity,omitempty"`
 
@@ -2667,7 +2659,6 @@ func (userAssignedIdentityProperties *UserAssignedIdentityProperties) AssignProp
 	return nil
 }
 
-//Generated from:
 type UserAssignedIdentityProperties_Status struct {
 	//UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
@@ -879,7 +879,6 @@ func (namespacesQueuesSpec *NamespacesQueues_Spec) SetAzureName(azureName string
 	namespacesQueuesSpec.AzureName = azureName
 }
 
-//Generated from:
 type SBQueue_Status struct {
 	//AccessedAt: Last time a message was sent, or the last time there was a receive
 	//request to this queue.
@@ -1556,7 +1555,6 @@ func (sbQueueStatus *SBQueue_Status) AssignPropertiesToSBQueueStatus(destination
 	return nil
 }
 
-//Generated from:
 type EntityStatus_Status string
 
 const (
@@ -1571,7 +1569,6 @@ const (
 	EntityStatus_StatusUnknown         = EntityStatus_Status("Unknown")
 )
 
-//Generated from:
 type MessageCountDetails_Status struct {
 	//ActiveMessageCount: Number of active messages in the queue, topic, or
 	//subscription.

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
@@ -753,7 +753,6 @@ func (namespacesTopicsSpec *NamespacesTopics_Spec) SetAzureName(azureName string
 	namespacesTopicsSpec.AzureName = azureName
 }
 
-//Generated from:
 type SBTopic_Status struct {
 	//AccessedAt: Last time the message was sent, or a request was received, for this
 	//topic.

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_namespace__status_arm_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_namespace__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210101preview
 
-//Generated from:
 type SBNamespace_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -33,7 +32,6 @@ type SBNamespace_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type Identity_StatusARM struct {
 	//PrincipalId: ObjectId from the KeyVault
 	PrincipalId *string `json:"principalId,omitempty"`
@@ -48,7 +46,6 @@ type Identity_StatusARM struct {
 	UserAssignedIdentities map[string]DictionaryValue_StatusARM `json:"userAssignedIdentities,omitempty"`
 }
 
-//Generated from:
 type SBNamespaceProperties_StatusARM struct {
 	//CreatedAt: The time the namespace was created
 	CreatedAt *string `json:"createdAt,omitempty"`
@@ -79,7 +76,6 @@ type SBNamespaceProperties_StatusARM struct {
 	ZoneRedundant *bool `json:"zoneRedundant,omitempty"`
 }
 
-//Generated from:
 type SBSku_StatusARM struct {
 	//Capacity: The specified messaging units for the tier. For Premium tier, capacity
 	//are 1,2 and 4.
@@ -92,7 +88,6 @@ type SBSku_StatusARM struct {
 	Tier *SBSkuStatusTier `json:"tier,omitempty"`
 }
 
-//Generated from:
 type SystemData_StatusARM struct {
 	//CreatedAt: The timestamp of resource creation (UTC).
 	CreatedAt *string `json:"createdAt,omitempty"`
@@ -113,7 +108,6 @@ type SystemData_StatusARM struct {
 	LastModifiedByType *SystemDataStatusLastModifiedByType `json:"lastModifiedByType,omitempty"`
 }
 
-//Generated from:
 type DictionaryValue_StatusARM struct {
 	//ClientId: Client Id of user assigned identity
 	ClientId *string `json:"clientId,omitempty"`
@@ -122,7 +116,6 @@ type DictionaryValue_StatusARM struct {
 	PrincipalId *string `json:"principalId,omitempty"`
 }
 
-//Generated from:
 type Encryption_StatusARM struct {
 	//KeySource: Enumerates the possible value of keySource for Encryption
 	KeySource *EncryptionStatusKeySource `json:"keySource,omitempty"`
@@ -144,7 +137,6 @@ const (
 	IdentityStatusTypeUserAssigned               = IdentityStatusType("UserAssigned")
 )
 
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbeddedARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -187,7 +179,6 @@ const (
 	SystemDataStatusLastModifiedByTypeUser            = SystemDataStatusLastModifiedByType("User")
 )
 
-//Generated from:
 type KeyVaultProperties_StatusARM struct {
 	Identity *UserAssignedIdentityProperties_StatusARM `json:"identity,omitempty"`
 
@@ -201,7 +192,6 @@ type KeyVaultProperties_StatusARM struct {
 	KeyVersion *string `json:"keyVersion,omitempty"`
 }
 
-//Generated from:
 type UserAssignedIdentityProperties_StatusARM struct {
 	//UserAssignedIdentity: ARM ID of user Identity selected for encryption
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_queue__status_arm_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_queue__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210101preview
 
-//Generated from:
 type SBQueue_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -21,7 +20,6 @@ type SBQueue_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SBQueueProperties_StatusARM struct {
 	//AccessedAt: Last time a message was sent, or the last time there was a receive
 	//request to this queue.
@@ -105,7 +103,6 @@ type SBQueueProperties_StatusARM struct {
 	UpdatedAt *string `json:"updatedAt,omitempty"`
 }
 
-//Generated from:
 type MessageCountDetails_StatusARM struct {
 	//ActiveMessageCount: Number of active messages in the queue, topic, or
 	//subscription.

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_topic__status_arm_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/sb_topic__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210101preview
 
-//Generated from:
 type SBTopic_StatusARM struct {
 	//Id: Resource Id
 	Id *string `json:"id,omitempty"`
@@ -21,7 +20,6 @@ type SBTopic_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type SBTopicProperties_StatusARM struct {
 	//AccessedAt: Last time the message was sent, or a request was received, for this
 	//topic.

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespace_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespace_types_gen.go
@@ -162,7 +162,6 @@ func (namespacesSpec *Namespaces_Spec) ConvertSpecTo(destination genruntime.Conv
 }
 
 //Storage version of v1alpha1api20210101preview.SBNamespace_Status
-//Generated from:
 type SBNamespace_Status struct {
 	Conditions                 []conditions.Condition                                 `json:"conditions,omitempty"`
 	CreatedAt                  *string                                                `json:"createdAt,omitempty"`
@@ -215,7 +214,6 @@ type Encryption struct {
 }
 
 //Storage version of v1alpha1api20210101preview.Encryption_Status
-//Generated from:
 type Encryption_Status struct {
 	KeySource                       *string                     `json:"keySource,omitempty"`
 	KeyVaultProperties              []KeyVaultProperties_Status `json:"keyVaultProperties,omitempty"`
@@ -231,7 +229,6 @@ type Identity struct {
 }
 
 //Storage version of v1alpha1api20210101preview.Identity_Status
-//Generated from:
 type Identity_Status struct {
 	PrincipalId            *string                           `json:"principalId,omitempty"`
 	PropertyBag            genruntime.PropertyBag            `json:"$propertyBag,omitempty"`
@@ -241,7 +238,6 @@ type Identity_Status struct {
 }
 
 //Storage version of v1alpha1api20210101preview.PrivateEndpointConnection_Status_SubResourceEmbedded
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -258,7 +254,6 @@ type SBSku struct {
 }
 
 //Storage version of v1alpha1api20210101preview.SBSku_Status
-//Generated from:
 type SBSku_Status struct {
 	Capacity    *int                   `json:"capacity,omitempty"`
 	Name        *string                `json:"name,omitempty"`
@@ -267,7 +262,6 @@ type SBSku_Status struct {
 }
 
 //Storage version of v1alpha1api20210101preview.SystemData_Status
-//Generated from:
 type SystemData_Status struct {
 	CreatedAt          *string                `json:"createdAt,omitempty"`
 	CreatedBy          *string                `json:"createdBy,omitempty"`
@@ -279,7 +273,6 @@ type SystemData_Status struct {
 }
 
 //Storage version of v1alpha1api20210101preview.DictionaryValue_Status
-//Generated from:
 type DictionaryValue_Status struct {
 	ClientId    *string                `json:"clientId,omitempty"`
 	PrincipalId *string                `json:"principalId,omitempty"`
@@ -297,7 +290,6 @@ type KeyVaultProperties struct {
 }
 
 //Storage version of v1alpha1api20210101preview.KeyVaultProperties_Status
-//Generated from:
 type KeyVaultProperties_Status struct {
 	Identity    *UserAssignedIdentityProperties_Status `json:"identity,omitempty"`
 	KeyName     *string                                `json:"keyName,omitempty"`
@@ -316,7 +308,6 @@ type UserAssignedIdentityProperties struct {
 }
 
 //Storage version of v1alpha1api20210101preview.UserAssignedIdentityProperties_Status
-//Generated from:
 type UserAssignedIdentityProperties_Status struct {
 	PropertyBag          genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	UserAssignedIdentity *string                `json:"userAssignedIdentity,omitempty"`

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_queue_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_queue_types_gen.go
@@ -174,7 +174,6 @@ func (namespacesQueuesSpec *NamespacesQueues_Spec) ConvertSpecTo(destination gen
 }
 
 //Storage version of v1alpha1api20210101preview.SBQueue_Status
-//Generated from:
 type SBQueue_Status struct {
 	AccessedAt                          *string                     `json:"accessedAt,omitempty"`
 	AutoDeleteOnIdle                    *string                     `json:"autoDeleteOnIdle,omitempty"`
@@ -226,7 +225,6 @@ func (sbQueueStatus *SBQueue_Status) ConvertStatusTo(destination genruntime.Conv
 }
 
 //Storage version of v1alpha1api20210101preview.MessageCountDetails_Status
-//Generated from:
 type MessageCountDetails_Status struct {
 	ActiveMessageCount             *int                   `json:"activeMessageCount,omitempty"`
 	DeadLetterMessageCount         *int                   `json:"deadLetterMessageCount,omitempty"`

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_topic_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/namespaces_topic_types_gen.go
@@ -169,7 +169,6 @@ func (namespacesTopicsSpec *NamespacesTopics_Spec) ConvertSpecTo(destination gen
 }
 
 //Storage version of v1alpha1api20210101preview.SBTopic_Status
-//Generated from:
 type SBTopic_Status struct {
 	AccessedAt                          *string                     `json:"accessedAt,omitempty"`
 	AutoDeleteOnIdle                    *string                     `json:"autoDeleteOnIdle,omitempty"`

--- a/v2/api/microsoft.storage/v1alpha1api20210401/blob_container__status_arm_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/blob_container__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210401
 
-//Generated from:
 type BlobContainer_StatusARM struct {
 	//Etag: Resource Etag.
 	Etag *string `json:"etag,omitempty"`
@@ -23,7 +22,6 @@ type BlobContainer_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ContainerProperties_StatusARM struct {
 	//DefaultEncryptionScope: Default the container to use specified encryption scope
 	//for all writes.
@@ -121,7 +119,6 @@ const (
 	ContainerPropertiesStatusPublicAccessNone      = ContainerPropertiesStatusPublicAccess("None")
 )
 
-//Generated from:
 type ImmutabilityPolicyProperties_StatusARM struct {
 	//Etag: ImmutabilityPolicy Etag.
 	Etag *string `json:"etag,omitempty"`
@@ -133,7 +130,6 @@ type ImmutabilityPolicyProperties_StatusARM struct {
 	UpdateHistory []UpdateHistoryProperty_StatusARM `json:"updateHistory,omitempty"`
 }
 
-//Generated from:
 type ImmutableStorageWithVersioning_StatusARM struct {
 	//Enabled: This is an immutable property, when set to true it enables object level
 	//immutability at the container level.
@@ -147,7 +143,6 @@ type ImmutableStorageWithVersioning_StatusARM struct {
 	TimeStamp *string `json:"timeStamp,omitempty"`
 }
 
-//Generated from:
 type LegalHoldProperties_StatusARM struct {
 	//HasLegalHold: The hasLegalHold public property is set to true by SRP if there
 	//are at least one existing tag. The hasLegalHold public property is set to false
@@ -159,7 +154,6 @@ type LegalHoldProperties_StatusARM struct {
 	Tags []TagProperty_StatusARM `json:"tags,omitempty"`
 }
 
-//Generated from:
 type ImmutabilityPolicyProperty_StatusARM struct {
 	//AllowProtectedAppendWrites: This property can only be changed for unlocked
 	//time-based retention policies. When enabled, new blocks can be written to an
@@ -184,7 +178,6 @@ const (
 	ImmutableStorageWithVersioningStatusMigrationStateInProgress = ImmutableStorageWithVersioningStatusMigrationState("InProgress")
 )
 
-//Generated from:
 type TagProperty_StatusARM struct {
 	//ObjectIdentifier: Returns the Object ID of the user who added the tag.
 	ObjectIdentifier *string `json:"objectIdentifier,omitempty"`
@@ -203,7 +196,6 @@ type TagProperty_StatusARM struct {
 	Upn *string `json:"upn,omitempty"`
 }
 
-//Generated from:
 type UpdateHistoryProperty_StatusARM struct {
 	//ImmutabilityPeriodSinceCreationInDays: The immutability period for the blobs in
 	//the container since the policy creation, in days.

--- a/v2/api/microsoft.storage/v1alpha1api20210401/blob_service_properties__status_arm_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/blob_service_properties__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210401
 
-//Generated from:
 type BlobServiceProperties_StatusARM struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -61,13 +60,11 @@ type BlobServiceProperties_Status_PropertiesARM struct {
 	RestorePolicy *RestorePolicyProperties_StatusARM `json:"restorePolicy,omitempty"`
 }
 
-//Generated from:
 type Sku_StatusARM struct {
 	Name SkuName_Status `json:"name"`
 	Tier *Tier_Status   `json:"tier,omitempty"`
 }
 
-//Generated from:
 type ChangeFeed_StatusARM struct {
 	//Enabled: Indicates whether change feed event logging is enabled for the Blob
 	//service.
@@ -79,14 +76,12 @@ type ChangeFeed_StatusARM struct {
 	RetentionInDays *int `json:"retentionInDays,omitempty"`
 }
 
-//Generated from:
 type CorsRules_StatusARM struct {
 	//CorsRules: The List of CORS rules. You can include up to five CorsRule elements
 	//in the request.
 	CorsRules []CorsRule_StatusARM `json:"corsRules,omitempty"`
 }
 
-//Generated from:
 type DeleteRetentionPolicy_StatusARM struct {
 	//Days: Indicates the number of days that the deleted item should be retained. The
 	//minimum specified value can be 1 and the maximum value can be 365.
@@ -96,7 +91,6 @@ type DeleteRetentionPolicy_StatusARM struct {
 	Enabled *bool `json:"enabled,omitempty"`
 }
 
-//Generated from:
 type LastAccessTimeTrackingPolicy_StatusARM struct {
 	//BlobType: An array of predefined supported blob types. Only blockBlob is the
 	//supported value. This field is currently read only
@@ -115,7 +109,6 @@ type LastAccessTimeTrackingPolicy_StatusARM struct {
 	TrackingGranularityInDays *int `json:"trackingGranularityInDays,omitempty"`
 }
 
-//Generated from:
 type RestorePolicyProperties_StatusARM struct {
 	//Days: how long this blob can be restored. It should be great than zero and less
 	//than DeleteRetentionPolicy.days.
@@ -132,7 +125,6 @@ type RestorePolicyProperties_StatusARM struct {
 	MinRestoreTime *string `json:"minRestoreTime,omitempty"`
 }
 
-//Generated from:
 type SkuName_Status string
 
 const (
@@ -146,7 +138,6 @@ const (
 	SkuName_StatusStandardZRS    = SkuName_Status("Standard_ZRS")
 )
 
-//Generated from:
 type Tier_Status string
 
 const (
@@ -154,7 +145,6 @@ const (
 	Tier_StatusStandard = Tier_Status("Standard")
 )
 
-//Generated from:
 type CorsRule_StatusARM struct {
 	//AllowedHeaders: Required if CorsRule element is present. A list of headers
 	//allowed to be part of the cross-origin request.

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_account__status_arm_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_account__status_arm_types_gen.go
@@ -3,7 +3,6 @@
 // Licensed under the MIT license.
 package v1alpha1api20210401
 
-//Generated from:
 type StorageAccount_StatusARM struct {
 	//ExtendedLocation: The extendedLocation of the resource.
 	ExtendedLocation *ExtendedLocation_StatusARM `json:"extendedLocation,omitempty"`
@@ -38,7 +37,6 @@ type StorageAccount_StatusARM struct {
 	Type *string `json:"type,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocation_StatusARM struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -47,7 +45,6 @@ type ExtendedLocation_StatusARM struct {
 	Type *ExtendedLocationType_Status `json:"type,omitempty"`
 }
 
-//Generated from:
 type Identity_StatusARM struct {
 	//PrincipalId: The principal ID of resource identity.
 	PrincipalId *string `json:"principalId,omitempty"`
@@ -65,7 +62,6 @@ type Identity_StatusARM struct {
 	UserAssignedIdentities map[string]UserAssignedIdentity_StatusARM `json:"userAssignedIdentities,omitempty"`
 }
 
-//Generated from:
 type StorageAccountProperties_StatusARM struct {
 	//AccessTier: Required for storage accounts where kind = BlobStorage. The access
 	//tier used for billing.
@@ -198,7 +194,6 @@ const (
 	StorageAccountStatusKindStorageV2        = StorageAccountStatusKind("StorageV2")
 )
 
-//Generated from:
 type AzureFilesIdentityBasedAuthentication_StatusARM struct {
 	//ActiveDirectoryProperties: Required if choose AD.
 	ActiveDirectoryProperties *ActiveDirectoryProperties_StatusARM `json:"activeDirectoryProperties,omitempty"`
@@ -211,7 +206,6 @@ type AzureFilesIdentityBasedAuthentication_StatusARM struct {
 	DirectoryServiceOptions AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptions `json:"directoryServiceOptions"`
 }
 
-//Generated from:
 type BlobRestoreStatus_StatusARM struct {
 	//FailureReason: Failure reason when blob restore is failed.
 	FailureReason *string `json:"failureReason,omitempty"`
@@ -228,7 +222,6 @@ type BlobRestoreStatus_StatusARM struct {
 	Status *BlobRestoreStatusStatusStatus `json:"status,omitempty"`
 }
 
-//Generated from:
 type CustomDomain_StatusARM struct {
 	//Name: Gets or sets the custom domain name assigned to the storage account. Name
 	//is the CNAME source.
@@ -239,7 +232,6 @@ type CustomDomain_StatusARM struct {
 	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
-//Generated from:
 type Encryption_StatusARM struct {
 	//Identity: The identity to be used with service-side encryption at rest.
 	Identity *EncryptionIdentity_StatusARM `json:"identity,omitempty"`
@@ -260,7 +252,6 @@ type Encryption_StatusARM struct {
 	Services *EncryptionServices_StatusARM `json:"services,omitempty"`
 }
 
-//Generated from:
 type Endpoints_StatusARM struct {
 	//Blob: Gets the blob endpoint.
 	Blob *string `json:"blob,omitempty"`
@@ -287,12 +278,10 @@ type Endpoints_StatusARM struct {
 	Web *string `json:"web,omitempty"`
 }
 
-//Generated from:
 type ExtendedLocationType_Status string
 
 const ExtendedLocationType_StatusEdgeZone = ExtendedLocationType_Status("EdgeZone")
 
-//Generated from:
 type GeoReplicationStats_StatusARM struct {
 	//CanFailover: A boolean flag which indicates whether or not account failover is
 	//supported for the account.
@@ -322,19 +311,16 @@ const (
 	IdentityStatusTypeUserAssigned               = IdentityStatusType("UserAssigned")
 )
 
-//Generated from:
 type KeyCreationTime_StatusARM struct {
 	Key1 *string `json:"key1,omitempty"`
 	Key2 *string `json:"key2,omitempty"`
 }
 
-//Generated from:
 type KeyPolicy_StatusARM struct {
 	//KeyExpirationPeriodInDays: The key expiration period in days.
 	KeyExpirationPeriodInDays int `json:"keyExpirationPeriodInDays"`
 }
 
-//Generated from:
 type NetworkRuleSet_StatusARM struct {
 	//Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices.
 	//Possible values are any combination of Logging|Metrics|AzureServices (For
@@ -355,14 +341,12 @@ type NetworkRuleSet_StatusARM struct {
 	VirtualNetworkRules []VirtualNetworkRule_StatusARM `json:"virtualNetworkRules,omitempty"`
 }
 
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbeddedARM struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	Id *string `json:"id,omitempty"`
 }
 
-//Generated from:
 type RoutingPreference_StatusARM struct {
 	//PublishInternetEndpoints: A boolean flag which indicates whether internet
 	//routing storage endpoints are to be published
@@ -377,7 +361,6 @@ type RoutingPreference_StatusARM struct {
 	RoutingChoice *RoutingPreferenceStatusRoutingChoice `json:"routingChoice,omitempty"`
 }
 
-//Generated from:
 type SasPolicy_StatusARM struct {
 	//ExpirationAction: The SAS expiration action. Can only be Log.
 	ExpirationAction SasPolicyStatusExpirationAction `json:"expirationAction"`
@@ -386,7 +369,6 @@ type SasPolicy_StatusARM struct {
 	SasExpirationPeriod string `json:"sasExpirationPeriod"`
 }
 
-//Generated from:
 type UserAssignedIdentity_StatusARM struct {
 	//ClientId: The client ID of the identity.
 	ClientId *string `json:"clientId,omitempty"`
@@ -395,7 +377,6 @@ type UserAssignedIdentity_StatusARM struct {
 	PrincipalId *string `json:"principalId,omitempty"`
 }
 
-//Generated from:
 type ActiveDirectoryProperties_StatusARM struct {
 	//AzureStorageSid: Specifies the security identifier (SID) for Azure Storage.
 	AzureStorageSid string `json:"azureStorageSid"`
@@ -417,7 +398,6 @@ type ActiveDirectoryProperties_StatusARM struct {
 	NetBiosDomainName string `json:"netBiosDomainName"`
 }
 
-//Generated from:
 type BlobRestoreParameters_StatusARM struct {
 	//BlobRanges: Blob ranges to restore.
 	BlobRanges []BlobRestoreRange_StatusARM `json:"blobRanges"`
@@ -426,14 +406,12 @@ type BlobRestoreParameters_StatusARM struct {
 	TimeToRestore string `json:"timeToRestore"`
 }
 
-//Generated from:
 type EncryptionIdentity_StatusARM struct {
 	//UserAssignedIdentity: Resource identifier of the UserAssigned identity to be
 	//associated with server-side encryption on the storage account.
 	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
 }
 
-//Generated from:
 type EncryptionServices_StatusARM struct {
 	//Blob: The encryption function of the blob storage service.
 	Blob *EncryptionService_StatusARM `json:"blob,omitempty"`
@@ -448,7 +426,6 @@ type EncryptionServices_StatusARM struct {
 	Table *EncryptionService_StatusARM `json:"table,omitempty"`
 }
 
-//Generated from:
 type IPRule_StatusARM struct {
 	//Action: The action of IP ACL rule.
 	Action *IPRuleStatusAction `json:"action,omitempty"`
@@ -457,7 +434,6 @@ type IPRule_StatusARM struct {
 	Value string `json:"value"`
 }
 
-//Generated from:
 type KeyVaultProperties_StatusARM struct {
 	//CurrentVersionedKeyIdentifier: The object identifier of the current versioned
 	//Key Vault Key in use.
@@ -476,7 +452,6 @@ type KeyVaultProperties_StatusARM struct {
 	LastKeyRotationTimestamp *string `json:"lastKeyRotationTimestamp,omitempty"`
 }
 
-//Generated from:
 type ResourceAccessRule_StatusARM struct {
 	//ResourceId: Resource Id
 	ResourceId *string `json:"resourceId,omitempty"`
@@ -485,7 +460,6 @@ type ResourceAccessRule_StatusARM struct {
 	TenantId *string `json:"tenantId,omitempty"`
 }
 
-//Generated from:
 type StorageAccountInternetEndpoints_StatusARM struct {
 	//Blob: Gets the blob endpoint.
 	Blob *string `json:"blob,omitempty"`
@@ -500,7 +474,6 @@ type StorageAccountInternetEndpoints_StatusARM struct {
 	Web *string `json:"web,omitempty"`
 }
 
-//Generated from:
 type StorageAccountMicrosoftEndpoints_StatusARM struct {
 	//Blob: Gets the blob endpoint.
 	Blob *string `json:"blob,omitempty"`
@@ -521,7 +494,6 @@ type StorageAccountMicrosoftEndpoints_StatusARM struct {
 	Web *string `json:"web,omitempty"`
 }
 
-//Generated from:
 type VirtualNetworkRule_StatusARM struct {
 	//Action: The action of virtual network rule.
 	Action *VirtualNetworkRuleStatusAction `json:"action,omitempty"`
@@ -534,7 +506,6 @@ type VirtualNetworkRule_StatusARM struct {
 	State *VirtualNetworkRuleStatusState `json:"state,omitempty"`
 }
 
-//Generated from:
 type BlobRestoreRange_StatusARM struct {
 	//EndRange: Blob end range. This is exclusive. Empty means account end.
 	EndRange string `json:"endRange"`
@@ -543,7 +514,6 @@ type BlobRestoreRange_StatusARM struct {
 	StartRange string `json:"startRange"`
 }
 
-//Generated from:
 type EncryptionService_StatusARM struct {
 	//Enabled: A boolean indicating whether or not the service encrypts the data as it
 	//is stored.

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
@@ -283,7 +283,6 @@ type StorageAccountList struct {
 	Items           []StorageAccount `json:"items"`
 }
 
-//Generated from:
 type StorageAccount_Status struct {
 	//AccessTier: Required for storage accounts where kind = BlobStorage. The access
 	//tier used for billing.
@@ -2778,7 +2777,6 @@ func (azureFilesIdentityBasedAuthentication *AzureFilesIdentityBasedAuthenticati
 	return nil
 }
 
-//Generated from:
 type AzureFilesIdentityBasedAuthentication_Status struct {
 	//ActiveDirectoryProperties: Required if choose AD.
 	ActiveDirectoryProperties *ActiveDirectoryProperties_Status `json:"activeDirectoryProperties,omitempty"`
@@ -2904,7 +2902,6 @@ func (azureFilesIdentityBasedAuthenticationStatus *AzureFilesIdentityBasedAuthen
 	return nil
 }
 
-//Generated from:
 type BlobRestoreStatus_Status struct {
 	//FailureReason: Failure reason when blob restore is failed.
 	FailureReason *string `json:"failureReason,omitempty"`
@@ -3146,7 +3143,6 @@ func (customDomain *CustomDomain) AssignPropertiesToCustomDomain(destination *v1
 	return nil
 }
 
-//Generated from:
 type CustomDomain_Status struct {
 	// +kubebuilder:validation:Required
 	//Name: Gets or sets the custom domain name assigned to the storage account. Name
@@ -3483,7 +3479,6 @@ func (encryption *Encryption) AssignPropertiesToEncryption(destination *v1alpha1
 	return nil
 }
 
-//Generated from:
 type Encryption_Status struct {
 	//Identity: The identity to be used with service-side encryption at rest.
 	Identity *EncryptionIdentity_Status `json:"identity,omitempty"`
@@ -3687,7 +3682,6 @@ func (encryptionStatus *Encryption_Status) AssignPropertiesToEncryptionStatus(de
 	return nil
 }
 
-//Generated from:
 type Endpoints_Status struct {
 	//Blob: Gets the blob endpoint.
 	Blob *string `json:"blob,omitempty"`
@@ -4002,7 +3996,6 @@ func (extendedLocation *ExtendedLocation) AssignPropertiesToExtendedLocation(des
 	return nil
 }
 
-//Generated from:
 type ExtendedLocation_Status struct {
 	//Name: The name of the extended location.
 	Name *string `json:"name,omitempty"`
@@ -4086,7 +4079,6 @@ func (extendedLocationStatus *ExtendedLocation_Status) AssignPropertiesToExtende
 	return nil
 }
 
-//Generated from:
 type GeoReplicationStats_Status struct {
 	//CanFailover: A boolean flag which indicates whether or not account failover is
 	//supported for the account.
@@ -4278,7 +4270,6 @@ func (identity *Identity) AssignPropertiesToIdentity(destination *v1alpha1api202
 	return nil
 }
 
-//Generated from:
 type Identity_Status struct {
 	//PrincipalId: The principal ID of resource identity.
 	PrincipalId *string `json:"principalId,omitempty"`
@@ -4425,7 +4416,6 @@ func (identityStatus *Identity_Status) AssignPropertiesToIdentityStatus(destinat
 	return nil
 }
 
-//Generated from:
 type KeyCreationTime_Status struct {
 	Key1 *string `json:"key1,omitempty"`
 	Key2 *string `json:"key2,omitempty"`
@@ -4566,7 +4556,6 @@ func (keyPolicy *KeyPolicy) AssignPropertiesToKeyPolicy(destination *v1alpha1api
 	return nil
 }
 
-//Generated from:
 type KeyPolicy_Status struct {
 	// +kubebuilder:validation:Required
 	//KeyExpirationPeriodInDays: The key expiration period in days.
@@ -4906,7 +4895,6 @@ func (networkRuleSet *NetworkRuleSet) AssignPropertiesToNetworkRuleSet(destinati
 	return nil
 }
 
-//Generated from:
 type NetworkRuleSet_Status struct {
 	//Bypass: Specifies whether traffic is bypassed for Logging/Metrics/AzureServices.
 	//Possible values are any combination of Logging|Metrics|AzureServices (For
@@ -5143,7 +5131,6 @@ func (networkRuleSetStatus *NetworkRuleSet_Status) AssignPropertiesToNetworkRule
 	return nil
 }
 
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbedded struct {
 	//Id: Fully qualified resource ID for the resource. Ex -
 	///subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -5352,7 +5339,6 @@ func (routingPreference *RoutingPreference) AssignPropertiesToRoutingPreference(
 	return nil
 }
 
-//Generated from:
 type RoutingPreference_Status struct {
 	//PublishInternetEndpoints: A boolean flag which indicates whether internet
 	//routing storage endpoints are to be published
@@ -5565,7 +5551,6 @@ func (sasPolicy *SasPolicy) AssignPropertiesToSasPolicy(destination *v1alpha1api
 	return nil
 }
 
-//Generated from:
 type SasPolicy_Status struct {
 	// +kubebuilder:validation:Required
 	//ExpirationAction: The SAS expiration action. Can only be Log.
@@ -5743,7 +5728,6 @@ func (sku *Sku) AssignPropertiesToSku(destination *v1alpha1api20210401storage.Sk
 	return nil
 }
 
-//Generated from:
 type Sku_Status struct {
 	// +kubebuilder:validation:Required
 	Name SkuName_Status `json:"name"`
@@ -6052,7 +6036,6 @@ func (activeDirectoryProperties *ActiveDirectoryProperties) AssignPropertiesToAc
 	return nil
 }
 
-//Generated from:
 type ActiveDirectoryProperties_Status struct {
 	// +kubebuilder:validation:Required
 	//AzureStorageSid: Specifies the security identifier (SID) for Azure Storage.
@@ -6219,7 +6202,6 @@ const (
 	AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptionsNone  = AzureFilesIdentityBasedAuthenticationStatusDirectoryServiceOptions("None")
 )
 
-//Generated from:
 type BlobRestoreParameters_Status struct {
 	// +kubebuilder:validation:Required
 	//BlobRanges: Blob ranges to restore.
@@ -6420,7 +6402,6 @@ func (encryptionIdentity *EncryptionIdentity) AssignPropertiesToEncryptionIdenti
 	return nil
 }
 
-//Generated from:
 type EncryptionIdentity_Status struct {
 	//UserAssignedIdentity: Resource identifier of the UserAssigned identity to be
 	//associated with server-side encryption on the storage account.
@@ -6733,7 +6714,6 @@ func (encryptionServices *EncryptionServices) AssignPropertiesToEncryptionServic
 	return nil
 }
 
-//Generated from:
 type EncryptionServices_Status struct {
 	//Blob: The encryption function of the blob storage service.
 	Blob *EncryptionService_Status `json:"blob,omitempty"`
@@ -7045,7 +7025,6 @@ func (ipRule *IPRule) AssignPropertiesToIPRule(destination *v1alpha1api20210401s
 	return nil
 }
 
-//Generated from:
 type IPRule_Status struct {
 	//Action: The action of IP ACL rule.
 	Action *IPRuleStatusAction `json:"action,omitempty"`
@@ -7244,7 +7223,6 @@ func (keyVaultProperties *KeyVaultProperties) AssignPropertiesToKeyVaultProperti
 	return nil
 }
 
-//Generated from:
 type KeyVaultProperties_Status struct {
 	//CurrentVersionedKeyIdentifier: The object identifier of the current versioned
 	//Key Vault Key in use.
@@ -7503,7 +7481,6 @@ func (resourceAccessRule *ResourceAccessRule) AssignPropertiesToResourceAccessRu
 	return nil
 }
 
-//Generated from:
 type ResourceAccessRule_Status struct {
 	//ResourceId: Resource Id
 	ResourceId *string `json:"resourceId,omitempty"`
@@ -7601,7 +7578,6 @@ type SasPolicyStatusExpirationAction string
 
 const SasPolicyStatusExpirationActionLog = SasPolicyStatusExpirationAction("Log")
 
-//Generated from:
 type StorageAccountInternetEndpoints_Status struct {
 	//Blob: Gets the blob endpoint.
 	Blob *string `json:"blob,omitempty"`
@@ -7705,7 +7681,6 @@ func (storageAccountInternetEndpointsStatus *StorageAccountInternetEndpoints_Sta
 	return nil
 }
 
-//Generated from:
 type StorageAccountMicrosoftEndpoints_Status struct {
 	//Blob: Gets the blob endpoint.
 	Blob *string `json:"blob,omitempty"`
@@ -7839,7 +7814,6 @@ func (storageAccountMicrosoftEndpointsStatus *StorageAccountMicrosoftEndpoints_S
 	return nil
 }
 
-//Generated from:
 type UserAssignedIdentity_Status struct {
 	//ClientId: The client ID of the identity.
 	ClientId *string `json:"clientId,omitempty"`
@@ -8048,7 +8022,6 @@ func (virtualNetworkRule *VirtualNetworkRule) AssignPropertiesToVirtualNetworkRu
 	return nil
 }
 
-//Generated from:
 type VirtualNetworkRule_Status struct {
 	//Action: The action of virtual network rule.
 	Action *VirtualNetworkRuleStatusAction `json:"action,omitempty"`
@@ -8157,7 +8130,6 @@ func (virtualNetworkRuleStatus *VirtualNetworkRule_Status) AssignPropertiesToVir
 	return nil
 }
 
-//Generated from:
 type BlobRestoreRange_Status struct {
 	// +kubebuilder:validation:Required
 	//EndRange: Blob end range. This is exclusive. Empty means account end.
@@ -8347,7 +8319,6 @@ func (encryptionService *EncryptionService) AssignPropertiesToEncryptionService(
 	return nil
 }
 
-//Generated from:
 type EncryptionService_Status struct {
 	//Enabled: A boolean indicating whether or not the service encrypts the data as it
 	//is stored.

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
@@ -276,7 +276,6 @@ type StorageAccountsBlobServiceList struct {
 	Items           []StorageAccountsBlobService `json:"items"`
 }
 
-//Generated from:
 type BlobServiceProperties_Status struct {
 	//AutomaticSnapshotPolicyEnabled: Deprecated in favor of isVersioningEnabled
 	//property.
@@ -1484,7 +1483,6 @@ func (changeFeed *ChangeFeed) AssignPropertiesToChangeFeed(destination *v1alpha1
 	return nil
 }
 
-//Generated from:
 type ChangeFeed_Status struct {
 	//Enabled: Indicates whether change feed event logging is enabled for the Blob
 	//service.
@@ -1683,7 +1681,6 @@ func (corsRules *CorsRules) AssignPropertiesToCorsRules(destination *v1alpha1api
 	return nil
 }
 
-//Generated from:
 type CorsRules_Status struct {
 	//CorsRules: The List of CORS rules. You can include up to five CorsRule elements
 	//in the request.
@@ -1895,7 +1892,6 @@ func (deleteRetentionPolicy *DeleteRetentionPolicy) AssignPropertiesToDeleteRete
 	return nil
 }
 
-//Generated from:
 type DeleteRetentionPolicy_Status struct {
 	//Days: Indicates the number of days that the deleted item should be retained. The
 	//minimum specified value can be 1 and the maximum value can be 365.
@@ -2129,7 +2125,6 @@ func (lastAccessTimeTrackingPolicy *LastAccessTimeTrackingPolicy) AssignProperti
 	return nil
 }
 
-//Generated from:
 type LastAccessTimeTrackingPolicy_Status struct {
 	//BlobType: An array of predefined supported blob types. Only blockBlob is the
 	//supported value. This field is currently read only
@@ -2357,7 +2352,6 @@ func (restorePolicyProperties *RestorePolicyProperties) AssignPropertiesToRestor
 	return nil
 }
 
-//Generated from:
 type RestorePolicyProperties_Status struct {
 	//Days: how long this blob can be restored. It should be great than zero and less
 	//than DeleteRetentionPolicy.days.
@@ -2641,7 +2635,6 @@ func (corsRule *CorsRule) AssignPropertiesToCorsRule(destination *v1alpha1api202
 	return nil
 }
 
-//Generated from:
 type CorsRule_Status struct {
 	// +kubebuilder:validation:Required
 	//AllowedHeaders: Required if CorsRule element is present. A list of headers

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
@@ -285,7 +285,6 @@ type StorageAccountsBlobServicesContainerList struct {
 	Items           []StorageAccountsBlobServicesContainer `json:"items"`
 }
 
-//Generated from:
 type BlobContainer_Status struct {
 	//Conditions: The observed state of the resource
 	Conditions []conditions.Condition `json:"conditions,omitempty"`
@@ -1298,7 +1297,6 @@ const (
 	ContainerPropertiesPublicAccessNone      = ContainerPropertiesPublicAccess("None")
 )
 
-//Generated from:
 type ImmutabilityPolicyProperties_Status struct {
 	//AllowProtectedAppendWrites: This property can only be changed for unlocked
 	//time-based retention policies. When enabled, new blocks can be written to an
@@ -1571,7 +1569,6 @@ func (immutableStorageWithVersioning *ImmutableStorageWithVersioning) AssignProp
 	return nil
 }
 
-//Generated from:
 type ImmutableStorageWithVersioning_Status struct {
 	//Enabled: This is an immutable property, when set to true it enables object level
 	//immutability at the container level.
@@ -1682,7 +1679,6 @@ func (immutableStorageWithVersioningStatus *ImmutableStorageWithVersioning_Statu
 	return nil
 }
 
-//Generated from:
 type LegalHoldProperties_Status struct {
 	//HasLegalHold: The hasLegalHold public property is set to true by SRP if there
 	//are at least one existing tag. The hasLegalHold public property is set to false
@@ -1810,7 +1806,6 @@ const (
 	ImmutabilityPolicyPropertyStatusStateUnlocked = ImmutabilityPolicyPropertyStatusState("Unlocked")
 )
 
-//Generated from:
 type TagProperty_Status struct {
 	//ObjectIdentifier: Returns the Object ID of the user who added the tag.
 	ObjectIdentifier *string `json:"objectIdentifier,omitempty"`
@@ -1930,7 +1925,6 @@ func (tagPropertyStatus *TagProperty_Status) AssignPropertiesToTagPropertyStatus
 	return nil
 }
 
-//Generated from:
 type UpdateHistoryProperty_Status struct {
 	//ImmutabilityPeriodSinceCreationInDays: The immutability period for the blobs in
 	//the container since the policy creation, in days.

--- a/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_account_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_account_types_gen.go
@@ -124,7 +124,6 @@ type StorageAccountList struct {
 }
 
 //Storage version of v1alpha1api20210401.StorageAccount_Status
-//Generated from:
 type StorageAccount_Status struct {
 	AccessTier                            *string                                                `json:"accessTier,omitempty"`
 	AllowBlobPublicAccess                 *bool                                                  `json:"allowBlobPublicAccess,omitempty"`
@@ -256,7 +255,6 @@ type AzureFilesIdentityBasedAuthentication struct {
 }
 
 //Storage version of v1alpha1api20210401.AzureFilesIdentityBasedAuthentication_Status
-//Generated from:
 type AzureFilesIdentityBasedAuthentication_Status struct {
 	ActiveDirectoryProperties *ActiveDirectoryProperties_Status `json:"activeDirectoryProperties,omitempty"`
 	DefaultSharePermission    *string                           `json:"defaultSharePermission,omitempty"`
@@ -265,7 +263,6 @@ type AzureFilesIdentityBasedAuthentication_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.BlobRestoreStatus_Status
-//Generated from:
 type BlobRestoreStatus_Status struct {
 	FailureReason *string                       `json:"failureReason,omitempty"`
 	Parameters    *BlobRestoreParameters_Status `json:"parameters,omitempty"`
@@ -283,7 +280,6 @@ type CustomDomain struct {
 }
 
 //Storage version of v1alpha1api20210401.CustomDomain_Status
-//Generated from:
 type CustomDomain_Status struct {
 	Name             *string                `json:"name,omitempty"`
 	PropertyBag      genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -302,7 +298,6 @@ type Encryption struct {
 }
 
 //Storage version of v1alpha1api20210401.Encryption_Status
-//Generated from:
 type Encryption_Status struct {
 	Identity                        *EncryptionIdentity_Status `json:"identity,omitempty"`
 	KeySource                       *string                    `json:"keySource,omitempty"`
@@ -313,7 +308,6 @@ type Encryption_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.Endpoints_Status
-//Generated from:
 type Endpoints_Status struct {
 	Blob               *string                                  `json:"blob,omitempty"`
 	Dfs                *string                                  `json:"dfs,omitempty"`
@@ -335,7 +329,6 @@ type ExtendedLocation struct {
 }
 
 //Storage version of v1alpha1api20210401.ExtendedLocation_Status
-//Generated from:
 type ExtendedLocation_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -343,7 +336,6 @@ type ExtendedLocation_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.GeoReplicationStats_Status
-//Generated from:
 type GeoReplicationStats_Status struct {
 	CanFailover  *bool                  `json:"canFailover,omitempty"`
 	LastSyncTime *string                `json:"lastSyncTime,omitempty"`
@@ -359,7 +351,6 @@ type Identity struct {
 }
 
 //Storage version of v1alpha1api20210401.Identity_Status
-//Generated from:
 type Identity_Status struct {
 	PrincipalId            *string                                `json:"principalId,omitempty"`
 	PropertyBag            genruntime.PropertyBag                 `json:"$propertyBag,omitempty"`
@@ -369,7 +360,6 @@ type Identity_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.KeyCreationTime_Status
-//Generated from:
 type KeyCreationTime_Status struct {
 	Key1        *string                `json:"key1,omitempty"`
 	Key2        *string                `json:"key2,omitempty"`
@@ -384,7 +374,6 @@ type KeyPolicy struct {
 }
 
 //Storage version of v1alpha1api20210401.KeyPolicy_Status
-//Generated from:
 type KeyPolicy_Status struct {
 	KeyExpirationPeriodInDays *int                   `json:"keyExpirationPeriodInDays,omitempty"`
 	PropertyBag               genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -402,7 +391,6 @@ type NetworkRuleSet struct {
 }
 
 //Storage version of v1alpha1api20210401.NetworkRuleSet_Status
-//Generated from:
 type NetworkRuleSet_Status struct {
 	Bypass              *string                     `json:"bypass,omitempty"`
 	DefaultAction       *string                     `json:"defaultAction,omitempty"`
@@ -413,7 +401,6 @@ type NetworkRuleSet_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.PrivateEndpointConnection_Status_SubResourceEmbedded
-//Generated from:
 type PrivateEndpointConnection_Status_SubResourceEmbedded struct {
 	Id          *string                `json:"id,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -429,7 +416,6 @@ type RoutingPreference struct {
 }
 
 //Storage version of v1alpha1api20210401.RoutingPreference_Status
-//Generated from:
 type RoutingPreference_Status struct {
 	PropertyBag               genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	PublishInternetEndpoints  *bool                  `json:"publishInternetEndpoints,omitempty"`
@@ -446,7 +432,6 @@ type SasPolicy struct {
 }
 
 //Storage version of v1alpha1api20210401.SasPolicy_Status
-//Generated from:
 type SasPolicy_Status struct {
 	ExpirationAction    *string                `json:"expirationAction,omitempty"`
 	PropertyBag         genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -462,7 +447,6 @@ type Sku struct {
 }
 
 //Storage version of v1alpha1api20210401.Sku_Status
-//Generated from:
 type Sku_Status struct {
 	Name        *string                `json:"name,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -482,7 +466,6 @@ type ActiveDirectoryProperties struct {
 }
 
 //Storage version of v1alpha1api20210401.ActiveDirectoryProperties_Status
-//Generated from:
 type ActiveDirectoryProperties_Status struct {
 	AzureStorageSid   *string                `json:"azureStorageSid,omitempty"`
 	DomainGuid        *string                `json:"domainGuid,omitempty"`
@@ -494,7 +477,6 @@ type ActiveDirectoryProperties_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.BlobRestoreParameters_Status
-//Generated from:
 type BlobRestoreParameters_Status struct {
 	BlobRanges    []BlobRestoreRange_Status `json:"blobRanges,omitempty"`
 	PropertyBag   genruntime.PropertyBag    `json:"$propertyBag,omitempty"`
@@ -512,7 +494,6 @@ type EncryptionIdentity struct {
 }
 
 //Storage version of v1alpha1api20210401.EncryptionIdentity_Status
-//Generated from:
 type EncryptionIdentity_Status struct {
 	PropertyBag          genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	UserAssignedIdentity *string                `json:"userAssignedIdentity,omitempty"`
@@ -529,7 +510,6 @@ type EncryptionServices struct {
 }
 
 //Storage version of v1alpha1api20210401.EncryptionServices_Status
-//Generated from:
 type EncryptionServices_Status struct {
 	Blob        *EncryptionService_Status `json:"blob,omitempty"`
 	File        *EncryptionService_Status `json:"file,omitempty"`
@@ -547,7 +527,6 @@ type IPRule struct {
 }
 
 //Storage version of v1alpha1api20210401.IPRule_Status
-//Generated from:
 type IPRule_Status struct {
 	Action      *string                `json:"action,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -564,7 +543,6 @@ type KeyVaultProperties struct {
 }
 
 //Storage version of v1alpha1api20210401.KeyVaultProperties_Status
-//Generated from:
 type KeyVaultProperties_Status struct {
 	CurrentVersionedKeyIdentifier *string                `json:"currentVersionedKeyIdentifier,omitempty"`
 	Keyname                       *string                `json:"keyname,omitempty"`
@@ -585,7 +563,6 @@ type ResourceAccessRule struct {
 }
 
 //Storage version of v1alpha1api20210401.ResourceAccessRule_Status
-//Generated from:
 type ResourceAccessRule_Status struct {
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
 	ResourceId  *string                `json:"resourceId,omitempty"`
@@ -593,7 +570,6 @@ type ResourceAccessRule_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.StorageAccountInternetEndpoints_Status
-//Generated from:
 type StorageAccountInternetEndpoints_Status struct {
 	Blob        *string                `json:"blob,omitempty"`
 	Dfs         *string                `json:"dfs,omitempty"`
@@ -603,7 +579,6 @@ type StorageAccountInternetEndpoints_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.StorageAccountMicrosoftEndpoints_Status
-//Generated from:
 type StorageAccountMicrosoftEndpoints_Status struct {
 	Blob        *string                `json:"blob,omitempty"`
 	Dfs         *string                `json:"dfs,omitempty"`
@@ -615,7 +590,6 @@ type StorageAccountMicrosoftEndpoints_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.UserAssignedIdentity_Status
-//Generated from:
 type UserAssignedIdentity_Status struct {
 	ClientId    *string                `json:"clientId,omitempty"`
 	PrincipalId *string                `json:"principalId,omitempty"`
@@ -636,7 +610,6 @@ type VirtualNetworkRule struct {
 }
 
 //Storage version of v1alpha1api20210401.VirtualNetworkRule_Status
-//Generated from:
 type VirtualNetworkRule_Status struct {
 	Action      *string                `json:"action,omitempty"`
 	Id          *string                `json:"id,omitempty"`
@@ -645,7 +618,6 @@ type VirtualNetworkRule_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.BlobRestoreRange_Status
-//Generated from:
 type BlobRestoreRange_Status struct {
 	EndRange    *string                `json:"endRange,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -661,7 +633,6 @@ type EncryptionService struct {
 }
 
 //Storage version of v1alpha1api20210401.EncryptionService_Status
-//Generated from:
 type EncryptionService_Status struct {
 	Enabled         *bool                  `json:"enabled,omitempty"`
 	KeyType         *string                `json:"keyType,omitempty"`

--- a/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_service_types_gen.go
@@ -124,7 +124,6 @@ type StorageAccountsBlobServiceList struct {
 }
 
 //Storage version of v1alpha1api20210401.BlobServiceProperties_Status
-//Generated from:
 type BlobServiceProperties_Status struct {
 	AutomaticSnapshotPolicyEnabled *bool                                `json:"automaticSnapshotPolicyEnabled,omitempty"`
 	ChangeFeed                     *ChangeFeed_Status                   `json:"changeFeed,omitempty"`
@@ -212,7 +211,6 @@ type ChangeFeed struct {
 }
 
 //Storage version of v1alpha1api20210401.ChangeFeed_Status
-//Generated from:
 type ChangeFeed_Status struct {
 	Enabled         *bool                  `json:"enabled,omitempty"`
 	PropertyBag     genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -227,7 +225,6 @@ type CorsRules struct {
 }
 
 //Storage version of v1alpha1api20210401.CorsRules_Status
-//Generated from:
 type CorsRules_Status struct {
 	CorsRules   []CorsRule_Status      `json:"corsRules,omitempty"`
 	PropertyBag genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -242,7 +239,6 @@ type DeleteRetentionPolicy struct {
 }
 
 //Storage version of v1alpha1api20210401.DeleteRetentionPolicy_Status
-//Generated from:
 type DeleteRetentionPolicy_Status struct {
 	Days        *int                   `json:"days,omitempty"`
 	Enabled     *bool                  `json:"enabled,omitempty"`
@@ -260,7 +256,6 @@ type LastAccessTimeTrackingPolicy struct {
 }
 
 //Storage version of v1alpha1api20210401.LastAccessTimeTrackingPolicy_Status
-//Generated from:
 type LastAccessTimeTrackingPolicy_Status struct {
 	BlobType                  []string               `json:"blobType,omitempty"`
 	Enable                    *bool                  `json:"enable,omitempty"`
@@ -278,7 +273,6 @@ type RestorePolicyProperties struct {
 }
 
 //Storage version of v1alpha1api20210401.RestorePolicyProperties_Status
-//Generated from:
 type RestorePolicyProperties_Status struct {
 	Days            *int                   `json:"days,omitempty"`
 	Enabled         *bool                  `json:"enabled,omitempty"`
@@ -299,7 +293,6 @@ type CorsRule struct {
 }
 
 //Storage version of v1alpha1api20210401.CorsRule_Status
-//Generated from:
 type CorsRule_Status struct {
 	AllowedHeaders  []string               `json:"allowedHeaders,omitempty"`
 	AllowedMethods  []string               `json:"allowedMethods,omitempty"`

--- a/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401storage/storage_accounts_blob_services_container_types_gen.go
@@ -124,7 +124,6 @@ type StorageAccountsBlobServicesContainerList struct {
 }
 
 //Storage version of v1alpha1api20210401.BlobContainer_Status
-//Generated from:
 type BlobContainer_Status struct {
 	Conditions                     []conditions.Condition                 `json:"conditions,omitempty"`
 	DefaultEncryptionScope         *string                                `json:"defaultEncryptionScope,omitempty"`
@@ -213,7 +212,6 @@ func (storageAccountsBlobServicesContainersSpec *StorageAccountsBlobServicesCont
 }
 
 //Storage version of v1alpha1api20210401.ImmutabilityPolicyProperties_Status
-//Generated from:
 type ImmutabilityPolicyProperties_Status struct {
 	AllowProtectedAppendWrites            *bool                          `json:"allowProtectedAppendWrites,omitempty"`
 	Etag                                  *string                        `json:"etag,omitempty"`
@@ -231,7 +229,6 @@ type ImmutableStorageWithVersioning struct {
 }
 
 //Storage version of v1alpha1api20210401.ImmutableStorageWithVersioning_Status
-//Generated from:
 type ImmutableStorageWithVersioning_Status struct {
 	Enabled        *bool                  `json:"enabled,omitempty"`
 	MigrationState *string                `json:"migrationState,omitempty"`
@@ -240,7 +237,6 @@ type ImmutableStorageWithVersioning_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.LegalHoldProperties_Status
-//Generated from:
 type LegalHoldProperties_Status struct {
 	HasLegalHold *bool                  `json:"hasLegalHold,omitempty"`
 	PropertyBag  genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -248,7 +244,6 @@ type LegalHoldProperties_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.TagProperty_Status
-//Generated from:
 type TagProperty_Status struct {
 	ObjectIdentifier *string                `json:"objectIdentifier,omitempty"`
 	PropertyBag      genruntime.PropertyBag `json:"$propertyBag,omitempty"`
@@ -259,7 +254,6 @@ type TagProperty_Status struct {
 }
 
 //Storage version of v1alpha1api20210401.UpdateHistoryProperty_Status
-//Generated from:
 type UpdateHistoryProperty_Status struct {
 	ImmutabilityPeriodSinceCreationInDays *int                   `json:"immutabilityPeriodSinceCreationInDays,omitempty"`
 	ObjectIdentifier                      *string                `json:"objectIdentifier,omitempty"`

--- a/v2/tools/generator/internal/jsonast/jsonast.go
+++ b/v2/tools/generator/internal/jsonast/jsonast.go
@@ -689,10 +689,16 @@ func generateDefinitionsFor(
 		result = astmodel.NewAzureResourceType(result, nil, typeName, *resourceType)
 	}
 
-	description := []string{
-		fmt.Sprintf("Generated from: %s", schema.url().String()),
+	definition := astmodel.MakeTypeDefinition(typeName, result)
+
+	// Add URL reference if we have one
+	if schema.url().String()!="" {
+		description := []string{
+			fmt.Sprintf("Generated from: %s", schema.url().String()),
+		}
+		
+		definition = definition.WithDescription(description)
 	}
-	definition := astmodel.MakeTypeDefinition(typeName, result).WithDescription(description)
 
 	scanner.addTypeDefinition(definition)
 

--- a/v2/tools/generator/internal/jsonast/jsonast.go
+++ b/v2/tools/generator/internal/jsonast/jsonast.go
@@ -692,11 +692,11 @@ func generateDefinitionsFor(
 	definition := astmodel.MakeTypeDefinition(typeName, result)
 
 	// Add URL reference if we have one
-	if schema.url().String()!="" {
+	if schema.url().String() != "" {
 		description := []string{
 			fmt.Sprintf("Generated from: %s", schema.url().String()),
 		}
-		
+
 		definition = definition.WithDescription(description)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The "Generated from:" comment is quite useful, but only when it has a reference URL; when that URL is missing, the comment is just noise. This PR removes those noise comments.

**Special notes for your reviewer**:

Key change is a few lines in `jsonast.go`; the rest of the PR is just the consequences of regeneration.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/2dnTHovkLt6Yo/giphy.gif)

**Change breakdown**

```
 PS> git diff main --dirstat=lines,0
   0.9% hack/crossplane/apis/microsoft.cache/v1alpha1api20200601/
   0.8% hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/
   0.3% v2/api/microsoft.authorization/v1alpha1api20200801preview/
   0.1% v2/api/microsoft.authorization/v1alpha1api20200801previewstorage/
   2.6% v2/api/microsoft.batch/v1alpha1api20210101/
   1.0% v2/api/microsoft.batch/v1alpha1api20210101storage/
   3.2% v2/api/microsoft.compute/v1alpha1api20200930/
   1.3% v2/api/microsoft.compute/v1alpha1api20200930storage/
  11.8% v2/api/microsoft.compute/v1alpha1api20201201/
   5.1% v2/api/microsoft.compute/v1alpha1api20201201storage/
   7.6% v2/api/microsoft.containerservice/v1alpha1api20210501/
   3.1% v2/api/microsoft.containerservice/v1alpha1api20210501storage/
   2.5% v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/
   1.0% v2/api/microsoft.dbforpostgresql/v1alpha1api20210601storage/
   9.9% v2/api/microsoft.documentdb/v1alpha1api20210515/
   4.1% v2/api/microsoft.documentdb/v1alpha1api20210515storage/
   1.1% v2/api/microsoft.eventgrid/v1alpha1api20200601/
   0.5% v2/api/microsoft.eventgrid/v1alpha1api20200601storage/
   0.3% v2/api/microsoft.managedidentity/v1alpha1api20181130/
   0.1% v2/api/microsoft.managedidentity/v1alpha1api20181130storage/
  16.2% v2/api/microsoft.network/v1alpha1api20201101/
   6.2% v2/api/microsoft.network/v1alpha1api20201101storage/
   2.9% v2/api/microsoft.servicebus/v1alpha1api20210101preview/
   1.2% v2/api/microsoft.servicebus/v1alpha1api20210101previewstorage/
   9.5% v2/api/microsoft.storage/v1alpha1api20210401/
   4.4% v2/api/microsoft.storage/v1alpha1api20210401storage/
   1.2% v2/tools/generator/internal/jsonast/
```