### PR TITLE
Copy both ObjectMeta and TypeMeta when doing version conversion

### DIFF
--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
@@ -222,6 +222,9 @@ func (roleAssignment *RoleAssignment) validateResourceReferences() error {
 // AssignPropertiesFromRoleAssignment populates our RoleAssignment from the provided source RoleAssignment
 func (roleAssignment *RoleAssignment) AssignPropertiesFromRoleAssignment(source *v1alpha1api20200801previewstorage.RoleAssignment) error {
 
+	// ObjectMeta
+	roleAssignment.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec RoleAssignments_Spec
 	err := spec.AssignPropertiesFromRoleAssignmentsSpec(&source.Spec)
@@ -238,12 +241,18 @@ func (roleAssignment *RoleAssignment) AssignPropertiesFromRoleAssignment(source 
 	}
 	roleAssignment.Status = status
 
+	// TypeMeta
+	roleAssignment.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToRoleAssignment populates the provided destination RoleAssignment from our RoleAssignment
 func (roleAssignment *RoleAssignment) AssignPropertiesToRoleAssignment(destination *v1alpha1api20200801previewstorage.RoleAssignment) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *roleAssignment.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20200801previewstorage.RoleAssignments_Spec
@@ -260,6 +269,9 @@ func (roleAssignment *RoleAssignment) AssignPropertiesToRoleAssignment(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToRoleAssignmentStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = roleAssignment.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
@@ -241,9 +241,6 @@ func (roleAssignment *RoleAssignment) AssignPropertiesFromRoleAssignment(source 
 	}
 	roleAssignment.Status = status
 
-	// TypeMeta
-	roleAssignment.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -269,9 +266,6 @@ func (roleAssignment *RoleAssignment) AssignPropertiesToRoleAssignment(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToRoleAssignmentStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = roleAssignment.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
@@ -223,6 +223,9 @@ func (batchAccount *BatchAccount) validateResourceReferences() error {
 // AssignPropertiesFromBatchAccount populates our BatchAccount from the provided source BatchAccount
 func (batchAccount *BatchAccount) AssignPropertiesFromBatchAccount(source *v1alpha1api20210101storage.BatchAccount) error {
 
+	// ObjectMeta
+	batchAccount.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec BatchAccounts_Spec
 	err := spec.AssignPropertiesFromBatchAccountsSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (batchAccount *BatchAccount) AssignPropertiesFromBatchAccount(source *v1alp
 	}
 	batchAccount.Status = status
 
+	// TypeMeta
+	batchAccount.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToBatchAccount populates the provided destination BatchAccount from our BatchAccount
 func (batchAccount *BatchAccount) AssignPropertiesToBatchAccount(destination *v1alpha1api20210101storage.BatchAccount) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *batchAccount.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210101storage.BatchAccounts_Spec
@@ -261,6 +270,9 @@ func (batchAccount *BatchAccount) AssignPropertiesToBatchAccount(destination *v1
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToBatchAccountStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = batchAccount.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen.go
@@ -242,9 +242,6 @@ func (batchAccount *BatchAccount) AssignPropertiesFromBatchAccount(source *v1alp
 	}
 	batchAccount.Status = status
 
-	// TypeMeta
-	batchAccount.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (batchAccount *BatchAccount) AssignPropertiesToBatchAccount(destination *v1
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToBatchAccountStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = batchAccount.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen.go
@@ -223,6 +223,9 @@ func (disk *Disk) validateResourceReferences() error {
 // AssignPropertiesFromDisk populates our Disk from the provided source Disk
 func (disk *Disk) AssignPropertiesFromDisk(source *v1alpha1api20200930storage.Disk) error {
 
+	// ObjectMeta
+	disk.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Disks_Spec
 	err := spec.AssignPropertiesFromDisksSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (disk *Disk) AssignPropertiesFromDisk(source *v1alpha1api20200930storage.Di
 	}
 	disk.Status = status
 
+	// TypeMeta
+	disk.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToDisk populates the provided destination Disk from our Disk
 func (disk *Disk) AssignPropertiesToDisk(destination *v1alpha1api20200930storage.Disk) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *disk.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20200930storage.Disks_Spec
@@ -261,6 +270,9 @@ func (disk *Disk) AssignPropertiesToDisk(destination *v1alpha1api20200930storage
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToDiskStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = disk.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen.go
@@ -242,9 +242,6 @@ func (disk *Disk) AssignPropertiesFromDisk(source *v1alpha1api20200930storage.Di
 	}
 	disk.Status = status
 
-	// TypeMeta
-	disk.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (disk *Disk) AssignPropertiesToDisk(destination *v1alpha1api20200930storage
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToDiskStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = disk.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
@@ -245,9 +245,6 @@ func (virtualMachineScaleSet *VirtualMachineScaleSet) AssignPropertiesFromVirtua
 	}
 	virtualMachineScaleSet.Status = status
 
-	// TypeMeta
-	virtualMachineScaleSet.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -273,9 +270,6 @@ func (virtualMachineScaleSet *VirtualMachineScaleSet) AssignPropertiesToVirtualM
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualMachineScaleSetStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = virtualMachineScaleSet.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
@@ -226,6 +226,9 @@ func (virtualMachineScaleSet *VirtualMachineScaleSet) validateResourceReferences
 // AssignPropertiesFromVirtualMachineScaleSet populates our VirtualMachineScaleSet from the provided source VirtualMachineScaleSet
 func (virtualMachineScaleSet *VirtualMachineScaleSet) AssignPropertiesFromVirtualMachineScaleSet(source *v1alpha1api20201201storage.VirtualMachineScaleSet) error {
 
+	// ObjectMeta
+	virtualMachineScaleSet.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec VirtualMachineScaleSets_Spec
 	err := spec.AssignPropertiesFromVirtualMachineScaleSetsSpec(&source.Spec)
@@ -242,12 +245,18 @@ func (virtualMachineScaleSet *VirtualMachineScaleSet) AssignPropertiesFromVirtua
 	}
 	virtualMachineScaleSet.Status = status
 
+	// TypeMeta
+	virtualMachineScaleSet.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToVirtualMachineScaleSet populates the provided destination VirtualMachineScaleSet from our VirtualMachineScaleSet
 func (virtualMachineScaleSet *VirtualMachineScaleSet) AssignPropertiesToVirtualMachineScaleSet(destination *v1alpha1api20201201storage.VirtualMachineScaleSet) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *virtualMachineScaleSet.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201201storage.VirtualMachineScaleSets_Spec
@@ -264,6 +273,9 @@ func (virtualMachineScaleSet *VirtualMachineScaleSet) AssignPropertiesToVirtualM
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualMachineScaleSetStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = virtualMachineScaleSet.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_types_gen.go
@@ -224,6 +224,9 @@ func (virtualMachine *VirtualMachine) validateResourceReferences() error {
 // AssignPropertiesFromVirtualMachine populates our VirtualMachine from the provided source VirtualMachine
 func (virtualMachine *VirtualMachine) AssignPropertiesFromVirtualMachine(source *v1alpha1api20201201storage.VirtualMachine) error {
 
+	// ObjectMeta
+	virtualMachine.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec VirtualMachines_Spec
 	err := spec.AssignPropertiesFromVirtualMachinesSpec(&source.Spec)
@@ -240,12 +243,18 @@ func (virtualMachine *VirtualMachine) AssignPropertiesFromVirtualMachine(source 
 	}
 	virtualMachine.Status = status
 
+	// TypeMeta
+	virtualMachine.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToVirtualMachine populates the provided destination VirtualMachine from our VirtualMachine
 func (virtualMachine *VirtualMachine) AssignPropertiesToVirtualMachine(destination *v1alpha1api20201201storage.VirtualMachine) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *virtualMachine.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201201storage.VirtualMachines_Spec
@@ -262,6 +271,9 @@ func (virtualMachine *VirtualMachine) AssignPropertiesToVirtualMachine(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualMachineStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = virtualMachine.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_types_gen.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_types_gen.go
@@ -243,9 +243,6 @@ func (virtualMachine *VirtualMachine) AssignPropertiesFromVirtualMachine(source 
 	}
 	virtualMachine.Status = status
 
-	// TypeMeta
-	virtualMachine.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -271,9 +268,6 @@ func (virtualMachine *VirtualMachine) AssignPropertiesToVirtualMachine(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualMachineStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = virtualMachine.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
@@ -224,6 +224,9 @@ func (managedCluster *ManagedCluster) validateResourceReferences() error {
 // AssignPropertiesFromManagedCluster populates our ManagedCluster from the provided source ManagedCluster
 func (managedCluster *ManagedCluster) AssignPropertiesFromManagedCluster(source *v1alpha1api20210501storage.ManagedCluster) error {
 
+	// ObjectMeta
+	managedCluster.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec ManagedClusters_Spec
 	err := spec.AssignPropertiesFromManagedClustersSpec(&source.Spec)
@@ -240,12 +243,18 @@ func (managedCluster *ManagedCluster) AssignPropertiesFromManagedCluster(source 
 	}
 	managedCluster.Status = status
 
+	// TypeMeta
+	managedCluster.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToManagedCluster populates the provided destination ManagedCluster from our ManagedCluster
 func (managedCluster *ManagedCluster) AssignPropertiesToManagedCluster(destination *v1alpha1api20210501storage.ManagedCluster) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *managedCluster.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210501storage.ManagedClusters_Spec
@@ -262,6 +271,9 @@ func (managedCluster *ManagedCluster) AssignPropertiesToManagedCluster(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToManagedClusterStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = managedCluster.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
@@ -243,9 +243,6 @@ func (managedCluster *ManagedCluster) AssignPropertiesFromManagedCluster(source 
 	}
 	managedCluster.Status = status
 
-	// TypeMeta
-	managedCluster.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -271,9 +268,6 @@ func (managedCluster *ManagedCluster) AssignPropertiesToManagedCluster(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToManagedClusterStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = managedCluster.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -244,9 +244,6 @@ func (managedClustersAgentPool *ManagedClustersAgentPool) AssignPropertiesFromMa
 	}
 	managedClustersAgentPool.Status = status
 
-	// TypeMeta
-	managedClustersAgentPool.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (managedClustersAgentPool *ManagedClustersAgentPool) AssignPropertiesToMana
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToAgentPoolStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = managedClustersAgentPool.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -225,6 +225,9 @@ func (managedClustersAgentPool *ManagedClustersAgentPool) validateResourceRefere
 // AssignPropertiesFromManagedClustersAgentPool populates our ManagedClustersAgentPool from the provided source ManagedClustersAgentPool
 func (managedClustersAgentPool *ManagedClustersAgentPool) AssignPropertiesFromManagedClustersAgentPool(source *v1alpha1api20210501storage.ManagedClustersAgentPool) error {
 
+	// ObjectMeta
+	managedClustersAgentPool.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec ManagedClustersAgentPools_Spec
 	err := spec.AssignPropertiesFromManagedClustersAgentPoolsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (managedClustersAgentPool *ManagedClustersAgentPool) AssignPropertiesFromMa
 	}
 	managedClustersAgentPool.Status = status
 
+	// TypeMeta
+	managedClustersAgentPool.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToManagedClustersAgentPool populates the provided destination ManagedClustersAgentPool from our ManagedClustersAgentPool
 func (managedClustersAgentPool *ManagedClustersAgentPool) AssignPropertiesToManagedClustersAgentPool(destination *v1alpha1api20210501storage.ManagedClustersAgentPool) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *managedClustersAgentPool.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210501storage.ManagedClustersAgentPools_Spec
@@ -263,6 +272,9 @@ func (managedClustersAgentPool *ManagedClustersAgentPool) AssignPropertiesToMana
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToAgentPoolStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = managedClustersAgentPool.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_server_types_gen.go
+++ b/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_server_types_gen.go
@@ -223,6 +223,9 @@ func (flexibleServer *FlexibleServer) validateResourceReferences() error {
 // AssignPropertiesFromFlexibleServer populates our FlexibleServer from the provided source FlexibleServer
 func (flexibleServer *FlexibleServer) AssignPropertiesFromFlexibleServer(source *v1alpha1api20210501storage.FlexibleServer) error {
 
+	// ObjectMeta
+	flexibleServer.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec FlexibleServers_Spec
 	err := spec.AssignPropertiesFromFlexibleServersSpec(&source.Spec)
@@ -245,6 +248,9 @@ func (flexibleServer *FlexibleServer) AssignPropertiesFromFlexibleServer(source 
 
 // AssignPropertiesToFlexibleServer populates the provided destination FlexibleServer from our FlexibleServer
 func (flexibleServer *FlexibleServer) AssignPropertiesToFlexibleServer(destination *v1alpha1api20210501storage.FlexibleServer) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *flexibleServer.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210501storage.FlexibleServers_Spec

--- a/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen.go
+++ b/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen.go
@@ -225,6 +225,9 @@ func (flexibleServersDatabase *FlexibleServersDatabase) validateResourceReferenc
 // AssignPropertiesFromFlexibleServersDatabase populates our FlexibleServersDatabase from the provided source FlexibleServersDatabase
 func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesFromFlexibleServersDatabase(source *v1alpha1api20210501storage.FlexibleServersDatabase) error {
 
+	// ObjectMeta
+	flexibleServersDatabase.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec FlexibleServersDatabases_Spec
 	err := spec.AssignPropertiesFromFlexibleServersDatabasesSpec(&source.Spec)
@@ -247,6 +250,9 @@ func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesFromFlex
 
 // AssignPropertiesToFlexibleServersDatabase populates the provided destination FlexibleServersDatabase from our FlexibleServersDatabase
 func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesToFlexibleServersDatabase(destination *v1alpha1api20210501storage.FlexibleServersDatabase) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *flexibleServersDatabase.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210501storage.FlexibleServersDatabases_Spec

--- a/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen.go
@@ -225,6 +225,9 @@ func (flexibleServersFirewallRule *FlexibleServersFirewallRule) validateResource
 // AssignPropertiesFromFlexibleServersFirewallRule populates our FlexibleServersFirewallRule from the provided source FlexibleServersFirewallRule
 func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignPropertiesFromFlexibleServersFirewallRule(source *v1alpha1api20210501storage.FlexibleServersFirewallRule) error {
 
+	// ObjectMeta
+	flexibleServersFirewallRule.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec FlexibleServersFirewallRules_Spec
 	err := spec.AssignPropertiesFromFlexibleServersFirewallRulesSpec(&source.Spec)
@@ -247,6 +250,9 @@ func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignProperties
 
 // AssignPropertiesToFlexibleServersFirewallRule populates the provided destination FlexibleServersFirewallRule from our FlexibleServersFirewallRule
 func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignPropertiesToFlexibleServersFirewallRule(destination *v1alpha1api20210501storage.FlexibleServersFirewallRule) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *flexibleServersFirewallRule.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210501storage.FlexibleServersFirewallRules_Spec

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
@@ -223,6 +223,9 @@ func (flexibleServer *FlexibleServer) validateResourceReferences() error {
 // AssignPropertiesFromFlexibleServer populates our FlexibleServer from the provided source FlexibleServer
 func (flexibleServer *FlexibleServer) AssignPropertiesFromFlexibleServer(source *v1alpha1api20210601storage.FlexibleServer) error {
 
+	// ObjectMeta
+	flexibleServer.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec FlexibleServers_Spec
 	err := spec.AssignPropertiesFromFlexibleServersSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (flexibleServer *FlexibleServer) AssignPropertiesFromFlexibleServer(source 
 	}
 	flexibleServer.Status = status
 
+	// TypeMeta
+	flexibleServer.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToFlexibleServer populates the provided destination FlexibleServer from our FlexibleServer
 func (flexibleServer *FlexibleServer) AssignPropertiesToFlexibleServer(destination *v1alpha1api20210601storage.FlexibleServer) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *flexibleServer.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210601storage.FlexibleServers_Spec
@@ -261,6 +270,9 @@ func (flexibleServer *FlexibleServer) AssignPropertiesToFlexibleServer(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToServerStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = flexibleServer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
@@ -242,9 +242,6 @@ func (flexibleServer *FlexibleServer) AssignPropertiesFromFlexibleServer(source 
 	}
 	flexibleServer.Status = status
 
-	// TypeMeta
-	flexibleServer.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (flexibleServer *FlexibleServer) AssignPropertiesToFlexibleServer(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToServerStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = flexibleServer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
@@ -244,9 +244,6 @@ func (flexibleServersConfiguration *FlexibleServersConfiguration) AssignProperti
 	}
 	flexibleServersConfiguration.Status = status
 
-	// TypeMeta
-	flexibleServersConfiguration.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (flexibleServersConfiguration *FlexibleServersConfiguration) AssignProperti
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToConfigurationStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = flexibleServersConfiguration.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
@@ -225,6 +225,9 @@ func (flexibleServersConfiguration *FlexibleServersConfiguration) validateResour
 // AssignPropertiesFromFlexibleServersConfiguration populates our FlexibleServersConfiguration from the provided source FlexibleServersConfiguration
 func (flexibleServersConfiguration *FlexibleServersConfiguration) AssignPropertiesFromFlexibleServersConfiguration(source *v1alpha1api20210601storage.FlexibleServersConfiguration) error {
 
+	// ObjectMeta
+	flexibleServersConfiguration.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec FlexibleServersConfigurations_Spec
 	err := spec.AssignPropertiesFromFlexibleServersConfigurationsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (flexibleServersConfiguration *FlexibleServersConfiguration) AssignProperti
 	}
 	flexibleServersConfiguration.Status = status
 
+	// TypeMeta
+	flexibleServersConfiguration.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToFlexibleServersConfiguration populates the provided destination FlexibleServersConfiguration from our FlexibleServersConfiguration
 func (flexibleServersConfiguration *FlexibleServersConfiguration) AssignPropertiesToFlexibleServersConfiguration(destination *v1alpha1api20210601storage.FlexibleServersConfiguration) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *flexibleServersConfiguration.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210601storage.FlexibleServersConfigurations_Spec
@@ -263,6 +272,9 @@ func (flexibleServersConfiguration *FlexibleServersConfiguration) AssignProperti
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToConfigurationStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = flexibleServersConfiguration.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
@@ -225,6 +225,9 @@ func (flexibleServersDatabase *FlexibleServersDatabase) validateResourceReferenc
 // AssignPropertiesFromFlexibleServersDatabase populates our FlexibleServersDatabase from the provided source FlexibleServersDatabase
 func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesFromFlexibleServersDatabase(source *v1alpha1api20210601storage.FlexibleServersDatabase) error {
 
+	// ObjectMeta
+	flexibleServersDatabase.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec FlexibleServersDatabases_Spec
 	err := spec.AssignPropertiesFromFlexibleServersDatabasesSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesFromFlex
 	}
 	flexibleServersDatabase.Status = status
 
+	// TypeMeta
+	flexibleServersDatabase.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToFlexibleServersDatabase populates the provided destination FlexibleServersDatabase from our FlexibleServersDatabase
 func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesToFlexibleServersDatabase(destination *v1alpha1api20210601storage.FlexibleServersDatabase) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *flexibleServersDatabase.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210601storage.FlexibleServersDatabases_Spec
@@ -263,6 +272,9 @@ func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesToFlexib
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToDatabaseStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = flexibleServersDatabase.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
@@ -244,9 +244,6 @@ func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesFromFlex
 	}
 	flexibleServersDatabase.Status = status
 
-	// TypeMeta
-	flexibleServersDatabase.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (flexibleServersDatabase *FlexibleServersDatabase) AssignPropertiesToFlexib
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToDatabaseStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = flexibleServersDatabase.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
@@ -244,9 +244,6 @@ func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignProperties
 	}
 	flexibleServersFirewallRule.Status = status
 
-	// TypeMeta
-	flexibleServersFirewallRule.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignProperties
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToFirewallRuleStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = flexibleServersFirewallRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
@@ -225,6 +225,9 @@ func (flexibleServersFirewallRule *FlexibleServersFirewallRule) validateResource
 // AssignPropertiesFromFlexibleServersFirewallRule populates our FlexibleServersFirewallRule from the provided source FlexibleServersFirewallRule
 func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignPropertiesFromFlexibleServersFirewallRule(source *v1alpha1api20210601storage.FlexibleServersFirewallRule) error {
 
+	// ObjectMeta
+	flexibleServersFirewallRule.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec FlexibleServersFirewallRules_Spec
 	err := spec.AssignPropertiesFromFlexibleServersFirewallRulesSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignProperties
 	}
 	flexibleServersFirewallRule.Status = status
 
+	// TypeMeta
+	flexibleServersFirewallRule.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToFlexibleServersFirewallRule populates the provided destination FlexibleServersFirewallRule from our FlexibleServersFirewallRule
 func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignPropertiesToFlexibleServersFirewallRule(destination *v1alpha1api20210601storage.FlexibleServersFirewallRule) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *flexibleServersFirewallRule.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210601storage.FlexibleServersFirewallRules_Spec
@@ -263,6 +272,9 @@ func (flexibleServersFirewallRule *FlexibleServersFirewallRule) AssignProperties
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToFirewallRuleStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = flexibleServersFirewallRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
@@ -242,9 +242,6 @@ func (databaseAccount *DatabaseAccount) AssignPropertiesFromDatabaseAccount(sour
 	}
 	databaseAccount.Status = status
 
-	// TypeMeta
-	databaseAccount.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (databaseAccount *DatabaseAccount) AssignPropertiesToDatabaseAccount(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToDatabaseAccountGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = databaseAccount.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen.go
@@ -223,6 +223,9 @@ func (databaseAccount *DatabaseAccount) validateResourceReferences() error {
 // AssignPropertiesFromDatabaseAccount populates our DatabaseAccount from the provided source DatabaseAccount
 func (databaseAccount *DatabaseAccount) AssignPropertiesFromDatabaseAccount(source *v1alpha1api20210515storage.DatabaseAccount) error {
 
+	// ObjectMeta
+	databaseAccount.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccounts_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (databaseAccount *DatabaseAccount) AssignPropertiesFromDatabaseAccount(sour
 	}
 	databaseAccount.Status = status
 
+	// TypeMeta
+	databaseAccount.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToDatabaseAccount populates the provided destination DatabaseAccount from our DatabaseAccount
 func (databaseAccount *DatabaseAccount) AssignPropertiesToDatabaseAccount(destination *v1alpha1api20210515storage.DatabaseAccount) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *databaseAccount.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccounts_Spec
@@ -261,6 +270,9 @@ func (databaseAccount *DatabaseAccount) AssignPropertiesToDatabaseAccount(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToDatabaseAccountGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = databaseAccount.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -217,6 +217,9 @@ func (mongodbDatabaseCollectionThroughputSetting *MongodbDatabaseCollectionThrou
 // AssignPropertiesFromMongodbDatabaseCollectionThroughputSetting populates our MongodbDatabaseCollectionThroughputSetting from the provided source MongodbDatabaseCollectionThroughputSetting
 func (mongodbDatabaseCollectionThroughputSetting *MongodbDatabaseCollectionThroughputSetting) AssignPropertiesFromMongodbDatabaseCollectionThroughputSetting(source *v1alpha1api20210515storage.MongodbDatabaseCollectionThroughputSetting) error {
 
+	// ObjectMeta
+	mongodbDatabaseCollectionThroughputSetting.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsMongodbDatabasesCollectionsThroughputSettingsSpec(&source.Spec)
@@ -233,12 +236,18 @@ func (mongodbDatabaseCollectionThroughputSetting *MongodbDatabaseCollectionThrou
 	}
 	mongodbDatabaseCollectionThroughputSetting.Status = status
 
+	// TypeMeta
+	mongodbDatabaseCollectionThroughputSetting.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToMongodbDatabaseCollectionThroughputSetting populates the provided destination MongodbDatabaseCollectionThroughputSetting from our MongodbDatabaseCollectionThroughputSetting
 func (mongodbDatabaseCollectionThroughputSetting *MongodbDatabaseCollectionThroughputSetting) AssignPropertiesToMongodbDatabaseCollectionThroughputSetting(destination *v1alpha1api20210515storage.MongodbDatabaseCollectionThroughputSetting) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *mongodbDatabaseCollectionThroughputSetting.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spec
@@ -255,6 +264,9 @@ func (mongodbDatabaseCollectionThroughputSetting *MongodbDatabaseCollectionThrou
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = mongodbDatabaseCollectionThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -236,9 +236,6 @@ func (mongodbDatabaseCollectionThroughputSetting *MongodbDatabaseCollectionThrou
 	}
 	mongodbDatabaseCollectionThroughputSetting.Status = status
 
-	// TypeMeta
-	mongodbDatabaseCollectionThroughputSetting.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -264,9 +261,6 @@ func (mongodbDatabaseCollectionThroughputSetting *MongodbDatabaseCollectionThrou
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = mongodbDatabaseCollectionThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
@@ -225,6 +225,9 @@ func (mongodbDatabaseCollection *MongodbDatabaseCollection) validateResourceRefe
 // AssignPropertiesFromMongodbDatabaseCollection populates our MongodbDatabaseCollection from the provided source MongodbDatabaseCollection
 func (mongodbDatabaseCollection *MongodbDatabaseCollection) AssignPropertiesFromMongodbDatabaseCollection(source *v1alpha1api20210515storage.MongodbDatabaseCollection) error {
 
+	// ObjectMeta
+	mongodbDatabaseCollection.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsMongodbDatabasesCollections_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsMongodbDatabasesCollectionsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (mongodbDatabaseCollection *MongodbDatabaseCollection) AssignPropertiesFrom
 	}
 	mongodbDatabaseCollection.Status = status
 
+	// TypeMeta
+	mongodbDatabaseCollection.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToMongodbDatabaseCollection populates the provided destination MongodbDatabaseCollection from our MongodbDatabaseCollection
 func (mongodbDatabaseCollection *MongodbDatabaseCollection) AssignPropertiesToMongodbDatabaseCollection(destination *v1alpha1api20210515storage.MongodbDatabaseCollection) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *mongodbDatabaseCollection.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsMongodbDatabasesCollections_Spec
@@ -263,6 +272,9 @@ func (mongodbDatabaseCollection *MongodbDatabaseCollection) AssignPropertiesToMo
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToMongoDBCollectionGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = mongodbDatabaseCollection.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
@@ -244,9 +244,6 @@ func (mongodbDatabaseCollection *MongodbDatabaseCollection) AssignPropertiesFrom
 	}
 	mongodbDatabaseCollection.Status = status
 
-	// TypeMeta
-	mongodbDatabaseCollection.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (mongodbDatabaseCollection *MongodbDatabaseCollection) AssignPropertiesToMo
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToMongoDBCollectionGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = mongodbDatabaseCollection.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
@@ -216,6 +216,9 @@ func (mongodbDatabaseThroughputSetting *MongodbDatabaseThroughputSetting) valida
 // AssignPropertiesFromMongodbDatabaseThroughputSetting populates our MongodbDatabaseThroughputSetting from the provided source MongodbDatabaseThroughputSetting
 func (mongodbDatabaseThroughputSetting *MongodbDatabaseThroughputSetting) AssignPropertiesFromMongodbDatabaseThroughputSetting(source *v1alpha1api20210515storage.MongodbDatabaseThroughputSetting) error {
 
+	// ObjectMeta
+	mongodbDatabaseThroughputSetting.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsMongodbDatabasesThroughputSettings_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsMongodbDatabasesThroughputSettingsSpec(&source.Spec)
@@ -232,12 +235,18 @@ func (mongodbDatabaseThroughputSetting *MongodbDatabaseThroughputSetting) Assign
 	}
 	mongodbDatabaseThroughputSetting.Status = status
 
+	// TypeMeta
+	mongodbDatabaseThroughputSetting.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToMongodbDatabaseThroughputSetting populates the provided destination MongodbDatabaseThroughputSetting from our MongodbDatabaseThroughputSetting
 func (mongodbDatabaseThroughputSetting *MongodbDatabaseThroughputSetting) AssignPropertiesToMongodbDatabaseThroughputSetting(destination *v1alpha1api20210515storage.MongodbDatabaseThroughputSetting) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *mongodbDatabaseThroughputSetting.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsMongodbDatabasesThroughputSettings_Spec
@@ -254,6 +263,9 @@ func (mongodbDatabaseThroughputSetting *MongodbDatabaseThroughputSetting) Assign
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = mongodbDatabaseThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
@@ -235,9 +235,6 @@ func (mongodbDatabaseThroughputSetting *MongodbDatabaseThroughputSetting) Assign
 	}
 	mongodbDatabaseThroughputSetting.Status = status
 
-	// TypeMeta
-	mongodbDatabaseThroughputSetting.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -263,9 +260,6 @@ func (mongodbDatabaseThroughputSetting *MongodbDatabaseThroughputSetting) Assign
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = mongodbDatabaseThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
@@ -223,6 +223,9 @@ func (mongodbDatabase *MongodbDatabase) validateResourceReferences() error {
 // AssignPropertiesFromMongodbDatabase populates our MongodbDatabase from the provided source MongodbDatabase
 func (mongodbDatabase *MongodbDatabase) AssignPropertiesFromMongodbDatabase(source *v1alpha1api20210515storage.MongodbDatabase) error {
 
+	// ObjectMeta
+	mongodbDatabase.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsMongodbDatabases_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsMongodbDatabasesSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (mongodbDatabase *MongodbDatabase) AssignPropertiesFromMongodbDatabase(sour
 	}
 	mongodbDatabase.Status = status
 
+	// TypeMeta
+	mongodbDatabase.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToMongodbDatabase populates the provided destination MongodbDatabase from our MongodbDatabase
 func (mongodbDatabase *MongodbDatabase) AssignPropertiesToMongodbDatabase(destination *v1alpha1api20210515storage.MongodbDatabase) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *mongodbDatabase.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsMongodbDatabases_Spec
@@ -261,6 +270,9 @@ func (mongodbDatabase *MongodbDatabase) AssignPropertiesToMongodbDatabase(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToMongoDBDatabaseGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = mongodbDatabase.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
@@ -242,9 +242,6 @@ func (mongodbDatabase *MongodbDatabase) AssignPropertiesFromMongodbDatabase(sour
 	}
 	mongodbDatabase.Status = status
 
-	// TypeMeta
-	mongodbDatabase.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (mongodbDatabase *MongodbDatabase) AssignPropertiesToMongodbDatabase(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToMongoDBDatabaseGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = mongodbDatabase.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
@@ -225,6 +225,9 @@ func (sqlDatabaseContainerStoredProcedure *SqlDatabaseContainerStoredProcedure) 
 // AssignPropertiesFromSqlDatabaseContainerStoredProcedure populates our SqlDatabaseContainerStoredProcedure from the provided source SqlDatabaseContainerStoredProcedure
 func (sqlDatabaseContainerStoredProcedure *SqlDatabaseContainerStoredProcedure) AssignPropertiesFromSqlDatabaseContainerStoredProcedure(source *v1alpha1api20210515storage.SqlDatabaseContainerStoredProcedure) error {
 
+	// ObjectMeta
+	sqlDatabaseContainerStoredProcedure.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSqlDatabasesContainersStoredProceduresSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (sqlDatabaseContainerStoredProcedure *SqlDatabaseContainerStoredProcedure) 
 	}
 	sqlDatabaseContainerStoredProcedure.Status = status
 
+	// TypeMeta
+	sqlDatabaseContainerStoredProcedure.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSqlDatabaseContainerStoredProcedure populates the provided destination SqlDatabaseContainerStoredProcedure from our SqlDatabaseContainerStoredProcedure
 func (sqlDatabaseContainerStoredProcedure *SqlDatabaseContainerStoredProcedure) AssignPropertiesToSqlDatabaseContainerStoredProcedure(destination *v1alpha1api20210515storage.SqlDatabaseContainerStoredProcedure) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *sqlDatabaseContainerStoredProcedure.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec
@@ -263,6 +272,9 @@ func (sqlDatabaseContainerStoredProcedure *SqlDatabaseContainerStoredProcedure) 
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlStoredProcedureGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = sqlDatabaseContainerStoredProcedure.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
@@ -244,9 +244,6 @@ func (sqlDatabaseContainerStoredProcedure *SqlDatabaseContainerStoredProcedure) 
 	}
 	sqlDatabaseContainerStoredProcedure.Status = status
 
-	// TypeMeta
-	sqlDatabaseContainerStoredProcedure.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (sqlDatabaseContainerStoredProcedure *SqlDatabaseContainerStoredProcedure) 
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlStoredProcedureGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = sqlDatabaseContainerStoredProcedure.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
@@ -216,6 +216,9 @@ func (sqlDatabaseContainerThroughputSetting *SqlDatabaseContainerThroughputSetti
 // AssignPropertiesFromSqlDatabaseContainerThroughputSetting populates our SqlDatabaseContainerThroughputSetting from the provided source SqlDatabaseContainerThroughputSetting
 func (sqlDatabaseContainerThroughputSetting *SqlDatabaseContainerThroughputSetting) AssignPropertiesFromSqlDatabaseContainerThroughputSetting(source *v1alpha1api20210515storage.SqlDatabaseContainerThroughputSetting) error {
 
+	// ObjectMeta
+	sqlDatabaseContainerThroughputSetting.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSqlDatabasesContainersThroughputSettingsSpec(&source.Spec)
@@ -232,12 +235,18 @@ func (sqlDatabaseContainerThroughputSetting *SqlDatabaseContainerThroughputSetti
 	}
 	sqlDatabaseContainerThroughputSetting.Status = status
 
+	// TypeMeta
+	sqlDatabaseContainerThroughputSetting.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSqlDatabaseContainerThroughputSetting populates the provided destination SqlDatabaseContainerThroughputSetting from our SqlDatabaseContainerThroughputSetting
 func (sqlDatabaseContainerThroughputSetting *SqlDatabaseContainerThroughputSetting) AssignPropertiesToSqlDatabaseContainerThroughputSetting(destination *v1alpha1api20210515storage.SqlDatabaseContainerThroughputSetting) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *sqlDatabaseContainerThroughputSetting.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec
@@ -254,6 +263,9 @@ func (sqlDatabaseContainerThroughputSetting *SqlDatabaseContainerThroughputSetti
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = sqlDatabaseContainerThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
@@ -235,9 +235,6 @@ func (sqlDatabaseContainerThroughputSetting *SqlDatabaseContainerThroughputSetti
 	}
 	sqlDatabaseContainerThroughputSetting.Status = status
 
-	// TypeMeta
-	sqlDatabaseContainerThroughputSetting.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -263,9 +260,6 @@ func (sqlDatabaseContainerThroughputSetting *SqlDatabaseContainerThroughputSetti
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = sqlDatabaseContainerThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
@@ -225,6 +225,9 @@ func (sqlDatabaseContainerTrigger *SqlDatabaseContainerTrigger) validateResource
 // AssignPropertiesFromSqlDatabaseContainerTrigger populates our SqlDatabaseContainerTrigger from the provided source SqlDatabaseContainerTrigger
 func (sqlDatabaseContainerTrigger *SqlDatabaseContainerTrigger) AssignPropertiesFromSqlDatabaseContainerTrigger(source *v1alpha1api20210515storage.SqlDatabaseContainerTrigger) error {
 
+	// ObjectMeta
+	sqlDatabaseContainerTrigger.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsSqlDatabasesContainersTriggers_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSqlDatabasesContainersTriggersSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (sqlDatabaseContainerTrigger *SqlDatabaseContainerTrigger) AssignProperties
 	}
 	sqlDatabaseContainerTrigger.Status = status
 
+	// TypeMeta
+	sqlDatabaseContainerTrigger.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSqlDatabaseContainerTrigger populates the provided destination SqlDatabaseContainerTrigger from our SqlDatabaseContainerTrigger
 func (sqlDatabaseContainerTrigger *SqlDatabaseContainerTrigger) AssignPropertiesToSqlDatabaseContainerTrigger(destination *v1alpha1api20210515storage.SqlDatabaseContainerTrigger) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *sqlDatabaseContainerTrigger.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersTriggers_Spec
@@ -263,6 +272,9 @@ func (sqlDatabaseContainerTrigger *SqlDatabaseContainerTrigger) AssignProperties
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlTriggerGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = sqlDatabaseContainerTrigger.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
@@ -244,9 +244,6 @@ func (sqlDatabaseContainerTrigger *SqlDatabaseContainerTrigger) AssignProperties
 	}
 	sqlDatabaseContainerTrigger.Status = status
 
-	// TypeMeta
-	sqlDatabaseContainerTrigger.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (sqlDatabaseContainerTrigger *SqlDatabaseContainerTrigger) AssignProperties
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlTriggerGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = sqlDatabaseContainerTrigger.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
@@ -225,6 +225,9 @@ func (sqlDatabaseContainer *SqlDatabaseContainer) validateResourceReferences() e
 // AssignPropertiesFromSqlDatabaseContainer populates our SqlDatabaseContainer from the provided source SqlDatabaseContainer
 func (sqlDatabaseContainer *SqlDatabaseContainer) AssignPropertiesFromSqlDatabaseContainer(source *v1alpha1api20210515storage.SqlDatabaseContainer) error {
 
+	// ObjectMeta
+	sqlDatabaseContainer.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsSqlDatabasesContainers_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSqlDatabasesContainersSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (sqlDatabaseContainer *SqlDatabaseContainer) AssignPropertiesFromSqlDatabas
 	}
 	sqlDatabaseContainer.Status = status
 
+	// TypeMeta
+	sqlDatabaseContainer.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSqlDatabaseContainer populates the provided destination SqlDatabaseContainer from our SqlDatabaseContainer
 func (sqlDatabaseContainer *SqlDatabaseContainer) AssignPropertiesToSqlDatabaseContainer(destination *v1alpha1api20210515storage.SqlDatabaseContainer) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *sqlDatabaseContainer.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainers_Spec
@@ -263,6 +272,9 @@ func (sqlDatabaseContainer *SqlDatabaseContainer) AssignPropertiesToSqlDatabaseC
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlContainerGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = sqlDatabaseContainer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
@@ -244,9 +244,6 @@ func (sqlDatabaseContainer *SqlDatabaseContainer) AssignPropertiesFromSqlDatabas
 	}
 	sqlDatabaseContainer.Status = status
 
-	// TypeMeta
-	sqlDatabaseContainer.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (sqlDatabaseContainer *SqlDatabaseContainer) AssignPropertiesToSqlDatabaseC
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlContainerGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = sqlDatabaseContainer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
@@ -244,9 +244,6 @@ func (sqlDatabaseContainerUserDefinedFunction *SqlDatabaseContainerUserDefinedFu
 	}
 	sqlDatabaseContainerUserDefinedFunction.Status = status
 
-	// TypeMeta
-	sqlDatabaseContainerUserDefinedFunction.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (sqlDatabaseContainerUserDefinedFunction *SqlDatabaseContainerUserDefinedFu
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlUserDefinedFunctionGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = sqlDatabaseContainerUserDefinedFunction.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
@@ -225,6 +225,9 @@ func (sqlDatabaseContainerUserDefinedFunction *SqlDatabaseContainerUserDefinedFu
 // AssignPropertiesFromSqlDatabaseContainerUserDefinedFunction populates our SqlDatabaseContainerUserDefinedFunction from the provided source SqlDatabaseContainerUserDefinedFunction
 func (sqlDatabaseContainerUserDefinedFunction *SqlDatabaseContainerUserDefinedFunction) AssignPropertiesFromSqlDatabaseContainerUserDefinedFunction(source *v1alpha1api20210515storage.SqlDatabaseContainerUserDefinedFunction) error {
 
+	// ObjectMeta
+	sqlDatabaseContainerUserDefinedFunction.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (sqlDatabaseContainerUserDefinedFunction *SqlDatabaseContainerUserDefinedFu
 	}
 	sqlDatabaseContainerUserDefinedFunction.Status = status
 
+	// TypeMeta
+	sqlDatabaseContainerUserDefinedFunction.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSqlDatabaseContainerUserDefinedFunction populates the provided destination SqlDatabaseContainerUserDefinedFunction from our SqlDatabaseContainerUserDefinedFunction
 func (sqlDatabaseContainerUserDefinedFunction *SqlDatabaseContainerUserDefinedFunction) AssignPropertiesToSqlDatabaseContainerUserDefinedFunction(destination *v1alpha1api20210515storage.SqlDatabaseContainerUserDefinedFunction) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *sqlDatabaseContainerUserDefinedFunction.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
@@ -263,6 +272,9 @@ func (sqlDatabaseContainerUserDefinedFunction *SqlDatabaseContainerUserDefinedFu
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlUserDefinedFunctionGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = sqlDatabaseContainerUserDefinedFunction.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
@@ -235,9 +235,6 @@ func (sqlDatabaseThroughputSetting *SqlDatabaseThroughputSetting) AssignProperti
 	}
 	sqlDatabaseThroughputSetting.Status = status
 
-	// TypeMeta
-	sqlDatabaseThroughputSetting.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -263,9 +260,6 @@ func (sqlDatabaseThroughputSetting *SqlDatabaseThroughputSetting) AssignProperti
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = sqlDatabaseThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
@@ -216,6 +216,9 @@ func (sqlDatabaseThroughputSetting *SqlDatabaseThroughputSetting) validateResour
 // AssignPropertiesFromSqlDatabaseThroughputSetting populates our SqlDatabaseThroughputSetting from the provided source SqlDatabaseThroughputSetting
 func (sqlDatabaseThroughputSetting *SqlDatabaseThroughputSetting) AssignPropertiesFromSqlDatabaseThroughputSetting(source *v1alpha1api20210515storage.SqlDatabaseThroughputSetting) error {
 
+	// ObjectMeta
+	sqlDatabaseThroughputSetting.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsSqlDatabasesThroughputSettings_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSqlDatabasesThroughputSettingsSpec(&source.Spec)
@@ -232,12 +235,18 @@ func (sqlDatabaseThroughputSetting *SqlDatabaseThroughputSetting) AssignProperti
 	}
 	sqlDatabaseThroughputSetting.Status = status
 
+	// TypeMeta
+	sqlDatabaseThroughputSetting.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSqlDatabaseThroughputSetting populates the provided destination SqlDatabaseThroughputSetting from our SqlDatabaseThroughputSetting
 func (sqlDatabaseThroughputSetting *SqlDatabaseThroughputSetting) AssignPropertiesToSqlDatabaseThroughputSetting(destination *v1alpha1api20210515storage.SqlDatabaseThroughputSetting) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *sqlDatabaseThroughputSetting.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesThroughputSettings_Spec
@@ -254,6 +263,9 @@ func (sqlDatabaseThroughputSetting *SqlDatabaseThroughputSetting) AssignProperti
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToThroughputSettingsGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = sqlDatabaseThroughputSetting.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen.go
@@ -242,9 +242,6 @@ func (sqlDatabase *SqlDatabase) AssignPropertiesFromSqlDatabase(source *v1alpha1
 	}
 	sqlDatabase.Status = status
 
-	// TypeMeta
-	sqlDatabase.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (sqlDatabase *SqlDatabase) AssignPropertiesToSqlDatabase(destination *v1alp
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlDatabaseGetResultsStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = sqlDatabase.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen.go
@@ -223,6 +223,9 @@ func (sqlDatabase *SqlDatabase) validateResourceReferences() error {
 // AssignPropertiesFromSqlDatabase populates our SqlDatabase from the provided source SqlDatabase
 func (sqlDatabase *SqlDatabase) AssignPropertiesFromSqlDatabase(source *v1alpha1api20210515storage.SqlDatabase) error {
 
+	// ObjectMeta
+	sqlDatabase.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec DatabaseAccountsSqlDatabases_Spec
 	err := spec.AssignPropertiesFromDatabaseAccountsSqlDatabasesSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (sqlDatabase *SqlDatabase) AssignPropertiesFromSqlDatabase(source *v1alpha1
 	}
 	sqlDatabase.Status = status
 
+	// TypeMeta
+	sqlDatabase.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSqlDatabase populates the provided destination SqlDatabase from our SqlDatabase
 func (sqlDatabase *SqlDatabase) AssignPropertiesToSqlDatabase(destination *v1alpha1api20210515storage.SqlDatabase) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *sqlDatabase.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210515storage.DatabaseAccountsSqlDatabases_Spec
@@ -261,6 +270,9 @@ func (sqlDatabase *SqlDatabase) AssignPropertiesToSqlDatabase(destination *v1alp
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSqlDatabaseGetResultsStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = sqlDatabase.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen.go
@@ -242,9 +242,6 @@ func (topic *Topic) AssignPropertiesFromTopic(source *v1alpha1api20200601storage
 	}
 	topic.Status = status
 
-	// TypeMeta
-	topic.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (topic *Topic) AssignPropertiesToTopic(destination *v1alpha1api20200601stor
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToTopicStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = topic.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen.go
@@ -223,6 +223,9 @@ func (topic *Topic) validateResourceReferences() error {
 // AssignPropertiesFromTopic populates our Topic from the provided source Topic
 func (topic *Topic) AssignPropertiesFromTopic(source *v1alpha1api20200601storage.Topic) error {
 
+	// ObjectMeta
+	topic.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Topics_Spec
 	err := spec.AssignPropertiesFromTopicsSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (topic *Topic) AssignPropertiesFromTopic(source *v1alpha1api20200601storage
 	}
 	topic.Status = status
 
+	// TypeMeta
+	topic.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToTopic populates the provided destination Topic from our Topic
 func (topic *Topic) AssignPropertiesToTopic(destination *v1alpha1api20200601storage.Topic) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *topic.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20200601storage.Topics_Spec
@@ -261,6 +270,9 @@ func (topic *Topic) AssignPropertiesToTopic(destination *v1alpha1api20200601stor
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToTopicStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = topic.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespace_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespace_types_gen.go
@@ -223,6 +223,9 @@ func (namespace *Namespace) validateResourceReferences() error {
 // AssignPropertiesFromNamespace populates our Namespace from the provided source Namespace
 func (namespace *Namespace) AssignPropertiesFromNamespace(source *v1alpha1api20211101storage.Namespace) error {
 
+	// ObjectMeta
+	namespace.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Namespaces_Spec
 	err := spec.AssignPropertiesFromNamespacesSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (namespace *Namespace) AssignPropertiesFromNamespace(source *v1alpha1api202
 	}
 	namespace.Status = status
 
+	// TypeMeta
+	namespace.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespace populates the provided destination Namespace from our Namespace
 func (namespace *Namespace) AssignPropertiesToNamespace(destination *v1alpha1api20211101storage.Namespace) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespace.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20211101storage.Namespaces_Spec
@@ -261,6 +270,9 @@ func (namespace *Namespace) AssignPropertiesToNamespace(destination *v1alpha1api
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToEHNamespaceStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespace.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespace_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespace_types_gen.go
@@ -242,9 +242,6 @@ func (namespace *Namespace) AssignPropertiesFromNamespace(source *v1alpha1api202
 	}
 	namespace.Status = status
 
-	// TypeMeta
-	namespace.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (namespace *Namespace) AssignPropertiesToNamespace(destination *v1alpha1api
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToEHNamespaceStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespace.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
@@ -244,9 +244,6 @@ func (namespacesAuthorizationRule *NamespacesAuthorizationRule) AssignProperties
 	}
 	namespacesAuthorizationRule.Status = status
 
-	// TypeMeta
-	namespacesAuthorizationRule.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (namespacesAuthorizationRule *NamespacesAuthorizationRule) AssignProperties
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToAuthorizationRuleStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespacesAuthorizationRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
@@ -225,6 +225,9 @@ func (namespacesAuthorizationRule *NamespacesAuthorizationRule) validateResource
 // AssignPropertiesFromNamespacesAuthorizationRule populates our NamespacesAuthorizationRule from the provided source NamespacesAuthorizationRule
 func (namespacesAuthorizationRule *NamespacesAuthorizationRule) AssignPropertiesFromNamespacesAuthorizationRule(source *v1alpha1api20211101storage.NamespacesAuthorizationRule) error {
 
+	// ObjectMeta
+	namespacesAuthorizationRule.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NamespacesAuthorizationRules_Spec
 	err := spec.AssignPropertiesFromNamespacesAuthorizationRulesSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (namespacesAuthorizationRule *NamespacesAuthorizationRule) AssignProperties
 	}
 	namespacesAuthorizationRule.Status = status
 
+	// TypeMeta
+	namespacesAuthorizationRule.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespacesAuthorizationRule populates the provided destination NamespacesAuthorizationRule from our NamespacesAuthorizationRule
 func (namespacesAuthorizationRule *NamespacesAuthorizationRule) AssignPropertiesToNamespacesAuthorizationRule(destination *v1alpha1api20211101storage.NamespacesAuthorizationRule) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespacesAuthorizationRule.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20211101storage.NamespacesAuthorizationRules_Spec
@@ -263,6 +272,9 @@ func (namespacesAuthorizationRule *NamespacesAuthorizationRule) AssignProperties
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToAuthorizationRuleStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespacesAuthorizationRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
@@ -223,6 +223,9 @@ func (namespacesEventhub *NamespacesEventhub) validateResourceReferences() error
 // AssignPropertiesFromNamespacesEventhub populates our NamespacesEventhub from the provided source NamespacesEventhub
 func (namespacesEventhub *NamespacesEventhub) AssignPropertiesFromNamespacesEventhub(source *v1alpha1api20211101storage.NamespacesEventhub) error {
 
+	// ObjectMeta
+	namespacesEventhub.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NamespacesEventhubs_Spec
 	err := spec.AssignPropertiesFromNamespacesEventhubsSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (namespacesEventhub *NamespacesEventhub) AssignPropertiesFromNamespacesEven
 	}
 	namespacesEventhub.Status = status
 
+	// TypeMeta
+	namespacesEventhub.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespacesEventhub populates the provided destination NamespacesEventhub from our NamespacesEventhub
 func (namespacesEventhub *NamespacesEventhub) AssignPropertiesToNamespacesEventhub(destination *v1alpha1api20211101storage.NamespacesEventhub) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespacesEventhub.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20211101storage.NamespacesEventhubs_Spec
@@ -261,6 +270,9 @@ func (namespacesEventhub *NamespacesEventhub) AssignPropertiesToNamespacesEventh
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToEventhubStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespacesEventhub.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
@@ -242,9 +242,6 @@ func (namespacesEventhub *NamespacesEventhub) AssignPropertiesFromNamespacesEven
 	}
 	namespacesEventhub.Status = status
 
-	// TypeMeta
-	namespacesEventhub.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (namespacesEventhub *NamespacesEventhub) AssignPropertiesToNamespacesEventh
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToEventhubStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespacesEventhub.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -225,6 +225,9 @@ func (namespacesEventhubsAuthorizationRule *NamespacesEventhubsAuthorizationRule
 // AssignPropertiesFromNamespacesEventhubsAuthorizationRule populates our NamespacesEventhubsAuthorizationRule from the provided source NamespacesEventhubsAuthorizationRule
 func (namespacesEventhubsAuthorizationRule *NamespacesEventhubsAuthorizationRule) AssignPropertiesFromNamespacesEventhubsAuthorizationRule(source *v1alpha1api20211101storage.NamespacesEventhubsAuthorizationRule) error {
 
+	// ObjectMeta
+	namespacesEventhubsAuthorizationRule.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NamespacesEventhubsAuthorizationRules_Spec
 	err := spec.AssignPropertiesFromNamespacesEventhubsAuthorizationRulesSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (namespacesEventhubsAuthorizationRule *NamespacesEventhubsAuthorizationRule
 	}
 	namespacesEventhubsAuthorizationRule.Status = status
 
+	// TypeMeta
+	namespacesEventhubsAuthorizationRule.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespacesEventhubsAuthorizationRule populates the provided destination NamespacesEventhubsAuthorizationRule from our NamespacesEventhubsAuthorizationRule
 func (namespacesEventhubsAuthorizationRule *NamespacesEventhubsAuthorizationRule) AssignPropertiesToNamespacesEventhubsAuthorizationRule(destination *v1alpha1api20211101storage.NamespacesEventhubsAuthorizationRule) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespacesEventhubsAuthorizationRule.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20211101storage.NamespacesEventhubsAuthorizationRules_Spec
@@ -263,6 +272,9 @@ func (namespacesEventhubsAuthorizationRule *NamespacesEventhubsAuthorizationRule
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToAuthorizationRuleStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespacesEventhubsAuthorizationRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -244,9 +244,6 @@ func (namespacesEventhubsAuthorizationRule *NamespacesEventhubsAuthorizationRule
 	}
 	namespacesEventhubsAuthorizationRule.Status = status
 
-	// TypeMeta
-	namespacesEventhubsAuthorizationRule.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (namespacesEventhubsAuthorizationRule *NamespacesEventhubsAuthorizationRule
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToAuthorizationRuleStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespacesEventhubsAuthorizationRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -225,6 +225,9 @@ func (namespacesEventhubsConsumerGroup *NamespacesEventhubsConsumerGroup) valida
 // AssignPropertiesFromNamespacesEventhubsConsumerGroup populates our NamespacesEventhubsConsumerGroup from the provided source NamespacesEventhubsConsumerGroup
 func (namespacesEventhubsConsumerGroup *NamespacesEventhubsConsumerGroup) AssignPropertiesFromNamespacesEventhubsConsumerGroup(source *v1alpha1api20211101storage.NamespacesEventhubsConsumerGroup) error {
 
+	// ObjectMeta
+	namespacesEventhubsConsumerGroup.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NamespacesEventhubsConsumergroups_Spec
 	err := spec.AssignPropertiesFromNamespacesEventhubsConsumergroupsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (namespacesEventhubsConsumerGroup *NamespacesEventhubsConsumerGroup) Assign
 	}
 	namespacesEventhubsConsumerGroup.Status = status
 
+	// TypeMeta
+	namespacesEventhubsConsumerGroup.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespacesEventhubsConsumerGroup populates the provided destination NamespacesEventhubsConsumerGroup from our NamespacesEventhubsConsumerGroup
 func (namespacesEventhubsConsumerGroup *NamespacesEventhubsConsumerGroup) AssignPropertiesToNamespacesEventhubsConsumerGroup(destination *v1alpha1api20211101storage.NamespacesEventhubsConsumerGroup) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespacesEventhubsConsumerGroup.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20211101storage.NamespacesEventhubsConsumergroups_Spec
@@ -263,6 +272,9 @@ func (namespacesEventhubsConsumerGroup *NamespacesEventhubsConsumerGroup) Assign
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToConsumerGroupStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespacesEventhubsConsumerGroup.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -244,9 +244,6 @@ func (namespacesEventhubsConsumerGroup *NamespacesEventhubsConsumerGroup) Assign
 	}
 	namespacesEventhubsConsumerGroup.Status = status
 
-	// TypeMeta
-	namespacesEventhubsConsumerGroup.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (namespacesEventhubsConsumerGroup *NamespacesEventhubsConsumerGroup) Assign
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToConsumerGroupStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespacesEventhubsConsumerGroup.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
@@ -244,9 +244,6 @@ func (userAssignedIdentity *UserAssignedIdentity) AssignPropertiesFromUserAssign
 	}
 	userAssignedIdentity.Status = status
 
-	// TypeMeta
-	userAssignedIdentity.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (userAssignedIdentity *UserAssignedIdentity) AssignPropertiesToUserAssigned
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToIdentityStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = userAssignedIdentity.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
@@ -225,6 +225,9 @@ func (userAssignedIdentity *UserAssignedIdentity) validateResourceReferences() e
 // AssignPropertiesFromUserAssignedIdentity populates our UserAssignedIdentity from the provided source UserAssignedIdentity
 func (userAssignedIdentity *UserAssignedIdentity) AssignPropertiesFromUserAssignedIdentity(source *v1alpha1api20181130storage.UserAssignedIdentity) error {
 
+	// ObjectMeta
+	userAssignedIdentity.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec UserAssignedIdentities_Spec
 	err := spec.AssignPropertiesFromUserAssignedIdentitiesSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (userAssignedIdentity *UserAssignedIdentity) AssignPropertiesFromUserAssign
 	}
 	userAssignedIdentity.Status = status
 
+	// TypeMeta
+	userAssignedIdentity.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToUserAssignedIdentity populates the provided destination UserAssignedIdentity from our UserAssignedIdentity
 func (userAssignedIdentity *UserAssignedIdentity) AssignPropertiesToUserAssignedIdentity(destination *v1alpha1api20181130storage.UserAssignedIdentity) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *userAssignedIdentity.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20181130storage.UserAssignedIdentities_Spec
@@ -263,6 +272,9 @@ func (userAssignedIdentity *UserAssignedIdentity) AssignPropertiesToUserAssigned
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToIdentityStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = userAssignedIdentity.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen.go
@@ -223,6 +223,9 @@ func (loadBalancer *LoadBalancer) validateResourceReferences() error {
 // AssignPropertiesFromLoadBalancer populates our LoadBalancer from the provided source LoadBalancer
 func (loadBalancer *LoadBalancer) AssignPropertiesFromLoadBalancer(source *v1alpha1api20201101storage.LoadBalancer) error {
 
+	// ObjectMeta
+	loadBalancer.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec LoadBalancers_Spec
 	err := spec.AssignPropertiesFromLoadBalancersSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (loadBalancer *LoadBalancer) AssignPropertiesFromLoadBalancer(source *v1alp
 	}
 	loadBalancer.Status = status
 
+	// TypeMeta
+	loadBalancer.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToLoadBalancer populates the provided destination LoadBalancer from our LoadBalancer
 func (loadBalancer *LoadBalancer) AssignPropertiesToLoadBalancer(destination *v1alpha1api20201101storage.LoadBalancer) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *loadBalancer.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.LoadBalancers_Spec
@@ -261,6 +270,9 @@ func (loadBalancer *LoadBalancer) AssignPropertiesToLoadBalancer(destination *v1
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToLoadBalancerStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = loadBalancer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen.go
@@ -242,9 +242,6 @@ func (loadBalancer *LoadBalancer) AssignPropertiesFromLoadBalancer(source *v1alp
 	}
 	loadBalancer.Status = status
 
-	// TypeMeta
-	loadBalancer.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (loadBalancer *LoadBalancer) AssignPropertiesToLoadBalancer(destination *v1
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToLoadBalancerStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = loadBalancer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_interface_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_interface_types_gen.go
@@ -223,6 +223,9 @@ func (networkInterface *NetworkInterface) validateResourceReferences() error {
 // AssignPropertiesFromNetworkInterface populates our NetworkInterface from the provided source NetworkInterface
 func (networkInterface *NetworkInterface) AssignPropertiesFromNetworkInterface(source *v1alpha1api20201101storage.NetworkInterface) error {
 
+	// ObjectMeta
+	networkInterface.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NetworkInterfaces_Spec
 	err := spec.AssignPropertiesFromNetworkInterfacesSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (networkInterface *NetworkInterface) AssignPropertiesFromNetworkInterface(s
 	}
 	networkInterface.Status = status
 
+	// TypeMeta
+	networkInterface.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNetworkInterface populates the provided destination NetworkInterface from our NetworkInterface
 func (networkInterface *NetworkInterface) AssignPropertiesToNetworkInterface(destination *v1alpha1api20201101storage.NetworkInterface) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *networkInterface.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.NetworkInterfaces_Spec
@@ -261,6 +270,9 @@ func (networkInterface *NetworkInterface) AssignPropertiesToNetworkInterface(des
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToNetworkInterfaceStatusNetworkInterfaceSubResourceEmbedded()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = networkInterface.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_interface_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_interface_types_gen.go
@@ -242,9 +242,6 @@ func (networkInterface *NetworkInterface) AssignPropertiesFromNetworkInterface(s
 	}
 	networkInterface.Status = status
 
-	// TypeMeta
-	networkInterface.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (networkInterface *NetworkInterface) AssignPropertiesToNetworkInterface(des
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToNetworkInterfaceStatusNetworkInterfaceSubResourceEmbedded()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = networkInterface.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen.go
@@ -244,9 +244,6 @@ func (networkSecurityGroup *NetworkSecurityGroup) AssignPropertiesFromNetworkSec
 	}
 	networkSecurityGroup.Status = status
 
-	// TypeMeta
-	networkSecurityGroup.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (networkSecurityGroup *NetworkSecurityGroup) AssignPropertiesToNetworkSecur
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToNetworkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = networkSecurityGroup.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen.go
@@ -225,6 +225,9 @@ func (networkSecurityGroup *NetworkSecurityGroup) validateResourceReferences() e
 // AssignPropertiesFromNetworkSecurityGroup populates our NetworkSecurityGroup from the provided source NetworkSecurityGroup
 func (networkSecurityGroup *NetworkSecurityGroup) AssignPropertiesFromNetworkSecurityGroup(source *v1alpha1api20201101storage.NetworkSecurityGroup) error {
 
+	// ObjectMeta
+	networkSecurityGroup.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NetworkSecurityGroups_Spec
 	err := spec.AssignPropertiesFromNetworkSecurityGroupsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (networkSecurityGroup *NetworkSecurityGroup) AssignPropertiesFromNetworkSec
 	}
 	networkSecurityGroup.Status = status
 
+	// TypeMeta
+	networkSecurityGroup.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNetworkSecurityGroup populates the provided destination NetworkSecurityGroup from our NetworkSecurityGroup
 func (networkSecurityGroup *NetworkSecurityGroup) AssignPropertiesToNetworkSecurityGroup(destination *v1alpha1api20201101storage.NetworkSecurityGroup) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *networkSecurityGroup.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.NetworkSecurityGroups_Spec
@@ -263,6 +272,9 @@ func (networkSecurityGroup *NetworkSecurityGroup) AssignPropertiesToNetworkSecur
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToNetworkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = networkSecurityGroup.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
@@ -225,6 +225,9 @@ func (networkSecurityGroupsSecurityRule *NetworkSecurityGroupsSecurityRule) vali
 // AssignPropertiesFromNetworkSecurityGroupsSecurityRule populates our NetworkSecurityGroupsSecurityRule from the provided source NetworkSecurityGroupsSecurityRule
 func (networkSecurityGroupsSecurityRule *NetworkSecurityGroupsSecurityRule) AssignPropertiesFromNetworkSecurityGroupsSecurityRule(source *v1alpha1api20201101storage.NetworkSecurityGroupsSecurityRule) error {
 
+	// ObjectMeta
+	networkSecurityGroupsSecurityRule.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NetworkSecurityGroupsSecurityRules_Spec
 	err := spec.AssignPropertiesFromNetworkSecurityGroupsSecurityRulesSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (networkSecurityGroupsSecurityRule *NetworkSecurityGroupsSecurityRule) Assi
 	}
 	networkSecurityGroupsSecurityRule.Status = status
 
+	// TypeMeta
+	networkSecurityGroupsSecurityRule.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNetworkSecurityGroupsSecurityRule populates the provided destination NetworkSecurityGroupsSecurityRule from our NetworkSecurityGroupsSecurityRule
 func (networkSecurityGroupsSecurityRule *NetworkSecurityGroupsSecurityRule) AssignPropertiesToNetworkSecurityGroupsSecurityRule(destination *v1alpha1api20201101storage.NetworkSecurityGroupsSecurityRule) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *networkSecurityGroupsSecurityRule.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.NetworkSecurityGroupsSecurityRules_Spec
@@ -263,6 +272,9 @@ func (networkSecurityGroupsSecurityRule *NetworkSecurityGroupsSecurityRule) Assi
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSecurityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = networkSecurityGroupsSecurityRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
@@ -244,9 +244,6 @@ func (networkSecurityGroupsSecurityRule *NetworkSecurityGroupsSecurityRule) Assi
 	}
 	networkSecurityGroupsSecurityRule.Status = status
 
-	// TypeMeta
-	networkSecurityGroupsSecurityRule.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (networkSecurityGroupsSecurityRule *NetworkSecurityGroupsSecurityRule) Assi
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSecurityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = networkSecurityGroupsSecurityRule.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen.go
@@ -242,9 +242,6 @@ func (publicIPAddress *PublicIPAddress) AssignPropertiesFromPublicIPAddress(sour
 	}
 	publicIPAddress.Status = status
 
-	// TypeMeta
-	publicIPAddress.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (publicIPAddress *PublicIPAddress) AssignPropertiesToPublicIPAddress(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPublicIPAddressStatusPublicIPAddressSubResourceEmbedded()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = publicIPAddress.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen.go
@@ -223,6 +223,9 @@ func (publicIPAddress *PublicIPAddress) validateResourceReferences() error {
 // AssignPropertiesFromPublicIPAddress populates our PublicIPAddress from the provided source PublicIPAddress
 func (publicIPAddress *PublicIPAddress) AssignPropertiesFromPublicIPAddress(source *v1alpha1api20201101storage.PublicIPAddress) error {
 
+	// ObjectMeta
+	publicIPAddress.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec PublicIPAddresses_Spec
 	err := spec.AssignPropertiesFromPublicIPAddressesSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (publicIPAddress *PublicIPAddress) AssignPropertiesFromPublicIPAddress(sour
 	}
 	publicIPAddress.Status = status
 
+	// TypeMeta
+	publicIPAddress.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPublicIPAddress populates the provided destination PublicIPAddress from our PublicIPAddress
 func (publicIPAddress *PublicIPAddress) AssignPropertiesToPublicIPAddress(destination *v1alpha1api20201101storage.PublicIPAddress) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *publicIPAddress.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.PublicIPAddresses_Spec
@@ -261,6 +270,9 @@ func (publicIPAddress *PublicIPAddress) AssignPropertiesToPublicIPAddress(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPublicIPAddressStatusPublicIPAddressSubResourceEmbedded()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = publicIPAddress.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
@@ -225,6 +225,9 @@ func (virtualNetworkGateway *VirtualNetworkGateway) validateResourceReferences()
 // AssignPropertiesFromVirtualNetworkGateway populates our VirtualNetworkGateway from the provided source VirtualNetworkGateway
 func (virtualNetworkGateway *VirtualNetworkGateway) AssignPropertiesFromVirtualNetworkGateway(source *v1alpha1api20201101storage.VirtualNetworkGateway) error {
 
+	// ObjectMeta
+	virtualNetworkGateway.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec VirtualNetworkGateways_Spec
 	err := spec.AssignPropertiesFromVirtualNetworkGatewaysSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (virtualNetworkGateway *VirtualNetworkGateway) AssignPropertiesFromVirtualN
 	}
 	virtualNetworkGateway.Status = status
 
+	// TypeMeta
+	virtualNetworkGateway.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToVirtualNetworkGateway populates the provided destination VirtualNetworkGateway from our VirtualNetworkGateway
 func (virtualNetworkGateway *VirtualNetworkGateway) AssignPropertiesToVirtualNetworkGateway(destination *v1alpha1api20201101storage.VirtualNetworkGateway) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *virtualNetworkGateway.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.VirtualNetworkGateways_Spec
@@ -263,6 +272,9 @@ func (virtualNetworkGateway *VirtualNetworkGateway) AssignPropertiesToVirtualNet
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualNetworkGatewayStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = virtualNetworkGateway.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
@@ -244,9 +244,6 @@ func (virtualNetworkGateway *VirtualNetworkGateway) AssignPropertiesFromVirtualN
 	}
 	virtualNetworkGateway.Status = status
 
-	// TypeMeta
-	virtualNetworkGateway.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (virtualNetworkGateway *VirtualNetworkGateway) AssignPropertiesToVirtualNet
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualNetworkGatewayStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = virtualNetworkGateway.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen.go
@@ -242,9 +242,6 @@ func (virtualNetwork *VirtualNetwork) AssignPropertiesFromVirtualNetwork(source 
 	}
 	virtualNetwork.Status = status
 
-	// TypeMeta
-	virtualNetwork.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (virtualNetwork *VirtualNetwork) AssignPropertiesToVirtualNetwork(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualNetworkStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = virtualNetwork.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen.go
@@ -223,6 +223,9 @@ func (virtualNetwork *VirtualNetwork) validateResourceReferences() error {
 // AssignPropertiesFromVirtualNetwork populates our VirtualNetwork from the provided source VirtualNetwork
 func (virtualNetwork *VirtualNetwork) AssignPropertiesFromVirtualNetwork(source *v1alpha1api20201101storage.VirtualNetwork) error {
 
+	// ObjectMeta
+	virtualNetwork.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec VirtualNetworks_Spec
 	err := spec.AssignPropertiesFromVirtualNetworksSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (virtualNetwork *VirtualNetwork) AssignPropertiesFromVirtualNetwork(source 
 	}
 	virtualNetwork.Status = status
 
+	// TypeMeta
+	virtualNetwork.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToVirtualNetwork populates the provided destination VirtualNetwork from our VirtualNetwork
 func (virtualNetwork *VirtualNetwork) AssignPropertiesToVirtualNetwork(destination *v1alpha1api20201101storage.VirtualNetwork) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *virtualNetwork.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.VirtualNetworks_Spec
@@ -261,6 +270,9 @@ func (virtualNetwork *VirtualNetwork) AssignPropertiesToVirtualNetwork(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualNetworkStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = virtualNetwork.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
@@ -244,9 +244,6 @@ func (virtualNetworksSubnet *VirtualNetworksSubnet) AssignPropertiesFromVirtualN
 	}
 	virtualNetworksSubnet.Status = status
 
-	// TypeMeta
-	virtualNetworksSubnet.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (virtualNetworksSubnet *VirtualNetworksSubnet) AssignPropertiesToVirtualNet
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSubnetStatusVirtualNetworksSubnetSubResourceEmbedded()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = virtualNetworksSubnet.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
@@ -225,6 +225,9 @@ func (virtualNetworksSubnet *VirtualNetworksSubnet) validateResourceReferences()
 // AssignPropertiesFromVirtualNetworksSubnet populates our VirtualNetworksSubnet from the provided source VirtualNetworksSubnet
 func (virtualNetworksSubnet *VirtualNetworksSubnet) AssignPropertiesFromVirtualNetworksSubnet(source *v1alpha1api20201101storage.VirtualNetworksSubnet) error {
 
+	// ObjectMeta
+	virtualNetworksSubnet.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec VirtualNetworksSubnets_Spec
 	err := spec.AssignPropertiesFromVirtualNetworksSubnetsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (virtualNetworksSubnet *VirtualNetworksSubnet) AssignPropertiesFromVirtualN
 	}
 	virtualNetworksSubnet.Status = status
 
+	// TypeMeta
+	virtualNetworksSubnet.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToVirtualNetworksSubnet populates the provided destination VirtualNetworksSubnet from our VirtualNetworksSubnet
 func (virtualNetworksSubnet *VirtualNetworksSubnet) AssignPropertiesToVirtualNetworksSubnet(destination *v1alpha1api20201101storage.VirtualNetworksSubnet) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *virtualNetworksSubnet.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.VirtualNetworksSubnets_Spec
@@ -263,6 +272,9 @@ func (virtualNetworksSubnet *VirtualNetworksSubnet) AssignPropertiesToVirtualNet
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSubnetStatusVirtualNetworksSubnetSubResourceEmbedded()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = virtualNetworksSubnet.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -225,6 +225,9 @@ func (virtualNetworksVirtualNetworkPeering *VirtualNetworksVirtualNetworkPeering
 // AssignPropertiesFromVirtualNetworksVirtualNetworkPeering populates our VirtualNetworksVirtualNetworkPeering from the provided source VirtualNetworksVirtualNetworkPeering
 func (virtualNetworksVirtualNetworkPeering *VirtualNetworksVirtualNetworkPeering) AssignPropertiesFromVirtualNetworksVirtualNetworkPeering(source *v1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeering) error {
 
+	// ObjectMeta
+	virtualNetworksVirtualNetworkPeering.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec VirtualNetworksVirtualNetworkPeerings_Spec
 	err := spec.AssignPropertiesFromVirtualNetworksVirtualNetworkPeeringsSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (virtualNetworksVirtualNetworkPeering *VirtualNetworksVirtualNetworkPeering
 	}
 	virtualNetworksVirtualNetworkPeering.Status = status
 
+	// TypeMeta
+	virtualNetworksVirtualNetworkPeering.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToVirtualNetworksVirtualNetworkPeering populates the provided destination VirtualNetworksVirtualNetworkPeering from our VirtualNetworksVirtualNetworkPeering
 func (virtualNetworksVirtualNetworkPeering *VirtualNetworksVirtualNetworkPeering) AssignPropertiesToVirtualNetworksVirtualNetworkPeering(destination *v1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeering) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *virtualNetworksVirtualNetworkPeering.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeerings_Spec
@@ -263,6 +272,9 @@ func (virtualNetworksVirtualNetworkPeering *VirtualNetworksVirtualNetworkPeering
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualNetworkPeeringStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = virtualNetworksVirtualNetworkPeering.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -244,9 +244,6 @@ func (virtualNetworksVirtualNetworkPeering *VirtualNetworksVirtualNetworkPeering
 	}
 	virtualNetworksVirtualNetworkPeering.Status = status
 
-	// TypeMeta
-	virtualNetworksVirtualNetworkPeering.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (virtualNetworksVirtualNetworkPeering *VirtualNetworksVirtualNetworkPeering
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToVirtualNetworkPeeringStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = virtualNetworksVirtualNetworkPeering.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
@@ -242,9 +242,6 @@ func (namespace *Namespace) AssignPropertiesFromNamespace(source *v1alpha1api202
 	}
 	namespace.Status = status
 
-	// TypeMeta
-	namespace.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (namespace *Namespace) AssignPropertiesToNamespace(destination *v1alpha1api
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSBNamespaceStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespace.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen.go
@@ -223,6 +223,9 @@ func (namespace *Namespace) validateResourceReferences() error {
 // AssignPropertiesFromNamespace populates our Namespace from the provided source Namespace
 func (namespace *Namespace) AssignPropertiesFromNamespace(source *v1alpha1api20210101previewstorage.Namespace) error {
 
+	// ObjectMeta
+	namespace.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Namespaces_Spec
 	err := spec.AssignPropertiesFromNamespacesSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (namespace *Namespace) AssignPropertiesFromNamespace(source *v1alpha1api202
 	}
 	namespace.Status = status
 
+	// TypeMeta
+	namespace.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespace populates the provided destination Namespace from our Namespace
 func (namespace *Namespace) AssignPropertiesToNamespace(destination *v1alpha1api20210101previewstorage.Namespace) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespace.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210101previewstorage.Namespaces_Spec
@@ -261,6 +270,9 @@ func (namespace *Namespace) AssignPropertiesToNamespace(destination *v1alpha1api
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSBNamespaceStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespace.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
@@ -223,6 +223,9 @@ func (namespacesQueue *NamespacesQueue) validateResourceReferences() error {
 // AssignPropertiesFromNamespacesQueue populates our NamespacesQueue from the provided source NamespacesQueue
 func (namespacesQueue *NamespacesQueue) AssignPropertiesFromNamespacesQueue(source *v1alpha1api20210101previewstorage.NamespacesQueue) error {
 
+	// ObjectMeta
+	namespacesQueue.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NamespacesQueues_Spec
 	err := spec.AssignPropertiesFromNamespacesQueuesSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (namespacesQueue *NamespacesQueue) AssignPropertiesFromNamespacesQueue(sour
 	}
 	namespacesQueue.Status = status
 
+	// TypeMeta
+	namespacesQueue.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespacesQueue populates the provided destination NamespacesQueue from our NamespacesQueue
 func (namespacesQueue *NamespacesQueue) AssignPropertiesToNamespacesQueue(destination *v1alpha1api20210101previewstorage.NamespacesQueue) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespacesQueue.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210101previewstorage.NamespacesQueues_Spec
@@ -261,6 +270,9 @@ func (namespacesQueue *NamespacesQueue) AssignPropertiesToNamespacesQueue(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSBQueueStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespacesQueue.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
@@ -242,9 +242,6 @@ func (namespacesQueue *NamespacesQueue) AssignPropertiesFromNamespacesQueue(sour
 	}
 	namespacesQueue.Status = status
 
-	// TypeMeta
-	namespacesQueue.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (namespacesQueue *NamespacesQueue) AssignPropertiesToNamespacesQueue(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSBQueueStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespacesQueue.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
@@ -242,9 +242,6 @@ func (namespacesTopic *NamespacesTopic) AssignPropertiesFromNamespacesTopic(sour
 	}
 	namespacesTopic.Status = status
 
-	// TypeMeta
-	namespacesTopic.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (namespacesTopic *NamespacesTopic) AssignPropertiesToNamespacesTopic(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSBTopicStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = namespacesTopic.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
@@ -223,6 +223,9 @@ func (namespacesTopic *NamespacesTopic) validateResourceReferences() error {
 // AssignPropertiesFromNamespacesTopic populates our NamespacesTopic from the provided source NamespacesTopic
 func (namespacesTopic *NamespacesTopic) AssignPropertiesFromNamespacesTopic(source *v1alpha1api20210101previewstorage.NamespacesTopic) error {
 
+	// ObjectMeta
+	namespacesTopic.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec NamespacesTopics_Spec
 	err := spec.AssignPropertiesFromNamespacesTopicsSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (namespacesTopic *NamespacesTopic) AssignPropertiesFromNamespacesTopic(sour
 	}
 	namespacesTopic.Status = status
 
+	// TypeMeta
+	namespacesTopic.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToNamespacesTopic populates the provided destination NamespacesTopic from our NamespacesTopic
 func (namespacesTopic *NamespacesTopic) AssignPropertiesToNamespacesTopic(destination *v1alpha1api20210101previewstorage.NamespacesTopic) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *namespacesTopic.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210101previewstorage.NamespacesTopics_Spec
@@ -261,6 +270,9 @@ func (namespacesTopic *NamespacesTopic) AssignPropertiesToNamespacesTopic(destin
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSBTopicStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = namespacesTopic.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.signalrservice/v1alpha1api20211001/signal_r_types_gen.go
+++ b/v2/api/microsoft.signalrservice/v1alpha1api20211001/signal_r_types_gen.go
@@ -224,6 +224,9 @@ func (signalR *SignalR) validateResourceReferences() error {
 // AssignPropertiesFromSignalR populates our SignalR from the provided source SignalR
 func (signalR *SignalR) AssignPropertiesFromSignalR(source *v1alpha1api20211001storage.SignalR) error {
 
+	// ObjectMeta
+	signalR.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec SignalR_Spec
 	err := spec.AssignPropertiesFromSignalRSpec(&source.Spec)
@@ -240,12 +243,18 @@ func (signalR *SignalR) AssignPropertiesFromSignalR(source *v1alpha1api20211001s
 	}
 	signalR.Status = status
 
+	// TypeMeta
+	signalR.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToSignalR populates the provided destination SignalR from our SignalR
 func (signalR *SignalR) AssignPropertiesToSignalR(destination *v1alpha1api20211001storage.SignalR) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *signalR.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20211001storage.SignalR_Spec
@@ -262,6 +271,9 @@ func (signalR *SignalR) AssignPropertiesToSignalR(destination *v1alpha1api202110
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSignalRResourceStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = signalR.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.signalrservice/v1alpha1api20211001/signal_r_types_gen.go
+++ b/v2/api/microsoft.signalrservice/v1alpha1api20211001/signal_r_types_gen.go
@@ -243,9 +243,6 @@ func (signalR *SignalR) AssignPropertiesFromSignalR(source *v1alpha1api20211001s
 	}
 	signalR.Status = status
 
-	// TypeMeta
-	signalR.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -271,9 +268,6 @@ func (signalR *SignalR) AssignPropertiesToSignalR(destination *v1alpha1api202110
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToSignalRResourceStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = signalR.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
@@ -223,6 +223,9 @@ func (storageAccount *StorageAccount) validateResourceReferences() error {
 // AssignPropertiesFromStorageAccount populates our StorageAccount from the provided source StorageAccount
 func (storageAccount *StorageAccount) AssignPropertiesFromStorageAccount(source *v1alpha1api20210401storage.StorageAccount) error {
 
+	// ObjectMeta
+	storageAccount.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec StorageAccounts_Spec
 	err := spec.AssignPropertiesFromStorageAccountsSpec(&source.Spec)
@@ -239,12 +242,18 @@ func (storageAccount *StorageAccount) AssignPropertiesFromStorageAccount(source 
 	}
 	storageAccount.Status = status
 
+	// TypeMeta
+	storageAccount.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToStorageAccount populates the provided destination StorageAccount from our StorageAccount
 func (storageAccount *StorageAccount) AssignPropertiesToStorageAccount(destination *v1alpha1api20210401storage.StorageAccount) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *storageAccount.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210401storage.StorageAccounts_Spec
@@ -261,6 +270,9 @@ func (storageAccount *StorageAccount) AssignPropertiesToStorageAccount(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToStorageAccountStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = storageAccount.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen.go
@@ -242,9 +242,6 @@ func (storageAccount *StorageAccount) AssignPropertiesFromStorageAccount(source 
 	}
 	storageAccount.Status = status
 
-	// TypeMeta
-	storageAccount.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -270,9 +267,6 @@ func (storageAccount *StorageAccount) AssignPropertiesToStorageAccount(destinati
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToStorageAccountStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = storageAccount.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
@@ -216,6 +216,9 @@ func (storageAccountsBlobService *StorageAccountsBlobService) validateResourceRe
 // AssignPropertiesFromStorageAccountsBlobService populates our StorageAccountsBlobService from the provided source StorageAccountsBlobService
 func (storageAccountsBlobService *StorageAccountsBlobService) AssignPropertiesFromStorageAccountsBlobService(source *v1alpha1api20210401storage.StorageAccountsBlobService) error {
 
+	// ObjectMeta
+	storageAccountsBlobService.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec StorageAccountsBlobServices_Spec
 	err := spec.AssignPropertiesFromStorageAccountsBlobServicesSpec(&source.Spec)
@@ -232,12 +235,18 @@ func (storageAccountsBlobService *StorageAccountsBlobService) AssignPropertiesFr
 	}
 	storageAccountsBlobService.Status = status
 
+	// TypeMeta
+	storageAccountsBlobService.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToStorageAccountsBlobService populates the provided destination StorageAccountsBlobService from our StorageAccountsBlobService
 func (storageAccountsBlobService *StorageAccountsBlobService) AssignPropertiesToStorageAccountsBlobService(destination *v1alpha1api20210401storage.StorageAccountsBlobService) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *storageAccountsBlobService.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210401storage.StorageAccountsBlobServices_Spec
@@ -254,6 +263,9 @@ func (storageAccountsBlobService *StorageAccountsBlobService) AssignPropertiesTo
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToBlobServicePropertiesStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = storageAccountsBlobService.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
@@ -235,9 +235,6 @@ func (storageAccountsBlobService *StorageAccountsBlobService) AssignPropertiesFr
 	}
 	storageAccountsBlobService.Status = status
 
-	// TypeMeta
-	storageAccountsBlobService.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -263,9 +260,6 @@ func (storageAccountsBlobService *StorageAccountsBlobService) AssignPropertiesTo
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToBlobServicePropertiesStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = storageAccountsBlobService.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
@@ -244,9 +244,6 @@ func (storageAccountsBlobServicesContainer *StorageAccountsBlobServicesContainer
 	}
 	storageAccountsBlobServicesContainer.Status = status
 
-	// TypeMeta
-	storageAccountsBlobServicesContainer.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -272,9 +269,6 @@ func (storageAccountsBlobServicesContainer *StorageAccountsBlobServicesContainer
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToBlobContainerStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = storageAccountsBlobServicesContainer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
@@ -225,6 +225,9 @@ func (storageAccountsBlobServicesContainer *StorageAccountsBlobServicesContainer
 // AssignPropertiesFromStorageAccountsBlobServicesContainer populates our StorageAccountsBlobServicesContainer from the provided source StorageAccountsBlobServicesContainer
 func (storageAccountsBlobServicesContainer *StorageAccountsBlobServicesContainer) AssignPropertiesFromStorageAccountsBlobServicesContainer(source *v1alpha1api20210401storage.StorageAccountsBlobServicesContainer) error {
 
+	// ObjectMeta
+	storageAccountsBlobServicesContainer.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec StorageAccountsBlobServicesContainers_Spec
 	err := spec.AssignPropertiesFromStorageAccountsBlobServicesContainersSpec(&source.Spec)
@@ -241,12 +244,18 @@ func (storageAccountsBlobServicesContainer *StorageAccountsBlobServicesContainer
 	}
 	storageAccountsBlobServicesContainer.Status = status
 
+	// TypeMeta
+	storageAccountsBlobServicesContainer.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToStorageAccountsBlobServicesContainer populates the provided destination StorageAccountsBlobServicesContainer from our StorageAccountsBlobServicesContainer
 func (storageAccountsBlobServicesContainer *StorageAccountsBlobServicesContainer) AssignPropertiesToStorageAccountsBlobServicesContainer(destination *v1alpha1api20210401storage.StorageAccountsBlobServicesContainer) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *storageAccountsBlobServicesContainer.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v1alpha1api20210401storage.StorageAccountsBlobServicesContainers_Spec
@@ -263,6 +272,9 @@ func (storageAccountsBlobServicesContainer *StorageAccountsBlobServicesContainer
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToBlobContainerStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = storageAccountsBlobServicesContainer.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/astmodel/file_definition.go
+++ b/v2/tools/generator/internal/astmodel/file_definition.go
@@ -140,7 +140,7 @@ func (file *FileDefinition) generateImports() *PackageImportSet {
 	requiredImports.Remove(selfImport)
 
 	// TODO: Make this configurable
-	requiredImports.ApplyName(MetaV1PackageReference, "metav1")
+	requiredImports.ApplyName(MetaV1Reference, "metav1")
 	requiredImports.ApplyName(APIMachineryErrorsReference, "kerrors")
 
 	// Force local imports to have explicit names based on the service

--- a/v2/tools/generator/internal/astmodel/object_type.go
+++ b/v2/tools/generator/internal/astmodel/object_type.go
@@ -106,7 +106,7 @@ func (objectType *ObjectType) Properties() PropertySet {
 	return objectType.properties.Copy()
 }
 
-// Property returns the details of a specific property based on its unique case sensitive name
+// Property returns the details of a specific property based on its unique case-sensitive name
 func (objectType *ObjectType) Property(name PropertyName) (*PropertyDefinition, bool) {
 	prop, ok := objectType.properties[name]
 	return prop, ok
@@ -234,7 +234,7 @@ func (objectType *ObjectType) References() TypeNameSet {
 	return results
 }
 
-// Equals returns true if the passed type is a object type with the same properties, false otherwise
+// Equals returns true if the passed type is an object type with the same properties, false otherwise
 // The order of the properties is not relevant
 func (objectType *ObjectType) Equals(t Type, overrides EqualityOverrides) bool {
 	if objectType == t {
@@ -528,7 +528,7 @@ func (objectType *ObjectType) TestCases() []TestCase {
 	return result
 }
 
-// IsObjectDefinition returns true if the passed definition is for a Arm type; false otherwise.
+// IsObjectDefinition returns true if the passed definition is for an ARM type; false otherwise.
 func IsObjectDefinition(definition TypeDefinition) bool {
 	_, ok := AsObjectType(definition.theType)
 	return ok
@@ -543,9 +543,9 @@ func extractEmbeddedTypeName(t Type) (TypeName, error) {
 	return TypeName{}, errors.Errorf("embedded property type must be TypeName, was: %T", t)
 }
 
-// WriteDebugDescription adds a description of the current type to the passed builder
-// builder receives the full description, including nested types
-// types is a dictionary for resolving named types
+// WriteDebugDescription adds a description of the current type to the passed builder.
+// builder receives the full description, including nested types.
+// types is a dictionary for resolving named types.
 func (objectType *ObjectType) WriteDebugDescription(builder *strings.Builder, _ Types) {
 	if objectType == nil {
 		builder.WriteString("<nilObject>")

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -18,8 +18,6 @@ const (
 	GroupSuffix          = ".azure.com"
 )
 
-var MetaV1PackageReference = MakeExternalPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
-
 type PackageReference interface {
 	// AsLocalPackage attempts conversion to a LocalPackageReference
 	AsLocalPackage() (LocalPackageReference, bool)

--- a/v2/tools/generator/internal/astmodel/property_container.go
+++ b/v2/tools/generator/internal/astmodel/property_container.go
@@ -13,6 +13,9 @@ type PropertyContainer interface {
 
 	// Property returns the property and true if the named property is found, nil and false otherwise
 	Property(name PropertyName) (*PropertyDefinition, bool)
+
+	// EmbeddedProperties returns all the embedded properties in this container
+	EmbeddedProperties() []*PropertyDefinition
 }
 
 // AsPropertyContainer converts a type into a property container

--- a/v2/tools/generator/internal/astmodel/property_container.go
+++ b/v2/tools/generator/internal/astmodel/property_container.go
@@ -8,7 +8,7 @@ package astmodel
 // PropertyContainer is implemented by Types that contain properties
 // Provides readonly access as we need to use a TypeVisitor for modifications to preserve type wrapping
 type PropertyContainer interface {
-	// Properties returns all the properties from this container
+	// Properties returns all the properties in this container
 	Properties() PropertySet
 
 	// Property returns the property and true if the named property is found, nil and false otherwise

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -83,10 +83,16 @@ func NewPropertyDefinition(propertyName PropertyName, jsonName string, propertyT
 	}
 }
 
-// WithName returns a new PropertyDefinition with the given name (and JSON name)
-func (property *PropertyDefinition) WithName(name PropertyName, jsonName string) *PropertyDefinition {
+// WithName returns a new PropertyDefinition with the given name
+func (property *PropertyDefinition) WithName(name PropertyName) *PropertyDefinition {
 	result := *property
 	result.propertyName = name
+	return &result
+}
+
+// WithName returns a new PropertyDefinition with the JSON name
+func (property *PropertyDefinition) WithJsonName(jsonName string) *PropertyDefinition {
+	result := *property
 	// TODO post-alpha: replace result.tags with structured types
 	if jsonName != result.tags["json"][0] {
 		// copy tags and update

--- a/v2/tools/generator/internal/astmodel/property_injector.go
+++ b/v2/tools/generator/internal/astmodel/property_injector.go
@@ -19,7 +19,6 @@ func NewPropertyInjector() *PropertyInjector {
 
 	result.visitor = TypeVisitorBuilder{
 		VisitObjectType:   result.injectPropertyIntoObject,
-		VisitResourceType: result.injectPropertyIntoResource,
 	}.Build()
 
 	return result
@@ -45,16 +44,4 @@ func (pi *PropertyInjector) injectPropertyIntoObject(
 	}
 
 	return ot.WithProperty(prop), nil
-}
-
-// injectPropertyIntoResource takes the property  provided as a context and includes it on the provided resource type
-func (pi *PropertyInjector) injectPropertyIntoResource(
-	_ *TypeVisitor, rt *ResourceType, ctx interface{}) (Type, error) {
-	prop := ctx.(*PropertyDefinition)
-	// Ensure that we don't already have a property with the same name
-	if _, ok := rt.Property(prop.PropertyName()); ok {
-		return nil, errors.Errorf("already has property named %q", prop.PropertyName())
-	}
-
-	return rt.WithProperty(prop), nil
 }

--- a/v2/tools/generator/internal/astmodel/property_injector.go
+++ b/v2/tools/generator/internal/astmodel/property_injector.go
@@ -18,7 +18,7 @@ func NewPropertyInjector() *PropertyInjector {
 	result := &PropertyInjector{}
 
 	result.visitor = TypeVisitorBuilder{
-		VisitObjectType:   result.injectPropertyIntoObject,
+		VisitObjectType: result.injectPropertyIntoObject,
 	}.Build()
 
 	return result

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -346,12 +346,11 @@ func (resource *ResourceType) Equals(other Type, override EqualityOverrides) boo
 // EmbeddedProperties returns all the embedded properties for this resource type
 // An ordered slice is returned to preserve immutability and provide determinism
 func (resource *ResourceType) EmbeddedProperties() []*PropertyDefinition {
-	typeMetaType := MakeTypeName(MetaV1PackageReference, "TypeMeta")
+	typeMetaType := MakeTypeName(MetaV1Reference, "TypeMeta")
 	typeMetaProperty := NewPropertyDefinition("", "", typeMetaType).
 		WithTag("json", "inline")
 
-	objectMetaType := MakeTypeName(MetaV1PackageReference, "ObjectMeta")
-	objectMetaProperty := NewPropertyDefinition("", "metadata", objectMetaType).
+	objectMetaProperty := NewPropertyDefinition("", "metadata", ObjectMetaType).
 		WithTag("json", "omitempty")
 
 	return []*PropertyDefinition{
@@ -513,7 +512,7 @@ func (resource *ResourceType) WithAnnotation(annotation string) *ResourceType {
 
 // RequiredPackageReferences returns a list of packages required by this
 func (resource *ResourceType) RequiredPackageReferences() *PackageReferenceSet {
-	references := NewPackageReferenceSet(MetaV1PackageReference)
+	references := NewPackageReferenceSet(MetaV1Reference)
 	references.Merge(resource.spec.RequiredPackageReferences())
 
 	if resource.status != nil {
@@ -648,7 +647,7 @@ func (resource *ResourceType) resourceListTypeDecls(
 
 	typeName := resource.makeResourceListTypeName(resourceTypeName)
 
-	packageName := codeGenerationContext.MustGetImportedPackageName(MetaV1PackageReference)
+	packageName := codeGenerationContext.MustGetImportedPackageName(MetaV1Reference)
 
 	typeMetaField := defineField("", dst.NewIdent(fmt.Sprintf("%s.TypeMeta", packageName)), "`json:\",inline\"`")
 	objectMetaField := defineField("", dst.NewIdent(fmt.Sprintf("%s.ListMeta", packageName)), "`json:\"metadata,omitempty\"`")

--- a/v2/tools/generator/internal/astmodel/resource_type_test.go
+++ b/v2/tools/generator/internal/astmodel/resource_type_test.go
@@ -86,68 +86,6 @@ func TestResourceType_Property_ForSpec_ReturnsProperty(t *testing.T) {
 }
 
 /*
- * WithProperty() tests
- */
-
-func TestResourceType_WithProperty_HasExpectedLength(t *testing.T) {
-	g := NewGomegaWithT(t)
-	base := NewResourceType(emptySpec, emptyStatus)
-	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
-	resource := base.WithProperty(ownerProp)
-	g.Expect(resource.Properties()).To(HaveLen(3))
-}
-
-func TestResourceType_WithProperty_IncludesProperty(t *testing.T) {
-	g := NewGomegaWithT(t)
-	base := NewResourceType(emptySpec, emptyStatus)
-	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
-	resource := base.WithProperty(ownerProp)
-	prop, ok := resource.Property("Owner")
-	g.Expect(ok).To(BeTrue())
-	g.Expect(prop).NotTo(BeNil())
-}
-
-func TestResourceType_WithProperty_OverridingSpec_Panics(t *testing.T) {
-	g := NewGomegaWithT(t)
-	base := NewResourceType(emptySpec, emptyStatus)
-	specProp := NewPropertyDefinition("Spec", "spec", StringType)
-	g.Expect(func() { base.WithProperty(specProp) }).To(Panic())
-}
-
-func TestResourceType_WithProperty_OverridingStatus_Panics(t *testing.T) {
-	g := NewGomegaWithT(t)
-	base := NewResourceType(emptySpec, emptyStatus)
-	statusProp := NewPropertyDefinition("Status", "status", StringType)
-	g.Expect(func() { base.WithProperty(statusProp) }).To(Panic())
-}
-
-/*
- * WithoutProperty() tests
- */
-
-func TestResourceType_WithoutProperty_ExcludesProperty(t *testing.T) {
-	g := NewGomegaWithT(t)
-	ownerProp := NewPropertyDefinition("Owner", "owner", StringType)
-	base := NewResourceType(emptySpec, emptyStatus).WithProperty(ownerProp)
-	resource := base.WithoutProperty("Owner")
-	prop, ok := resource.Property("Owner")
-	g.Expect(ok).To(BeFalse())
-	g.Expect(prop).To(BeNil())
-}
-
-func TestResourceType_WithoutSpecProperty_Panics(t *testing.T) {
-	g := NewGomegaWithT(t)
-	base := NewResourceType(emptySpec, emptyStatus)
-	g.Expect(func() { base.WithoutProperty("Spec") }).To(Panic())
-}
-
-func TestResourceType_WithoutStatusProperty_Panics(t *testing.T) {
-	g := NewGomegaWithT(t)
-	base := NewResourceType(emptySpec, emptyStatus)
-	g.Expect(func() { base.WithoutProperty("Status") }).To(Panic())
-}
-
-/*
  * WithAnnotation() tests
  */
 

--- a/v2/tools/generator/internal/astmodel/std_references.go
+++ b/v2/tools/generator/internal/astmodel/std_references.go
@@ -73,7 +73,6 @@ var (
 	GroupVersionKindType = MakeTypeName(APIMachinerySchemaReference, "GroupVersionKind")
 	SchemeType           = MakeTypeName(APIMachineryRuntimeReference, "Scheme")
 	JSONType             = MakeTypeName(APIExtensionsReference, "JSON")
-	TypeMetaType         = MakeTypeName(MetaV1Reference, "TypeMeta")
 	ObjectMetaType       = MakeTypeName(MetaV1Reference, "ObjectMeta")
 
 	// Type names - Controller Runtime

--- a/v2/tools/generator/internal/astmodel/std_references.go
+++ b/v2/tools/generator/internal/astmodel/std_references.go
@@ -73,6 +73,7 @@ var (
 	GroupVersionKindType = MakeTypeName(APIMachinerySchemaReference, "GroupVersionKind")
 	SchemeType           = MakeTypeName(APIMachineryRuntimeReference, "Scheme")
 	JSONType             = MakeTypeName(APIExtensionsReference, "JSON")
+	TypeMetaType         = MakeTypeName(MetaV1Reference, "TypeMeta")
 	ObjectMetaType       = MakeTypeName(MetaV1Reference, "ObjectMeta")
 
 	// Type names - Controller Runtime

--- a/v2/tools/generator/internal/astmodel/std_references.go
+++ b/v2/tools/generator/internal/astmodel/std_references.go
@@ -29,6 +29,7 @@ var (
 	APIMachineryErrorsReference  = MakeExternalPackageReference("k8s.io/apimachinery/pkg/util/errors")
 	APIMachineryRuntimeReference = MakeExternalPackageReference("k8s.io/apimachinery/pkg/runtime")
 	APIMachinerySchemaReference  = MakeExternalPackageReference("k8s.io/apimachinery/pkg/runtime/schema")
+	MetaV1Reference              = MakeExternalPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
 
 	ClientGoSchemeReference     = MakeExternalPackageReference("k8s.io/client-go/kubernetes/scheme")
 	ControllerRuntimeAdmission  = MakeExternalPackageReference("sigs.k8s.io/controller-runtime/pkg/webhook/admission")
@@ -72,6 +73,7 @@ var (
 	GroupVersionKindType = MakeTypeName(APIMachinerySchemaReference, "GroupVersionKind")
 	SchemeType           = MakeTypeName(APIMachineryRuntimeReference, "Scheme")
 	JSONType             = MakeTypeName(APIExtensionsReference, "JSON")
+	ObjectMetaType       = MakeTypeName(MetaV1Reference, "ObjectMeta")
 
 	// Type names - Controller Runtime
 	ConvertibleInterface = MakeTypeName(ControllerRuntimeConversion, "Convertible")

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
@@ -128,7 +128,7 @@ func fixCollisions(props []*astmodel.PropertyDefinition) []*astmodel.PropertyDef
 				// disambiguate by prefixing with properties
 				newName := astmodel.PropertyName(strings.Join(stringNames, "") + string(p.PropertyName()))
 				newJsonName := strings.ToLower(strings.Join(stringNames, "_") + string(p.PropertyName()))
-				p = p.WithName(newName, newJsonName)
+				p = p.WithName(newName).WithJsonName(newJsonName)
 			}
 		}
 

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_properties_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_properties_test.go
@@ -37,7 +37,10 @@ func TestDuplicateNamesAreCaughtAndRenamed(t *testing.T) {
 	// should have a renamed property which is flattened-from "inner"
 	newName := astmodel.PropertyName("InnerDuplicate")
 	newJsonName := "inner_duplicate"
-	newObjType := astmodel.NewObjectType().WithProperties(prop, prop.WithName(newName, newJsonName).AddFlattenedFrom(astmodel.PropertyName("Inner")))
+	newObjType := astmodel.NewObjectType().
+		WithProperties(
+			prop,
+			prop.WithName(newName).WithJsonName(newJsonName).AddFlattenedFrom(astmodel.PropertyName("Inner")))
 	expectedTypes := make(astmodel.Types)
 	expectedTypes.Add(astmodel.MakeTypeDefinition(astmodel.MakeTypeName(placeholderPackage, "ObjType"), newObjType))
 

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101.golden
@@ -59,6 +59,9 @@
  // AssignPropertiesFromPerson populates our Person from the provided source Person
  func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person) error {
  
+ 	// ObjectMeta
+ 	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+ 
  	// Spec
  	var spec Person_Spec
  	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -75,12 +78,18 @@
  	}
  	person.Status = status
  
+ 	// TypeMeta
+ 	person.TypeMeta = source.TypeMeta
+ 
  	// No error
  	return nil
  }
  
  // AssignPropertiesToPerson populates the provided destination Person from our Person
  func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Person) error {
+ 
+ 	// ObjectMeta
+ 	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
  
  	// Spec
  	var spec v20200101storage.Person_Spec
@@ -97,6 +106,9 @@
  		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
  	}
  	destination.Status = status
+ 
+ 	// TypeMeta
+ 	destination.TypeMeta = person.TypeMeta
  
  	// No error
  	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101.golden
@@ -78,9 +78,6 @@
  	}
  	person.Status = status
  
- 	// TypeMeta
- 	person.TypeMeta = source.TypeMeta
- 
  	// No error
  	return nil
  }
@@ -106,9 +103,6 @@
  		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
  	}
  	destination.Status = status
- 
- 	// TypeMeta
- 	destination.TypeMeta = person.TypeMeta
  
  	// No error
  	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
@@ -47,6 +47,9 @@
  // AssignPropertiesFromPerson populates our Person from the provided source Person
  func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
  
+ 	// ObjectMeta
+ 	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+ 
  	// Spec
  	var spec Person_Spec
  	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -63,12 +66,18 @@
  	}
  	person.Status = status
  
+ 	// TypeMeta
+ 	person.TypeMeta = source.TypeMeta
+ 
  	// No error
  	return nil
  }
  
  // AssignPropertiesToPerson populates the provided destination Person from our Person
  func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+ 
+ 	// ObjectMeta
+ 	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
  
  	// Spec
  	var spec v20211231storage.Person_Spec
@@ -85,6 +94,9 @@
  		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
  	}
  	destination.Status = status
+ 
+ 	// TypeMeta
+ 	destination.TypeMeta = person.TypeMeta
  
  	// No error
  	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20200101storage.golden
@@ -66,9 +66,6 @@
  	}
  	person.Status = status
  
- 	// TypeMeta
- 	person.TypeMeta = source.TypeMeta
- 
  	// No error
  	return nil
  }
@@ -94,9 +91,6 @@
  		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
  	}
  	destination.Status = status
- 
- 	// TypeMeta
- 	destination.TypeMeta = person.TypeMeta
  
  	// No error
  	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231.golden
@@ -65,9 +65,6 @@
  	}
  	person.Status = status
  
- 	// TypeMeta
- 	person.TypeMeta = source.TypeMeta
- 
  	// No error
  	return nil
  }
@@ -93,9 +90,6 @@
  		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
  	}
  	destination.Status = status
- 
- 	// TypeMeta
- 	destination.TypeMeta = person.TypeMeta
  
  	// No error
  	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleInterface/microsoft.person-v20211231.golden
@@ -46,6 +46,9 @@
  // AssignPropertiesFromPerson populates our Person from the provided source Person
  func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
  
+ 	// ObjectMeta
+ 	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+ 
  	// Spec
  	var spec Person_Spec
  	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -62,12 +65,18 @@
  	}
  	person.Status = status
  
+ 	// TypeMeta
+ 	person.TypeMeta = source.TypeMeta
+ 
  	// No error
  	return nil
  }
  
  // AssignPropertiesToPerson populates the provided destination Person from our Person
  func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+ 
+ 	// ObjectMeta
+ 	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
  
  	// Spec
  	var spec v20211231storage.Person_Spec
@@ -84,6 +93,9 @@
  		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
  	}
  	destination.Status = status
+ 
+ 	// TypeMeta
+ 	destination.TypeMeta = person.TypeMeta
  
  	// No error
  	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20200101storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
@@ -42,9 +42,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -70,9 +67,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20200101storage.golden
@@ -23,6 +23,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -39,12 +42,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -61,6 +70,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20211231.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleSpecInterface/microsoft.person-v20211231.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20200101storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
@@ -42,9 +42,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -70,9 +67,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20200101storage.golden
@@ -23,6 +23,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -39,12 +42,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -61,6 +70,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20211231.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectConvertibleStatusInterface/microsoft.person-v20211231.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20200101storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101storage.golden
@@ -42,9 +42,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -70,9 +67,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20200101storage.golden
@@ -23,6 +23,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -39,12 +42,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -61,6 +70,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20211231.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/microsoft.person-v20211231.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20200101storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
@@ -42,9 +42,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -70,9 +67,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20200101storage.golden
@@ -23,6 +23,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -39,12 +42,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -61,6 +70,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20211231.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/microsoft.person-v20211231.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20200101storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
@@ -42,9 +42,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -70,9 +67,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20200101storage.golden
@@ -23,6 +23,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -39,12 +42,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -61,6 +70,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20211231.golden
@@ -22,6 +22,9 @@ type Person struct {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -38,12 +41,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -60,6 +69,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/microsoft.person-v20211231.golden
@@ -41,9 +41,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -69,9 +66,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101.golden
@@ -59,6 +59,9 @@ func (person *Person) ConvertTo(hub conversion.Hub) error {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -75,12 +78,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20200101storage.Person_Spec
@@ -97,6 +106,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101.golden
@@ -78,9 +78,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20200101storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -106,9 +103,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20200101storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101storage.golden
@@ -47,6 +47,9 @@ func (person *Person) ConvertTo(hub conversion.Hub) error {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -63,12 +66,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -85,6 +94,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20200101storage.golden
@@ -66,9 +66,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -94,9 +91,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231.golden
@@ -46,6 +46,9 @@ func (person *Person) ConvertTo(hub conversion.Hub) error {
 // AssignPropertiesFromPerson populates our Person from the provided source Person
 func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person) error {
 
+	// ObjectMeta
+	person.ObjectMeta = *source.ObjectMeta.DeepCopy()
+
 	// Spec
 	var spec Person_Spec
 	err := spec.AssignPropertiesFromPersonSpec(&source.Spec)
@@ -62,12 +65,18 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
+	// TypeMeta
+	person.TypeMeta = source.TypeMeta
+
 	// No error
 	return nil
 }
 
 // AssignPropertiesToPerson populates the provided destination Person from our Person
 func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Person) error {
+
+	// ObjectMeta
+	destination.ObjectMeta = *person.ObjectMeta.DeepCopy()
 
 	// Spec
 	var spec v20211231storage.Person_Spec
@@ -84,6 +93,9 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
+
+	// TypeMeta
+	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/microsoft.person-v20211231.golden
@@ -65,9 +65,6 @@ func (person *Person) AssignPropertiesFromPerson(source *v20211231storage.Person
 	}
 	person.Status = status
 
-	// TypeMeta
-	person.TypeMeta = source.TypeMeta
-
 	// No error
 	return nil
 }
@@ -93,9 +90,6 @@ func (person *Person) AssignPropertiesToPerson(destination *v20211231storage.Per
 		return errors.Wrap(err, "populating Status from Status, calling AssignPropertiesToPersonStatus()")
 	}
 	destination.Status = status
-
-	// TypeMeta
-	destination.TypeMeta = person.TypeMeta
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -72,6 +72,8 @@ func init() {
 		copyKnownType(astmodel.ArbitraryOwnerReference, "Copy", returnsValue),
 		copyKnownType(astmodel.ConditionType, "Copy", returnsValue),
 		copyKnownType(astmodel.JSONType, "DeepCopy", returnsReference),
+		copyKnownType(astmodel.ObjectMetaType, "DeepCopy", returnsReference),
+		assignKnownType(astmodel.TypeMetaType),
 		// Meta-conversions
 		assignFromOptional,
 		assignToOptional,
@@ -1309,8 +1311,7 @@ func assignObjectFromObject(
 //
 // <destination> = <source>
 //
-// TODO: Make this internal once referenced ;-)
-func AssignKnownType(name astmodel.TypeName) func(*TypedConversionEndpoint, *TypedConversionEndpoint, *PropertyConversionContext) PropertyConversion {
+func assignKnownType(name astmodel.TypeName) func(*TypedConversionEndpoint, *TypedConversionEndpoint, *PropertyConversionContext) PropertyConversion {
 	return func(sourceEndpoint *TypedConversionEndpoint, destinationEndpoint *TypedConversionEndpoint, _ *PropertyConversionContext) PropertyConversion {
 		// Require destination to not be a bag item
 		if _, destinationIsBagItem := AsPropertyBagMemberType(destinationEndpoint.Type()); destinationIsBagItem {

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -73,7 +73,6 @@ func init() {
 		copyKnownType(astmodel.ConditionType, "Copy", returnsValue),
 		copyKnownType(astmodel.JSONType, "DeepCopy", returnsReference),
 		copyKnownType(astmodel.ObjectMetaType, "DeepCopy", returnsReference),
-		assignKnownType(astmodel.TypeMetaType),
 		// Meta-conversions
 		assignFromOptional,
 		assignToOptional,

--- a/v2/tools/generator/internal/conversions/property_conversions.go
+++ b/v2/tools/generator/internal/conversions/property_conversions.go
@@ -1310,6 +1310,7 @@ func assignObjectFromObject(
 //
 // <destination> = <source>
 //
+//nolint:deadcode,unused
 func assignKnownType(name astmodel.TypeName) func(*TypedConversionEndpoint, *TypedConversionEndpoint, *PropertyConversionContext) PropertyConversion {
 	return func(sourceEndpoint *TypedConversionEndpoint, destinationEndpoint *TypedConversionEndpoint, _ *PropertyConversionContext) PropertyConversion {
 		// Require destination to not be a bag item

--- a/v2/tools/generator/internal/conversions/readable_conversion_endpoint_set.go
+++ b/v2/tools/generator/internal/conversions/readable_conversion_endpoint_set.go
@@ -61,12 +61,20 @@ func (set ReadableConversionEndpointSet) addForEachProperty(
 	count := 0
 	if container, ok := astmodel.AsPropertyContainer(instance); ok {
 
-		// Construct a set containing both named and embedded properties
-		// (we give embeded properties a temporary name for conversion purposes)
+		// Construct a set containing the properties we can assign
+		// This is made up of all regular properties, plus specific kinds of embedded properties
+
 		properties := container.Properties()
+		typesToCopy := astmodel.NewTypeNameSet(astmodel.ObjectMetaType)
 		for _, prop := range container.EmbeddedProperties() {
 			name, ok := astmodel.AsTypeName(prop.PropertyType())
 			if !ok {
+				// We only expect to get embedded type names, but skip any others just in case
+				continue
+			}
+
+			if !typesToCopy.Contains(name) {
+				// Not a type we need to copy
 				continue
 			}
 

--- a/v2/tools/generator/internal/conversions/writable_conversion_endpoint_set.go
+++ b/v2/tools/generator/internal/conversions/writable_conversion_endpoint_set.go
@@ -51,12 +51,20 @@ func (set WritableConversionEndpointSet) addForEachProperty(
 	count := 0
 	if container, ok := astmodel.AsPropertyContainer(instance); ok {
 
-		// Construct a set containing both named and embedded properties
-		// (we give embeded properties a temporary name for conversion purposes)
+		// Construct a set containing the properties we can assign
+		// This is made up of all regular properties, plus specific kinds of embedded properties
+
 		properties := container.Properties()
+		typesToCopy := astmodel.NewTypeNameSet(astmodel.ObjectMetaType)
 		for _, prop := range container.EmbeddedProperties() {
 			name, ok := astmodel.AsTypeName(prop.PropertyType())
 			if !ok {
+				// We only expect to get embedded type names, but skip any others just in case
+				continue
+			}
+
+			if !typesToCopy.Contains(name) {
+				// Not a type we need to copy
 				continue
 			}
 

--- a/v2/tools/generator/internal/conversions/writable_conversion_endpoint_set.go
+++ b/v2/tools/generator/internal/conversions/writable_conversion_endpoint_set.go
@@ -50,7 +50,20 @@ func (set WritableConversionEndpointSet) addForEachProperty(
 	factory func(definition *astmodel.PropertyDefinition) *WritableConversionEndpoint) int {
 	count := 0
 	if container, ok := astmodel.AsPropertyContainer(instance); ok {
-		for _, prop := range container.Properties() {
+
+		// Construct a set containing both named and embedded properties
+		// (we give embeded properties a temporary name for conversion purposes)
+		properties := container.Properties()
+		for _, prop := range container.EmbeddedProperties() {
+			name, ok := astmodel.AsTypeName(prop.PropertyType())
+			if !ok {
+				continue
+			}
+
+			properties.Add(prop.WithName(astmodel.PropertyName(name.Name())))
+		}
+
+		for _, prop := range properties {
 			name := string(prop.PropertyName())
 			if _, defined := set[name]; defined {
 				// Don't overwrite any existing endpoints


### PR DESCRIPTION
**What this PR does / why we need it**:

Includes embedded properties when doing intra-version conversion of resources; copying of `ObjectMeta` is required to maintain the name of the resource.

Also simplifies ResourceType by removing support for arbitrary properties - we've found that we don't need it.

Resolves #1565

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3o7qE5ZmED05HBHsbe/giphy.gif)
