### PR TITLE
Update docs to use `kubectl apply --server-side=true`

### DIFF
--- a/docs/hugo/content/contributing/create-a-new-release.md
+++ b/docs/hugo/content/contributing/create-a-new-release.md
@@ -13,7 +13,7 @@
 3. Install cert-manager: `task controller:install-cert-manager`
 4. Create the namespace for the operator: `k create namespace azureserviceoperator-system`
 5. Source the SP credentials to use for the secret and then run `./scripts/deploy_testing_secret.sh sp`
-6. Deploy the operator from MCR: `k create -f <path-to-downloaded-yaml>` (We can't use `apply` because the yaml for VirtualMachines is too large - it can't be stored in the `last-applied-configuration` annotation.)
+6. Deploy the operator from MCR: `k apply --server-side=true -f <path-to-downloaded-yaml>` (We need to use [server-side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) because the CRD for VirtualMachines is large enough that it can't fit in the `last-applied-configuration` annotation client-side `kubectl apply` uses.)
 7. Wait for it to start: `k get all -n azureserviceoperator-system`
 8. Create a resource group: `k apply -f v2/config/samples/microsoft.resources/v1alpha1api20200601_resourcegroup.yaml`
 9. Make sure it deploys successfully, and check in the portal.

--- a/v2/README.md
+++ b/v2/README.md
@@ -37,8 +37,10 @@ Sample YAMLs for creating each of these resources can be found in the [samples d
    cert-manager-webhook-c4b5687dc-x66bj      1/1     Running   0          1m
    ```
 
+   (Alternatively, you can wait for cert-manager to be ready with `cmctl check api --wait=2m` - see the [cert-manager documentation](https://cert-manager.io/docs/usage/cmctl/) for more information about `cmctl`.)
+
 2. Create an Azure Service Principal. You'll need this to grant Azure Service Operator permissions to create resources in your subscription.
-   
+
    First, set the following environment variables to your Azure Tenant ID and Subscription ID with your values:
    ```yaml
    AZURE_TENANT_ID=<your-tenant-id-goes-here>

--- a/v2/README.md
+++ b/v2/README.md
@@ -27,6 +27,15 @@ Sample YAMLs for creating each of these resources can be found in the [samples d
     ```bash
     kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
     ```
+   Check that the cert-manager pods have started successfully before continuing.
+
+   ```bash
+   $ kubectl get pods -n cert-manager
+   NAME                                      READY   STATUS    RESTARTS   AGE
+   cert-manager-5597cff495-lmphj             1/1     Running   0          1m
+   cert-manager-cainjector-bd5f9c764-gvxm4   1/1     Running   0          1m
+   cert-manager-webhook-c4b5687dc-x66bj      1/1     Running   0          1m
+   ```
 
 2. Create an Azure Service Principal. You'll need this to grant Azure Service Operator permissions to create resources in your subscription.
    
@@ -61,7 +70,7 @@ Sample YAMLs for creating each of these resources can be found in the [samples d
    ```
 3. Download [the latest **v2+** release](https://github.com/Azure/azure-service-operator/releases) of Azure Service Operator and install it into your cluster.
    ```bash
-   kubectl create -f azureserviceoperator_v2.0.0-alpha.0.yaml
+   kubectl apply --server-side=true -f azureserviceoperator_v2.0.0-alpha.3.yaml
    ```
 4. Create the Azure Service Operator v2 secret. This secret contains the identity that Azure Service Operator will run as. Make sure that you have the 4 environment variables from step 2 set before running this command. 
    To learn more about other authentication options, see the [authentication documentation](https://azure.github.io/azure-service-operator/introduction/authentication/):


### PR DESCRIPTION
We can't use client-side apply because the VirtualMachines CRD is too big to fit in the `last-applied-configuration` annotation kubectl uses, but using `kubectl create` is a bit unpleasant (since it won't update existing resources).

Also note to wait for cert-manager to be started before installing ASO - if we don't do this the ASO webhook-service certificate creation fails because it can't talk to the cert-manager webhook, and the ASO pod won't start. (It bit me while I was testing the various options.)

