### PR TITLE
Improve the generated versions report to show ARM API versions

### DIFF
--- a/hack/crossplane/apis/resources.md
+++ b/hack/crossplane/apis/resources.md
@@ -1,13 +1,19 @@
 ### microsoft.cache
 
-v1alpha1api20200601
 
-- Redis
+#### ARM version 2020-06-01
+
+- github.com/Azure/azure-service-operator/hack/crossplane/apis/microsoft.cache/v1alpha1api20200601/Redis
+
+Use CRD version `v1alpha1api20200601`
 
 ### microsoft.sql
 
-v1alpha1api20201101preview
 
-- Server
-- ServersDatabase
+#### ARM version 2020-11-01-preview
+
+- github.com/Azure/azure-service-operator/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/Server
+- github.com/Azure/azure-service-operator/hack/crossplane/apis/microsoft.sql/v1alpha1api20201101preview/ServersDatabase
+
+Use CRD version `v1alpha1api20201101preview`
 

--- a/v2/api/resources.md
+++ b/v2/api/resources.md
@@ -1,44 +1,63 @@
 ### microsoft.authorization
 
-v1alpha1api20200801preview
+
+#### ARM version 2020-08-01-preview
 
 - RoleAssignment ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.authorization/v1alpha1api20200801preview_roleassignment.yaml))
 
+Use CRD version `v1alpha1api20200801preview`
+
 ### microsoft.batch
 
-v1alpha1api20210101
+
+#### ARM version 2021-01-01
 
 - BatchAccount ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.batch/v1alpha1api20210101_batchaccount.yaml))
 
+Use CRD version `v1alpha1api20210101`
+
 ### microsoft.compute
 
-v1alpha1api20200930
+
+#### ARM version 2020-09-30
 
 - Disk ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.compute/v1alpha1api20200930_disk.yaml))
 
-v1alpha1api20201201
+Use CRD version `v1alpha1api20200930`
+
+
+#### ARM version 2020-12-01
 
 - VirtualMachine ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.compute/v1alpha1api20201201_virtualmachine.yaml))
 - VirtualMachineScaleSet ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.compute/v1alpha1api20201201_virtualmachinescaleset.yaml))
 
+Use CRD version `v1alpha1api20201201`
+
 ### microsoft.containerservice
 
-v1alpha1api20210501
+
+#### ARM version 2021-05-01
 
 - ManagedCluster ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.containerservice/v1alpha1api20210501_managedcluster.yaml))
 - ManagedClustersAgentPool ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.containerservice/v1alpha1api20210501_managedclustersagentpool.yaml))
 
+Use CRD version `v1alpha1api20210501`
+
 ### microsoft.dbforpostgresql
 
-v1alpha1api20210601
+
+#### ARM version 2021-06-01
 
 - FlexibleServer ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.dbforpostgresql/v1alpha1api20210601_flexibleserver.yaml))
 - FlexibleServersDatabase ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.dbforpostgresql/v1alpha1api20210601_flexibleserversdatabase.yaml))
 - FlexibleServersFirewallRule ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.dbforpostgresql/v1alpha1api20210601_flexibleserversfirewallrule.yaml))
 
+Use CRD version `v1alpha1api20210601`
+
 ### microsoft.documentdb
 
-v1alpha1api20210515
+
+#### ARM version 2021-05-15
 
 - DatabaseAccount ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.documentdb/v1alpha1api20210515_databaseaccount.yaml))
 - MongodbDatabase ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.documentdb/v1alpha1api20210515_mongodbdatabase.yaml))
@@ -53,15 +72,21 @@ v1alpha1api20210515
 - SqlDatabaseContainerUserDefinedFunction ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.documentdb/v1alpha1api20210515_sqldatabasecontaineruserdefinedfunction.yaml))
 - SqlDatabaseThroughputSetting ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.documentdb/v1alpha1api20210515_sqldatabasethroughputsetting.yaml))
 
+Use CRD version `v1alpha1api20210515`
+
 ### microsoft.eventgrid
 
-v1alpha1api20200601
+
+#### ARM version 2020-06-01
 
 - Topic ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.eventgrid/v1alpha1api20200601_topic.yaml))
 
+Use CRD version `v1alpha1api20200601`
+
 ### microsoft.eventhub
 
-v1alpha1api20211101
+
+#### ARM version 2021-11-01
 
 - Namespace ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.eventhub/v1alpha1api20211101_namespace.yaml))
 - NamespacesAuthorizationRule ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.eventhub/v1alpha1api20211101_namespacesauthorizationrule.yaml))
@@ -69,15 +94,21 @@ v1alpha1api20211101
 - NamespacesEventhubsAuthorizationRule ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.eventhub/v1alpha1api20211101_namespaceseventhubsauthorizationrule.yaml))
 - NamespacesEventhubsConsumerGroup ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.eventhub/v1alpha1api20211101_namespaceseventhubsconsumergroup.yaml))
 
+Use CRD version `v1alpha1api20211101`
+
 ### microsoft.managedidentity
 
-v1alpha1api20181130
+
+#### ARM version 2018-11-30
 
 - UserAssignedIdentity ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.managedidentity/v1alpha1api20181130_userassignedidentity.yaml))
 
+Use CRD version `v1alpha1api20181130`
+
 ### microsoft.network
 
-v1alpha1api20201101
+
+#### ARM version 2020-11-01
 
 - LoadBalancer ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.network/v1alpha1api20201101_loadbalancer.yaml))
 - NetworkInterface ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.network/v1alpha1api20201101_networkinterface.yaml))
@@ -89,19 +120,27 @@ v1alpha1api20201101
 - VirtualNetworksSubnet ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.network/v1alpha1api20201101_virtualnetworkssubnet.yaml))
 - VirtualNetworksVirtualNetworkPeering ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.network/v1alpha1api20201101_virtualnetworksvirtualnetworkpeering.yaml))
 
