### PR TITLE
Improve test reliability

### DIFF
--- a/v2/internal/controllers/generic_controller.go
+++ b/v2/internal/controllers/generic_controller.go
@@ -169,7 +169,7 @@ func register(
 		For(obj).
 		// Note: These predicates prevent status updates from triggering a reconcile.
 		// to learn more look at https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/predicate#GenerationChangedPredicate
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{})).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(options.Options).
 		Complete(reconciler)
 	if err != nil {

--- a/v2/internal/controllers/generic_controller.go
+++ b/v2/internal/controllers/generic_controller.go
@@ -169,7 +169,7 @@ func register(
 		For(obj).
 		// Note: These predicates prevent status updates from triggering a reconcile.
 		// to learn more look at https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/predicate#GenerationChangedPredicate
-		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{})).
 		WithOptions(options.Options).
 		Complete(reconciler)
 	if err != nil {
@@ -252,9 +252,7 @@ func (gr *GenericReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	} else if reconcilerNamespace == "" && gr.Config.PodNamespace != "" {
 		genruntime.AddAnnotation(metaObj, NamespaceAnnotation, gr.Config.PodNamespace)
-		// Setting the annotation will trigger another reconcile so we
-		// don't need to requeue explicitly.
-		return ctrl.Result{}, gr.KubeClient.Client.Update(ctx, obj)
+		return ctrl.Result{Requeue: true}, gr.KubeClient.Client.Update(ctx, obj)
 	}
 
 	// TODO: We need some factory-lookup here

--- a/v2/internal/reconcilers/azure_generic_arm_reconciler.go
+++ b/v2/internal/reconcilers/azure_generic_arm_reconciler.go
@@ -538,7 +538,6 @@ func (r *AzureDeploymentReconciler) handlePollerFailed(ctx context.Context, err 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// We probably just modified spec so don't need to requeue this
 	return ctrl.Result{Requeue: true}, nil
 }
 

--- a/v2/internal/testcommon/direct_client.go
+++ b/v2/internal/testcommon/direct_client.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package testcommon
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type directClient struct {
+	inner client.Client
+}
+
+// NewTestClient is a thin wrapper around controller-runtime client.New, except that we
+// repopulate the objects GVK since for some reason they do that in the cached client and not
+// in the direct one...
+func NewTestClient(config *rest.Config, options client.Options) (client.Client, error) {
+	inner, err := client.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return &directClient{
+		inner: inner,
+	}, nil
+}
+
+func (d *directClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	gvk, err := apiutil.GVKForObject(obj, d.inner.Scheme())
+	if err != nil {
+		return err
+	}
+	err = d.inner.Get(ctx, key, obj)
+	if err != nil {
+		return err
+	}
+
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+	return nil
+}
+
+func (d *directClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return d.inner.List(ctx, list, opts...)
+}
+
+func (d *directClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return d.inner.Create(ctx, obj, opts...)
+}
+
+func (d *directClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return d.inner.Delete(ctx, obj, opts...)
+}
+
+func (d *directClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return d.inner.Update(ctx, obj, opts...)
+}
+
+func (d *directClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return d.inner.Patch(ctx, obj, patch, opts...)
+}
+
+func (d *directClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return d.inner.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (d *directClient) Status() client.StatusWriter {
+	return d.inner.Status()
+}
+
+func (d *directClient) Scheme() *runtime.Scheme {
+	return d.inner.Scheme()
+}
+
+func (d *directClient) RESTMapper() meta.RESTMapper {
+	return d.inner.RESTMapper()
+}
+
+var _ client.Client = &directClient{}


### PR DESCRIPTION
 * Use a KubeClient in EnvTest that always hits APIServer to avoid cache latency and inconsistency issues that can cause races and intermittent test failures. See kubernetes-sigs/controller-runtime#1464 and kubernetes-sigs/controller-runtime#343 for details.
 * Write Status after Spec. This ensures that tests waiting for a status update cannot possibly see it so fast that they go on   to perform a write that conflicts with the Spec write of the controller.
 * Improve log messages to be clearer (aids in test debugging).
 * Prior to performing any deletion actions (either monitoring or deletion), verify that the finalizer is still set. If it's not set,
immediately allow the k8s resource to be deleted. Don't take any action on the Azure resource in this instance.

**How does this PR make you feel:**
![gif](https://media.giphy.com/media/ndDR192PNKd2g/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