+Use CRD version `v1alpha1api20201101`
+
 ### microsoft.servicebus
 
-v1alpha1api20210101preview
+
+#### ARM version 2021-01-01-preview
 
 - Namespace ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.servicebus/v1alpha1api20210101preview_namespace.yaml))
 - NamespacesQueue ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.servicebus/v1alpha1api20210101preview_namespacesqueue.yaml))
 - NamespacesTopic ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.servicebus/v1alpha1api20210101preview_namespacestopic.yaml))
 
+Use CRD version `v1alpha1api20210101preview`
+
 ### microsoft.storage
 
-v1alpha1api20210401
+
+#### ARM version 2021-04-01
 
 - StorageAccount ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.storage/v1alpha1api20210401_storageaccount.yaml))
 - StorageAccountsBlobService ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.storage/v1alpha1api20210401_storageaccountsblobservice.yaml))
 - StorageAccountsBlobServicesContainer ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.storage/v1alpha1api20210401_storageaccountsblobservicescontainer.yaml))
+
+Use CRD version `v1alpha1api20210401`
 

--- a/v2/tools/generator/internal/astmodel/meta_type.go
+++ b/v2/tools/generator/internal/astmodel/meta_type.go
@@ -5,6 +5,10 @@
 
 package astmodel
 
+import (
+	"fmt"
+)
+
 // A MetaType is a type wrapper that provide additional information/context about another type
 type MetaType interface {
 	// Unwrap returns the type contained within the wrapper type
@@ -118,4 +122,13 @@ func AsResourceType(aType Type) (*ResourceType, bool) {
 	}
 
 	return nil, false
+}
+
+func MustBeResourceType(aType Type) *ResourceType {
+	result, ok := AsResourceType(aType)
+	if !ok {
+		panic(fmt.Sprintf("must have ResourceType, but received %T", aType))
+	}
+
+	return result
 }

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -28,7 +28,7 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) Stage {
 
 			modifiedTypes, err := astmodel.FindResourceTypes(state.Types()).Process(
 				func(def astmodel.TypeDefinition) (*astmodel.TypeDefinition, error) {
-					rsrc, _ := astmodel.AsResourceType(def.Type())
+					rsrc := astmodel.MustBeResourceType(def.Type())
 					hub := state.ConversionGraph().FindHub(def.Name(), state.Types())
 					if astmodel.TypeEquals(def.Name(), hub) {
 						// The hub storage version doesn't implement Convertible

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -25,7 +25,7 @@ func MarkLatestStorageVariantAsHubVersion() Stage {
 		func(ctx context.Context, state *State) (*State, error) {
 			updatedDefs, err := astmodel.FindResourceTypes(state.Types()).Process(
 				func(def astmodel.TypeDefinition) (*astmodel.TypeDefinition, error) {
-					rsrc, _ := astmodel.AsResourceType(def.Type())
+					rsrc := astmodel.MustBeResourceType(def.Type())
 					hub := state.ConversionGraph().FindHub(def.Name(), state.Types())
 					if astmodel.TypeEquals(def.Name(), hub) {
 						// We have the hub type, modify it and return for Process() to accumulate into updatedDefs

--- a/v2/tools/generator/internal/codegen/pipeline/recursivetypefixer/simple_recursive_type_fixer.go
+++ b/v2/tools/generator/internal/codegen/pipeline/recursivetypefixer/simple_recursive_type_fixer.go
@@ -103,7 +103,7 @@ func (s *SimpleRecursiveTypeFixer) unrollRecursiveReference(this *astmodel.TypeV
 		return astmodel.IdentityVisitOfTypeName(this, it, ctx)
 	}
 
-	klog.Warningf("%q references itself, removing the self-reference by unrolling to %q", typedCtx.name, typedCtx.unrolledName)
+	klog.V(3).Infof("%q references itself, removing the self-reference by unrolling to %q", typedCtx.name, typedCtx.unrolledName)
 	return astmodel.IdentityVisitOfTypeName(this, typedCtx.unrolledName, typedCtx)
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_ReportResourceVersions.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_ReportResourceVersions.golden
@@ -1,12 +1,18 @@
 ### microsoft.person
 
-v20200101
+
+#### ARM version v20200101
 
 - Address ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.person/v20200101_address.yaml))
 - Person ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.person/v20200101_person.yaml))
 
-v20211231
+Use CRD version `v20200101`
+
+
+#### ARM version v20211231
 
 - Address ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.person/v20211231_address.yaml))
 - Person ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/microsoft.person/v20211231_person.yaml))
+
+Use CRD version `v20211231`
 

--- a/v2/tools/generator/internal/testcases/resource_conversion_test_case_test.go
+++ b/v2/tools/generator/internal/testcases/resource_conversion_test_case_test.go
@@ -69,7 +69,7 @@ func TestGolden_ResourceConversionTestCase_AsFunc(t *testing.T) {
 	person2020, err = interfaceInjector.Inject(person2020, implementation)
 	g.Expect(err).To(Succeed())
 
-	resource, _ := astmodel.AsResourceType(person2020.Type())
+	resource := astmodel.MustBeResourceType(person2020.Type())
 	testcase, err := NewResourceConversionTestCase(person2020.Name(), resource, idFactory)
 	g.Expect(err).To(Succeed())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The supported resources list was showing only our internal version reference, not the matching ARM resource version, which may have been confusing for those new to ASO. 

I've changed it to show the ARM api version (which can therefore be searched for) as well as the CRD version as a note for those who need it.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/NFA61GS9qKZ68/giphy.gif)

**If applicable**:
- [x] this PR contains documentation

