### PR TITLE
Add a deepcopy to generated property assignment/conversion tests

### DIFF
--- a/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen_test.go
+++ b/v2/api/microsoft.authorization/v1alpha1api20200801preview/role_assignment_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_RoleAssignment_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForRoleAssignment tests if a specific instance of RoleAssignment can be assigned to v1alpha1api20200801previewstorage and back losslessly
 func RunPropertyAssignmentTestForRoleAssignment(subject RoleAssignment) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200801previewstorage.RoleAssignment
-	err := subject.AssignPropertiesToRoleAssignment(&other)
+	err := copied.AssignPropertiesToRoleAssignment(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_RoleAssignment_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForRoleAssignmentStatus tests if a specific instance of RoleAssignment_Status can be assigned to v1alpha1api20200801previewstorage and back losslessly
 func RunPropertyAssignmentTestForRoleAssignmentStatus(subject RoleAssignment_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200801previewstorage.RoleAssignment_Status
-	err := subject.AssignPropertiesToRoleAssignmentStatus(&other)
+	err := copied.AssignPropertiesToRoleAssignmentStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_RoleAssignments_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForRoleAssignmentsSpec tests if a specific instance of RoleAssignments_Spec can be assigned to v1alpha1api20200801previewstorage and back losslessly
 func RunPropertyAssignmentTestForRoleAssignmentsSpec(subject RoleAssignments_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200801previewstorage.RoleAssignments_Spec
-	err := subject.AssignPropertiesToRoleAssignmentsSpec(&other)
+	err := copied.AssignPropertiesToRoleAssignmentsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen_test.go
+++ b/v2/api/microsoft.batch/v1alpha1api20210101/batch_account_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_BatchAccount_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForBatchAccount tests if a specific instance of BatchAccount can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForBatchAccount(subject BatchAccount) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.BatchAccount
-	err := subject.AssignPropertiesToBatchAccount(&other)
+	err := copied.AssignPropertiesToBatchAccount(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_BatchAccount_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForBatchAccountStatus tests if a specific instance of BatchAccount_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForBatchAccountStatus(subject BatchAccount_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.BatchAccount_Status
-	err := subject.AssignPropertiesToBatchAccountStatus(&other)
+	err := copied.AssignPropertiesToBatchAccountStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -266,9 +272,12 @@ func Test_BatchAccounts_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForBatchAccountsSpec tests if a specific instance of BatchAccounts_Spec can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForBatchAccountsSpec(subject BatchAccounts_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.BatchAccounts_Spec
-	err := subject.AssignPropertiesToBatchAccountsSpec(&other)
+	err := copied.AssignPropertiesToBatchAccountsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -385,9 +394,12 @@ func Test_AutoStorageBaseProperties_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForAutoStorageBaseProperties tests if a specific instance of AutoStorageBaseProperties can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForAutoStorageBaseProperties(subject AutoStorageBaseProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.AutoStorageBaseProperties
-	err := subject.AssignPropertiesToAutoStorageBaseProperties(&other)
+	err := copied.AssignPropertiesToAutoStorageBaseProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -478,9 +490,12 @@ func Test_AutoStorageProperties_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForAutoStoragePropertiesStatus tests if a specific instance of AutoStorageProperties_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForAutoStoragePropertiesStatus(subject AutoStorageProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.AutoStorageProperties_Status
-	err := subject.AssignPropertiesToAutoStoragePropertiesStatus(&other)
+	err := copied.AssignPropertiesToAutoStoragePropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -578,9 +593,12 @@ func Test_BatchAccountIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForBatchAccountIdentity tests if a specific instance of BatchAccountIdentity can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForBatchAccountIdentity(subject BatchAccountIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.BatchAccountIdentity
-	err := subject.AssignPropertiesToBatchAccountIdentity(&other)
+	err := copied.AssignPropertiesToBatchAccountIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -677,9 +695,12 @@ func Test_BatchAccountIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForBatchAccountIdentityStatus tests if a specific instance of BatchAccountIdentity_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForBatchAccountIdentityStatus(subject BatchAccountIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.BatchAccountIdentity_Status
-	err := subject.AssignPropertiesToBatchAccountIdentityStatus(&other)
+	err := copied.AssignPropertiesToBatchAccountIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -792,9 +813,12 @@ func Test_EncryptionProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForEncryptionProperties tests if a specific instance of EncryptionProperties can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionProperties(subject EncryptionProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.EncryptionProperties
-	err := subject.AssignPropertiesToEncryptionProperties(&other)
+	err := copied.AssignPropertiesToEncryptionProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -905,9 +929,12 @@ func Test_EncryptionProperties_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForEncryptionPropertiesStatus tests if a specific instance of EncryptionProperties_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionPropertiesStatus(subject EncryptionProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.EncryptionProperties_Status
-	err := subject.AssignPropertiesToEncryptionPropertiesStatus(&other)
+	err := copied.AssignPropertiesToEncryptionPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1018,9 +1045,12 @@ func Test_KeyVaultReference_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForKeyVaultReference tests if a specific instance of KeyVaultReference can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultReference(subject KeyVaultReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.KeyVaultReference
-	err := subject.AssignPropertiesToKeyVaultReference(&other)
+	err := copied.AssignPropertiesToKeyVaultReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1116,9 +1146,12 @@ func Test_KeyVaultReference_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForKeyVaultReferenceStatus tests if a specific instance of KeyVaultReference_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultReferenceStatus(subject KeyVaultReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.KeyVaultReference_Status
-	err := subject.AssignPropertiesToKeyVaultReferenceStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1216,9 +1249,12 @@ func Test_PrivateEndpointConnection_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForPrivateEndpointConnectionStatus tests if a specific instance of PrivateEndpointConnection_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointConnectionStatus(subject PrivateEndpointConnection_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.PrivateEndpointConnection_Status
-	err := subject.AssignPropertiesToPrivateEndpointConnectionStatus(&other)
+	err := copied.AssignPropertiesToPrivateEndpointConnectionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1334,9 +1370,12 @@ func Test_VirtualMachineFamilyCoreQuota_Status_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForVirtualMachineFamilyCoreQuotaStatus tests if a specific instance of VirtualMachineFamilyCoreQuota_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineFamilyCoreQuotaStatus(subject VirtualMachineFamilyCoreQuota_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.VirtualMachineFamilyCoreQuota_Status
-	err := subject.AssignPropertiesToVirtualMachineFamilyCoreQuotaStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineFamilyCoreQuotaStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1434,9 +1473,12 @@ func Test_BatchAccountIdentity_Status_UserAssignedIdentities_WhenPropertiesConve
 
 // RunPropertyAssignmentTestForBatchAccountIdentityStatusUserAssignedIdentities tests if a specific instance of BatchAccountIdentity_Status_UserAssignedIdentities can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForBatchAccountIdentityStatusUserAssignedIdentities(subject BatchAccountIdentity_Status_UserAssignedIdentities) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.BatchAccountIdentity_Status_UserAssignedIdentities
-	err := subject.AssignPropertiesToBatchAccountIdentityStatusUserAssignedIdentities(&other)
+	err := copied.AssignPropertiesToBatchAccountIdentityStatusUserAssignedIdentities(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1534,9 +1576,12 @@ func Test_KeyVaultProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForKeyVaultProperties tests if a specific instance of KeyVaultProperties can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultProperties(subject KeyVaultProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.KeyVaultProperties
-	err := subject.AssignPropertiesToKeyVaultProperties(&other)
+	err := copied.AssignPropertiesToKeyVaultProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1632,9 +1677,12 @@ func Test_KeyVaultProperties_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForKeyVaultPropertiesStatus tests if a specific instance of KeyVaultProperties_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultPropertiesStatus(subject KeyVaultProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.KeyVaultProperties_Status
-	err := subject.AssignPropertiesToKeyVaultPropertiesStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1731,9 +1779,12 @@ func Test_PrivateEndpoint_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForPrivateEndpointStatus tests if a specific instance of PrivateEndpoint_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointStatus(subject PrivateEndpoint_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.PrivateEndpoint_Status
-	err := subject.AssignPropertiesToPrivateEndpointStatus(&other)
+	err := copied.AssignPropertiesToPrivateEndpointStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1830,9 +1881,12 @@ func Test_PrivateLinkServiceConnectionState_Status_WhenPropertiesConverted_Round
 
 // RunPropertyAssignmentTestForPrivateLinkServiceConnectionStateStatus tests if a specific instance of PrivateLinkServiceConnectionState_Status can be assigned to v1alpha1api20210101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateLinkServiceConnectionStateStatus(subject PrivateLinkServiceConnectionState_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101storage.PrivateLinkServiceConnectionState_Status
-	err := subject.AssignPropertiesToPrivateLinkServiceConnectionStateStatus(&other)
+	err := copied.AssignPropertiesToPrivateLinkServiceConnectionStateStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930/disk_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_Disk_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForDisk tests if a specific instance of Disk can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForDisk(subject Disk) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.Disk
-	err := subject.AssignPropertiesToDisk(&other)
+	err := copied.AssignPropertiesToDisk(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_Disk_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForDiskStatus tests if a specific instance of Disk_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForDiskStatus(subject Disk_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.Disk_Status
-	err := subject.AssignPropertiesToDiskStatus(&other)
+	err := copied.AssignPropertiesToDiskStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -278,9 +284,12 @@ func Test_Disks_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForDisksSpec tests if a specific instance of Disks_Spec can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForDisksSpec(subject Disks_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.Disks_Spec
-	err := subject.AssignPropertiesToDisksSpec(&other)
+	err := copied.AssignPropertiesToDisksSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -409,9 +418,12 @@ func Test_CreationData_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForCreationData tests if a specific instance of CreationData can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForCreationData(subject CreationData) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.CreationData
-	err := subject.AssignPropertiesToCreationData(&other)
+	err := copied.AssignPropertiesToCreationData(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -533,9 +545,12 @@ func Test_CreationData_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForCreationDataStatus tests if a specific instance of CreationData_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForCreationDataStatus(subject CreationData_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.CreationData_Status
-	err := subject.AssignPropertiesToCreationDataStatus(&other)
+	err := copied.AssignPropertiesToCreationDataStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -659,9 +674,12 @@ func Test_DiskSku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForDiskSku tests if a specific instance of DiskSku can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForDiskSku(subject DiskSku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.DiskSku
-	err := subject.AssignPropertiesToDiskSku(&other)
+	err := copied.AssignPropertiesToDiskSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -761,9 +779,12 @@ func Test_DiskSku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForDiskSkuStatus tests if a specific instance of DiskSku_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForDiskSkuStatus(subject DiskSku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.DiskSku_Status
-	err := subject.AssignPropertiesToDiskSkuStatus(&other)
+	err := copied.AssignPropertiesToDiskSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -864,9 +885,12 @@ func Test_Encryption_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForEncryption tests if a specific instance of Encryption can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForEncryption(subject Encryption) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.Encryption
-	err := subject.AssignPropertiesToEncryption(&other)
+	err := copied.AssignPropertiesToEncryption(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -963,9 +987,12 @@ func Test_EncryptionSettingsCollection_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForEncryptionSettingsCollection tests if a specific instance of EncryptionSettingsCollection can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionSettingsCollection(subject EncryptionSettingsCollection) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.EncryptionSettingsCollection
-	err := subject.AssignPropertiesToEncryptionSettingsCollection(&other)
+	err := copied.AssignPropertiesToEncryptionSettingsCollection(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1077,9 +1104,12 @@ func Test_EncryptionSettingsCollection_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForEncryptionSettingsCollectionStatus tests if a specific instance of EncryptionSettingsCollection_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionSettingsCollectionStatus(subject EncryptionSettingsCollection_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.EncryptionSettingsCollection_Status
-	err := subject.AssignPropertiesToEncryptionSettingsCollectionStatus(&other)
+	err := copied.AssignPropertiesToEncryptionSettingsCollectionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1191,9 +1221,12 @@ func Test_Encryption_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForEncryptionStatus tests if a specific instance of Encryption_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionStatus(subject Encryption_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.Encryption_Status
-	err := subject.AssignPropertiesToEncryptionStatus(&other)
+	err := copied.AssignPropertiesToEncryptionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1290,9 +1323,12 @@ func Test_ExtendedLocation_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForExtendedLocation tests if a specific instance of ExtendedLocation can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocation(subject ExtendedLocation) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.ExtendedLocation
-	err := subject.AssignPropertiesToExtendedLocation(&other)
+	err := copied.AssignPropertiesToExtendedLocation(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1389,9 +1425,12 @@ func Test_ExtendedLocation_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForExtendedLocationStatus tests if a specific instance of ExtendedLocation_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocationStatus(subject ExtendedLocation_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.ExtendedLocation_Status
-	err := subject.AssignPropertiesToExtendedLocationStatus(&other)
+	err := copied.AssignPropertiesToExtendedLocationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1489,9 +1528,12 @@ func Test_PurchasePlan_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForPurchasePlan tests if a specific instance of PurchasePlan can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForPurchasePlan(subject PurchasePlan) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.PurchasePlan
-	err := subject.AssignPropertiesToPurchasePlan(&other)
+	err := copied.AssignPropertiesToPurchasePlan(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1590,9 +1632,12 @@ func Test_PurchasePlan_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForPurchasePlanStatus tests if a specific instance of PurchasePlan_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForPurchasePlanStatus(subject PurchasePlan_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.PurchasePlan_Status
-	err := subject.AssignPropertiesToPurchasePlanStatus(&other)
+	err := copied.AssignPropertiesToPurchasePlanStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1691,9 +1736,12 @@ func Test_ShareInfoElement_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForShareInfoElementStatus tests if a specific instance of ShareInfoElement_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForShareInfoElementStatus(subject ShareInfoElement_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.ShareInfoElement_Status
-	err := subject.AssignPropertiesToShareInfoElementStatus(&other)
+	err := copied.AssignPropertiesToShareInfoElementStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1790,9 +1838,12 @@ func Test_EncryptionSettingsElement_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForEncryptionSettingsElement tests if a specific instance of EncryptionSettingsElement can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionSettingsElement(subject EncryptionSettingsElement) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.EncryptionSettingsElement
-	err := subject.AssignPropertiesToEncryptionSettingsElement(&other)
+	err := copied.AssignPropertiesToEncryptionSettingsElement(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1890,9 +1941,12 @@ func Test_EncryptionSettingsElement_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForEncryptionSettingsElementStatus tests if a specific instance of EncryptionSettingsElement_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionSettingsElementStatus(subject EncryptionSettingsElement_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.EncryptionSettingsElement_Status
-	err := subject.AssignPropertiesToEncryptionSettingsElementStatus(&other)
+	err := copied.AssignPropertiesToEncryptionSettingsElementStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1990,9 +2044,12 @@ func Test_ImageDiskReference_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForImageDiskReference tests if a specific instance of ImageDiskReference can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForImageDiskReference(subject ImageDiskReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.ImageDiskReference
-	err := subject.AssignPropertiesToImageDiskReference(&other)
+	err := copied.AssignPropertiesToImageDiskReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2088,9 +2145,12 @@ func Test_ImageDiskReference_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForImageDiskReferenceStatus tests if a specific instance of ImageDiskReference_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForImageDiskReferenceStatus(subject ImageDiskReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.ImageDiskReference_Status
-	err := subject.AssignPropertiesToImageDiskReferenceStatus(&other)
+	err := copied.AssignPropertiesToImageDiskReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2188,9 +2248,12 @@ func Test_KeyVaultAndKeyReference_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForKeyVaultAndKeyReference tests if a specific instance of KeyVaultAndKeyReference can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultAndKeyReference(subject KeyVaultAndKeyReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.KeyVaultAndKeyReference
-	err := subject.AssignPropertiesToKeyVaultAndKeyReference(&other)
+	err := copied.AssignPropertiesToKeyVaultAndKeyReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2301,9 +2364,12 @@ func Test_KeyVaultAndKeyReference_Status_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForKeyVaultAndKeyReferenceStatus tests if a specific instance of KeyVaultAndKeyReference_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultAndKeyReferenceStatus(subject KeyVaultAndKeyReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.KeyVaultAndKeyReference_Status
-	err := subject.AssignPropertiesToKeyVaultAndKeyReferenceStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultAndKeyReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2414,9 +2480,12 @@ func Test_KeyVaultAndSecretReference_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForKeyVaultAndSecretReference tests if a specific instance of KeyVaultAndSecretReference can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultAndSecretReference(subject KeyVaultAndSecretReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.KeyVaultAndSecretReference
-	err := subject.AssignPropertiesToKeyVaultAndSecretReference(&other)
+	err := copied.AssignPropertiesToKeyVaultAndSecretReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2527,9 +2596,12 @@ func Test_KeyVaultAndSecretReference_Status_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForKeyVaultAndSecretReferenceStatus tests if a specific instance of KeyVaultAndSecretReference_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultAndSecretReferenceStatus(subject KeyVaultAndSecretReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.KeyVaultAndSecretReference_Status
-	err := subject.AssignPropertiesToKeyVaultAndSecretReferenceStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultAndSecretReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2640,9 +2712,12 @@ func Test_SourceVault_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForSourceVault tests if a specific instance of SourceVault can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForSourceVault(subject SourceVault) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.SourceVault
-	err := subject.AssignPropertiesToSourceVault(&other)
+	err := copied.AssignPropertiesToSourceVault(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2732,9 +2807,12 @@ func Test_SourceVault_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSourceVaultStatus tests if a specific instance of SourceVault_Status can be assigned to v1alpha1api20200930storage and back losslessly
 func RunPropertyAssignmentTestForSourceVaultStatus(subject SourceVault_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200930storage.SourceVault_Status
-	err := subject.AssignPropertiesToSourceVaultStatus(&other)
+	err := copied.AssignPropertiesToSourceVaultStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.compute/v1alpha1api20200930storage/disk_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20200930storage/disk_types_gen_test.go
@@ -834,9 +834,12 @@ func Test_ExtendedLocation_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForExtendedLocation tests if a specific instance of ExtendedLocation can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocation(subject ExtendedLocation) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ExtendedLocation
-	err := subject.AssignPropertiesToExtendedLocation(&other)
+	err := copied.AssignPropertiesToExtendedLocation(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -933,9 +936,12 @@ func Test_ExtendedLocation_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForExtendedLocationStatus tests if a specific instance of ExtendedLocation_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocationStatus(subject ExtendedLocation_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ExtendedLocation_Status
-	err := subject.AssignPropertiesToExtendedLocationStatus(&other)
+	err := copied.AssignPropertiesToExtendedLocationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_VirtualMachineScaleSet_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSet tests if a specific instance of VirtualMachineScaleSet can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSet(subject VirtualMachineScaleSet) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSet
-	err := subject.AssignPropertiesToVirtualMachineScaleSet(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSet(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_VirtualMachineScaleSet_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetStatus tests if a specific instance of VirtualMachineScaleSet_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetStatus(subject VirtualMachineScaleSet_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSet_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -267,9 +273,12 @@ func Test_VirtualMachineScaleSets_Spec_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpec tests if a specific instance of VirtualMachineScaleSets_Spec can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpec(subject VirtualMachineScaleSets_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpec(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -399,9 +408,12 @@ func Test_AutomaticRepairsPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForAutomaticRepairsPolicy tests if a specific instance of AutomaticRepairsPolicy can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAutomaticRepairsPolicy(subject AutomaticRepairsPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AutomaticRepairsPolicy
-	err := subject.AssignPropertiesToAutomaticRepairsPolicy(&other)
+	err := copied.AssignPropertiesToAutomaticRepairsPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -499,9 +511,12 @@ func Test_AutomaticRepairsPolicy_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForAutomaticRepairsPolicyStatus tests if a specific instance of AutomaticRepairsPolicy_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAutomaticRepairsPolicyStatus(subject AutomaticRepairsPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AutomaticRepairsPolicy_Status
-	err := subject.AssignPropertiesToAutomaticRepairsPolicyStatus(&other)
+	err := copied.AssignPropertiesToAutomaticRepairsPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -599,9 +614,12 @@ func Test_ScaleInPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForScaleInPolicy tests if a specific instance of ScaleInPolicy can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForScaleInPolicy(subject ScaleInPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ScaleInPolicy
-	err := subject.AssignPropertiesToScaleInPolicy(&other)
+	err := copied.AssignPropertiesToScaleInPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -697,9 +715,12 @@ func Test_ScaleInPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForScaleInPolicyStatus tests if a specific instance of ScaleInPolicy_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForScaleInPolicyStatus(subject ScaleInPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ScaleInPolicy_Status
-	err := subject.AssignPropertiesToScaleInPolicyStatus(&other)
+	err := copied.AssignPropertiesToScaleInPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -796,9 +817,12 @@ func Test_Sku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForSku tests if a specific instance of Sku can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSku(subject Sku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.Sku
-	err := subject.AssignPropertiesToSku(&other)
+	err := copied.AssignPropertiesToSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -896,9 +920,12 @@ func Test_Sku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForSkuStatus tests if a specific instance of Sku_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSkuStatus(subject Sku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.Sku_Status
-	err := subject.AssignPropertiesToSkuStatus(&other)
+	err := copied.AssignPropertiesToSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -996,9 +1023,12 @@ func Test_UpgradePolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForUpgradePolicy tests if a specific instance of UpgradePolicy can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForUpgradePolicy(subject UpgradePolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.UpgradePolicy
-	err := subject.AssignPropertiesToUpgradePolicy(&other)
+	err := copied.AssignPropertiesToUpgradePolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1109,9 +1139,12 @@ func Test_UpgradePolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForUpgradePolicyStatus tests if a specific instance of UpgradePolicy_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForUpgradePolicyStatus(subject UpgradePolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.UpgradePolicy_Status
-	err := subject.AssignPropertiesToUpgradePolicyStatus(&other)
+	err := copied.AssignPropertiesToUpgradePolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1223,9 +1256,12 @@ func Test_VirtualMachineScaleSetIdentity_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetIdentity tests if a specific instance of VirtualMachineScaleSetIdentity can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetIdentity(subject VirtualMachineScaleSetIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetIdentity
-	err := subject.AssignPropertiesToVirtualMachineScaleSetIdentity(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1326,9 +1362,12 @@ func Test_VirtualMachineScaleSetIdentity_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetIdentityStatus tests if a specific instance of VirtualMachineScaleSetIdentity_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetIdentityStatus(subject VirtualMachineScaleSetIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetIdentity_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetIdentityStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1445,9 +1484,12 @@ func Test_VirtualMachineScaleSetVMProfile_Status_WhenPropertiesConverted_RoundTr
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetVMProfileStatus tests if a specific instance of VirtualMachineScaleSetVMProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetVMProfileStatus(subject VirtualMachineScaleSetVMProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetVMProfile_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetVMProfileStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetVMProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1567,9 +1609,12 @@ func Test_VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_WhenProp
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfile tests if a specific instance of VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfile(subject VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfile(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1689,9 +1734,12 @@ func Test_AutomaticOSUpgradePolicy_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForAutomaticOSUpgradePolicy tests if a specific instance of AutomaticOSUpgradePolicy can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAutomaticOSUpgradePolicy(subject AutomaticOSUpgradePolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AutomaticOSUpgradePolicy
-	err := subject.AssignPropertiesToAutomaticOSUpgradePolicy(&other)
+	err := copied.AssignPropertiesToAutomaticOSUpgradePolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1789,9 +1837,12 @@ func Test_AutomaticOSUpgradePolicy_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForAutomaticOSUpgradePolicyStatus tests if a specific instance of AutomaticOSUpgradePolicy_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAutomaticOSUpgradePolicyStatus(subject AutomaticOSUpgradePolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AutomaticOSUpgradePolicy_Status
-	err := subject.AssignPropertiesToAutomaticOSUpgradePolicyStatus(&other)
+	err := copied.AssignPropertiesToAutomaticOSUpgradePolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1889,9 +1940,12 @@ func Test_RollingUpgradePolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForRollingUpgradePolicy tests if a specific instance of RollingUpgradePolicy can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForRollingUpgradePolicy(subject RollingUpgradePolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.RollingUpgradePolicy
-	err := subject.AssignPropertiesToRollingUpgradePolicy(&other)
+	err := copied.AssignPropertiesToRollingUpgradePolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1993,9 +2047,12 @@ func Test_RollingUpgradePolicy_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForRollingUpgradePolicyStatus tests if a specific instance of RollingUpgradePolicy_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForRollingUpgradePolicyStatus(subject RollingUpgradePolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.RollingUpgradePolicy_Status
-	err := subject.AssignPropertiesToRollingUpgradePolicyStatus(&other)
+	err := copied.AssignPropertiesToRollingUpgradePolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2097,9 +2154,12 @@ func Test_ScheduledEventsProfile_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForScheduledEventsProfile tests if a specific instance of ScheduledEventsProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForScheduledEventsProfile(subject ScheduledEventsProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ScheduledEventsProfile
-	err := subject.AssignPropertiesToScheduledEventsProfile(&other)
+	err := copied.AssignPropertiesToScheduledEventsProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2196,9 +2256,12 @@ func Test_ScheduledEventsProfile_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForScheduledEventsProfileStatus tests if a specific instance of ScheduledEventsProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForScheduledEventsProfileStatus(subject ScheduledEventsProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ScheduledEventsProfile_Status
-	err := subject.AssignPropertiesToScheduledEventsProfileStatus(&other)
+	err := copied.AssignPropertiesToScheduledEventsProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2295,9 +2358,12 @@ func Test_VirtualMachineScaleSetExtensionProfile_Status_WhenPropertiesConverted_
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetExtensionProfileStatus tests if a specific instance of VirtualMachineScaleSetExtensionProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetExtensionProfileStatus(subject VirtualMachineScaleSetExtensionProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetExtensionProfile_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetExtensionProfileStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetExtensionProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2408,9 +2474,12 @@ func Test_VirtualMachineScaleSetIdentity_Status_UserAssignedIdentities_WhenPrope
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetIdentityStatusUserAssignedIdentities tests if a specific instance of VirtualMachineScaleSetIdentity_Status_UserAssignedIdentities can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetIdentityStatusUserAssignedIdentities(subject VirtualMachineScaleSetIdentity_Status_UserAssignedIdentities) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetIdentity_Status_UserAssignedIdentities
-	err := subject.AssignPropertiesToVirtualMachineScaleSetIdentityStatusUserAssignedIdentities(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetIdentityStatusUserAssignedIdentities(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2508,9 +2577,12 @@ func Test_VirtualMachineScaleSetNetworkProfile_Status_WhenPropertiesConverted_Ro
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkProfileStatus tests if a specific instance of VirtualMachineScaleSetNetworkProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkProfileStatus(subject VirtualMachineScaleSetNetworkProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetNetworkProfile_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetNetworkProfileStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetNetworkProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2608,9 +2680,12 @@ func Test_VirtualMachineScaleSetOSProfile_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetOSProfile tests if a specific instance of VirtualMachineScaleSetOSProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetOSProfile(subject VirtualMachineScaleSetOSProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetOSProfile
-	err := subject.AssignPropertiesToVirtualMachineScaleSetOSProfile(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetOSProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2726,9 +2801,12 @@ func Test_VirtualMachineScaleSetOSProfile_Status_WhenPropertiesConverted_RoundTr
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetOSProfileStatus tests if a specific instance of VirtualMachineScaleSetOSProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetOSProfileStatus(subject VirtualMachineScaleSetOSProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetOSProfile_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetOSProfileStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetOSProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2844,9 +2922,12 @@ func Test_VirtualMachineScaleSetStorageProfile_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetStorageProfile tests if a specific instance of VirtualMachineScaleSetStorageProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetStorageProfile(subject VirtualMachineScaleSetStorageProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetStorageProfile
-	err := subject.AssignPropertiesToVirtualMachineScaleSetStorageProfile(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetStorageProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2945,9 +3026,12 @@ func Test_VirtualMachineScaleSetStorageProfile_Status_WhenPropertiesConverted_Ro
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetStorageProfileStatus tests if a specific instance of VirtualMachineScaleSetStorageProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetStorageProfileStatus(subject VirtualMachineScaleSetStorageProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetStorageProfile_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetStorageProfileStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetStorageProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3046,9 +3130,12 @@ func Test_VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Extensio
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfile tests if a specific instance of VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfile(subject VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfile(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3159,9 +3246,12 @@ func Test_VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkP
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfile tests if a specific instance of VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfile(subject VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfile(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3259,9 +3349,12 @@ func Test_ApiEntityReference_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForApiEntityReference tests if a specific instance of ApiEntityReference can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForApiEntityReference(subject ApiEntityReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ApiEntityReference
-	err := subject.AssignPropertiesToApiEntityReference(&other)
+	err := copied.AssignPropertiesToApiEntityReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3351,9 +3444,12 @@ func Test_ApiEntityReference_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForApiEntityReferenceStatus tests if a specific instance of ApiEntityReference_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForApiEntityReferenceStatus(subject ApiEntityReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ApiEntityReference_Status
-	err := subject.AssignPropertiesToApiEntityReferenceStatus(&other)
+	err := copied.AssignPropertiesToApiEntityReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3450,9 +3546,12 @@ func Test_TerminateNotificationProfile_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForTerminateNotificationProfile tests if a specific instance of TerminateNotificationProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForTerminateNotificationProfile(subject TerminateNotificationProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.TerminateNotificationProfile
-	err := subject.AssignPropertiesToTerminateNotificationProfile(&other)
+	err := copied.AssignPropertiesToTerminateNotificationProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3550,9 +3649,12 @@ func Test_TerminateNotificationProfile_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForTerminateNotificationProfileStatus tests if a specific instance of TerminateNotificationProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForTerminateNotificationProfileStatus(subject TerminateNotificationProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.TerminateNotificationProfile_Status
-	err := subject.AssignPropertiesToTerminateNotificationProfileStatus(&other)
+	err := copied.AssignPropertiesToTerminateNotificationProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3650,9 +3752,12 @@ func Test_VirtualMachineScaleSetDataDisk_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetDataDisk tests if a specific instance of VirtualMachineScaleSetDataDisk can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetDataDisk(subject VirtualMachineScaleSetDataDisk) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetDataDisk
-	err := subject.AssignPropertiesToVirtualMachineScaleSetDataDisk(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetDataDisk(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3770,9 +3875,12 @@ func Test_VirtualMachineScaleSetDataDisk_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetDataDiskStatus tests if a specific instance of VirtualMachineScaleSetDataDisk_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetDataDiskStatus(subject VirtualMachineScaleSetDataDisk_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetDataDisk_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetDataDiskStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetDataDiskStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3890,9 +3998,12 @@ func Test_VirtualMachineScaleSetExtension_Status_WhenPropertiesConverted_RoundTr
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetExtensionStatus tests if a specific instance of VirtualMachineScaleSetExtension_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetExtensionStatus(subject VirtualMachineScaleSetExtension_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetExtension_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetExtensionStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetExtensionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3999,9 +4110,12 @@ func Test_VirtualMachineScaleSetNetworkConfiguration_Status_WhenPropertiesConver
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkConfigurationStatus tests if a specific instance of VirtualMachineScaleSetNetworkConfiguration_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkConfigurationStatus(subject VirtualMachineScaleSetNetworkConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetNetworkConfiguration_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetNetworkConfigurationStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetNetworkConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4119,9 +4233,12 @@ func Test_VirtualMachineScaleSetOSDisk_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetOSDisk tests if a specific instance of VirtualMachineScaleSetOSDisk can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetOSDisk(subject VirtualMachineScaleSetOSDisk) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetOSDisk
-	err := subject.AssignPropertiesToVirtualMachineScaleSetOSDisk(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetOSDisk(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4240,9 +4357,12 @@ func Test_VirtualMachineScaleSetOSDisk_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetOSDiskStatus tests if a specific instance of VirtualMachineScaleSetOSDisk_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetOSDiskStatus(subject VirtualMachineScaleSetOSDisk_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetOSDisk_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetOSDiskStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetOSDiskStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4361,9 +4481,12 @@ func Test_VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Extensio
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfileExtensions tests if a specific instance of VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_Extensions can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfileExtensions(subject VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_Extensions) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_Extensions
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfileExtensions(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileExtensionProfileExtensions(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4464,9 +4587,12 @@ func Test_VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkP
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurations tests if a specific instance of VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurations(subject VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurations(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurations(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4586,9 +4712,12 @@ func Test_VirtualMachineScaleSetIPConfiguration_Status_WhenPropertiesConverted_R
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetIPConfigurationStatus tests if a specific instance of VirtualMachineScaleSetIPConfiguration_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetIPConfigurationStatus(subject VirtualMachineScaleSetIPConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetIPConfiguration_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetIPConfigurationStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetIPConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4707,9 +4836,12 @@ func Test_VirtualMachineScaleSetManagedDiskParameters_WhenPropertiesConverted_Ro
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetManagedDiskParameters tests if a specific instance of VirtualMachineScaleSetManagedDiskParameters can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetManagedDiskParameters(subject VirtualMachineScaleSetManagedDiskParameters) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetManagedDiskParameters
-	err := subject.AssignPropertiesToVirtualMachineScaleSetManagedDiskParameters(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetManagedDiskParameters(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4826,9 +4958,12 @@ func Test_VirtualMachineScaleSetManagedDiskParameters_Status_WhenPropertiesConve
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetManagedDiskParametersStatus tests if a specific instance of VirtualMachineScaleSetManagedDiskParameters_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetManagedDiskParametersStatus(subject VirtualMachineScaleSetManagedDiskParameters_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetManagedDiskParameters_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetManagedDiskParametersStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetManagedDiskParametersStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4945,9 +5080,12 @@ func Test_VirtualMachineScaleSetNetworkConfigurationDnsSettings_WhenPropertiesCo
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkConfigurationDnsSettings tests if a specific instance of VirtualMachineScaleSetNetworkConfigurationDnsSettings can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkConfigurationDnsSettings(subject VirtualMachineScaleSetNetworkConfigurationDnsSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetNetworkConfigurationDnsSettings
-	err := subject.AssignPropertiesToVirtualMachineScaleSetNetworkConfigurationDnsSettings(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetNetworkConfigurationDnsSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5044,9 +5182,12 @@ func Test_VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status_WhenPrope
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkConfigurationDnsSettingsStatus tests if a specific instance of VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetNetworkConfigurationDnsSettingsStatus(subject VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetNetworkConfigurationDnsSettings_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetNetworkConfigurationDnsSettingsStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetNetworkConfigurationDnsSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5143,9 +5284,12 @@ func Test_VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkP
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurations tests if a specific instance of VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurations(subject VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurations(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurations(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5266,9 +5410,12 @@ func Test_VirtualMachineScaleSetPublicIPAddressConfiguration_Status_WhenProperti
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetPublicIPAddressConfigurationStatus tests if a specific instance of VirtualMachineScaleSetPublicIPAddressConfiguration_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetPublicIPAddressConfigurationStatus(subject VirtualMachineScaleSetPublicIPAddressConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetPublicIPAddressConfiguration_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetPublicIPAddressConfigurationStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetPublicIPAddressConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5383,9 +5530,12 @@ func Test_VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkP
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurationsPropertiesPublicIPAddressConfiguration tests if a specific instance of VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfiguration can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurationsPropertiesPublicIPAddressConfiguration(subject VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfiguration
-	err := subject.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurationsPropertiesPublicIPAddressConfiguration(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetsSpecPropertiesVirtualMachineProfileNetworkProfileNetworkInterfaceConfigurationsPropertiesIpConfigurationsPropertiesPublicIPAddressConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5502,9 +5652,12 @@ func Test_VirtualMachineScaleSetIpTag_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetIpTag tests if a specific instance of VirtualMachineScaleSetIpTag can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetIpTag(subject VirtualMachineScaleSetIpTag) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetIpTag
-	err := subject.AssignPropertiesToVirtualMachineScaleSetIpTag(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetIpTag(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5602,9 +5755,12 @@ func Test_VirtualMachineScaleSetIpTag_Status_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetIpTagStatus tests if a specific instance of VirtualMachineScaleSetIpTag_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetIpTagStatus(subject VirtualMachineScaleSetIpTag_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetIpTag_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetIpTagStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetIpTagStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5702,9 +5858,12 @@ func Test_VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_WhenProp
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings tests if a specific instance of VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings(subject VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings
-	err := subject.AssignPropertiesToVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5801,9 +5960,12 @@ func Test_VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status_W
 
 // RunPropertyAssignmentTestForVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsStatus tests if a specific instance of VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsStatus(subject VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings_Status
-	err := subject.AssignPropertiesToVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_types_gen_test.go
+++ b/v2/api/microsoft.compute/v1alpha1api20201201/virtual_machine_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_VirtualMachine_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForVirtualMachine tests if a specific instance of VirtualMachine can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachine(subject VirtualMachine) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachine
-	err := subject.AssignPropertiesToVirtualMachine(&other)
+	err := copied.AssignPropertiesToVirtualMachine(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_VirtualMachine_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForVirtualMachineStatus tests if a specific instance of VirtualMachine_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineStatus(subject VirtualMachine_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachine_Status
-	err := subject.AssignPropertiesToVirtualMachineStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -272,9 +278,12 @@ func Test_VirtualMachines_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForVirtualMachinesSpec tests if a specific instance of VirtualMachines_Spec can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachinesSpec(subject VirtualMachines_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachines_Spec
-	err := subject.AssignPropertiesToVirtualMachinesSpec(&other)
+	err := copied.AssignPropertiesToVirtualMachinesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -408,9 +417,12 @@ func Test_AdditionalCapabilities_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForAdditionalCapabilities tests if a specific instance of AdditionalCapabilities can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAdditionalCapabilities(subject AdditionalCapabilities) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AdditionalCapabilities
-	err := subject.AssignPropertiesToAdditionalCapabilities(&other)
+	err := copied.AssignPropertiesToAdditionalCapabilities(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -507,9 +519,12 @@ func Test_AdditionalCapabilities_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForAdditionalCapabilitiesStatus tests if a specific instance of AdditionalCapabilities_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAdditionalCapabilitiesStatus(subject AdditionalCapabilities_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AdditionalCapabilities_Status
-	err := subject.AssignPropertiesToAdditionalCapabilitiesStatus(&other)
+	err := copied.AssignPropertiesToAdditionalCapabilitiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -606,9 +621,12 @@ func Test_BillingProfile_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForBillingProfile tests if a specific instance of BillingProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForBillingProfile(subject BillingProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.BillingProfile
-	err := subject.AssignPropertiesToBillingProfile(&other)
+	err := copied.AssignPropertiesToBillingProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -704,9 +722,12 @@ func Test_BillingProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForBillingProfileStatus tests if a specific instance of BillingProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForBillingProfileStatus(subject BillingProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.BillingProfile_Status
-	err := subject.AssignPropertiesToBillingProfileStatus(&other)
+	err := copied.AssignPropertiesToBillingProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -803,9 +824,12 @@ func Test_DiagnosticsProfile_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForDiagnosticsProfile tests if a specific instance of DiagnosticsProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiagnosticsProfile(subject DiagnosticsProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiagnosticsProfile
-	err := subject.AssignPropertiesToDiagnosticsProfile(&other)
+	err := copied.AssignPropertiesToDiagnosticsProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -901,9 +925,12 @@ func Test_DiagnosticsProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForDiagnosticsProfileStatus tests if a specific instance of DiagnosticsProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiagnosticsProfileStatus(subject DiagnosticsProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiagnosticsProfile_Status
-	err := subject.AssignPropertiesToDiagnosticsProfileStatus(&other)
+	err := copied.AssignPropertiesToDiagnosticsProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1000,9 +1027,12 @@ func Test_ExtendedLocation_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForExtendedLocation tests if a specific instance of ExtendedLocation can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocation(subject ExtendedLocation) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ExtendedLocation
-	err := subject.AssignPropertiesToExtendedLocation(&other)
+	err := copied.AssignPropertiesToExtendedLocation(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1099,9 +1129,12 @@ func Test_ExtendedLocation_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForExtendedLocationStatus tests if a specific instance of ExtendedLocation_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocationStatus(subject ExtendedLocation_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ExtendedLocation_Status
-	err := subject.AssignPropertiesToExtendedLocationStatus(&other)
+	err := copied.AssignPropertiesToExtendedLocationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1199,9 +1232,12 @@ func Test_HardwareProfile_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForHardwareProfile tests if a specific instance of HardwareProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForHardwareProfile(subject HardwareProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.HardwareProfile
-	err := subject.AssignPropertiesToHardwareProfile(&other)
+	err := copied.AssignPropertiesToHardwareProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1463,9 +1499,12 @@ func Test_HardwareProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForHardwareProfileStatus tests if a specific instance of HardwareProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForHardwareProfileStatus(subject HardwareProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.HardwareProfile_Status
-	err := subject.AssignPropertiesToHardwareProfileStatus(&other)
+	err := copied.AssignPropertiesToHardwareProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1728,9 +1767,12 @@ func Test_NetworkProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForNetworkProfileStatus tests if a specific instance of NetworkProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForNetworkProfileStatus(subject NetworkProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.NetworkProfile_Status
-	err := subject.AssignPropertiesToNetworkProfileStatus(&other)
+	err := copied.AssignPropertiesToNetworkProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1827,9 +1869,12 @@ func Test_OSProfile_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) 
 
 // RunPropertyAssignmentTestForOSProfile tests if a specific instance of OSProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForOSProfile(subject OSProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.OSProfile
-	err := subject.AssignPropertiesToOSProfile(&other)
+	err := copied.AssignPropertiesToOSProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1946,9 +1991,12 @@ func Test_OSProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForOSProfileStatus tests if a specific instance of OSProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForOSProfileStatus(subject OSProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.OSProfile_Status
-	err := subject.AssignPropertiesToOSProfileStatus(&other)
+	err := copied.AssignPropertiesToOSProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2065,9 +2113,12 @@ func Test_Plan_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForPlan tests if a specific instance of Plan can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForPlan(subject Plan) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.Plan
-	err := subject.AssignPropertiesToPlan(&other)
+	err := copied.AssignPropertiesToPlan(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2166,9 +2217,12 @@ func Test_Plan_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForPlanStatus tests if a specific instance of Plan_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForPlanStatus(subject Plan_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.Plan_Status
-	err := subject.AssignPropertiesToPlanStatus(&other)
+	err := copied.AssignPropertiesToPlanStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2267,9 +2321,12 @@ func Test_SecurityProfile_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForSecurityProfile tests if a specific instance of SecurityProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSecurityProfile(subject SecurityProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SecurityProfile
-	err := subject.AssignPropertiesToSecurityProfile(&other)
+	err := copied.AssignPropertiesToSecurityProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2380,9 +2437,12 @@ func Test_SecurityProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForSecurityProfileStatus tests if a specific instance of SecurityProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSecurityProfileStatus(subject SecurityProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SecurityProfile_Status
-	err := subject.AssignPropertiesToSecurityProfileStatus(&other)
+	err := copied.AssignPropertiesToSecurityProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2494,9 +2554,12 @@ func Test_StorageProfile_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForStorageProfile tests if a specific instance of StorageProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForStorageProfile(subject StorageProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.StorageProfile
-	err := subject.AssignPropertiesToStorageProfile(&other)
+	err := copied.AssignPropertiesToStorageProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2594,9 +2657,12 @@ func Test_StorageProfile_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForStorageProfileStatus tests if a specific instance of StorageProfile_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForStorageProfileStatus(subject StorageProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.StorageProfile_Status
-	err := subject.AssignPropertiesToStorageProfileStatus(&other)
+	err := copied.AssignPropertiesToStorageProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2695,9 +2761,12 @@ func Test_SubResource_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForSubResource tests if a specific instance of SubResource can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSubResource(subject SubResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SubResource
-	err := subject.AssignPropertiesToSubResource(&other)
+	err := copied.AssignPropertiesToSubResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2787,9 +2856,12 @@ func Test_SubResource_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSubResourceStatus tests if a specific instance of SubResource_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSubResourceStatus(subject SubResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SubResource_Status
-	err := subject.AssignPropertiesToSubResourceStatus(&other)
+	err := copied.AssignPropertiesToSubResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2885,9 +2957,12 @@ func Test_VirtualMachineExtension_Status_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForVirtualMachineExtensionStatus tests if a specific instance of VirtualMachineExtension_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineExtensionStatus(subject VirtualMachineExtension_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineExtension_Status
-	err := subject.AssignPropertiesToVirtualMachineExtensionStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineExtensionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3009,9 +3084,12 @@ func Test_VirtualMachineIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForVirtualMachineIdentity tests if a specific instance of VirtualMachineIdentity can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineIdentity(subject VirtualMachineIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineIdentity
-	err := subject.AssignPropertiesToVirtualMachineIdentity(&other)
+	err := copied.AssignPropertiesToVirtualMachineIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3112,9 +3190,12 @@ func Test_VirtualMachineIdentity_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForVirtualMachineIdentityStatus tests if a specific instance of VirtualMachineIdentity_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineIdentityStatus(subject VirtualMachineIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineIdentity_Status
-	err := subject.AssignPropertiesToVirtualMachineIdentityStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3231,9 +3312,12 @@ func Test_VirtualMachineInstanceView_Status_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForVirtualMachineInstanceViewStatus tests if a specific instance of VirtualMachineInstanceView_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineInstanceViewStatus(subject VirtualMachineInstanceView_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineInstanceView_Status
-	err := subject.AssignPropertiesToVirtualMachineInstanceViewStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineInstanceViewStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3358,9 +3442,12 @@ func Test_VirtualMachines_Spec_Properties_NetworkProfile_WhenPropertiesConverted
 
 // RunPropertyAssignmentTestForVirtualMachinesSpecPropertiesNetworkProfile tests if a specific instance of VirtualMachines_Spec_Properties_NetworkProfile can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachinesSpecPropertiesNetworkProfile(subject VirtualMachines_Spec_Properties_NetworkProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachines_Spec_Properties_NetworkProfile
-	err := subject.AssignPropertiesToVirtualMachinesSpecPropertiesNetworkProfile(&other)
+	err := copied.AssignPropertiesToVirtualMachinesSpecPropertiesNetworkProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3457,9 +3544,12 @@ func Test_BootDiagnostics_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForBootDiagnostics tests if a specific instance of BootDiagnostics can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForBootDiagnostics(subject BootDiagnostics) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.BootDiagnostics
-	err := subject.AssignPropertiesToBootDiagnostics(&other)
+	err := copied.AssignPropertiesToBootDiagnostics(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3556,9 +3646,12 @@ func Test_BootDiagnosticsInstanceView_Status_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForBootDiagnosticsInstanceViewStatus tests if a specific instance of BootDiagnosticsInstanceView_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForBootDiagnosticsInstanceViewStatus(subject BootDiagnosticsInstanceView_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.BootDiagnosticsInstanceView_Status
-	err := subject.AssignPropertiesToBootDiagnosticsInstanceViewStatus(&other)
+	err := copied.AssignPropertiesToBootDiagnosticsInstanceViewStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3670,9 +3763,12 @@ func Test_BootDiagnostics_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForBootDiagnosticsStatus tests if a specific instance of BootDiagnostics_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForBootDiagnosticsStatus(subject BootDiagnostics_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.BootDiagnostics_Status
-	err := subject.AssignPropertiesToBootDiagnosticsStatus(&other)
+	err := copied.AssignPropertiesToBootDiagnosticsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3770,9 +3866,12 @@ func Test_DataDisk_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForDataDisk tests if a specific instance of DataDisk can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDataDisk(subject DataDisk) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DataDisk
-	err := subject.AssignPropertiesToDataDisk(&other)
+	err := copied.AssignPropertiesToDataDisk(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3891,9 +3990,12 @@ func Test_DataDisk_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForDataDiskStatus tests if a specific instance of DataDisk_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDataDiskStatus(subject DataDisk_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DataDisk_Status
-	err := subject.AssignPropertiesToDataDiskStatus(&other)
+	err := copied.AssignPropertiesToDataDiskStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4014,9 +4116,12 @@ func Test_DiskInstanceView_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForDiskInstanceViewStatus tests if a specific instance of DiskInstanceView_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiskInstanceViewStatus(subject DiskInstanceView_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiskInstanceView_Status
-	err := subject.AssignPropertiesToDiskInstanceViewStatus(&other)
+	err := copied.AssignPropertiesToDiskInstanceViewStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4128,9 +4233,12 @@ func Test_ImageReference_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForImageReference tests if a specific instance of ImageReference can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForImageReference(subject ImageReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ImageReference
-	err := subject.AssignPropertiesToImageReference(&other)
+	err := copied.AssignPropertiesToImageReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4229,9 +4337,12 @@ func Test_ImageReference_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForImageReferenceStatus tests if a specific instance of ImageReference_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForImageReferenceStatus(subject ImageReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ImageReference_Status
-	err := subject.AssignPropertiesToImageReferenceStatus(&other)
+	err := copied.AssignPropertiesToImageReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4333,9 +4444,12 @@ func Test_InstanceViewStatus_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForInstanceViewStatusStatus tests if a specific instance of InstanceViewStatus_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForInstanceViewStatusStatus(subject InstanceViewStatus_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.InstanceViewStatus_Status
-	err := subject.AssignPropertiesToInstanceViewStatusStatus(&other)
+	err := copied.AssignPropertiesToInstanceViewStatusStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4436,9 +4550,12 @@ func Test_LinuxConfiguration_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForLinuxConfiguration tests if a specific instance of LinuxConfiguration can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForLinuxConfiguration(subject LinuxConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.LinuxConfiguration
-	err := subject.AssignPropertiesToLinuxConfiguration(&other)
+	err := copied.AssignPropertiesToLinuxConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4550,9 +4667,12 @@ func Test_LinuxConfiguration_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForLinuxConfigurationStatus tests if a specific instance of LinuxConfiguration_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForLinuxConfigurationStatus(subject LinuxConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.LinuxConfiguration_Status
-	err := subject.AssignPropertiesToLinuxConfigurationStatus(&other)
+	err := copied.AssignPropertiesToLinuxConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4665,9 +4785,12 @@ func Test_MaintenanceRedeployStatus_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForMaintenanceRedeployStatusStatus tests if a specific instance of MaintenanceRedeployStatus_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForMaintenanceRedeployStatusStatus(subject MaintenanceRedeployStatus_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.MaintenanceRedeployStatus_Status
-	err := subject.AssignPropertiesToMaintenanceRedeployStatusStatus(&other)
+	err := copied.AssignPropertiesToMaintenanceRedeployStatusStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4774,9 +4897,12 @@ func Test_NetworkInterfaceReference_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForNetworkInterfaceReferenceStatus tests if a specific instance of NetworkInterfaceReference_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceReferenceStatus(subject NetworkInterfaceReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.NetworkInterfaceReference_Status
-	err := subject.AssignPropertiesToNetworkInterfaceReferenceStatus(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4874,9 +5000,12 @@ func Test_OSDisk_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForOSDisk tests if a specific instance of OSDisk can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForOSDisk(subject OSDisk) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.OSDisk
-	err := subject.AssignPropertiesToOSDisk(&other)
+	err := copied.AssignPropertiesToOSDisk(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4995,9 +5124,12 @@ func Test_OSDisk_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForOSDiskStatus tests if a specific instance of OSDisk_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForOSDiskStatus(subject OSDisk_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.OSDisk_Status
-	err := subject.AssignPropertiesToOSDiskStatus(&other)
+	err := copied.AssignPropertiesToOSDiskStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5116,9 +5248,12 @@ func Test_UefiSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForUefiSettings tests if a specific instance of UefiSettings can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForUefiSettings(subject UefiSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.UefiSettings
-	err := subject.AssignPropertiesToUefiSettings(&other)
+	err := copied.AssignPropertiesToUefiSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5215,9 +5350,12 @@ func Test_UefiSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForUefiSettingsStatus tests if a specific instance of UefiSettings_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForUefiSettingsStatus(subject UefiSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.UefiSettings_Status
-	err := subject.AssignPropertiesToUefiSettingsStatus(&other)
+	err := copied.AssignPropertiesToUefiSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5314,9 +5452,12 @@ func Test_VaultSecretGroup_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForVaultSecretGroup tests if a specific instance of VaultSecretGroup can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVaultSecretGroup(subject VaultSecretGroup) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VaultSecretGroup
-	err := subject.AssignPropertiesToVaultSecretGroup(&other)
+	err := copied.AssignPropertiesToVaultSecretGroup(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5413,9 +5554,12 @@ func Test_VaultSecretGroup_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForVaultSecretGroupStatus tests if a specific instance of VaultSecretGroup_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVaultSecretGroupStatus(subject VaultSecretGroup_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VaultSecretGroup_Status
-	err := subject.AssignPropertiesToVaultSecretGroupStatus(&other)
+	err := copied.AssignPropertiesToVaultSecretGroupStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5513,9 +5657,12 @@ func Test_VirtualMachineAgentInstanceView_Status_WhenPropertiesConverted_RoundTr
 
 // RunPropertyAssignmentTestForVirtualMachineAgentInstanceViewStatus tests if a specific instance of VirtualMachineAgentInstanceView_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineAgentInstanceViewStatus(subject VirtualMachineAgentInstanceView_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineAgentInstanceView_Status
-	err := subject.AssignPropertiesToVirtualMachineAgentInstanceViewStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineAgentInstanceViewStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5627,9 +5774,12 @@ func Test_VirtualMachineExtensionInstanceView_Status_WhenPropertiesConverted_Rou
 
 // RunPropertyAssignmentTestForVirtualMachineExtensionInstanceViewStatus tests if a specific instance of VirtualMachineExtensionInstanceView_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineExtensionInstanceViewStatus(subject VirtualMachineExtensionInstanceView_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineExtensionInstanceView_Status
-	err := subject.AssignPropertiesToVirtualMachineExtensionInstanceViewStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineExtensionInstanceViewStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5743,9 +5893,12 @@ func Test_VirtualMachineHealthStatus_Status_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForVirtualMachineHealthStatusStatus tests if a specific instance of VirtualMachineHealthStatus_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineHealthStatusStatus(subject VirtualMachineHealthStatus_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineHealthStatus_Status
-	err := subject.AssignPropertiesToVirtualMachineHealthStatusStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineHealthStatusStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5842,9 +5995,12 @@ func Test_VirtualMachineIdentity_Status_UserAssignedIdentities_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForVirtualMachineIdentityStatusUserAssignedIdentities tests if a specific instance of VirtualMachineIdentity_Status_UserAssignedIdentities can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineIdentityStatusUserAssignedIdentities(subject VirtualMachineIdentity_Status_UserAssignedIdentities) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineIdentity_Status_UserAssignedIdentities
-	err := subject.AssignPropertiesToVirtualMachineIdentityStatusUserAssignedIdentities(&other)
+	err := copied.AssignPropertiesToVirtualMachineIdentityStatusUserAssignedIdentities(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5942,9 +6098,12 @@ func Test_VirtualMachinePatchStatus_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForVirtualMachinePatchStatusStatus tests if a specific instance of VirtualMachinePatchStatus_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachinePatchStatusStatus(subject VirtualMachinePatchStatus_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachinePatchStatus_Status
-	err := subject.AssignPropertiesToVirtualMachinePatchStatusStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachinePatchStatusStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6043,9 +6202,12 @@ func Test_VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfaces_WhenP
 
 // RunPropertyAssignmentTestForVirtualMachinesSpecPropertiesNetworkProfileNetworkInterfaces tests if a specific instance of VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfaces can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachinesSpecPropertiesNetworkProfileNetworkInterfaces(subject VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfaces) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfaces
-	err := subject.AssignPropertiesToVirtualMachinesSpecPropertiesNetworkProfileNetworkInterfaces(&other)
+	err := copied.AssignPropertiesToVirtualMachinesSpecPropertiesNetworkProfileNetworkInterfaces(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6142,9 +6304,12 @@ func Test_WindowsConfiguration_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForWindowsConfiguration tests if a specific instance of WindowsConfiguration can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForWindowsConfiguration(subject WindowsConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.WindowsConfiguration
-	err := subject.AssignPropertiesToWindowsConfiguration(&other)
+	err := copied.AssignPropertiesToWindowsConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6259,9 +6424,12 @@ func Test_WindowsConfiguration_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForWindowsConfigurationStatus tests if a specific instance of WindowsConfiguration_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForWindowsConfigurationStatus(subject WindowsConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.WindowsConfiguration_Status
-	err := subject.AssignPropertiesToWindowsConfigurationStatus(&other)
+	err := copied.AssignPropertiesToWindowsConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6376,9 +6544,12 @@ func Test_AdditionalUnattendContent_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForAdditionalUnattendContent tests if a specific instance of AdditionalUnattendContent can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAdditionalUnattendContent(subject AdditionalUnattendContent) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AdditionalUnattendContent
-	err := subject.AssignPropertiesToAdditionalUnattendContent(&other)
+	err := copied.AssignPropertiesToAdditionalUnattendContent(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6478,9 +6649,12 @@ func Test_AdditionalUnattendContent_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForAdditionalUnattendContentStatus tests if a specific instance of AdditionalUnattendContent_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAdditionalUnattendContentStatus(subject AdditionalUnattendContent_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AdditionalUnattendContent_Status
-	err := subject.AssignPropertiesToAdditionalUnattendContentStatus(&other)
+	err := copied.AssignPropertiesToAdditionalUnattendContentStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6580,9 +6754,12 @@ func Test_AvailablePatchSummary_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForAvailablePatchSummaryStatus tests if a specific instance of AvailablePatchSummary_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForAvailablePatchSummaryStatus(subject AvailablePatchSummary_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.AvailablePatchSummary_Status
-	err := subject.AssignPropertiesToAvailablePatchSummaryStatus(&other)
+	err := copied.AssignPropertiesToAvailablePatchSummaryStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6704,9 +6881,12 @@ func Test_DiffDiskSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForDiffDiskSettings tests if a specific instance of DiffDiskSettings can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiffDiskSettings(subject DiffDiskSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiffDiskSettings
-	err := subject.AssignPropertiesToDiffDiskSettings(&other)
+	err := copied.AssignPropertiesToDiffDiskSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6803,9 +6983,12 @@ func Test_DiffDiskSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForDiffDiskSettingsStatus tests if a specific instance of DiffDiskSettings_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiffDiskSettingsStatus(subject DiffDiskSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiffDiskSettings_Status
-	err := subject.AssignPropertiesToDiffDiskSettingsStatus(&other)
+	err := copied.AssignPropertiesToDiffDiskSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6903,9 +7086,12 @@ func Test_DiskEncryptionSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForDiskEncryptionSettings tests if a specific instance of DiskEncryptionSettings can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiskEncryptionSettings(subject DiskEncryptionSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiskEncryptionSettings
-	err := subject.AssignPropertiesToDiskEncryptionSettings(&other)
+	err := copied.AssignPropertiesToDiskEncryptionSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7017,9 +7203,12 @@ func Test_DiskEncryptionSettings_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForDiskEncryptionSettingsStatus tests if a specific instance of DiskEncryptionSettings_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiskEncryptionSettingsStatus(subject DiskEncryptionSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiskEncryptionSettings_Status
-	err := subject.AssignPropertiesToDiskEncryptionSettingsStatus(&other)
+	err := copied.AssignPropertiesToDiskEncryptionSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7131,9 +7320,12 @@ func Test_LastPatchInstallationSummary_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForLastPatchInstallationSummaryStatus tests if a specific instance of LastPatchInstallationSummary_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForLastPatchInstallationSummaryStatus(subject LastPatchInstallationSummary_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.LastPatchInstallationSummary_Status
-	err := subject.AssignPropertiesToLastPatchInstallationSummaryStatus(&other)
+	err := copied.AssignPropertiesToLastPatchInstallationSummaryStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7258,9 +7450,12 @@ func Test_LinuxPatchSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForLinuxPatchSettings tests if a specific instance of LinuxPatchSettings can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForLinuxPatchSettings(subject LinuxPatchSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.LinuxPatchSettings
-	err := subject.AssignPropertiesToLinuxPatchSettings(&other)
+	err := copied.AssignPropertiesToLinuxPatchSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7356,9 +7551,12 @@ func Test_LinuxPatchSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForLinuxPatchSettingsStatus tests if a specific instance of LinuxPatchSettings_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForLinuxPatchSettingsStatus(subject LinuxPatchSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.LinuxPatchSettings_Status
-	err := subject.AssignPropertiesToLinuxPatchSettingsStatus(&other)
+	err := copied.AssignPropertiesToLinuxPatchSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7455,9 +7653,12 @@ func Test_ManagedDiskParameters_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForManagedDiskParameters tests if a specific instance of ManagedDiskParameters can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForManagedDiskParameters(subject ManagedDiskParameters) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ManagedDiskParameters
-	err := subject.AssignPropertiesToManagedDiskParameters(&other)
+	err := copied.AssignPropertiesToManagedDiskParameters(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7574,9 +7775,12 @@ func Test_ManagedDiskParameters_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForManagedDiskParametersStatus tests if a specific instance of ManagedDiskParameters_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForManagedDiskParametersStatus(subject ManagedDiskParameters_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ManagedDiskParameters_Status
-	err := subject.AssignPropertiesToManagedDiskParametersStatus(&other)
+	err := copied.AssignPropertiesToManagedDiskParametersStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7694,9 +7898,12 @@ func Test_PatchSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForPatchSettings tests if a specific instance of PatchSettings can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForPatchSettings(subject PatchSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.PatchSettings
-	err := subject.AssignPropertiesToPatchSettings(&other)
+	err := copied.AssignPropertiesToPatchSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7793,9 +8000,12 @@ func Test_PatchSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForPatchSettingsStatus tests if a specific instance of PatchSettings_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForPatchSettingsStatus(subject PatchSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.PatchSettings_Status
-	err := subject.AssignPropertiesToPatchSettingsStatus(&other)
+	err := copied.AssignPropertiesToPatchSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7893,9 +8103,12 @@ func Test_SshConfiguration_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForSshConfiguration tests if a specific instance of SshConfiguration can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSshConfiguration(subject SshConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SshConfiguration
-	err := subject.AssignPropertiesToSshConfiguration(&other)
+	err := copied.AssignPropertiesToSshConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -7991,9 +8204,12 @@ func Test_SshConfiguration_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForSshConfigurationStatus tests if a specific instance of SshConfiguration_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSshConfigurationStatus(subject SshConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SshConfiguration_Status
-	err := subject.AssignPropertiesToSshConfigurationStatus(&other)
+	err := copied.AssignPropertiesToSshConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8090,9 +8306,12 @@ func Test_VaultCertificate_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForVaultCertificate tests if a specific instance of VaultCertificate can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVaultCertificate(subject VaultCertificate) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VaultCertificate
-	err := subject.AssignPropertiesToVaultCertificate(&other)
+	err := copied.AssignPropertiesToVaultCertificate(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8189,9 +8408,12 @@ func Test_VaultCertificate_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForVaultCertificateStatus tests if a specific instance of VaultCertificate_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVaultCertificateStatus(subject VaultCertificate_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VaultCertificate_Status
-	err := subject.AssignPropertiesToVaultCertificateStatus(&other)
+	err := copied.AssignPropertiesToVaultCertificateStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8289,9 +8511,12 @@ func Test_VirtualHardDisk_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForVirtualHardDisk tests if a specific instance of VirtualHardDisk can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualHardDisk(subject VirtualHardDisk) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualHardDisk
-	err := subject.AssignPropertiesToVirtualHardDisk(&other)
+	err := copied.AssignPropertiesToVirtualHardDisk(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8387,9 +8612,12 @@ func Test_VirtualHardDisk_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForVirtualHardDiskStatus tests if a specific instance of VirtualHardDisk_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualHardDiskStatus(subject VirtualHardDisk_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualHardDisk_Status
-	err := subject.AssignPropertiesToVirtualHardDiskStatus(&other)
+	err := copied.AssignPropertiesToVirtualHardDiskStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8486,9 +8714,12 @@ func Test_VirtualMachineExtensionHandlerInstanceView_Status_WhenPropertiesConver
 
 // RunPropertyAssignmentTestForVirtualMachineExtensionHandlerInstanceViewStatus tests if a specific instance of VirtualMachineExtensionHandlerInstanceView_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForVirtualMachineExtensionHandlerInstanceViewStatus(subject VirtualMachineExtensionHandlerInstanceView_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.VirtualMachineExtensionHandlerInstanceView_Status
-	err := subject.AssignPropertiesToVirtualMachineExtensionHandlerInstanceViewStatus(&other)
+	err := copied.AssignPropertiesToVirtualMachineExtensionHandlerInstanceViewStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8600,9 +8831,12 @@ func Test_WinRMConfiguration_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForWinRMConfiguration tests if a specific instance of WinRMConfiguration can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForWinRMConfiguration(subject WinRMConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.WinRMConfiguration
-	err := subject.AssignPropertiesToWinRMConfiguration(&other)
+	err := copied.AssignPropertiesToWinRMConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8698,9 +8932,12 @@ func Test_WinRMConfiguration_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForWinRMConfigurationStatus tests if a specific instance of WinRMConfiguration_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForWinRMConfigurationStatus(subject WinRMConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.WinRMConfiguration_Status
-	err := subject.AssignPropertiesToWinRMConfigurationStatus(&other)
+	err := copied.AssignPropertiesToWinRMConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8797,9 +9034,12 @@ func Test_ApiError_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForApiErrorStatus tests if a specific instance of ApiError_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForApiErrorStatus(subject ApiError_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ApiError_Status
-	err := subject.AssignPropertiesToApiErrorStatus(&other)
+	err := copied.AssignPropertiesToApiErrorStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -8912,9 +9152,12 @@ func Test_DiskEncryptionSetParameters_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForDiskEncryptionSetParameters tests if a specific instance of DiskEncryptionSetParameters can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForDiskEncryptionSetParameters(subject DiskEncryptionSetParameters) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.DiskEncryptionSetParameters
-	err := subject.AssignPropertiesToDiskEncryptionSetParameters(&other)
+	err := copied.AssignPropertiesToDiskEncryptionSetParameters(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9005,9 +9248,12 @@ func Test_KeyVaultKeyReference_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForKeyVaultKeyReference tests if a specific instance of KeyVaultKeyReference can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultKeyReference(subject KeyVaultKeyReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.KeyVaultKeyReference
-	err := subject.AssignPropertiesToKeyVaultKeyReference(&other)
+	err := copied.AssignPropertiesToKeyVaultKeyReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9118,9 +9364,12 @@ func Test_KeyVaultKeyReference_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForKeyVaultKeyReferenceStatus tests if a specific instance of KeyVaultKeyReference_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultKeyReferenceStatus(subject KeyVaultKeyReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.KeyVaultKeyReference_Status
-	err := subject.AssignPropertiesToKeyVaultKeyReferenceStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultKeyReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9231,9 +9480,12 @@ func Test_KeyVaultSecretReference_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForKeyVaultSecretReference tests if a specific instance of KeyVaultSecretReference can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultSecretReference(subject KeyVaultSecretReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.KeyVaultSecretReference
-	err := subject.AssignPropertiesToKeyVaultSecretReference(&other)
+	err := copied.AssignPropertiesToKeyVaultSecretReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9344,9 +9596,12 @@ func Test_KeyVaultSecretReference_Status_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForKeyVaultSecretReferenceStatus tests if a specific instance of KeyVaultSecretReference_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultSecretReferenceStatus(subject KeyVaultSecretReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.KeyVaultSecretReference_Status
-	err := subject.AssignPropertiesToKeyVaultSecretReferenceStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultSecretReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9457,9 +9712,12 @@ func Test_SshPublicKey_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForSshPublicKey tests if a specific instance of SshPublicKey can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSshPublicKey(subject SshPublicKey) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SshPublicKey
-	err := subject.AssignPropertiesToSshPublicKey(&other)
+	err := copied.AssignPropertiesToSshPublicKey(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9556,9 +9814,12 @@ func Test_SshPublicKey_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForSshPublicKeyStatus tests if a specific instance of SshPublicKey_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForSshPublicKeyStatus(subject SshPublicKey_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.SshPublicKey_Status
-	err := subject.AssignPropertiesToSshPublicKeyStatus(&other)
+	err := copied.AssignPropertiesToSshPublicKeyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9655,9 +9916,12 @@ func Test_WinRMListener_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForWinRMListener tests if a specific instance of WinRMListener can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForWinRMListener(subject WinRMListener) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.WinRMListener
-	err := subject.AssignPropertiesToWinRMListener(&other)
+	err := copied.AssignPropertiesToWinRMListener(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9754,9 +10018,12 @@ func Test_WinRMListener_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForWinRMListenerStatus tests if a specific instance of WinRMListener_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForWinRMListenerStatus(subject WinRMListener_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.WinRMListener_Status
-	err := subject.AssignPropertiesToWinRMListenerStatus(&other)
+	err := copied.AssignPropertiesToWinRMListenerStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9854,9 +10121,12 @@ func Test_ApiErrorBase_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForApiErrorBaseStatus tests if a specific instance of ApiErrorBase_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForApiErrorBaseStatus(subject ApiErrorBase_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.ApiErrorBase_Status
-	err := subject.AssignPropertiesToApiErrorBaseStatus(&other)
+	err := copied.AssignPropertiesToApiErrorBaseStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -9954,9 +10224,12 @@ func Test_InnerError_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForInnerErrorStatus tests if a specific instance of InnerError_Status can be assigned to v1alpha1api20201201storage and back losslessly
 func RunPropertyAssignmentTestForInnerErrorStatus(subject InnerError_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201201storage.InnerError_Status
-	err := subject.AssignPropertiesToInnerErrorStatus(&other)
+	err := copied.AssignPropertiesToInnerErrorStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_cluster_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_ManagedCluster_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForManagedCluster tests if a specific instance of ManagedCluster can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedCluster(subject ManagedCluster) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedCluster
-	err := subject.AssignPropertiesToManagedCluster(&other)
+	err := copied.AssignPropertiesToManagedCluster(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_ManagedCluster_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForManagedClusterStatus tests if a specific instance of ManagedCluster_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterStatus(subject ManagedCluster_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedCluster_Status
-	err := subject.AssignPropertiesToManagedClusterStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -275,9 +281,12 @@ func Test_ManagedClusters_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForManagedClustersSpec tests if a specific instance of ManagedClusters_Spec can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClustersSpec(subject ManagedClusters_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusters_Spec
-	err := subject.AssignPropertiesToManagedClustersSpec(&other)
+	err := copied.AssignPropertiesToManagedClustersSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -413,9 +422,12 @@ func Test_Componentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofi
 
 // RunPropertyAssignmentTestForComponentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties tests if a specific instance of Componentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForComponentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties(subject Componentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Componentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties
-	err := subject.AssignPropertiesToComponentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties(&other)
+	err := copied.AssignPropertiesToComponentsqit0Etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -514,9 +526,12 @@ func Test_ContainerServiceLinuxProfile_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForContainerServiceLinuxProfile tests if a specific instance of ContainerServiceLinuxProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceLinuxProfile(subject ContainerServiceLinuxProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceLinuxProfile
-	err := subject.AssignPropertiesToContainerServiceLinuxProfile(&other)
+	err := copied.AssignPropertiesToContainerServiceLinuxProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -627,9 +642,12 @@ func Test_ContainerServiceLinuxProfile_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForContainerServiceLinuxProfileStatus tests if a specific instance of ContainerServiceLinuxProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceLinuxProfileStatus(subject ContainerServiceLinuxProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceLinuxProfile_Status
-	err := subject.AssignPropertiesToContainerServiceLinuxProfileStatus(&other)
+	err := copied.AssignPropertiesToContainerServiceLinuxProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -740,9 +758,12 @@ func Test_ContainerServiceNetworkProfile_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForContainerServiceNetworkProfile tests if a specific instance of ContainerServiceNetworkProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceNetworkProfile(subject ContainerServiceNetworkProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceNetworkProfile
-	err := subject.AssignPropertiesToContainerServiceNetworkProfile(&other)
+	err := copied.AssignPropertiesToContainerServiceNetworkProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -861,9 +882,12 @@ func Test_ContainerServiceNetworkProfile_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForContainerServiceNetworkProfileStatus tests if a specific instance of ContainerServiceNetworkProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceNetworkProfileStatus(subject ContainerServiceNetworkProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceNetworkProfile_Status
-	err := subject.AssignPropertiesToContainerServiceNetworkProfileStatus(&other)
+	err := copied.AssignPropertiesToContainerServiceNetworkProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -982,9 +1006,12 @@ func Test_ExtendedLocation_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForExtendedLocation tests if a specific instance of ExtendedLocation can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocation(subject ExtendedLocation) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ExtendedLocation
-	err := subject.AssignPropertiesToExtendedLocation(&other)
+	err := copied.AssignPropertiesToExtendedLocation(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1081,9 +1108,12 @@ func Test_ExtendedLocation_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForExtendedLocationStatus tests if a specific instance of ExtendedLocation_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocationStatus(subject ExtendedLocation_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ExtendedLocation_Status
-	err := subject.AssignPropertiesToExtendedLocationStatus(&other)
+	err := copied.AssignPropertiesToExtendedLocationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1181,9 +1211,12 @@ func Test_ManagedClusterAADProfile_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForManagedClusterAADProfile tests if a specific instance of ManagedClusterAADProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAADProfile(subject ManagedClusterAADProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAADProfile
-	err := subject.AssignPropertiesToManagedClusterAADProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterAADProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1286,9 +1319,12 @@ func Test_ManagedClusterAADProfile_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForManagedClusterAADProfileStatus tests if a specific instance of ManagedClusterAADProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAADProfileStatus(subject ManagedClusterAADProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAADProfile_Status
-	err := subject.AssignPropertiesToManagedClusterAADProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterAADProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1391,9 +1427,12 @@ func Test_ManagedClusterAPIServerAccessProfile_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForManagedClusterAPIServerAccessProfile tests if a specific instance of ManagedClusterAPIServerAccessProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAPIServerAccessProfile(subject ManagedClusterAPIServerAccessProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAPIServerAccessProfile
-	err := subject.AssignPropertiesToManagedClusterAPIServerAccessProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterAPIServerAccessProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1493,9 +1532,12 @@ func Test_ManagedClusterAPIServerAccessProfile_Status_WhenPropertiesConverted_Ro
 
 // RunPropertyAssignmentTestForManagedClusterAPIServerAccessProfileStatus tests if a specific instance of ManagedClusterAPIServerAccessProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAPIServerAccessProfileStatus(subject ManagedClusterAPIServerAccessProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAPIServerAccessProfile_Status
-	err := subject.AssignPropertiesToManagedClusterAPIServerAccessProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterAPIServerAccessProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1595,9 +1637,12 @@ func Test_ManagedClusterAddonProfile_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForManagedClusterAddonProfile tests if a specific instance of ManagedClusterAddonProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAddonProfile(subject ManagedClusterAddonProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAddonProfile
-	err := subject.AssignPropertiesToManagedClusterAddonProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterAddonProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1695,9 +1740,12 @@ func Test_ManagedClusterAgentPoolProfile_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForManagedClusterAgentPoolProfile tests if a specific instance of ManagedClusterAgentPoolProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAgentPoolProfile(subject ManagedClusterAgentPoolProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAgentPoolProfile
-	err := subject.AssignPropertiesToManagedClusterAgentPoolProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterAgentPoolProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1842,9 +1890,12 @@ func Test_ManagedClusterAgentPoolProfile_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForManagedClusterAgentPoolProfileStatus tests if a specific instance of ManagedClusterAgentPoolProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAgentPoolProfileStatus(subject ManagedClusterAgentPoolProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAgentPoolProfile_Status
-	err := subject.AssignPropertiesToManagedClusterAgentPoolProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterAgentPoolProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1995,9 +2046,12 @@ func Test_ManagedClusterAutoUpgradeProfile_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForManagedClusterAutoUpgradeProfile tests if a specific instance of ManagedClusterAutoUpgradeProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAutoUpgradeProfile(subject ManagedClusterAutoUpgradeProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAutoUpgradeProfile
-	err := subject.AssignPropertiesToManagedClusterAutoUpgradeProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterAutoUpgradeProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2099,9 +2153,12 @@ func Test_ManagedClusterAutoUpgradeProfile_Status_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForManagedClusterAutoUpgradeProfileStatus tests if a specific instance of ManagedClusterAutoUpgradeProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterAutoUpgradeProfileStatus(subject ManagedClusterAutoUpgradeProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterAutoUpgradeProfile_Status
-	err := subject.AssignPropertiesToManagedClusterAutoUpgradeProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterAutoUpgradeProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2203,9 +2260,12 @@ func Test_ManagedClusterHTTPProxyConfig_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForManagedClusterHTTPProxyConfig tests if a specific instance of ManagedClusterHTTPProxyConfig can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterHTTPProxyConfig(subject ManagedClusterHTTPProxyConfig) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterHTTPProxyConfig
-	err := subject.AssignPropertiesToManagedClusterHTTPProxyConfig(&other)
+	err := copied.AssignPropertiesToManagedClusterHTTPProxyConfig(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2305,9 +2365,12 @@ func Test_ManagedClusterHTTPProxyConfig_Status_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForManagedClusterHTTPProxyConfigStatus tests if a specific instance of ManagedClusterHTTPProxyConfig_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterHTTPProxyConfigStatus(subject ManagedClusterHTTPProxyConfig_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterHTTPProxyConfig_Status
-	err := subject.AssignPropertiesToManagedClusterHTTPProxyConfigStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterHTTPProxyConfigStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2407,9 +2470,12 @@ func Test_ManagedClusterIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForManagedClusterIdentity tests if a specific instance of ManagedClusterIdentity can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterIdentity(subject ManagedClusterIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterIdentity
-	err := subject.AssignPropertiesToManagedClusterIdentity(&other)
+	err := copied.AssignPropertiesToManagedClusterIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2506,9 +2572,12 @@ func Test_ManagedClusterIdentity_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForManagedClusterIdentityStatus tests if a specific instance of ManagedClusterIdentity_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterIdentityStatus(subject ManagedClusterIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterIdentity_Status
-	err := subject.AssignPropertiesToManagedClusterIdentityStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2621,9 +2690,12 @@ func Test_ManagedClusterPodIdentityProfile_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityProfile tests if a specific instance of ManagedClusterPodIdentityProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityProfile(subject ManagedClusterPodIdentityProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentityProfile
-	err := subject.AssignPropertiesToManagedClusterPodIdentityProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2736,9 +2808,12 @@ func Test_ManagedClusterPodIdentityProfile_Status_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityProfileStatus tests if a specific instance of ManagedClusterPodIdentityProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityProfileStatus(subject ManagedClusterPodIdentityProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentityProfile_Status
-	err := subject.AssignPropertiesToManagedClusterPodIdentityProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2851,9 +2926,12 @@ func Test_ManagedClusterPropertiesAutoScalerProfile_WhenPropertiesConverted_Roun
 
 // RunPropertyAssignmentTestForManagedClusterPropertiesAutoScalerProfile tests if a specific instance of ManagedClusterPropertiesAutoScalerProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPropertiesAutoScalerProfile(subject ManagedClusterPropertiesAutoScalerProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPropertiesAutoScalerProfile
-	err := subject.AssignPropertiesToManagedClusterPropertiesAutoScalerProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterPropertiesAutoScalerProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2970,9 +3048,12 @@ func Test_ManagedClusterProperties_Status_AutoScalerProfile_WhenPropertiesConver
 
 // RunPropertyAssignmentTestForManagedClusterPropertiesStatusAutoScalerProfile tests if a specific instance of ManagedClusterProperties_Status_AutoScalerProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPropertiesStatusAutoScalerProfile(subject ManagedClusterProperties_Status_AutoScalerProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterProperties_Status_AutoScalerProfile
-	err := subject.AssignPropertiesToManagedClusterPropertiesStatusAutoScalerProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterPropertiesStatusAutoScalerProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3089,9 +3170,12 @@ func Test_ManagedClusterSKU_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForManagedClusterSKU tests if a specific instance of ManagedClusterSKU can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterSKU(subject ManagedClusterSKU) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterSKU
-	err := subject.AssignPropertiesToManagedClusterSKU(&other)
+	err := copied.AssignPropertiesToManagedClusterSKU(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3188,9 +3272,12 @@ func Test_ManagedClusterSKU_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForManagedClusterSKUStatus tests if a specific instance of ManagedClusterSKU_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterSKUStatus(subject ManagedClusterSKU_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterSKU_Status
-	err := subject.AssignPropertiesToManagedClusterSKUStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterSKUStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3288,9 +3375,12 @@ func Test_ManagedClusterServicePrincipalProfile_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForManagedClusterServicePrincipalProfile tests if a specific instance of ManagedClusterServicePrincipalProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterServicePrincipalProfile(subject ManagedClusterServicePrincipalProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterServicePrincipalProfile
-	err := subject.AssignPropertiesToManagedClusterServicePrincipalProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterServicePrincipalProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3388,9 +3478,12 @@ func Test_ManagedClusterServicePrincipalProfile_Status_WhenPropertiesConverted_R
 
 // RunPropertyAssignmentTestForManagedClusterServicePrincipalProfileStatus tests if a specific instance of ManagedClusterServicePrincipalProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterServicePrincipalProfileStatus(subject ManagedClusterServicePrincipalProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterServicePrincipalProfile_Status
-	err := subject.AssignPropertiesToManagedClusterServicePrincipalProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterServicePrincipalProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3488,9 +3581,12 @@ func Test_ManagedClusterWindowsProfile_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForManagedClusterWindowsProfile tests if a specific instance of ManagedClusterWindowsProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterWindowsProfile(subject ManagedClusterWindowsProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterWindowsProfile
-	err := subject.AssignPropertiesToManagedClusterWindowsProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterWindowsProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3590,9 +3686,12 @@ func Test_ManagedClusterWindowsProfile_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForManagedClusterWindowsProfileStatus tests if a specific instance of ManagedClusterWindowsProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterWindowsProfileStatus(subject ManagedClusterWindowsProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterWindowsProfile_Status
-	err := subject.AssignPropertiesToManagedClusterWindowsProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterWindowsProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3692,9 +3791,12 @@ func Test_PowerState_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForPowerStateStatus tests if a specific instance of PowerState_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForPowerStateStatus(subject PowerState_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.PowerState_Status
-	err := subject.AssignPropertiesToPowerStateStatus(&other)
+	err := copied.AssignPropertiesToPowerStateStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3790,9 +3892,12 @@ func Test_PrivateLinkResource_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForPrivateLinkResource tests if a specific instance of PrivateLinkResource can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForPrivateLinkResource(subject PrivateLinkResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.PrivateLinkResource
-	err := subject.AssignPropertiesToPrivateLinkResource(&other)
+	err := copied.AssignPropertiesToPrivateLinkResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3892,9 +3997,12 @@ func Test_PrivateLinkResource_Status_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForPrivateLinkResourceStatus tests if a specific instance of PrivateLinkResource_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForPrivateLinkResourceStatus(subject PrivateLinkResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.PrivateLinkResource_Status
-	err := subject.AssignPropertiesToPrivateLinkResourceStatus(&other)
+	err := copied.AssignPropertiesToPrivateLinkResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3996,9 +4104,12 @@ func Test_ContainerServiceSshConfiguration_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForContainerServiceSshConfiguration tests if a specific instance of ContainerServiceSshConfiguration can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceSshConfiguration(subject ContainerServiceSshConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceSshConfiguration
-	err := subject.AssignPropertiesToContainerServiceSshConfiguration(&other)
+	err := copied.AssignPropertiesToContainerServiceSshConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4095,9 +4206,12 @@ func Test_ContainerServiceSshConfiguration_Status_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForContainerServiceSshConfigurationStatus tests if a specific instance of ContainerServiceSshConfiguration_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceSshConfigurationStatus(subject ContainerServiceSshConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceSshConfiguration_Status
-	err := subject.AssignPropertiesToContainerServiceSshConfigurationStatus(&other)
+	err := copied.AssignPropertiesToContainerServiceSshConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4194,9 +4308,12 @@ func Test_ManagedClusterIdentity_Status_UserAssignedIdentities_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForManagedClusterIdentityStatusUserAssignedIdentities tests if a specific instance of ManagedClusterIdentity_Status_UserAssignedIdentities can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterIdentityStatusUserAssignedIdentities(subject ManagedClusterIdentity_Status_UserAssignedIdentities) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterIdentity_Status_UserAssignedIdentities
-	err := subject.AssignPropertiesToManagedClusterIdentityStatusUserAssignedIdentities(&other)
+	err := copied.AssignPropertiesToManagedClusterIdentityStatusUserAssignedIdentities(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4294,9 +4411,12 @@ func Test_ManagedClusterLoadBalancerProfile_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfile tests if a specific instance of ManagedClusterLoadBalancerProfile can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfile(subject ManagedClusterLoadBalancerProfile) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfile
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfile(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfile(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4411,9 +4531,12 @@ func Test_ManagedClusterLoadBalancerProfile_Status_WhenPropertiesConverted_Round
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatus tests if a specific instance of ManagedClusterLoadBalancerProfile_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatus(subject ManagedClusterLoadBalancerProfile_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfile_Status
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfileStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfileStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4528,9 +4651,12 @@ func Test_ManagedClusterPodIdentity_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentity tests if a specific instance of ManagedClusterPodIdentity can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentity(subject ManagedClusterPodIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentity
-	err := subject.AssignPropertiesToManagedClusterPodIdentity(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4643,9 +4769,12 @@ func Test_ManagedClusterPodIdentityException_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityException tests if a specific instance of ManagedClusterPodIdentityException can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityException(subject ManagedClusterPodIdentityException) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentityException
-	err := subject.AssignPropertiesToManagedClusterPodIdentityException(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityException(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4744,9 +4873,12 @@ func Test_ManagedClusterPodIdentityException_Status_WhenPropertiesConverted_Roun
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityExceptionStatus tests if a specific instance of ManagedClusterPodIdentityException_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityExceptionStatus(subject ManagedClusterPodIdentityException_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentityException_Status
-	err := subject.AssignPropertiesToManagedClusterPodIdentityExceptionStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityExceptionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4845,9 +4977,12 @@ func Test_ManagedClusterPodIdentity_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityStatus tests if a specific instance of ManagedClusterPodIdentity_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityStatus(subject ManagedClusterPodIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentity_Status
-	err := subject.AssignPropertiesToManagedClusterPodIdentityStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4966,9 +5101,12 @@ func Test_ContainerServiceSshPublicKey_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForContainerServiceSshPublicKey tests if a specific instance of ContainerServiceSshPublicKey can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceSshPublicKey(subject ContainerServiceSshPublicKey) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceSshPublicKey
-	err := subject.AssignPropertiesToContainerServiceSshPublicKey(&other)
+	err := copied.AssignPropertiesToContainerServiceSshPublicKey(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5065,9 +5203,12 @@ func Test_ContainerServiceSshPublicKey_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForContainerServiceSshPublicKeyStatus tests if a specific instance of ContainerServiceSshPublicKey_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForContainerServiceSshPublicKeyStatus(subject ContainerServiceSshPublicKey_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ContainerServiceSshPublicKey_Status
-	err := subject.AssignPropertiesToContainerServiceSshPublicKeyStatus(&other)
+	err := copied.AssignPropertiesToContainerServiceSshPublicKeyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5164,9 +5305,12 @@ func Test_ManagedClusterLoadBalancerProfileManagedOutboundIPs_WhenPropertiesConv
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileManagedOutboundIPs tests if a specific instance of ManagedClusterLoadBalancerProfileManagedOutboundIPs can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileManagedOutboundIPs(subject ManagedClusterLoadBalancerProfileManagedOutboundIPs) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfileManagedOutboundIPs
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfileManagedOutboundIPs(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfileManagedOutboundIPs(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5263,9 +5407,12 @@ func Test_ManagedClusterLoadBalancerProfileOutboundIPPrefixes_WhenPropertiesConv
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileOutboundIPPrefixes tests if a specific instance of ManagedClusterLoadBalancerProfileOutboundIPPrefixes can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileOutboundIPPrefixes(subject ManagedClusterLoadBalancerProfileOutboundIPPrefixes) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfileOutboundIPPrefixes
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfileOutboundIPPrefixes(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfileOutboundIPPrefixes(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5362,9 +5509,12 @@ func Test_ManagedClusterLoadBalancerProfileOutboundIPs_WhenPropertiesConverted_R
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileOutboundIPs tests if a specific instance of ManagedClusterLoadBalancerProfileOutboundIPs can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileOutboundIPs(subject ManagedClusterLoadBalancerProfileOutboundIPs) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfileOutboundIPs
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfileOutboundIPs(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfileOutboundIPs(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5461,9 +5611,12 @@ func Test_ManagedClusterLoadBalancerProfile_Status_ManagedOutboundIPs_WhenProper
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatusManagedOutboundIPs tests if a specific instance of ManagedClusterLoadBalancerProfile_Status_ManagedOutboundIPs can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatusManagedOutboundIPs(subject ManagedClusterLoadBalancerProfile_Status_ManagedOutboundIPs) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfile_Status_ManagedOutboundIPs
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfileStatusManagedOutboundIPs(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfileStatusManagedOutboundIPs(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5560,9 +5713,12 @@ func Test_ManagedClusterLoadBalancerProfile_Status_OutboundIPPrefixes_WhenProper
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatusOutboundIPPrefixes tests if a specific instance of ManagedClusterLoadBalancerProfile_Status_OutboundIPPrefixes can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatusOutboundIPPrefixes(subject ManagedClusterLoadBalancerProfile_Status_OutboundIPPrefixes) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfile_Status_OutboundIPPrefixes
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfileStatusOutboundIPPrefixes(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfileStatusOutboundIPPrefixes(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5659,9 +5815,12 @@ func Test_ManagedClusterLoadBalancerProfile_Status_OutboundIPs_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatusOutboundIPs tests if a specific instance of ManagedClusterLoadBalancerProfile_Status_OutboundIPs can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterLoadBalancerProfileStatusOutboundIPs(subject ManagedClusterLoadBalancerProfile_Status_OutboundIPs) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterLoadBalancerProfile_Status_OutboundIPs
-	err := subject.AssignPropertiesToManagedClusterLoadBalancerProfileStatusOutboundIPs(&other)
+	err := copied.AssignPropertiesToManagedClusterLoadBalancerProfileStatusOutboundIPs(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5758,9 +5917,12 @@ func Test_ManagedClusterPodIdentity_Status_ProvisioningInfo_WhenPropertiesConver
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityStatusProvisioningInfo tests if a specific instance of ManagedClusterPodIdentity_Status_ProvisioningInfo can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityStatusProvisioningInfo(subject ManagedClusterPodIdentity_Status_ProvisioningInfo) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentity_Status_ProvisioningInfo
-	err := subject.AssignPropertiesToManagedClusterPodIdentityStatusProvisioningInfo(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityStatusProvisioningInfo(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5857,9 +6019,12 @@ func Test_ResourceReference_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForResourceReference tests if a specific instance of ResourceReference can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForResourceReference(subject ResourceReference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ResourceReference
-	err := subject.AssignPropertiesToResourceReference(&other)
+	err := copied.AssignPropertiesToResourceReference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5949,9 +6114,12 @@ func Test_ResourceReference_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForResourceReferenceStatus tests if a specific instance of ResourceReference_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForResourceReferenceStatus(subject ResourceReference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ResourceReference_Status
-	err := subject.AssignPropertiesToResourceReferenceStatus(&other)
+	err := copied.AssignPropertiesToResourceReferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6048,9 +6216,12 @@ func Test_UserAssignedIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForUserAssignedIdentity tests if a specific instance of UserAssignedIdentity can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentity(subject UserAssignedIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.UserAssignedIdentity
-	err := subject.AssignPropertiesToUserAssignedIdentity(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6148,9 +6319,12 @@ func Test_UserAssignedIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForUserAssignedIdentityStatus tests if a specific instance of UserAssignedIdentity_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityStatus(subject UserAssignedIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.UserAssignedIdentity_Status
-	err := subject.AssignPropertiesToUserAssignedIdentityStatus(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6249,9 +6423,12 @@ func Test_ManagedClusterPodIdentityProvisioningError_Status_WhenPropertiesConver
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityProvisioningErrorStatus tests if a specific instance of ManagedClusterPodIdentityProvisioningError_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityProvisioningErrorStatus(subject ManagedClusterPodIdentityProvisioningError_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentityProvisioningError_Status
-	err := subject.AssignPropertiesToManagedClusterPodIdentityProvisioningErrorStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityProvisioningErrorStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6348,9 +6525,12 @@ func Test_ManagedClusterPodIdentityProvisioningErrorBody_Status_WhenPropertiesCo
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityProvisioningErrorBodyStatus tests if a specific instance of ManagedClusterPodIdentityProvisioningErrorBody_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityProvisioningErrorBodyStatus(subject ManagedClusterPodIdentityProvisioningErrorBody_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentityProvisioningErrorBody_Status
-	err := subject.AssignPropertiesToManagedClusterPodIdentityProvisioningErrorBodyStatus(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityProvisioningErrorBodyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -6463,9 +6643,12 @@ func Test_ManagedClusterPodIdentityProvisioningErrorBody_Status_Unrolled_WhenPro
 
 // RunPropertyAssignmentTestForManagedClusterPodIdentityProvisioningErrorBodyStatusUnrolled tests if a specific instance of ManagedClusterPodIdentityProvisioningErrorBody_Status_Unrolled can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClusterPodIdentityProvisioningErrorBodyStatusUnrolled(subject ManagedClusterPodIdentityProvisioningErrorBody_Status_Unrolled) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClusterPodIdentityProvisioningErrorBody_Status_Unrolled
-	err := subject.AssignPropertiesToManagedClusterPodIdentityProvisioningErrorBodyStatusUnrolled(&other)
+	err := copied.AssignPropertiesToManagedClusterPodIdentityProvisioningErrorBodyStatusUnrolled(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen_test.go
+++ b/v2/api/microsoft.containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_ManagedClustersAgentPool_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForManagedClustersAgentPool tests if a specific instance of ManagedClustersAgentPool can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClustersAgentPool(subject ManagedClustersAgentPool) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClustersAgentPool
-	err := subject.AssignPropertiesToManagedClustersAgentPool(&other)
+	err := copied.AssignPropertiesToManagedClustersAgentPool(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_AgentPool_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForAgentPoolStatus tests if a specific instance of AgentPool_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForAgentPoolStatus(subject AgentPool_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.AgentPool_Status
-	err := subject.AssignPropertiesToAgentPoolStatus(&other)
+	err := copied.AssignPropertiesToAgentPoolStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -285,9 +291,12 @@ func Test_ManagedClustersAgentPools_Spec_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForManagedClustersAgentPoolsSpec tests if a specific instance of ManagedClustersAgentPools_Spec can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForManagedClustersAgentPoolsSpec(subject ManagedClustersAgentPools_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.ManagedClustersAgentPools_Spec
-	err := subject.AssignPropertiesToManagedClustersAgentPoolsSpec(&other)
+	err := copied.AssignPropertiesToManagedClustersAgentPoolsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -433,9 +442,12 @@ func Test_AgentPoolUpgradeSettings_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForAgentPoolUpgradeSettings tests if a specific instance of AgentPoolUpgradeSettings can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForAgentPoolUpgradeSettings(subject AgentPoolUpgradeSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.AgentPoolUpgradeSettings
-	err := subject.AssignPropertiesToAgentPoolUpgradeSettings(&other)
+	err := copied.AssignPropertiesToAgentPoolUpgradeSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -532,9 +544,12 @@ func Test_AgentPoolUpgradeSettings_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForAgentPoolUpgradeSettingsStatus tests if a specific instance of AgentPoolUpgradeSettings_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForAgentPoolUpgradeSettingsStatus(subject AgentPoolUpgradeSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.AgentPoolUpgradeSettings_Status
-	err := subject.AssignPropertiesToAgentPoolUpgradeSettingsStatus(&other)
+	err := copied.AssignPropertiesToAgentPoolUpgradeSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -631,9 +646,12 @@ func Test_KubeletConfig_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForKubeletConfig tests if a specific instance of KubeletConfig can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForKubeletConfig(subject KubeletConfig) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.KubeletConfig
-	err := subject.AssignPropertiesToKubeletConfig(&other)
+	err := copied.AssignPropertiesToKubeletConfig(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -739,9 +757,12 @@ func Test_KubeletConfig_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForKubeletConfigStatus tests if a specific instance of KubeletConfig_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForKubeletConfigStatus(subject KubeletConfig_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.KubeletConfig_Status
-	err := subject.AssignPropertiesToKubeletConfigStatus(&other)
+	err := copied.AssignPropertiesToKubeletConfigStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -848,9 +869,12 @@ func Test_LinuxOSConfig_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForLinuxOSConfig tests if a specific instance of LinuxOSConfig can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForLinuxOSConfig(subject LinuxOSConfig) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.LinuxOSConfig
-	err := subject.AssignPropertiesToLinuxOSConfig(&other)
+	err := copied.AssignPropertiesToLinuxOSConfig(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -962,9 +986,12 @@ func Test_LinuxOSConfig_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForLinuxOSConfigStatus tests if a specific instance of LinuxOSConfig_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForLinuxOSConfigStatus(subject LinuxOSConfig_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.LinuxOSConfig_Status
-	err := subject.AssignPropertiesToLinuxOSConfigStatus(&other)
+	err := copied.AssignPropertiesToLinuxOSConfigStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1077,9 +1104,12 @@ func Test_SysctlConfig_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForSysctlConfig tests if a specific instance of SysctlConfig can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForSysctlConfig(subject SysctlConfig) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.SysctlConfig
-	err := subject.AssignPropertiesToSysctlConfig(&other)
+	err := copied.AssignPropertiesToSysctlConfig(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1202,9 +1232,12 @@ func Test_SysctlConfig_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForSysctlConfigStatus tests if a specific instance of SysctlConfig_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForSysctlConfigStatus(subject SysctlConfig_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.SysctlConfig_Status
-	err := subject.AssignPropertiesToSysctlConfigStatus(&other)
+	err := copied.AssignPropertiesToSysctlConfigStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_server_types_gen_test.go
+++ b/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_server_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_FlexibleServer_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForFlexibleServer tests if a specific instance of FlexibleServer can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServer(subject FlexibleServer) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.FlexibleServer
-	err := subject.AssignPropertiesToFlexibleServer(&other)
+	err := copied.AssignPropertiesToFlexibleServer(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_FlexibleServers_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForFlexibleServersSpec tests if a specific instance of FlexibleServers_Spec can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersSpec(subject FlexibleServers_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.FlexibleServers_Spec
-	err := subject.AssignPropertiesToFlexibleServersSpec(&other)
+	err := copied.AssignPropertiesToFlexibleServersSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -262,9 +268,12 @@ func Test_Server_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForServerStatus tests if a specific instance of Server_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForServerStatus(subject Server_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Server_Status
-	err := subject.AssignPropertiesToServerStatus(&other)
+	err := copied.AssignPropertiesToServerStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -406,9 +415,12 @@ func Test_Backup_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForBackup tests if a specific instance of Backup can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForBackup(subject Backup) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Backup
-	err := subject.AssignPropertiesToBackup(&other)
+	err := copied.AssignPropertiesToBackup(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -505,9 +517,12 @@ func Test_Backup_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForBackupStatus tests if a specific instance of Backup_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForBackupStatus(subject Backup_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Backup_Status
-	err := subject.AssignPropertiesToBackupStatus(&other)
+	err := copied.AssignPropertiesToBackupStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -605,9 +620,12 @@ func Test_HighAvailability_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForHighAvailability tests if a specific instance of HighAvailability can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForHighAvailability(subject HighAvailability) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.HighAvailability
-	err := subject.AssignPropertiesToHighAvailability(&other)
+	err := copied.AssignPropertiesToHighAvailability(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -704,9 +722,12 @@ func Test_HighAvailability_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForHighAvailabilityStatus tests if a specific instance of HighAvailability_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForHighAvailabilityStatus(subject HighAvailability_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.HighAvailability_Status
-	err := subject.AssignPropertiesToHighAvailabilityStatus(&other)
+	err := copied.AssignPropertiesToHighAvailabilityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -810,9 +831,12 @@ func Test_MaintenanceWindow_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForMaintenanceWindow tests if a specific instance of MaintenanceWindow can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForMaintenanceWindow(subject MaintenanceWindow) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.MaintenanceWindow
-	err := subject.AssignPropertiesToMaintenanceWindow(&other)
+	err := copied.AssignPropertiesToMaintenanceWindow(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -911,9 +935,12 @@ func Test_MaintenanceWindow_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForMaintenanceWindowStatus tests if a specific instance of MaintenanceWindow_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForMaintenanceWindowStatus(subject MaintenanceWindow_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.MaintenanceWindow_Status
-	err := subject.AssignPropertiesToMaintenanceWindowStatus(&other)
+	err := copied.AssignPropertiesToMaintenanceWindowStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1013,9 +1040,12 @@ func Test_Network_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForNetwork tests if a specific instance of Network can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForNetwork(subject Network) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Network
-	err := subject.AssignPropertiesToNetwork(&other)
+	err := copied.AssignPropertiesToNetwork(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1105,9 +1135,12 @@ func Test_Network_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForNetworkStatus tests if a specific instance of Network_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForNetworkStatus(subject Network_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Network_Status
-	err := subject.AssignPropertiesToNetworkStatus(&other)
+	err := copied.AssignPropertiesToNetworkStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1205,9 +1238,12 @@ func Test_Sku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForSku tests if a specific instance of Sku can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForSku(subject Sku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Sku
-	err := subject.AssignPropertiesToSku(&other)
+	err := copied.AssignPropertiesToSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1304,9 +1340,12 @@ func Test_Sku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForSkuStatus tests if a specific instance of Sku_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForSkuStatus(subject Sku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Sku_Status
-	err := subject.AssignPropertiesToSkuStatus(&other)
+	err := copied.AssignPropertiesToSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1403,9 +1442,12 @@ func Test_Storage_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForStorage tests if a specific instance of Storage can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForStorage(subject Storage) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Storage
-	err := subject.AssignPropertiesToStorage(&other)
+	err := copied.AssignPropertiesToStorage(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1503,9 +1545,12 @@ func Test_Storage_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForStorageStatus tests if a specific instance of Storage_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForStorageStatus(subject Storage_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Storage_Status
-	err := subject.AssignPropertiesToStorageStatus(&other)
+	err := copied.AssignPropertiesToStorageStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1604,9 +1649,12 @@ func Test_SystemData_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForSystemDataStatus tests if a specific instance of SystemData_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForSystemDataStatus(subject SystemData_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.SystemData_Status
-	err := subject.AssignPropertiesToSystemDataStatus(&other)
+	err := copied.AssignPropertiesToSystemDataStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen_test.go
+++ b/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_FlexibleServersDatabase_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForFlexibleServersDatabase tests if a specific instance of FlexibleServersDatabase can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersDatabase(subject FlexibleServersDatabase) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.FlexibleServersDatabase
-	err := subject.AssignPropertiesToFlexibleServersDatabase(&other)
+	err := copied.AssignPropertiesToFlexibleServersDatabase(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_Database_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForDatabaseStatus tests if a specific instance of Database_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseStatus(subject Database_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.Database_Status
-	err := subject.AssignPropertiesToDatabaseStatus(&other)
+	err := copied.AssignPropertiesToDatabaseStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_FlexibleServersDatabases_Spec_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForFlexibleServersDatabasesSpec tests if a specific instance of FlexibleServersDatabases_Spec can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersDatabasesSpec(subject FlexibleServersDatabases_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.FlexibleServersDatabases_Spec
-	err := subject.AssignPropertiesToFlexibleServersDatabasesSpec(&other)
+	err := copied.AssignPropertiesToFlexibleServersDatabasesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/microsoft.dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_FlexibleServersFirewallRule_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForFlexibleServersFirewallRule tests if a specific instance of FlexibleServersFirewallRule can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersFirewallRule(subject FlexibleServersFirewallRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.FlexibleServersFirewallRule
-	err := subject.AssignPropertiesToFlexibleServersFirewallRule(&other)
+	err := copied.AssignPropertiesToFlexibleServersFirewallRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_FirewallRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForFirewallRuleStatus tests if a specific instance of FirewallRule_Status can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForFirewallRuleStatus(subject FirewallRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.FirewallRule_Status
-	err := subject.AssignPropertiesToFirewallRuleStatus(&other)
+	err := copied.AssignPropertiesToFirewallRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_FlexibleServersFirewallRules_Spec_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForFlexibleServersFirewallRulesSpec tests if a specific instance of FlexibleServersFirewallRules_Spec can be assigned to v1alpha1api20210501storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersFirewallRulesSpec(subject FlexibleServersFirewallRules_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210501storage.FlexibleServersFirewallRules_Spec
-	err := subject.AssignPropertiesToFlexibleServersFirewallRulesSpec(&other)
+	err := copied.AssignPropertiesToFlexibleServersFirewallRulesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_FlexibleServer_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForFlexibleServer tests if a specific instance of FlexibleServer can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServer(subject FlexibleServer) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServer
-	err := subject.AssignPropertiesToFlexibleServer(&other)
+	err := copied.AssignPropertiesToFlexibleServer(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_FlexibleServers_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForFlexibleServersSpec tests if a specific instance of FlexibleServers_Spec can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersSpec(subject FlexibleServers_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServers_Spec
-	err := subject.AssignPropertiesToFlexibleServersSpec(&other)
+	err := copied.AssignPropertiesToFlexibleServersSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -261,9 +267,12 @@ func Test_Server_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForServerStatus tests if a specific instance of Server_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForServerStatus(subject Server_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Server_Status
-	err := subject.AssignPropertiesToServerStatus(&other)
+	err := copied.AssignPropertiesToServerStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -405,9 +414,12 @@ func Test_Backup_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForBackup tests if a specific instance of Backup can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForBackup(subject Backup) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Backup
-	err := subject.AssignPropertiesToBackup(&other)
+	err := copied.AssignPropertiesToBackup(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -504,9 +516,12 @@ func Test_Backup_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForBackupStatus tests if a specific instance of Backup_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForBackupStatus(subject Backup_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Backup_Status
-	err := subject.AssignPropertiesToBackupStatus(&other)
+	err := copied.AssignPropertiesToBackupStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -604,9 +619,12 @@ func Test_HighAvailability_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForHighAvailability tests if a specific instance of HighAvailability can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForHighAvailability(subject HighAvailability) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.HighAvailability
-	err := subject.AssignPropertiesToHighAvailability(&other)
+	err := copied.AssignPropertiesToHighAvailability(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -703,9 +721,12 @@ func Test_HighAvailability_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForHighAvailabilityStatus tests if a specific instance of HighAvailability_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForHighAvailabilityStatus(subject HighAvailability_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.HighAvailability_Status
-	err := subject.AssignPropertiesToHighAvailabilityStatus(&other)
+	err := copied.AssignPropertiesToHighAvailabilityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -810,9 +831,12 @@ func Test_MaintenanceWindow_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForMaintenanceWindow tests if a specific instance of MaintenanceWindow can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForMaintenanceWindow(subject MaintenanceWindow) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.MaintenanceWindow
-	err := subject.AssignPropertiesToMaintenanceWindow(&other)
+	err := copied.AssignPropertiesToMaintenanceWindow(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -911,9 +935,12 @@ func Test_MaintenanceWindow_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForMaintenanceWindowStatus tests if a specific instance of MaintenanceWindow_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForMaintenanceWindowStatus(subject MaintenanceWindow_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.MaintenanceWindow_Status
-	err := subject.AssignPropertiesToMaintenanceWindowStatus(&other)
+	err := copied.AssignPropertiesToMaintenanceWindowStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1013,9 +1040,12 @@ func Test_Network_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForNetwork tests if a specific instance of Network can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForNetwork(subject Network) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Network
-	err := subject.AssignPropertiesToNetwork(&other)
+	err := copied.AssignPropertiesToNetwork(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1105,9 +1135,12 @@ func Test_Network_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForNetworkStatus tests if a specific instance of Network_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForNetworkStatus(subject Network_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Network_Status
-	err := subject.AssignPropertiesToNetworkStatus(&other)
+	err := copied.AssignPropertiesToNetworkStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1205,9 +1238,12 @@ func Test_Sku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForSku tests if a specific instance of Sku can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForSku(subject Sku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Sku
-	err := subject.AssignPropertiesToSku(&other)
+	err := copied.AssignPropertiesToSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1304,9 +1340,12 @@ func Test_Sku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForSkuStatus tests if a specific instance of Sku_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForSkuStatus(subject Sku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Sku_Status
-	err := subject.AssignPropertiesToSkuStatus(&other)
+	err := copied.AssignPropertiesToSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1403,9 +1442,12 @@ func Test_Storage_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForStorage tests if a specific instance of Storage can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForStorage(subject Storage) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Storage
-	err := subject.AssignPropertiesToStorage(&other)
+	err := copied.AssignPropertiesToStorage(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1501,9 +1543,12 @@ func Test_Storage_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForStorageStatus tests if a specific instance of Storage_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForStorageStatus(subject Storage_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Storage_Status
-	err := subject.AssignPropertiesToStorageStatus(&other)
+	err := copied.AssignPropertiesToStorageStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1599,9 +1644,12 @@ func Test_SystemData_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForSystemDataStatus tests if a specific instance of SystemData_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForSystemDataStatus(subject SystemData_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.SystemData_Status
-	err := subject.AssignPropertiesToSystemDataStatus(&other)
+	err := copied.AssignPropertiesToSystemDataStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_FlexibleServersConfiguration_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForFlexibleServersConfiguration tests if a specific instance of FlexibleServersConfiguration can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersConfiguration(subject FlexibleServersConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServersConfiguration
-	err := subject.AssignPropertiesToFlexibleServersConfiguration(&other)
+	err := copied.AssignPropertiesToFlexibleServersConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_Configuration_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForConfigurationStatus tests if a specific instance of Configuration_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForConfigurationStatus(subject Configuration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Configuration_Status
-	err := subject.AssignPropertiesToConfigurationStatus(&other)
+	err := copied.AssignPropertiesToConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -256,9 +262,12 @@ func Test_FlexibleServersConfigurations_Spec_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForFlexibleServersConfigurationsSpec tests if a specific instance of FlexibleServersConfigurations_Spec can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersConfigurationsSpec(subject FlexibleServersConfigurations_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServersConfigurations_Spec
-	err := subject.AssignPropertiesToFlexibleServersConfigurationsSpec(&other)
+	err := copied.AssignPropertiesToFlexibleServersConfigurationsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_FlexibleServersDatabase_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForFlexibleServersDatabase tests if a specific instance of FlexibleServersDatabase can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersDatabase(subject FlexibleServersDatabase) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServersDatabase
-	err := subject.AssignPropertiesToFlexibleServersDatabase(&other)
+	err := copied.AssignPropertiesToFlexibleServersDatabase(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_Database_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForDatabaseStatus tests if a specific instance of Database_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseStatus(subject Database_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.Database_Status
-	err := subject.AssignPropertiesToDatabaseStatus(&other)
+	err := copied.AssignPropertiesToDatabaseStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_FlexibleServersDatabases_Spec_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForFlexibleServersDatabasesSpec tests if a specific instance of FlexibleServersDatabases_Spec can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersDatabasesSpec(subject FlexibleServersDatabases_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServersDatabases_Spec
-	err := subject.AssignPropertiesToFlexibleServersDatabasesSpec(&other)
+	err := copied.AssignPropertiesToFlexibleServersDatabasesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/microsoft.dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_FlexibleServersFirewallRule_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForFlexibleServersFirewallRule tests if a specific instance of FlexibleServersFirewallRule can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersFirewallRule(subject FlexibleServersFirewallRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServersFirewallRule
-	err := subject.AssignPropertiesToFlexibleServersFirewallRule(&other)
+	err := copied.AssignPropertiesToFlexibleServersFirewallRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_FirewallRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForFirewallRuleStatus tests if a specific instance of FirewallRule_Status can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFirewallRuleStatus(subject FirewallRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FirewallRule_Status
-	err := subject.AssignPropertiesToFirewallRuleStatus(&other)
+	err := copied.AssignPropertiesToFirewallRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_FlexibleServersFirewallRules_Spec_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForFlexibleServersFirewallRulesSpec tests if a specific instance of FlexibleServersFirewallRules_Spec can be assigned to v1alpha1api20210601storage and back losslessly
 func RunPropertyAssignmentTestForFlexibleServersFirewallRulesSpec(subject FlexibleServersFirewallRules_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210601storage.FlexibleServersFirewallRules_Spec
-	err := subject.AssignPropertiesToFlexibleServersFirewallRulesSpec(&other)
+	err := copied.AssignPropertiesToFlexibleServersFirewallRulesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/database_account_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_DatabaseAccount_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForDatabaseAccount tests if a specific instance of DatabaseAccount can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccount(subject DatabaseAccount) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccount
-	err := subject.AssignPropertiesToDatabaseAccount(&other)
+	err := copied.AssignPropertiesToDatabaseAccount(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_DatabaseAccountGetResults_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForDatabaseAccountGetResultsStatus tests if a specific instance of DatabaseAccountGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountGetResultsStatus(subject DatabaseAccountGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountGetResults_Status
-	err := subject.AssignPropertiesToDatabaseAccountGetResultsStatus(&other)
+	err := copied.AssignPropertiesToDatabaseAccountGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -277,9 +283,12 @@ func Test_DatabaseAccounts_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForDatabaseAccountsSpec tests if a specific instance of DatabaseAccounts_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSpec(subject DatabaseAccounts_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccounts_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -416,9 +425,12 @@ func Test_AnalyticalStorageConfiguration_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForAnalyticalStorageConfiguration tests if a specific instance of AnalyticalStorageConfiguration can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAnalyticalStorageConfiguration(subject AnalyticalStorageConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AnalyticalStorageConfiguration
-	err := subject.AssignPropertiesToAnalyticalStorageConfiguration(&other)
+	err := copied.AssignPropertiesToAnalyticalStorageConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -515,9 +527,12 @@ func Test_AnalyticalStorageConfiguration_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForAnalyticalStorageConfigurationStatus tests if a specific instance of AnalyticalStorageConfiguration_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAnalyticalStorageConfigurationStatus(subject AnalyticalStorageConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AnalyticalStorageConfiguration_Status
-	err := subject.AssignPropertiesToAnalyticalStorageConfigurationStatus(&other)
+	err := copied.AssignPropertiesToAnalyticalStorageConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -614,9 +629,12 @@ func Test_ApiProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForApiProperties tests if a specific instance of ApiProperties can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForApiProperties(subject ApiProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ApiProperties
-	err := subject.AssignPropertiesToApiProperties(&other)
+	err := copied.AssignPropertiesToApiProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -712,9 +730,12 @@ func Test_ApiProperties_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForApiPropertiesStatus tests if a specific instance of ApiProperties_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForApiPropertiesStatus(subject ApiProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ApiProperties_Status
-	err := subject.AssignPropertiesToApiPropertiesStatus(&other)
+	err := copied.AssignPropertiesToApiPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -811,9 +832,12 @@ func Test_BackupPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForBackupPolicy tests if a specific instance of BackupPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForBackupPolicy(subject BackupPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.BackupPolicy
-	err := subject.AssignPropertiesToBackupPolicy(&other)
+	err := copied.AssignPropertiesToBackupPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -922,9 +946,12 @@ func Test_BackupPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForBackupPolicyStatus tests if a specific instance of BackupPolicy_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForBackupPolicyStatus(subject BackupPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.BackupPolicy_Status
-	err := subject.AssignPropertiesToBackupPolicyStatus(&other)
+	err := copied.AssignPropertiesToBackupPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1020,9 +1047,12 @@ func Test_Capability_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForCapability tests if a specific instance of Capability can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForCapability(subject Capability) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.Capability
-	err := subject.AssignPropertiesToCapability(&other)
+	err := copied.AssignPropertiesToCapability(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1118,9 +1148,12 @@ func Test_Capability_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForCapabilityStatus tests if a specific instance of Capability_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForCapabilityStatus(subject Capability_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.Capability_Status
-	err := subject.AssignPropertiesToCapabilityStatus(&other)
+	err := copied.AssignPropertiesToCapabilityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1216,9 +1249,12 @@ func Test_ConsistencyPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForConsistencyPolicy tests if a specific instance of ConsistencyPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForConsistencyPolicy(subject ConsistencyPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ConsistencyPolicy
-	err := subject.AssignPropertiesToConsistencyPolicy(&other)
+	err := copied.AssignPropertiesToConsistencyPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1321,9 +1357,12 @@ func Test_ConsistencyPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForConsistencyPolicyStatus tests if a specific instance of ConsistencyPolicy_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForConsistencyPolicyStatus(subject ConsistencyPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ConsistencyPolicy_Status
-	err := subject.AssignPropertiesToConsistencyPolicyStatus(&other)
+	err := copied.AssignPropertiesToConsistencyPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1427,9 +1466,12 @@ func Test_CorsPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForCorsPolicy tests if a specific instance of CorsPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForCorsPolicy(subject CorsPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.CorsPolicy
-	err := subject.AssignPropertiesToCorsPolicy(&other)
+	err := copied.AssignPropertiesToCorsPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1529,9 +1571,12 @@ func Test_CorsPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForCorsPolicyStatus tests if a specific instance of CorsPolicy_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForCorsPolicyStatus(subject CorsPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.CorsPolicy_Status
-	err := subject.AssignPropertiesToCorsPolicyStatus(&other)
+	err := copied.AssignPropertiesToCorsPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1631,9 +1676,12 @@ func Test_FailoverPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForFailoverPolicyStatus tests if a specific instance of FailoverPolicy_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForFailoverPolicyStatus(subject FailoverPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.FailoverPolicy_Status
-	err := subject.AssignPropertiesToFailoverPolicyStatus(&other)
+	err := copied.AssignPropertiesToFailoverPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1732,9 +1780,12 @@ func Test_IpAddressOrRange_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForIpAddressOrRange tests if a specific instance of IpAddressOrRange can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIpAddressOrRange(subject IpAddressOrRange) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.IpAddressOrRange
-	err := subject.AssignPropertiesToIpAddressOrRange(&other)
+	err := copied.AssignPropertiesToIpAddressOrRange(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1830,9 +1881,12 @@ func Test_IpAddressOrRange_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForIpAddressOrRangeStatus tests if a specific instance of IpAddressOrRange_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIpAddressOrRangeStatus(subject IpAddressOrRange_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.IpAddressOrRange_Status
-	err := subject.AssignPropertiesToIpAddressOrRangeStatus(&other)
+	err := copied.AssignPropertiesToIpAddressOrRangeStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1929,9 +1983,12 @@ func Test_Location_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForLocation tests if a specific instance of Location can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForLocation(subject Location) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.Location
-	err := subject.AssignPropertiesToLocation(&other)
+	err := copied.AssignPropertiesToLocation(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2029,9 +2086,12 @@ func Test_Location_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForLocationStatus tests if a specific instance of Location_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForLocationStatus(subject Location_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.Location_Status
-	err := subject.AssignPropertiesToLocationStatus(&other)
+	err := copied.AssignPropertiesToLocationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2132,9 +2192,12 @@ func Test_ManagedServiceIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForManagedServiceIdentity tests if a specific instance of ManagedServiceIdentity can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForManagedServiceIdentity(subject ManagedServiceIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ManagedServiceIdentity
-	err := subject.AssignPropertiesToManagedServiceIdentity(&other)
+	err := copied.AssignPropertiesToManagedServiceIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2235,9 +2298,12 @@ func Test_ManagedServiceIdentity_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForManagedServiceIdentityStatus tests if a specific instance of ManagedServiceIdentity_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForManagedServiceIdentityStatus(subject ManagedServiceIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ManagedServiceIdentity_Status
-	err := subject.AssignPropertiesToManagedServiceIdentityStatus(&other)
+	err := copied.AssignPropertiesToManagedServiceIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2354,9 +2420,12 @@ func Test_PrivateEndpointConnection_Status_SubResourceEmbedded_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded tests if a specific instance of PrivateEndpointConnection_Status_SubResourceEmbedded can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded(subject PrivateEndpointConnection_Status_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.PrivateEndpointConnection_Status_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2453,9 +2522,12 @@ func Test_VirtualNetworkRule_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForVirtualNetworkRule tests if a specific instance of VirtualNetworkRule can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkRule(subject VirtualNetworkRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.VirtualNetworkRule
-	err := subject.AssignPropertiesToVirtualNetworkRule(&other)
+	err := copied.AssignPropertiesToVirtualNetworkRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2551,9 +2623,12 @@ func Test_VirtualNetworkRule_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForVirtualNetworkRuleStatus tests if a specific instance of VirtualNetworkRule_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkRuleStatus(subject VirtualNetworkRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.VirtualNetworkRule_Status
-	err := subject.AssignPropertiesToVirtualNetworkRuleStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2651,9 +2726,12 @@ func Test_ContinuousModeBackupPolicy_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForContinuousModeBackupPolicy tests if a specific instance of ContinuousModeBackupPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForContinuousModeBackupPolicy(subject ContinuousModeBackupPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ContinuousModeBackupPolicy
-	err := subject.AssignPropertiesToContinuousModeBackupPolicy(&other)
+	err := copied.AssignPropertiesToContinuousModeBackupPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2750,9 +2828,12 @@ func Test_ManagedServiceIdentity_Status_UserAssignedIdentities_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForManagedServiceIdentityStatusUserAssignedIdentities tests if a specific instance of ManagedServiceIdentity_Status_UserAssignedIdentities can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForManagedServiceIdentityStatusUserAssignedIdentities(subject ManagedServiceIdentity_Status_UserAssignedIdentities) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ManagedServiceIdentity_Status_UserAssignedIdentities
-	err := subject.AssignPropertiesToManagedServiceIdentityStatusUserAssignedIdentities(&other)
+	err := copied.AssignPropertiesToManagedServiceIdentityStatusUserAssignedIdentities(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2850,9 +2931,12 @@ func Test_PeriodicModeBackupPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForPeriodicModeBackupPolicy tests if a specific instance of PeriodicModeBackupPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForPeriodicModeBackupPolicy(subject PeriodicModeBackupPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.PeriodicModeBackupPolicy
-	err := subject.AssignPropertiesToPeriodicModeBackupPolicy(&other)
+	err := copied.AssignPropertiesToPeriodicModeBackupPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2963,9 +3047,12 @@ func Test_PeriodicModeProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForPeriodicModeProperties tests if a specific instance of PeriodicModeProperties can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForPeriodicModeProperties(subject PeriodicModeProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.PeriodicModeProperties
-	err := subject.AssignPropertiesToPeriodicModeProperties(&other)
+	err := copied.AssignPropertiesToPeriodicModeProperties(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_MongodbDatabaseCollectionThroughputSetting_WhenPropertiesConverted_Rou
 
 // RunPropertyAssignmentTestForMongodbDatabaseCollectionThroughputSetting tests if a specific instance of MongodbDatabaseCollectionThroughputSetting can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongodbDatabaseCollectionThroughputSetting(subject MongodbDatabaseCollectionThroughputSetting) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongodbDatabaseCollectionThroughputSetting
-	err := subject.AssignPropertiesToMongodbDatabaseCollectionThroughputSetting(&other)
+	err := copied.AssignPropertiesToMongodbDatabaseCollectionThroughputSetting(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spec_Whe
 
 // RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesCollectionsThroughputSettingsSpec tests if a specific instance of DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesCollectionsThroughputSettingsSpec(subject DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsMongodbDatabasesCollectionsThroughputSettingsSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsMongodbDatabasesCollectionsThroughputSettingsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -245,9 +251,12 @@ func Test_ThroughputSettingsGetResults_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForThroughputSettingsGetResultsStatus tests if a specific instance of ThroughputSettingsGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForThroughputSettingsGetResultsStatus(subject ThroughputSettingsGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ThroughputSettingsGetResults_Status
-	err := subject.AssignPropertiesToThroughputSettingsGetResultsStatus(&other)
+	err := copied.AssignPropertiesToThroughputSettingsGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -362,9 +371,12 @@ func Test_ThroughputSettingsGetProperties_Status_Resource_WhenPropertiesConverte
 
 // RunPropertyAssignmentTestForThroughputSettingsGetPropertiesStatusResource tests if a specific instance of ThroughputSettingsGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForThroughputSettingsGetPropertiesStatusResource(subject ThroughputSettingsGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ThroughputSettingsGetProperties_Status_Resource
-	err := subject.AssignPropertiesToThroughputSettingsGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToThroughputSettingsGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -480,9 +492,12 @@ func Test_ThroughputSettingsResource_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForThroughputSettingsResource tests if a specific instance of ThroughputSettingsResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForThroughputSettingsResource(subject ThroughputSettingsResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ThroughputSettingsResource
-	err := subject.AssignPropertiesToThroughputSettingsResource(&other)
+	err := copied.AssignPropertiesToThroughputSettingsResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -593,9 +608,12 @@ func Test_AutoscaleSettingsResource_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForAutoscaleSettingsResource tests if a specific instance of AutoscaleSettingsResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAutoscaleSettingsResource(subject AutoscaleSettingsResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AutoscaleSettingsResource
-	err := subject.AssignPropertiesToAutoscaleSettingsResource(&other)
+	err := copied.AssignPropertiesToAutoscaleSettingsResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -706,9 +724,12 @@ func Test_AutoscaleSettingsResource_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForAutoscaleSettingsResourceStatus tests if a specific instance of AutoscaleSettingsResource_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAutoscaleSettingsResourceStatus(subject AutoscaleSettingsResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AutoscaleSettingsResource_Status
-	err := subject.AssignPropertiesToAutoscaleSettingsResourceStatus(&other)
+	err := copied.AssignPropertiesToAutoscaleSettingsResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -820,9 +841,12 @@ func Test_AutoUpgradePolicyResource_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForAutoUpgradePolicyResource tests if a specific instance of AutoUpgradePolicyResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAutoUpgradePolicyResource(subject AutoUpgradePolicyResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AutoUpgradePolicyResource
-	err := subject.AssignPropertiesToAutoUpgradePolicyResource(&other)
+	err := copied.AssignPropertiesToAutoUpgradePolicyResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -919,9 +943,12 @@ func Test_AutoUpgradePolicyResource_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForAutoUpgradePolicyResourceStatus tests if a specific instance of AutoUpgradePolicyResource_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAutoUpgradePolicyResourceStatus(subject AutoUpgradePolicyResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AutoUpgradePolicyResource_Status
-	err := subject.AssignPropertiesToAutoUpgradePolicyResourceStatus(&other)
+	err := copied.AssignPropertiesToAutoUpgradePolicyResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1018,9 +1045,12 @@ func Test_ThroughputPolicyResource_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForThroughputPolicyResource tests if a specific instance of ThroughputPolicyResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForThroughputPolicyResource(subject ThroughputPolicyResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ThroughputPolicyResource
-	err := subject.AssignPropertiesToThroughputPolicyResource(&other)
+	err := copied.AssignPropertiesToThroughputPolicyResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1118,9 +1148,12 @@ func Test_ThroughputPolicyResource_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForThroughputPolicyResourceStatus tests if a specific instance of ThroughputPolicyResource_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForThroughputPolicyResourceStatus(subject ThroughputPolicyResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ThroughputPolicyResource_Status
-	err := subject.AssignPropertiesToThroughputPolicyResourceStatus(&other)
+	err := copied.AssignPropertiesToThroughputPolicyResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_MongodbDatabaseCollection_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForMongodbDatabaseCollection tests if a specific instance of MongodbDatabaseCollection can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongodbDatabaseCollection(subject MongodbDatabaseCollection) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongodbDatabaseCollection
-	err := subject.AssignPropertiesToMongodbDatabaseCollection(&other)
+	err := copied.AssignPropertiesToMongodbDatabaseCollection(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsMongodbDatabasesCollections_Spec_WhenPropertiesConvert
 
 // RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesCollectionsSpec tests if a specific instance of DatabaseAccountsMongodbDatabasesCollections_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesCollectionsSpec(subject DatabaseAccountsMongodbDatabasesCollections_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsMongodbDatabasesCollections_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsMongodbDatabasesCollectionsSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsMongodbDatabasesCollectionsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_MongoDBCollectionGetResults_Status_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForMongoDBCollectionGetResultsStatus tests if a specific instance of MongoDBCollectionGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoDBCollectionGetResultsStatus(subject MongoDBCollectionGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoDBCollectionGetResults_Status
-	err := subject.AssignPropertiesToMongoDBCollectionGetResultsStatus(&other)
+	err := copied.AssignPropertiesToMongoDBCollectionGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -365,9 +374,12 @@ func Test_MongoDBCollectionGetProperties_Status_Resource_WhenPropertiesConverted
 
 // RunPropertyAssignmentTestForMongoDBCollectionGetPropertiesStatusResource tests if a specific instance of MongoDBCollectionGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoDBCollectionGetPropertiesStatusResource(subject MongoDBCollectionGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoDBCollectionGetProperties_Status_Resource
-	err := subject.AssignPropertiesToMongoDBCollectionGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToMongoDBCollectionGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -483,9 +495,12 @@ func Test_MongoDBCollectionResource_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForMongoDBCollectionResource tests if a specific instance of MongoDBCollectionResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoDBCollectionResource(subject MongoDBCollectionResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoDBCollectionResource
-	err := subject.AssignPropertiesToMongoDBCollectionResource(&other)
+	err := copied.AssignPropertiesToMongoDBCollectionResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -598,9 +613,12 @@ func Test_MongoIndex_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForMongoIndex tests if a specific instance of MongoIndex can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoIndex(subject MongoIndex) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoIndex
-	err := subject.AssignPropertiesToMongoIndex(&other)
+	err := copied.AssignPropertiesToMongoIndex(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -697,9 +715,12 @@ func Test_MongoIndex_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForMongoIndexStatus tests if a specific instance of MongoIndex_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoIndexStatus(subject MongoIndex_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoIndex_Status
-	err := subject.AssignPropertiesToMongoIndexStatus(&other)
+	err := copied.AssignPropertiesToMongoIndexStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -796,9 +817,12 @@ func Test_MongoIndexKeys_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForMongoIndexKeys tests if a specific instance of MongoIndexKeys can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoIndexKeys(subject MongoIndexKeys) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoIndexKeys
-	err := subject.AssignPropertiesToMongoIndexKeys(&other)
+	err := copied.AssignPropertiesToMongoIndexKeys(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -894,9 +918,12 @@ func Test_MongoIndexKeys_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForMongoIndexKeysStatus tests if a specific instance of MongoIndexKeys_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoIndexKeysStatus(subject MongoIndexKeys_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoIndexKeys_Status
-	err := subject.AssignPropertiesToMongoIndexKeysStatus(&other)
+	err := copied.AssignPropertiesToMongoIndexKeysStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -993,9 +1020,12 @@ func Test_MongoIndexOptions_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForMongoIndexOptions tests if a specific instance of MongoIndexOptions can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoIndexOptions(subject MongoIndexOptions) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoIndexOptions
-	err := subject.AssignPropertiesToMongoIndexOptions(&other)
+	err := copied.AssignPropertiesToMongoIndexOptions(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1092,9 +1122,12 @@ func Test_MongoIndexOptions_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForMongoIndexOptionsStatus tests if a specific instance of MongoIndexOptions_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoIndexOptionsStatus(subject MongoIndexOptions_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoIndexOptions_Status
-	err := subject.AssignPropertiesToMongoIndexOptionsStatus(&other)
+	err := copied.AssignPropertiesToMongoIndexOptionsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_MongodbDatabaseThroughputSetting_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForMongodbDatabaseThroughputSetting tests if a specific instance of MongodbDatabaseThroughputSetting can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongodbDatabaseThroughputSetting(subject MongodbDatabaseThroughputSetting) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongodbDatabaseThroughputSetting
-	err := subject.AssignPropertiesToMongodbDatabaseThroughputSetting(&other)
+	err := copied.AssignPropertiesToMongodbDatabaseThroughputSetting(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsMongodbDatabasesThroughputSettings_Spec_WhenProperties
 
 // RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesThroughputSettingsSpec tests if a specific instance of DatabaseAccountsMongodbDatabasesThroughputSettings_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesThroughputSettingsSpec(subject DatabaseAccountsMongodbDatabasesThroughputSettings_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsMongodbDatabasesThroughputSettings_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsMongodbDatabasesThroughputSettingsSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsMongodbDatabasesThroughputSettingsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/mongodb_database_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_MongodbDatabase_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForMongodbDatabase tests if a specific instance of MongodbDatabase can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongodbDatabase(subject MongodbDatabase) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongodbDatabase
-	err := subject.AssignPropertiesToMongodbDatabase(&other)
+	err := copied.AssignPropertiesToMongodbDatabase(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_DatabaseAccountsMongodbDatabases_Spec_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesSpec tests if a specific instance of DatabaseAccountsMongodbDatabases_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsMongodbDatabasesSpec(subject DatabaseAccountsMongodbDatabases_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsMongodbDatabases_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsMongodbDatabasesSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsMongodbDatabasesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -246,9 +252,12 @@ func Test_MongoDBDatabaseGetResults_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForMongoDBDatabaseGetResultsStatus tests if a specific instance of MongoDBDatabaseGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoDBDatabaseGetResultsStatus(subject MongoDBDatabaseGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoDBDatabaseGetResults_Status
-	err := subject.AssignPropertiesToMongoDBDatabaseGetResultsStatus(&other)
+	err := copied.AssignPropertiesToMongoDBDatabaseGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -364,9 +373,12 @@ func Test_CreateUpdateOptions_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForCreateUpdateOptions tests if a specific instance of CreateUpdateOptions can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForCreateUpdateOptions(subject CreateUpdateOptions) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.CreateUpdateOptions
-	err := subject.AssignPropertiesToCreateUpdateOptions(&other)
+	err := copied.AssignPropertiesToCreateUpdateOptions(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -477,9 +489,12 @@ func Test_MongoDBDatabaseGetProperties_Status_Resource_WhenPropertiesConverted_R
 
 // RunPropertyAssignmentTestForMongoDBDatabaseGetPropertiesStatusResource tests if a specific instance of MongoDBDatabaseGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoDBDatabaseGetPropertiesStatusResource(subject MongoDBDatabaseGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoDBDatabaseGetProperties_Status_Resource
-	err := subject.AssignPropertiesToMongoDBDatabaseGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToMongoDBDatabaseGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -579,9 +594,12 @@ func Test_MongoDBDatabaseResource_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForMongoDBDatabaseResource tests if a specific instance of MongoDBDatabaseResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForMongoDBDatabaseResource(subject MongoDBDatabaseResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.MongoDBDatabaseResource
-	err := subject.AssignPropertiesToMongoDBDatabaseResource(&other)
+	err := copied.AssignPropertiesToMongoDBDatabaseResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -678,9 +696,12 @@ func Test_OptionsResource_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForOptionsResourceStatus tests if a specific instance of OptionsResource_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForOptionsResourceStatus(subject OptionsResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.OptionsResource_Status
-	err := subject.AssignPropertiesToOptionsResourceStatus(&other)
+	err := copied.AssignPropertiesToOptionsResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -791,9 +812,12 @@ func Test_AutoscaleSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForAutoscaleSettings tests if a specific instance of AutoscaleSettings can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAutoscaleSettings(subject AutoscaleSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AutoscaleSettings
-	err := subject.AssignPropertiesToAutoscaleSettings(&other)
+	err := copied.AssignPropertiesToAutoscaleSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -889,9 +913,12 @@ func Test_AutoscaleSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForAutoscaleSettingsStatus tests if a specific instance of AutoscaleSettings_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForAutoscaleSettingsStatus(subject AutoscaleSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.AutoscaleSettings_Status
-	err := subject.AssignPropertiesToAutoscaleSettingsStatus(&other)
+	err := copied.AssignPropertiesToAutoscaleSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SqlDatabaseContainerStoredProcedure_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForSqlDatabaseContainerStoredProcedure tests if a specific instance of SqlDatabaseContainerStoredProcedure can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseContainerStoredProcedure(subject SqlDatabaseContainerStoredProcedure) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseContainerStoredProcedure
-	err := subject.AssignPropertiesToSqlDatabaseContainerStoredProcedure(&other)
+	err := copied.AssignPropertiesToSqlDatabaseContainerStoredProcedure(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec_WhenProper
 
 // RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersStoredProceduresSpec tests if a specific instance of DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersStoredProceduresSpec(subject DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersStoredProceduresSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersStoredProceduresSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_SqlStoredProcedureGetResults_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForSqlStoredProcedureGetResultsStatus tests if a specific instance of SqlStoredProcedureGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlStoredProcedureGetResultsStatus(subject SqlStoredProcedureGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlStoredProcedureGetResults_Status
-	err := subject.AssignPropertiesToSqlStoredProcedureGetResultsStatus(&other)
+	err := copied.AssignPropertiesToSqlStoredProcedureGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -364,9 +373,12 @@ func Test_SqlStoredProcedureGetProperties_Status_Resource_WhenPropertiesConverte
 
 // RunPropertyAssignmentTestForSqlStoredProcedureGetPropertiesStatusResource tests if a specific instance of SqlStoredProcedureGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlStoredProcedureGetPropertiesStatusResource(subject SqlStoredProcedureGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlStoredProcedureGetProperties_Status_Resource
-	err := subject.AssignPropertiesToSqlStoredProcedureGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToSqlStoredProcedureGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -467,9 +479,12 @@ func Test_SqlStoredProcedureResource_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForSqlStoredProcedureResource tests if a specific instance of SqlStoredProcedureResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlStoredProcedureResource(subject SqlStoredProcedureResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlStoredProcedureResource
-	err := subject.AssignPropertiesToSqlStoredProcedureResource(&other)
+	err := copied.AssignPropertiesToSqlStoredProcedureResource(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SqlDatabaseContainerThroughputSetting_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForSqlDatabaseContainerThroughputSetting tests if a specific instance of SqlDatabaseContainerThroughputSetting can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseContainerThroughputSetting(subject SqlDatabaseContainerThroughputSetting) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseContainerThroughputSetting
-	err := subject.AssignPropertiesToSqlDatabaseContainerThroughputSetting(&other)
+	err := copied.AssignPropertiesToSqlDatabaseContainerThroughputSetting(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec_WhenProp
 
 // RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersThroughputSettingsSpec tests if a specific instance of DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersThroughputSettingsSpec(subject DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersThroughputSettingsSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersThroughputSettingsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SqlDatabaseContainerTrigger_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForSqlDatabaseContainerTrigger tests if a specific instance of SqlDatabaseContainerTrigger can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseContainerTrigger(subject SqlDatabaseContainerTrigger) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseContainerTrigger
-	err := subject.AssignPropertiesToSqlDatabaseContainerTrigger(&other)
+	err := copied.AssignPropertiesToSqlDatabaseContainerTrigger(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsSqlDatabasesContainersTriggers_Spec_WhenPropertiesConv
 
 // RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersTriggersSpec tests if a specific instance of DatabaseAccountsSqlDatabasesContainersTriggers_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersTriggersSpec(subject DatabaseAccountsSqlDatabasesContainersTriggers_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersTriggers_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersTriggersSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersTriggersSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_SqlTriggerGetResults_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForSqlTriggerGetResultsStatus tests if a specific instance of SqlTriggerGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlTriggerGetResultsStatus(subject SqlTriggerGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlTriggerGetResults_Status
-	err := subject.AssignPropertiesToSqlTriggerGetResultsStatus(&other)
+	err := copied.AssignPropertiesToSqlTriggerGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -364,9 +373,12 @@ func Test_SqlTriggerGetProperties_Status_Resource_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForSqlTriggerGetPropertiesStatusResource tests if a specific instance of SqlTriggerGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlTriggerGetPropertiesStatusResource(subject SqlTriggerGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlTriggerGetProperties_Status_Resource
-	err := subject.AssignPropertiesToSqlTriggerGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToSqlTriggerGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -474,9 +486,12 @@ func Test_SqlTriggerResource_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSqlTriggerResource tests if a specific instance of SqlTriggerResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlTriggerResource(subject SqlTriggerResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlTriggerResource
-	err := subject.AssignPropertiesToSqlTriggerResource(&other)
+	err := copied.AssignPropertiesToSqlTriggerResource(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SqlDatabaseContainer_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForSqlDatabaseContainer tests if a specific instance of SqlDatabaseContainer can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseContainer(subject SqlDatabaseContainer) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseContainer
-	err := subject.AssignPropertiesToSqlDatabaseContainer(&other)
+	err := copied.AssignPropertiesToSqlDatabaseContainer(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsSqlDatabasesContainers_Spec_WhenPropertiesConverted_Ro
 
 // RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersSpec tests if a specific instance of DatabaseAccountsSqlDatabasesContainers_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersSpec(subject DatabaseAccountsSqlDatabasesContainers_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainers_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_SqlContainerGetResults_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForSqlContainerGetResultsStatus tests if a specific instance of SqlContainerGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlContainerGetResultsStatus(subject SqlContainerGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlContainerGetResults_Status
-	err := subject.AssignPropertiesToSqlContainerGetResultsStatus(&other)
+	err := copied.AssignPropertiesToSqlContainerGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -365,9 +374,12 @@ func Test_SqlContainerGetProperties_Status_Resource_WhenPropertiesConverted_Roun
 
 // RunPropertyAssignmentTestForSqlContainerGetPropertiesStatusResource tests if a specific instance of SqlContainerGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlContainerGetPropertiesStatusResource(subject SqlContainerGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlContainerGetProperties_Status_Resource
-	err := subject.AssignPropertiesToSqlContainerGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToSqlContainerGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -486,9 +498,12 @@ func Test_SqlContainerResource_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForSqlContainerResource tests if a specific instance of SqlContainerResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlContainerResource(subject SqlContainerResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlContainerResource
-	err := subject.AssignPropertiesToSqlContainerResource(&other)
+	err := copied.AssignPropertiesToSqlContainerResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -604,9 +619,12 @@ func Test_ConflictResolutionPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForConflictResolutionPolicy tests if a specific instance of ConflictResolutionPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForConflictResolutionPolicy(subject ConflictResolutionPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ConflictResolutionPolicy
-	err := subject.AssignPropertiesToConflictResolutionPolicy(&other)
+	err := copied.AssignPropertiesToConflictResolutionPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -705,9 +723,12 @@ func Test_ConflictResolutionPolicy_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForConflictResolutionPolicyStatus tests if a specific instance of ConflictResolutionPolicy_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForConflictResolutionPolicyStatus(subject ConflictResolutionPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ConflictResolutionPolicy_Status
-	err := subject.AssignPropertiesToConflictResolutionPolicyStatus(&other)
+	err := copied.AssignPropertiesToConflictResolutionPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -806,9 +827,12 @@ func Test_ContainerPartitionKey_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForContainerPartitionKey tests if a specific instance of ContainerPartitionKey can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForContainerPartitionKey(subject ContainerPartitionKey) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ContainerPartitionKey
-	err := subject.AssignPropertiesToContainerPartitionKey(&other)
+	err := copied.AssignPropertiesToContainerPartitionKey(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -907,9 +931,12 @@ func Test_ContainerPartitionKey_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForContainerPartitionKeyStatus tests if a specific instance of ContainerPartitionKey_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForContainerPartitionKeyStatus(subject ContainerPartitionKey_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ContainerPartitionKey_Status
-	err := subject.AssignPropertiesToContainerPartitionKeyStatus(&other)
+	err := copied.AssignPropertiesToContainerPartitionKeyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1009,9 +1036,12 @@ func Test_IndexingPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForIndexingPolicy tests if a specific instance of IndexingPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIndexingPolicy(subject IndexingPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.IndexingPolicy
-	err := subject.AssignPropertiesToIndexingPolicy(&other)
+	err := copied.AssignPropertiesToIndexingPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1125,9 +1155,12 @@ func Test_IndexingPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForIndexingPolicyStatus tests if a specific instance of IndexingPolicy_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIndexingPolicyStatus(subject IndexingPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.IndexingPolicy_Status
-	err := subject.AssignPropertiesToIndexingPolicyStatus(&other)
+	err := copied.AssignPropertiesToIndexingPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1242,9 +1275,12 @@ func Test_UniqueKeyPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForUniqueKeyPolicy tests if a specific instance of UniqueKeyPolicy can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForUniqueKeyPolicy(subject UniqueKeyPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.UniqueKeyPolicy
-	err := subject.AssignPropertiesToUniqueKeyPolicy(&other)
+	err := copied.AssignPropertiesToUniqueKeyPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1340,9 +1376,12 @@ func Test_UniqueKeyPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForUniqueKeyPolicyStatus tests if a specific instance of UniqueKeyPolicy_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForUniqueKeyPolicyStatus(subject UniqueKeyPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.UniqueKeyPolicy_Status
-	err := subject.AssignPropertiesToUniqueKeyPolicyStatus(&other)
+	err := copied.AssignPropertiesToUniqueKeyPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1439,9 +1478,12 @@ func Test_CompositePath_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForCompositePath tests if a specific instance of CompositePath can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForCompositePath(subject CompositePath) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.CompositePath
-	err := subject.AssignPropertiesToCompositePath(&other)
+	err := copied.AssignPropertiesToCompositePath(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1538,9 +1580,12 @@ func Test_CompositePath_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForCompositePathStatus tests if a specific instance of CompositePath_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForCompositePathStatus(subject CompositePath_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.CompositePath_Status
-	err := subject.AssignPropertiesToCompositePathStatus(&other)
+	err := copied.AssignPropertiesToCompositePathStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1638,9 +1683,12 @@ func Test_ExcludedPath_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForExcludedPath tests if a specific instance of ExcludedPath can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForExcludedPath(subject ExcludedPath) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ExcludedPath
-	err := subject.AssignPropertiesToExcludedPath(&other)
+	err := copied.AssignPropertiesToExcludedPath(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1736,9 +1784,12 @@ func Test_ExcludedPath_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForExcludedPathStatus tests if a specific instance of ExcludedPath_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForExcludedPathStatus(subject ExcludedPath_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.ExcludedPath_Status
-	err := subject.AssignPropertiesToExcludedPathStatus(&other)
+	err := copied.AssignPropertiesToExcludedPathStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1834,9 +1885,12 @@ func Test_IncludedPath_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForIncludedPath tests if a specific instance of IncludedPath can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIncludedPath(subject IncludedPath) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.IncludedPath
-	err := subject.AssignPropertiesToIncludedPath(&other)
+	err := copied.AssignPropertiesToIncludedPath(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1946,9 +2000,12 @@ func Test_IncludedPath_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForIncludedPathStatus tests if a specific instance of IncludedPath_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIncludedPathStatus(subject IncludedPath_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.IncludedPath_Status
-	err := subject.AssignPropertiesToIncludedPathStatus(&other)
+	err := copied.AssignPropertiesToIncludedPathStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2058,9 +2115,12 @@ func Test_SpatialSpec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForSpatialSpec tests if a specific instance of SpatialSpec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSpatialSpec(subject SpatialSpec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SpatialSpec
-	err := subject.AssignPropertiesToSpatialSpec(&other)
+	err := copied.AssignPropertiesToSpatialSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2161,9 +2221,12 @@ func Test_SpatialSpec_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSpatialSpecStatus tests if a specific instance of SpatialSpec_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSpatialSpecStatus(subject SpatialSpec_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SpatialSpec_Status
-	err := subject.AssignPropertiesToSpatialSpecStatus(&other)
+	err := copied.AssignPropertiesToSpatialSpecStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2264,9 +2327,12 @@ func Test_UniqueKey_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) 
 
 // RunPropertyAssignmentTestForUniqueKey tests if a specific instance of UniqueKey can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForUniqueKey(subject UniqueKey) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.UniqueKey
-	err := subject.AssignPropertiesToUniqueKey(&other)
+	err := copied.AssignPropertiesToUniqueKey(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2362,9 +2428,12 @@ func Test_UniqueKey_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForUniqueKeyStatus tests if a specific instance of UniqueKey_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForUniqueKeyStatus(subject UniqueKey_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.UniqueKey_Status
-	err := subject.AssignPropertiesToUniqueKeyStatus(&other)
+	err := copied.AssignPropertiesToUniqueKeyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2460,9 +2529,12 @@ func Test_Indexes_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForIndexes tests if a specific instance of Indexes can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIndexes(subject Indexes) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.Indexes
-	err := subject.AssignPropertiesToIndexes(&other)
+	err := copied.AssignPropertiesToIndexes(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2566,9 +2638,12 @@ func Test_Indexes_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForIndexesStatus tests if a specific instance of Indexes_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForIndexesStatus(subject Indexes_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.Indexes_Status
-	err := subject.AssignPropertiesToIndexesStatus(&other)
+	err := copied.AssignPropertiesToIndexesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SqlDatabaseContainerUserDefinedFunction_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForSqlDatabaseContainerUserDefinedFunction tests if a specific instance of SqlDatabaseContainerUserDefinedFunction can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseContainerUserDefinedFunction(subject SqlDatabaseContainerUserDefinedFunction) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseContainerUserDefinedFunction
-	err := subject.AssignPropertiesToSqlDatabaseContainerUserDefinedFunction(&other)
+	err := copied.AssignPropertiesToSqlDatabaseContainerUserDefinedFunction(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec_WhenPr
 
 // RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec tests if a specific instance of DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec(subject DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSqlDatabasesContainersUserDefinedFunctionsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_SqlUserDefinedFunctionGetResults_Status_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForSqlUserDefinedFunctionGetResultsStatus tests if a specific instance of SqlUserDefinedFunctionGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlUserDefinedFunctionGetResultsStatus(subject SqlUserDefinedFunctionGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlUserDefinedFunctionGetResults_Status
-	err := subject.AssignPropertiesToSqlUserDefinedFunctionGetResultsStatus(&other)
+	err := copied.AssignPropertiesToSqlUserDefinedFunctionGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -364,9 +373,12 @@ func Test_SqlUserDefinedFunctionGetProperties_Status_Resource_WhenPropertiesConv
 
 // RunPropertyAssignmentTestForSqlUserDefinedFunctionGetPropertiesStatusResource tests if a specific instance of SqlUserDefinedFunctionGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlUserDefinedFunctionGetPropertiesStatusResource(subject SqlUserDefinedFunctionGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlUserDefinedFunctionGetProperties_Status_Resource
-	err := subject.AssignPropertiesToSqlUserDefinedFunctionGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToSqlUserDefinedFunctionGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -467,9 +479,12 @@ func Test_SqlUserDefinedFunctionResource_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForSqlUserDefinedFunctionResource tests if a specific instance of SqlUserDefinedFunctionResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlUserDefinedFunctionResource(subject SqlUserDefinedFunctionResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlUserDefinedFunctionResource
-	err := subject.AssignPropertiesToSqlUserDefinedFunctionResource(&other)
+	err := copied.AssignPropertiesToSqlUserDefinedFunctionResource(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SqlDatabaseThroughputSetting_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForSqlDatabaseThroughputSetting tests if a specific instance of SqlDatabaseThroughputSetting can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseThroughputSetting(subject SqlDatabaseThroughputSetting) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseThroughputSetting
-	err := subject.AssignPropertiesToSqlDatabaseThroughputSetting(&other)
+	err := copied.AssignPropertiesToSqlDatabaseThroughputSetting(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_DatabaseAccountsSqlDatabasesThroughputSettings_Spec_WhenPropertiesConv
 
 // RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesThroughputSettingsSpec tests if a specific instance of DatabaseAccountsSqlDatabasesThroughputSettings_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesThroughputSettingsSpec(subject DatabaseAccountsSqlDatabasesThroughputSettings_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsSqlDatabasesThroughputSettings_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSqlDatabasesThroughputSettingsSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSqlDatabasesThroughputSettingsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen_test.go
+++ b/v2/api/microsoft.documentdb/v1alpha1api20210515/sql_database_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SqlDatabase_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForSqlDatabase tests if a specific instance of SqlDatabase can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabase(subject SqlDatabase) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabase
-	err := subject.AssignPropertiesToSqlDatabase(&other)
+	err := copied.AssignPropertiesToSqlDatabase(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_DatabaseAccountsSqlDatabases_Spec_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesSpec tests if a specific instance of DatabaseAccountsSqlDatabases_Spec can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForDatabaseAccountsSqlDatabasesSpec(subject DatabaseAccountsSqlDatabases_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.DatabaseAccountsSqlDatabases_Spec
-	err := subject.AssignPropertiesToDatabaseAccountsSqlDatabasesSpec(&other)
+	err := copied.AssignPropertiesToDatabaseAccountsSqlDatabasesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -246,9 +252,12 @@ func Test_SqlDatabaseGetResults_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForSqlDatabaseGetResultsStatus tests if a specific instance of SqlDatabaseGetResults_Status can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseGetResultsStatus(subject SqlDatabaseGetResults_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseGetResults_Status
-	err := subject.AssignPropertiesToSqlDatabaseGetResultsStatus(&other)
+	err := copied.AssignPropertiesToSqlDatabaseGetResultsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -364,9 +373,12 @@ func Test_SqlDatabaseGetProperties_Status_Resource_WhenPropertiesConverted_Round
 
 // RunPropertyAssignmentTestForSqlDatabaseGetPropertiesStatusResource tests if a specific instance of SqlDatabaseGetProperties_Status_Resource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseGetPropertiesStatusResource(subject SqlDatabaseGetProperties_Status_Resource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseGetProperties_Status_Resource
-	err := subject.AssignPropertiesToSqlDatabaseGetPropertiesStatusResource(&other)
+	err := copied.AssignPropertiesToSqlDatabaseGetPropertiesStatusResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -468,9 +480,12 @@ func Test_SqlDatabaseResource_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForSqlDatabaseResource tests if a specific instance of SqlDatabaseResource can be assigned to v1alpha1api20210515storage and back losslessly
 func RunPropertyAssignmentTestForSqlDatabaseResource(subject SqlDatabaseResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210515storage.SqlDatabaseResource
-	err := subject.AssignPropertiesToSqlDatabaseResource(&other)
+	err := copied.AssignPropertiesToSqlDatabaseResource(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen_test.go
+++ b/v2/api/microsoft.eventgrid/v1alpha1api20200601/topic_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_Topic_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForTopic tests if a specific instance of Topic can be assigned to v1alpha1api20200601storage and back losslessly
 func RunPropertyAssignmentTestForTopic(subject Topic) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200601storage.Topic
-	err := subject.AssignPropertiesToTopic(&other)
+	err := copied.AssignPropertiesToTopic(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_Topic_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForTopicStatus tests if a specific instance of Topic_Status can be assigned to v1alpha1api20200601storage and back losslessly
 func RunPropertyAssignmentTestForTopicStatus(subject Topic_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200601storage.Topic_Status
-	err := subject.AssignPropertiesToTopicStatus(&other)
+	err := copied.AssignPropertiesToTopicStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -260,9 +266,12 @@ func Test_Topics_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForTopicsSpec tests if a specific instance of Topics_Spec can be assigned to v1alpha1api20200601storage and back losslessly
 func RunPropertyAssignmentTestForTopicsSpec(subject Topics_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200601storage.Topics_Spec
-	err := subject.AssignPropertiesToTopicsSpec(&other)
+	err := copied.AssignPropertiesToTopicsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -360,9 +369,12 @@ func Test_InboundIpRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForInboundIpRuleStatus tests if a specific instance of InboundIpRule_Status can be assigned to v1alpha1api20200601storage and back losslessly
 func RunPropertyAssignmentTestForInboundIpRuleStatus(subject InboundIpRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200601storage.InboundIpRule_Status
-	err := subject.AssignPropertiesToInboundIpRuleStatus(&other)
+	err := copied.AssignPropertiesToInboundIpRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -460,9 +472,12 @@ func Test_InputSchemaMapping_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForInputSchemaMappingStatus tests if a specific instance of InputSchemaMapping_Status can be assigned to v1alpha1api20200601storage and back losslessly
 func RunPropertyAssignmentTestForInputSchemaMappingStatus(subject InputSchemaMapping_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200601storage.InputSchemaMapping_Status
-	err := subject.AssignPropertiesToInputSchemaMappingStatus(&other)
+	err := copied.AssignPropertiesToInputSchemaMappingStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -559,9 +574,12 @@ func Test_PrivateEndpointConnection_Status_Topic_SubResourceEmbedded_WhenPropert
 
 // RunPropertyAssignmentTestForPrivateEndpointConnectionStatusTopicSubResourceEmbedded tests if a specific instance of PrivateEndpointConnection_Status_Topic_SubResourceEmbedded can be assigned to v1alpha1api20200601storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointConnectionStatusTopicSubResourceEmbedded(subject PrivateEndpointConnection_Status_Topic_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200601storage.PrivateEndpointConnection_Status_Topic_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointConnectionStatusTopicSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointConnectionStatusTopicSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -658,9 +676,12 @@ func Test_SystemData_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForSystemDataStatus tests if a specific instance of SystemData_Status can be assigned to v1alpha1api20200601storage and back losslessly
 func RunPropertyAssignmentTestForSystemDataStatus(subject SystemData_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20200601storage.SystemData_Status
-	err := subject.AssignPropertiesToSystemDataStatus(&other)
+	err := copied.AssignPropertiesToSystemDataStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespace_types_gen_test.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespace_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_Namespace_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) 
 
 // RunPropertyAssignmentTestForNamespace tests if a specific instance of Namespace can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespace(subject Namespace) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Namespace
-	err := subject.AssignPropertiesToNamespace(&other)
+	err := copied.AssignPropertiesToNamespace(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_EHNamespace_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForEHNamespaceStatus tests if a specific instance of EHNamespace_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForEHNamespaceStatus(subject EHNamespace_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.EHNamespace_Status
-	err := subject.AssignPropertiesToEHNamespaceStatus(&other)
+	err := copied.AssignPropertiesToEHNamespaceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -263,9 +269,12 @@ func Test_Namespaces_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForNamespacesSpec tests if a specific instance of Namespaces_Spec can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesSpec(subject Namespaces_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Namespaces_Spec
-	err := subject.AssignPropertiesToNamespacesSpec(&other)
+	err := copied.AssignPropertiesToNamespacesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -386,9 +395,12 @@ func Test_Encryption_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForEncryption tests if a specific instance of Encryption can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForEncryption(subject Encryption) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Encryption
-	err := subject.AssignPropertiesToEncryption(&other)
+	err := copied.AssignPropertiesToEncryption(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -499,9 +511,12 @@ func Test_Encryption_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForEncryptionStatus tests if a specific instance of Encryption_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionStatus(subject Encryption_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Encryption_Status
-	err := subject.AssignPropertiesToEncryptionStatus(&other)
+	err := copied.AssignPropertiesToEncryptionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -612,9 +627,12 @@ func Test_Identity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForIdentity tests if a specific instance of Identity can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForIdentity(subject Identity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Identity
-	err := subject.AssignPropertiesToIdentity(&other)
+	err := copied.AssignPropertiesToIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -714,9 +732,12 @@ func Test_Identity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForIdentityStatus tests if a specific instance of Identity_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForIdentityStatus(subject Identity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Identity_Status
-	err := subject.AssignPropertiesToIdentityStatus(&other)
+	err := copied.AssignPropertiesToIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -832,9 +853,12 @@ func Test_Namespaces_Spec_Properties_PrivateEndpointConnections_WhenPropertiesCo
 
 // RunPropertyAssignmentTestForNamespacesSpecPropertiesPrivateEndpointConnections tests if a specific instance of Namespaces_Spec_Properties_PrivateEndpointConnections can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesSpecPropertiesPrivateEndpointConnections(subject Namespaces_Spec_Properties_PrivateEndpointConnections) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Namespaces_Spec_Properties_PrivateEndpointConnections
-	err := subject.AssignPropertiesToNamespacesSpecPropertiesPrivateEndpointConnections(&other)
+	err := copied.AssignPropertiesToNamespacesSpecPropertiesPrivateEndpointConnections(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -931,9 +955,12 @@ func Test_PrivateEndpointConnection_Status_SubResourceEmbedded_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded tests if a specific instance of PrivateEndpointConnection_Status_SubResourceEmbedded can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded(subject PrivateEndpointConnection_Status_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.PrivateEndpointConnection_Status_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1044,9 +1071,12 @@ func Test_Sku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForSku tests if a specific instance of Sku can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForSku(subject Sku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Sku
-	err := subject.AssignPropertiesToSku(&other)
+	err := copied.AssignPropertiesToSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1144,9 +1174,12 @@ func Test_Sku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForSkuStatus tests if a specific instance of Sku_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForSkuStatus(subject Sku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Sku_Status
-	err := subject.AssignPropertiesToSkuStatus(&other)
+	err := copied.AssignPropertiesToSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1244,9 +1277,12 @@ func Test_SystemData_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForSystemDataStatus tests if a specific instance of SystemData_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForSystemDataStatus(subject SystemData_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.SystemData_Status
-	err := subject.AssignPropertiesToSystemDataStatus(&other)
+	err := copied.AssignPropertiesToSystemDataStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1355,9 +1391,12 @@ func Test_KeyVaultProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForKeyVaultProperties tests if a specific instance of KeyVaultProperties can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultProperties(subject KeyVaultProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.KeyVaultProperties
-	err := subject.AssignPropertiesToKeyVaultProperties(&other)
+	err := copied.AssignPropertiesToKeyVaultProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1469,9 +1508,12 @@ func Test_KeyVaultProperties_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForKeyVaultPropertiesStatus tests if a specific instance of KeyVaultProperties_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultPropertiesStatus(subject KeyVaultProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.KeyVaultProperties_Status
-	err := subject.AssignPropertiesToKeyVaultPropertiesStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1584,9 +1626,12 @@ func Test_PrivateEndpoint_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForPrivateEndpoint tests if a specific instance of PrivateEndpoint can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpoint(subject PrivateEndpoint) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.PrivateEndpoint
-	err := subject.AssignPropertiesToPrivateEndpoint(&other)
+	err := copied.AssignPropertiesToPrivateEndpoint(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1676,9 +1721,12 @@ func Test_UserAssignedIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForUserAssignedIdentityStatus tests if a specific instance of UserAssignedIdentity_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityStatus(subject UserAssignedIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.UserAssignedIdentity_Status
-	err := subject.AssignPropertiesToUserAssignedIdentityStatus(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1776,9 +1824,12 @@ func Test_UserAssignedIdentityProperties_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForUserAssignedIdentityProperties tests if a specific instance of UserAssignedIdentityProperties can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityProperties(subject UserAssignedIdentityProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.UserAssignedIdentityProperties
-	err := subject.AssignPropertiesToUserAssignedIdentityProperties(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1869,9 +1920,12 @@ func Test_UserAssignedIdentityProperties_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForUserAssignedIdentityPropertiesStatus tests if a specific instance of UserAssignedIdentityProperties_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityPropertiesStatus(subject UserAssignedIdentityProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.UserAssignedIdentityProperties_Status
-	err := subject.AssignPropertiesToUserAssignedIdentityPropertiesStatus(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen_test.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NamespacesAuthorizationRule_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForNamespacesAuthorizationRule tests if a specific instance of NamespacesAuthorizationRule can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesAuthorizationRule(subject NamespacesAuthorizationRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesAuthorizationRule
-	err := subject.AssignPropertiesToNamespacesAuthorizationRule(&other)
+	err := copied.AssignPropertiesToNamespacesAuthorizationRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_AuthorizationRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForAuthorizationRuleStatus tests if a specific instance of AuthorizationRule_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForAuthorizationRuleStatus(subject AuthorizationRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.AuthorizationRule_Status
-	err := subject.AssignPropertiesToAuthorizationRuleStatus(&other)
+	err := copied.AssignPropertiesToAuthorizationRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -248,9 +254,12 @@ func Test_NamespacesAuthorizationRules_Spec_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForNamespacesAuthorizationRulesSpec tests if a specific instance of NamespacesAuthorizationRules_Spec can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesAuthorizationRulesSpec(subject NamespacesAuthorizationRules_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesAuthorizationRules_Spec
-	err := subject.AssignPropertiesToNamespacesAuthorizationRulesSpec(&other)
+	err := copied.AssignPropertiesToNamespacesAuthorizationRulesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen_test.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NamespacesEventhub_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForNamespacesEventhub tests if a specific instance of NamespacesEventhub can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhub(subject NamespacesEventhub) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhub
-	err := subject.AssignPropertiesToNamespacesEventhub(&other)
+	err := copied.AssignPropertiesToNamespacesEventhub(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_Eventhub_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForEventhubStatus tests if a specific instance of Eventhub_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForEventhubStatus(subject Eventhub_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Eventhub_Status
-	err := subject.AssignPropertiesToEventhubStatus(&other)
+	err := copied.AssignPropertiesToEventhubStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -261,9 +267,12 @@ func Test_NamespacesEventhubs_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForNamespacesEventhubsSpec tests if a specific instance of NamespacesEventhubs_Spec can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhubsSpec(subject NamespacesEventhubs_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhubs_Spec
-	err := subject.AssignPropertiesToNamespacesEventhubsSpec(&other)
+	err := copied.AssignPropertiesToNamespacesEventhubsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -378,9 +387,12 @@ func Test_CaptureDescription_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForCaptureDescriptionStatus tests if a specific instance of CaptureDescription_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForCaptureDescriptionStatus(subject CaptureDescription_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.CaptureDescription_Status
-	err := subject.AssignPropertiesToCaptureDescriptionStatus(&other)
+	err := copied.AssignPropertiesToCaptureDescriptionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -495,9 +507,12 @@ func Test_NamespacesEventhubs_Spec_Properties_CaptureDescription_WhenPropertiesC
 
 // RunPropertyAssignmentTestForNamespacesEventhubsSpecPropertiesCaptureDescription tests if a specific instance of NamespacesEventhubs_Spec_Properties_CaptureDescription can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhubsSpecPropertiesCaptureDescription(subject NamespacesEventhubs_Spec_Properties_CaptureDescription) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhubs_Spec_Properties_CaptureDescription
-	err := subject.AssignPropertiesToNamespacesEventhubsSpecPropertiesCaptureDescription(&other)
+	err := copied.AssignPropertiesToNamespacesEventhubsSpecPropertiesCaptureDescription(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -612,9 +627,12 @@ func Test_Destination_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForDestinationStatus tests if a specific instance of Destination_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForDestinationStatus(subject Destination_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.Destination_Status
-	err := subject.AssignPropertiesToDestinationStatus(&other)
+	err := copied.AssignPropertiesToDestinationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -716,9 +734,12 @@ func Test_NamespacesEventhubs_Spec_Properties_CaptureDescription_Destination_Whe
 
 // RunPropertyAssignmentTestForNamespacesEventhubsSpecPropertiesCaptureDescriptionDestination tests if a specific instance of NamespacesEventhubs_Spec_Properties_CaptureDescription_Destination can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhubsSpecPropertiesCaptureDescriptionDestination(subject NamespacesEventhubs_Spec_Properties_CaptureDescription_Destination) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhubs_Spec_Properties_CaptureDescription_Destination
-	err := subject.AssignPropertiesToNamespacesEventhubsSpecPropertiesCaptureDescriptionDestination(&other)
+	err := copied.AssignPropertiesToNamespacesEventhubsSpecPropertiesCaptureDescriptionDestination(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen_test.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NamespacesEventhubsAuthorizationRule_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForNamespacesEventhubsAuthorizationRule tests if a specific instance of NamespacesEventhubsAuthorizationRule can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhubsAuthorizationRule(subject NamespacesEventhubsAuthorizationRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhubsAuthorizationRule
-	err := subject.AssignPropertiesToNamespacesEventhubsAuthorizationRule(&other)
+	err := copied.AssignPropertiesToNamespacesEventhubsAuthorizationRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_NamespacesEventhubsAuthorizationRules_Spec_WhenPropertiesConverted_Rou
 
 // RunPropertyAssignmentTestForNamespacesEventhubsAuthorizationRulesSpec tests if a specific instance of NamespacesEventhubsAuthorizationRules_Spec can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhubsAuthorizationRulesSpec(subject NamespacesEventhubsAuthorizationRules_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhubsAuthorizationRules_Spec
-	err := subject.AssignPropertiesToNamespacesEventhubsAuthorizationRulesSpec(&other)
+	err := copied.AssignPropertiesToNamespacesEventhubsAuthorizationRulesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen_test.go
+++ b/v2/api/microsoft.eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NamespacesEventhubsConsumerGroup_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForNamespacesEventhubsConsumerGroup tests if a specific instance of NamespacesEventhubsConsumerGroup can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhubsConsumerGroup(subject NamespacesEventhubsConsumerGroup) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhubsConsumerGroup
-	err := subject.AssignPropertiesToNamespacesEventhubsConsumerGroup(&other)
+	err := copied.AssignPropertiesToNamespacesEventhubsConsumerGroup(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_ConsumerGroup_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForConsumerGroupStatus tests if a specific instance of ConsumerGroup_Status can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForConsumerGroupStatus(subject ConsumerGroup_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.ConsumerGroup_Status
-	err := subject.AssignPropertiesToConsumerGroupStatus(&other)
+	err := copied.AssignPropertiesToConsumerGroupStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -250,9 +256,12 @@ func Test_NamespacesEventhubsConsumergroups_Spec_WhenPropertiesConverted_RoundTr
 
 // RunPropertyAssignmentTestForNamespacesEventhubsConsumergroupsSpec tests if a specific instance of NamespacesEventhubsConsumergroups_Spec can be assigned to v1alpha1api20211101storage and back losslessly
 func RunPropertyAssignmentTestForNamespacesEventhubsConsumergroupsSpec(subject NamespacesEventhubsConsumergroups_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211101storage.NamespacesEventhubsConsumergroups_Spec
-	err := subject.AssignPropertiesToNamespacesEventhubsConsumergroupsSpec(&other)
+	err := copied.AssignPropertiesToNamespacesEventhubsConsumergroupsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen_test.go
+++ b/v2/api/microsoft.managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_UserAssignedIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForUserAssignedIdentity tests if a specific instance of UserAssignedIdentity can be assigned to v1alpha1api20181130storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentity(subject UserAssignedIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20181130storage.UserAssignedIdentity
-	err := subject.AssignPropertiesToUserAssignedIdentity(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_Identity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForIdentityStatus tests if a specific instance of Identity_Status can be assigned to v1alpha1api20181130storage and back losslessly
 func RunPropertyAssignmentTestForIdentityStatus(subject Identity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20181130storage.Identity_Status
-	err := subject.AssignPropertiesToIdentityStatus(&other)
+	err := copied.AssignPropertiesToIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -236,9 +242,12 @@ func Test_UserAssignedIdentities_Spec_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForUserAssignedIdentitiesSpec tests if a specific instance of UserAssignedIdentities_Spec can be assigned to v1alpha1api20181130storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentitiesSpec(subject UserAssignedIdentities_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20181130storage.UserAssignedIdentities_Spec
-	err := subject.AssignPropertiesToUserAssignedIdentitiesSpec(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentitiesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/load_balancer_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_LoadBalancer_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForLoadBalancer tests if a specific instance of LoadBalancer can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancer(subject LoadBalancer) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancer
-	err := subject.AssignPropertiesToLoadBalancer(&other)
+	err := copied.AssignPropertiesToLoadBalancer(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_LoadBalancer_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForLoadBalancerStatus tests if a specific instance of LoadBalancer_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancerStatus(subject LoadBalancer_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancer_Status
-	err := subject.AssignPropertiesToLoadBalancerStatus(&other)
+	err := copied.AssignPropertiesToLoadBalancerStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -261,9 +267,12 @@ func Test_LoadBalancers_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForLoadBalancersSpec tests if a specific instance of LoadBalancers_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpec(subject LoadBalancers_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec
-	err := subject.AssignPropertiesToLoadBalancersSpec(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -382,9 +391,12 @@ func Test_BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded_WhenPropert
 
 // RunPropertyAssignmentTestForBackendAddressPoolStatusLoadBalancerSubResourceEmbedded tests if a specific instance of BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForBackendAddressPoolStatusLoadBalancerSubResourceEmbedded(subject BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded
-	err := subject.AssignPropertiesToBackendAddressPoolStatusLoadBalancerSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToBackendAddressPoolStatusLoadBalancerSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -481,9 +493,12 @@ func Test_ExtendedLocation_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForExtendedLocation tests if a specific instance of ExtendedLocation can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocation(subject ExtendedLocation) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ExtendedLocation
-	err := subject.AssignPropertiesToExtendedLocation(&other)
+	err := copied.AssignPropertiesToExtendedLocation(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -580,9 +595,12 @@ func Test_ExtendedLocation_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForExtendedLocationStatus tests if a specific instance of ExtendedLocation_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocationStatus(subject ExtendedLocation_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ExtendedLocation_Status
-	err := subject.AssignPropertiesToExtendedLocationStatus(&other)
+	err := copied.AssignPropertiesToExtendedLocationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -680,9 +698,12 @@ func Test_FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded_WhenPr
 
 // RunPropertyAssignmentTestForFrontendIPConfigurationStatusLoadBalancerSubResourceEmbedded tests if a specific instance of FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForFrontendIPConfigurationStatusLoadBalancerSubResourceEmbedded(subject FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded
-	err := subject.AssignPropertiesToFrontendIPConfigurationStatusLoadBalancerSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToFrontendIPConfigurationStatusLoadBalancerSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -811,9 +832,12 @@ func Test_InboundNatPool_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForInboundNatPoolStatus tests if a specific instance of InboundNatPool_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForInboundNatPoolStatus(subject InboundNatPool_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.InboundNatPool_Status
-	err := subject.AssignPropertiesToInboundNatPoolStatus(&other)
+	err := copied.AssignPropertiesToInboundNatPoolStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -939,9 +963,12 @@ func Test_InboundNatRule_Status_LoadBalancer_SubResourceEmbedded_WhenPropertiesC
 
 // RunPropertyAssignmentTestForInboundNatRuleStatusLoadBalancerSubResourceEmbedded tests if a specific instance of InboundNatRule_Status_LoadBalancer_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForInboundNatRuleStatusLoadBalancerSubResourceEmbedded(subject InboundNatRule_Status_LoadBalancer_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.InboundNatRule_Status_LoadBalancer_SubResourceEmbedded
-	err := subject.AssignPropertiesToInboundNatRuleStatusLoadBalancerSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToInboundNatRuleStatusLoadBalancerSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1038,9 +1065,12 @@ func Test_LoadBalancerSku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForLoadBalancerSku tests if a specific instance of LoadBalancerSku can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancerSku(subject LoadBalancerSku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancerSku
-	err := subject.AssignPropertiesToLoadBalancerSku(&other)
+	err := copied.AssignPropertiesToLoadBalancerSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1137,9 +1167,12 @@ func Test_LoadBalancerSku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForLoadBalancerSkuStatus tests if a specific instance of LoadBalancerSku_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancerSkuStatus(subject LoadBalancerSku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancerSku_Status
-	err := subject.AssignPropertiesToLoadBalancerSkuStatus(&other)
+	err := copied.AssignPropertiesToLoadBalancerSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1237,9 +1270,12 @@ func Test_LoadBalancers_Spec_Properties_BackendAddressPools_WhenPropertiesConver
 
 // RunPropertyAssignmentTestForLoadBalancersSpecPropertiesBackendAddressPools tests if a specific instance of LoadBalancers_Spec_Properties_BackendAddressPools can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpecPropertiesBackendAddressPools(subject LoadBalancers_Spec_Properties_BackendAddressPools) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec_Properties_BackendAddressPools
-	err := subject.AssignPropertiesToLoadBalancersSpecPropertiesBackendAddressPools(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpecPropertiesBackendAddressPools(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1351,9 +1387,12 @@ func Test_LoadBalancers_Spec_Properties_FrontendIPConfigurations_WhenPropertiesC
 
 // RunPropertyAssignmentTestForLoadBalancersSpecPropertiesFrontendIPConfigurations tests if a specific instance of LoadBalancers_Spec_Properties_FrontendIPConfigurations can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpecPropertiesFrontendIPConfigurations(subject LoadBalancers_Spec_Properties_FrontendIPConfigurations) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec_Properties_FrontendIPConfigurations
-	err := subject.AssignPropertiesToLoadBalancersSpecPropertiesFrontendIPConfigurations(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpecPropertiesFrontendIPConfigurations(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1470,9 +1509,12 @@ func Test_LoadBalancers_Spec_Properties_InboundNatPools_WhenPropertiesConverted_
 
 // RunPropertyAssignmentTestForLoadBalancersSpecPropertiesInboundNatPools tests if a specific instance of LoadBalancers_Spec_Properties_InboundNatPools can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpecPropertiesInboundNatPools(subject LoadBalancers_Spec_Properties_InboundNatPools) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec_Properties_InboundNatPools
-	err := subject.AssignPropertiesToLoadBalancersSpecPropertiesInboundNatPools(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpecPropertiesInboundNatPools(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1590,9 +1632,12 @@ func Test_LoadBalancers_Spec_Properties_LoadBalancingRules_WhenPropertiesConvert
 
 // RunPropertyAssignmentTestForLoadBalancersSpecPropertiesLoadBalancingRules tests if a specific instance of LoadBalancers_Spec_Properties_LoadBalancingRules can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpecPropertiesLoadBalancingRules(subject LoadBalancers_Spec_Properties_LoadBalancingRules) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec_Properties_LoadBalancingRules
-	err := subject.AssignPropertiesToLoadBalancersSpecPropertiesLoadBalancingRules(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpecPropertiesLoadBalancingRules(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1713,9 +1758,12 @@ func Test_LoadBalancers_Spec_Properties_OutboundRules_WhenPropertiesConverted_Ro
 
 // RunPropertyAssignmentTestForLoadBalancersSpecPropertiesOutboundRules tests if a specific instance of LoadBalancers_Spec_Properties_OutboundRules can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpecPropertiesOutboundRules(subject LoadBalancers_Spec_Properties_OutboundRules) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec_Properties_OutboundRules
-	err := subject.AssignPropertiesToLoadBalancersSpecPropertiesOutboundRules(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpecPropertiesOutboundRules(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1831,9 +1879,12 @@ func Test_LoadBalancers_Spec_Properties_Probes_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForLoadBalancersSpecPropertiesProbes tests if a specific instance of LoadBalancers_Spec_Properties_Probes can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpecPropertiesProbes(subject LoadBalancers_Spec_Properties_Probes) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec_Properties_Probes
-	err := subject.AssignPropertiesToLoadBalancersSpecPropertiesProbes(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpecPropertiesProbes(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1935,9 +1986,12 @@ func Test_LoadBalancingRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForLoadBalancingRuleStatus tests if a specific instance of LoadBalancingRule_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancingRuleStatus(subject LoadBalancingRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancingRule_Status
-	err := subject.AssignPropertiesToLoadBalancingRuleStatus(&other)
+	err := copied.AssignPropertiesToLoadBalancingRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2066,9 +2120,12 @@ func Test_OutboundRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForOutboundRuleStatus tests if a specific instance of OutboundRule_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForOutboundRuleStatus(subject OutboundRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.OutboundRule_Status
-	err := subject.AssignPropertiesToOutboundRuleStatus(&other)
+	err := copied.AssignPropertiesToOutboundRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2191,9 +2248,12 @@ func Test_Probe_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForProbeStatus tests if a specific instance of Probe_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForProbeStatus(subject Probe_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Probe_Status
-	err := subject.AssignPropertiesToProbeStatus(&other)
+	err := copied.AssignPropertiesToProbeStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2316,9 +2376,12 @@ func Test_LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalan
 
 // RunPropertyAssignmentTestForLoadBalancersSpecPropertiesBackendAddressPoolsPropertiesLoadBalancerBackendAddresses tests if a specific instance of LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddresses can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForLoadBalancersSpecPropertiesBackendAddressPoolsPropertiesLoadBalancerBackendAddresses(subject LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddresses) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddresses
-	err := subject.AssignPropertiesToLoadBalancersSpecPropertiesBackendAddressPoolsPropertiesLoadBalancerBackendAddresses(&other)
+	err := copied.AssignPropertiesToLoadBalancersSpecPropertiesBackendAddressPoolsPropertiesLoadBalancerBackendAddresses(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2433,9 +2496,12 @@ func Test_PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded_WhenProperties
 
 // RunPropertyAssignmentTestForPublicIPAddressStatusLoadBalancerSubResourceEmbedded tests if a specific instance of PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressStatusLoadBalancerSubResourceEmbedded(subject PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded
-	err := subject.AssignPropertiesToPublicIPAddressStatusLoadBalancerSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPublicIPAddressStatusLoadBalancerSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2548,9 +2614,12 @@ func Test_Subnet_Status_LoadBalancer_SubResourceEmbedded_WhenPropertiesConverted
 
 // RunPropertyAssignmentTestForSubnetStatusLoadBalancerSubResourceEmbedded tests if a specific instance of Subnet_Status_LoadBalancer_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubnetStatusLoadBalancerSubResourceEmbedded(subject Subnet_Status_LoadBalancer_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Subnet_Status_LoadBalancer_SubResourceEmbedded
-	err := subject.AssignPropertiesToSubnetStatusLoadBalancerSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSubnetStatusLoadBalancerSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_interface_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_interface_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NetworkInterface_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForNetworkInterface tests if a specific instance of NetworkInterface can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterface(subject NetworkInterface) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterface
-	err := subject.AssignPropertiesToNetworkInterface(&other)
+	err := copied.AssignPropertiesToNetworkInterface(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_NetworkInterface_Status_NetworkInterface_SubResourceEmbedded_WhenPrope
 
 // RunPropertyAssignmentTestForNetworkInterfaceStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of NetworkInterface_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceStatusNetworkInterfaceSubResourceEmbedded(subject NetworkInterface_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterface_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToNetworkInterfaceStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -274,9 +280,12 @@ func Test_NetworkInterfaces_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForNetworkInterfacesSpec tests if a specific instance of NetworkInterfaces_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfacesSpec(subject NetworkInterfaces_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterfaces_Spec
-	err := subject.AssignPropertiesToNetworkInterfacesSpec(&other)
+	err := copied.AssignPropertiesToNetworkInterfacesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -394,9 +403,12 @@ func Test_NetworkInterfaceDnsSettings_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForNetworkInterfaceDnsSettings tests if a specific instance of NetworkInterfaceDnsSettings can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceDnsSettings(subject NetworkInterfaceDnsSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterfaceDnsSettings
-	err := subject.AssignPropertiesToNetworkInterfaceDnsSettings(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceDnsSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -494,9 +506,12 @@ func Test_NetworkInterfaceDnsSettings_Status_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForNetworkInterfaceDnsSettingsStatus tests if a specific instance of NetworkInterfaceDnsSettings_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceDnsSettingsStatus(subject NetworkInterfaceDnsSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterfaceDnsSettings_Status
-	err := subject.AssignPropertiesToNetworkInterfaceDnsSettingsStatus(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceDnsSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -597,9 +612,12 @@ func Test_NetworkInterfaceIPConfiguration_Status_NetworkInterface_SubResourceEmb
 
 // RunPropertyAssignmentTestForNetworkInterfaceIPConfigurationStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of NetworkInterfaceIPConfiguration_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceIPConfigurationStatusNetworkInterfaceSubResourceEmbedded(subject NetworkInterfaceIPConfiguration_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterfaceIPConfiguration_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToNetworkInterfaceIPConfigurationStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceIPConfigurationStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -729,9 +747,12 @@ func Test_NetworkInterfaceTapConfiguration_Status_NetworkInterface_SubResourceEm
 
 // RunPropertyAssignmentTestForNetworkInterfaceTapConfigurationStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of NetworkInterfaceTapConfiguration_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceTapConfigurationStatusNetworkInterfaceSubResourceEmbedded(subject NetworkInterfaceTapConfiguration_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterfaceTapConfiguration_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToNetworkInterfaceTapConfigurationStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceTapConfigurationStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -828,9 +849,12 @@ func Test_NetworkInterfaces_Spec_Properties_IpConfigurations_WhenPropertiesConve
 
 // RunPropertyAssignmentTestForNetworkInterfacesSpecPropertiesIpConfigurations tests if a specific instance of NetworkInterfaces_Spec_Properties_IpConfigurations can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfacesSpecPropertiesIpConfigurations(subject NetworkInterfaces_Spec_Properties_IpConfigurations) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterfaces_Spec_Properties_IpConfigurations
-	err := subject.AssignPropertiesToNetworkInterfacesSpecPropertiesIpConfigurations(&other)
+	err := copied.AssignPropertiesToNetworkInterfacesSpecPropertiesIpConfigurations(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -951,9 +975,12 @@ func Test_NetworkSecurityGroup_Status_NetworkInterface_SubResourceEmbedded_WhenP
 
 // RunPropertyAssignmentTestForNetworkSecurityGroupStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of NetworkSecurityGroup_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkSecurityGroupStatusNetworkInterfaceSubResourceEmbedded(subject NetworkSecurityGroup_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkSecurityGroup_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToNetworkSecurityGroupStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNetworkSecurityGroupStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1050,9 +1077,12 @@ func Test_PrivateEndpoint_Status_NetworkInterface_SubResourceEmbedded_WhenProper
 
 // RunPropertyAssignmentTestForPrivateEndpointStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of PrivateEndpoint_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointStatusNetworkInterfaceSubResourceEmbedded(subject PrivateEndpoint_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PrivateEndpoint_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1163,9 +1193,12 @@ func Test_PrivateLinkService_Status_NetworkInterface_SubResourceEmbedded_WhenPro
 
 // RunPropertyAssignmentTestForPrivateLinkServiceStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of PrivateLinkService_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateLinkServiceStatusNetworkInterfaceSubResourceEmbedded(subject PrivateLinkService_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PrivateLinkService_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateLinkServiceStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateLinkServiceStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1276,9 +1309,12 @@ func Test_SubResource_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForSubResource tests if a specific instance of SubResource can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubResource(subject SubResource) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.SubResource
-	err := subject.AssignPropertiesToSubResource(&other)
+	err := copied.AssignPropertiesToSubResource(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1368,9 +1404,12 @@ func Test_SubResource_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSubResourceStatus tests if a specific instance of SubResource_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubResourceStatus(subject SubResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.SubResource_Status
-	err := subject.AssignPropertiesToSubResourceStatus(&other)
+	err := copied.AssignPropertiesToSubResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1466,9 +1505,12 @@ func Test_ApplicationGatewayBackendAddressPool_Status_NetworkInterface_SubResour
 
 // RunPropertyAssignmentTestForApplicationGatewayBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of ApplicationGatewayBackendAddressPool_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForApplicationGatewayBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded(subject ApplicationGatewayBackendAddressPool_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ApplicationGatewayBackendAddressPool_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToApplicationGatewayBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToApplicationGatewayBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1587,9 +1629,12 @@ func Test_ApplicationSecurityGroup_Status_NetworkInterface_SubResourceEmbedded_W
 
 // RunPropertyAssignmentTestForApplicationSecurityGroupStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of ApplicationSecurityGroup_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForApplicationSecurityGroupStatusNetworkInterfaceSubResourceEmbedded(subject ApplicationSecurityGroup_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ApplicationSecurityGroup_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToApplicationSecurityGroupStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToApplicationSecurityGroupStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1686,9 +1731,12 @@ func Test_BackendAddressPool_Status_NetworkInterface_SubResourceEmbedded_WhenPro
 
 // RunPropertyAssignmentTestForBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of BackendAddressPool_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded(subject BackendAddressPool_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.BackendAddressPool_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToBackendAddressPoolStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1785,9 +1833,12 @@ func Test_InboundNatRule_Status_NetworkInterface_SubResourceEmbedded_WhenPropert
 
 // RunPropertyAssignmentTestForInboundNatRuleStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of InboundNatRule_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForInboundNatRuleStatusNetworkInterfaceSubResourceEmbedded(subject InboundNatRule_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.InboundNatRule_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToInboundNatRuleStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToInboundNatRuleStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1884,9 +1935,12 @@ func Test_NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_Status_
 
 // RunPropertyAssignmentTestForNetworkInterfaceIPConfigurationPrivateLinkConnectionPropertiesStatus tests if a specific instance of NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceIPConfigurationPrivateLinkConnectionPropertiesStatus(subject NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_Status
-	err := subject.AssignPropertiesToNetworkInterfaceIPConfigurationPrivateLinkConnectionPropertiesStatus(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceIPConfigurationPrivateLinkConnectionPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1985,9 +2039,12 @@ func Test_PublicIPAddress_Status_NetworkInterface_SubResourceEmbedded_WhenProper
 
 // RunPropertyAssignmentTestForPublicIPAddressStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of PublicIPAddress_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressStatusNetworkInterfaceSubResourceEmbedded(subject PublicIPAddress_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddress_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToPublicIPAddressStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPublicIPAddressStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2100,9 +2157,12 @@ func Test_Subnet_Status_NetworkInterface_SubResourceEmbedded_WhenPropertiesConve
 
 // RunPropertyAssignmentTestForSubnetStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of Subnet_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubnetStatusNetworkInterfaceSubResourceEmbedded(subject Subnet_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Subnet_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToSubnetStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSubnetStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2199,9 +2259,12 @@ func Test_VirtualNetworkTap_Status_NetworkInterface_SubResourceEmbedded_WhenProp
 
 // RunPropertyAssignmentTestForVirtualNetworkTapStatusNetworkInterfaceSubResourceEmbedded tests if a specific instance of VirtualNetworkTap_Status_NetworkInterface_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkTapStatusNetworkInterfaceSubResourceEmbedded(subject VirtualNetworkTap_Status_NetworkInterface_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkTap_Status_NetworkInterface_SubResourceEmbedded
-	err := subject.AssignPropertiesToVirtualNetworkTapStatusNetworkInterfaceSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToVirtualNetworkTapStatusNetworkInterfaceSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2298,9 +2361,12 @@ func Test_ApplicationGatewayBackendAddress_Status_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForApplicationGatewayBackendAddressStatus tests if a specific instance of ApplicationGatewayBackendAddress_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForApplicationGatewayBackendAddressStatus(subject ApplicationGatewayBackendAddress_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ApplicationGatewayBackendAddress_Status
-	err := subject.AssignPropertiesToApplicationGatewayBackendAddressStatus(&other)
+	err := copied.AssignPropertiesToApplicationGatewayBackendAddressStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_group_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NetworkSecurityGroup_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForNetworkSecurityGroup tests if a specific instance of NetworkSecurityGroup can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkSecurityGroup(subject NetworkSecurityGroup) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkSecurityGroup
-	err := subject.AssignPropertiesToNetworkSecurityGroup(&other)
+	err := copied.AssignPropertiesToNetworkSecurityGroup(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded_W
 
 // RunPropertyAssignmentTestForNetworkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded tests if a specific instance of NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded(subject NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded
-	err := subject.AssignPropertiesToNetworkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNetworkSecurityGroupStatusNetworkSecurityGroupSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -259,9 +265,12 @@ func Test_NetworkSecurityGroups_Spec_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForNetworkSecurityGroupsSpec tests if a specific instance of NetworkSecurityGroups_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkSecurityGroupsSpec(subject NetworkSecurityGroups_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkSecurityGroups_Spec
-	err := subject.AssignPropertiesToNetworkSecurityGroupsSpec(&other)
+	err := copied.AssignPropertiesToNetworkSecurityGroupsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -360,9 +369,12 @@ func Test_FlowLog_Status_SubResourceEmbedded_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForFlowLogStatusSubResourceEmbedded tests if a specific instance of FlowLog_Status_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForFlowLogStatusSubResourceEmbedded(subject FlowLog_Status_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.FlowLog_Status_SubResourceEmbedded
-	err := subject.AssignPropertiesToFlowLogStatusSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToFlowLogStatusSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -459,9 +471,12 @@ func Test_NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded_WhenP
 
 // RunPropertyAssignmentTestForNetworkInterfaceStatusNetworkSecurityGroupSubResourceEmbedded tests if a specific instance of NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkInterfaceStatusNetworkSecurityGroupSubResourceEmbedded(subject NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded
-	err := subject.AssignPropertiesToNetworkInterfaceStatusNetworkSecurityGroupSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNetworkInterfaceStatusNetworkSecurityGroupSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -572,9 +587,12 @@ func Test_SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded_WhenPrope
 
 // RunPropertyAssignmentTestForSecurityRuleStatusNetworkSecurityGroupSubResourceEmbedded tests if a specific instance of SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSecurityRuleStatusNetworkSecurityGroupSubResourceEmbedded(subject SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded
-	err := subject.AssignPropertiesToSecurityRuleStatusNetworkSecurityGroupSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSecurityRuleStatusNetworkSecurityGroupSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -671,9 +689,12 @@ func Test_Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded_WhenPropertiesC
 
 // RunPropertyAssignmentTestForSubnetStatusNetworkSecurityGroupSubResourceEmbedded tests if a specific instance of Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubnetStatusNetworkSecurityGroupSubResourceEmbedded(subject Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded
-	err := subject.AssignPropertiesToSubnetStatusNetworkSecurityGroupSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSubnetStatusNetworkSecurityGroupSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/network_security_groups_security_rule_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NetworkSecurityGroupsSecurityRule_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForNetworkSecurityGroupsSecurityRule tests if a specific instance of NetworkSecurityGroupsSecurityRule can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkSecurityGroupsSecurityRule(subject NetworkSecurityGroupsSecurityRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkSecurityGroupsSecurityRule
-	err := subject.AssignPropertiesToNetworkSecurityGroupsSecurityRule(&other)
+	err := copied.AssignPropertiesToNetworkSecurityGroupsSecurityRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_NetworkSecurityGroupsSecurityRules_Spec_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForNetworkSecurityGroupsSecurityRulesSpec tests if a specific instance of NetworkSecurityGroupsSecurityRules_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkSecurityGroupsSecurityRulesSpec(subject NetworkSecurityGroupsSecurityRules_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkSecurityGroupsSecurityRules_Spec
-	err := subject.AssignPropertiesToNetworkSecurityGroupsSecurityRulesSpec(&other)
+	err := copied.AssignPropertiesToNetworkSecurityGroupsSecurityRulesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -266,9 +272,12 @@ func Test_SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbed
 
 // RunPropertyAssignmentTestForSecurityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded tests if a specific instance of SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSecurityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded(subject SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded
-	err := subject.AssignPropertiesToSecurityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSecurityRuleStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -407,9 +416,12 @@ func Test_ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubR
 
 // RunPropertyAssignmentTestForApplicationSecurityGroupStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded tests if a specific instance of ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForApplicationSecurityGroupStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded(subject ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded
-	err := subject.AssignPropertiesToApplicationSecurityGroupStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToApplicationSecurityGroupStatusNetworkSecurityGroupsSecurityRuleSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/public_ip_address_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_PublicIPAddress_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForPublicIPAddress tests if a specific instance of PublicIPAddress can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddress(subject PublicIPAddress) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddress
-	err := subject.AssignPropertiesToPublicIPAddress(&other)
+	err := copied.AssignPropertiesToPublicIPAddress(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded_WhenPropert
 
 // RunPropertyAssignmentTestForPublicIPAddressStatusPublicIPAddressSubResourceEmbedded tests if a specific instance of PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressStatusPublicIPAddressSubResourceEmbedded(subject PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded
-	err := subject.AssignPropertiesToPublicIPAddressStatusPublicIPAddressSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPublicIPAddressStatusPublicIPAddressSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -272,9 +278,12 @@ func Test_PublicIPAddresses_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForPublicIPAddressesSpec tests if a specific instance of PublicIPAddresses_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressesSpec(subject PublicIPAddresses_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddresses_Spec
-	err := subject.AssignPropertiesToPublicIPAddressesSpec(&other)
+	err := copied.AssignPropertiesToPublicIPAddressesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -397,9 +406,12 @@ func Test_DdosSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForDdosSettings tests if a specific instance of DdosSettings can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForDdosSettings(subject DdosSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.DdosSettings
-	err := subject.AssignPropertiesToDdosSettings(&other)
+	err := copied.AssignPropertiesToDdosSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -510,9 +522,12 @@ func Test_DdosSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForDdosSettingsStatus tests if a specific instance of DdosSettings_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForDdosSettingsStatus(subject DdosSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.DdosSettings_Status
-	err := subject.AssignPropertiesToDdosSettingsStatus(&other)
+	err := copied.AssignPropertiesToDdosSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -623,9 +638,12 @@ func Test_IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded_WhenPropert
 
 // RunPropertyAssignmentTestForIPConfigurationStatusPublicIPAddressSubResourceEmbedded tests if a specific instance of IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIPConfigurationStatusPublicIPAddressSubResourceEmbedded(subject IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded
-	err := subject.AssignPropertiesToIPConfigurationStatusPublicIPAddressSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToIPConfigurationStatusPublicIPAddressSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -745,9 +763,12 @@ func Test_IpTag_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForIpTag tests if a specific instance of IpTag can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIpTag(subject IpTag) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IpTag
-	err := subject.AssignPropertiesToIpTag(&other)
+	err := copied.AssignPropertiesToIpTag(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -844,9 +865,12 @@ func Test_IpTag_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForIpTagStatus tests if a specific instance of IpTag_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIpTagStatus(subject IpTag_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IpTag_Status
-	err := subject.AssignPropertiesToIpTagStatus(&other)
+	err := copied.AssignPropertiesToIpTagStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -943,9 +967,12 @@ func Test_NatGateway_Status_PublicIPAddress_SubResourceEmbedded_WhenPropertiesCo
 
 // RunPropertyAssignmentTestForNatGatewayStatusPublicIPAddressSubResourceEmbedded tests if a specific instance of NatGateway_Status_PublicIPAddress_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNatGatewayStatusPublicIPAddressSubResourceEmbedded(subject NatGateway_Status_PublicIPAddress_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NatGateway_Status_PublicIPAddress_SubResourceEmbedded
-	err := subject.AssignPropertiesToNatGatewayStatusPublicIPAddressSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNatGatewayStatusPublicIPAddressSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1057,9 +1084,12 @@ func Test_PublicIPAddressDnsSettings_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForPublicIPAddressDnsSettings tests if a specific instance of PublicIPAddressDnsSettings can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressDnsSettings(subject PublicIPAddressDnsSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddressDnsSettings
-	err := subject.AssignPropertiesToPublicIPAddressDnsSettings(&other)
+	err := copied.AssignPropertiesToPublicIPAddressDnsSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1158,9 +1188,12 @@ func Test_PublicIPAddressDnsSettings_Status_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForPublicIPAddressDnsSettingsStatus tests if a specific instance of PublicIPAddressDnsSettings_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressDnsSettingsStatus(subject PublicIPAddressDnsSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddressDnsSettings_Status
-	err := subject.AssignPropertiesToPublicIPAddressDnsSettingsStatus(&other)
+	err := copied.AssignPropertiesToPublicIPAddressDnsSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1259,9 +1292,12 @@ func Test_PublicIPAddressSku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForPublicIPAddressSku tests if a specific instance of PublicIPAddressSku can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressSku(subject PublicIPAddressSku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddressSku
-	err := subject.AssignPropertiesToPublicIPAddressSku(&other)
+	err := copied.AssignPropertiesToPublicIPAddressSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1358,9 +1394,12 @@ func Test_PublicIPAddressSku_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForPublicIPAddressSkuStatus tests if a specific instance of PublicIPAddressSku_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressSkuStatus(subject PublicIPAddressSku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddressSku_Status
-	err := subject.AssignPropertiesToPublicIPAddressSkuStatus(&other)
+	err := copied.AssignPropertiesToPublicIPAddressSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1458,9 +1497,12 @@ func Test_NatGatewaySku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForNatGatewaySkuStatus tests if a specific instance of NatGatewaySku_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNatGatewaySkuStatus(subject NatGatewaySku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NatGatewaySku_Status
-	err := subject.AssignPropertiesToNatGatewaySkuStatus(&other)
+	err := copied.AssignPropertiesToNatGatewaySkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1557,9 +1599,12 @@ func Test_Subnet_Status_PublicIPAddress_SubResourceEmbedded_WhenPropertiesConver
 
 // RunPropertyAssignmentTestForSubnetStatusPublicIPAddressSubResourceEmbedded tests if a specific instance of Subnet_Status_PublicIPAddress_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubnetStatusPublicIPAddressSubResourceEmbedded(subject Subnet_Status_PublicIPAddress_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Subnet_Status_PublicIPAddress_SubResourceEmbedded
-	err := subject.AssignPropertiesToSubnetStatusPublicIPAddressSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSubnetStatusPublicIPAddressSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_gateway_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_VirtualNetworkGateway_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForVirtualNetworkGateway tests if a specific instance of VirtualNetworkGateway can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGateway(subject VirtualNetworkGateway) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGateway
-	err := subject.AssignPropertiesToVirtualNetworkGateway(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGateway(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_VirtualNetworkGateway_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewayStatus tests if a specific instance of VirtualNetworkGateway_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewayStatus(subject VirtualNetworkGateway_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGateway_Status
-	err := subject.AssignPropertiesToVirtualNetworkGatewayStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewayStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -270,9 +276,12 @@ func Test_VirtualNetworkGateways_Spec_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewaysSpec tests if a specific instance of VirtualNetworkGateways_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewaysSpec(subject VirtualNetworkGateways_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGateways_Spec
-	err := subject.AssignPropertiesToVirtualNetworkGatewaysSpec(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewaysSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -402,9 +411,12 @@ func Test_BgpSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForBgpSettings tests if a specific instance of BgpSettings can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForBgpSettings(subject BgpSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.BgpSettings
-	err := subject.AssignPropertiesToBgpSettings(&other)
+	err := copied.AssignPropertiesToBgpSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -516,9 +528,12 @@ func Test_BgpSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForBgpSettingsStatus tests if a specific instance of BgpSettings_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForBgpSettingsStatus(subject BgpSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.BgpSettings_Status
-	err := subject.AssignPropertiesToBgpSettingsStatus(&other)
+	err := copied.AssignPropertiesToBgpSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -630,9 +645,12 @@ func Test_VirtualNetworkGatewayIPConfiguration_Status_WhenPropertiesConverted_Ro
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewayIPConfigurationStatus tests if a specific instance of VirtualNetworkGatewayIPConfiguration_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewayIPConfigurationStatus(subject VirtualNetworkGatewayIPConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGatewayIPConfiguration_Status
-	err := subject.AssignPropertiesToVirtualNetworkGatewayIPConfigurationStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewayIPConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -753,9 +771,12 @@ func Test_VirtualNetworkGatewaySku_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewaySku tests if a specific instance of VirtualNetworkGatewaySku can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewaySku(subject VirtualNetworkGatewaySku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGatewaySku
-	err := subject.AssignPropertiesToVirtualNetworkGatewaySku(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewaySku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -887,9 +908,12 @@ func Test_VirtualNetworkGatewaySku_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewaySkuStatus tests if a specific instance of VirtualNetworkGatewaySku_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewaySkuStatus(subject VirtualNetworkGatewaySku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGatewaySku_Status
-	err := subject.AssignPropertiesToVirtualNetworkGatewaySkuStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewaySkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1022,9 +1046,12 @@ func Test_VirtualNetworkGateways_Spec_Properties_IpConfigurations_WhenProperties
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesIpConfigurations tests if a specific instance of VirtualNetworkGateways_Spec_Properties_IpConfigurations can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesIpConfigurations(subject VirtualNetworkGateways_Spec_Properties_IpConfigurations) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGateways_Spec_Properties_IpConfigurations
-	err := subject.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesIpConfigurations(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesIpConfigurations(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1137,9 +1164,12 @@ func Test_VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_WhenProp
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesVpnClientConfiguration tests if a specific instance of VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesVpnClientConfiguration(subject VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration
-	err := subject.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesVpnClientConfiguration(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesVpnClientConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1260,9 +1290,12 @@ func Test_VpnClientConfiguration_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForVpnClientConfigurationStatus tests if a specific instance of VpnClientConfiguration_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVpnClientConfigurationStatus(subject VpnClientConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VpnClientConfiguration_Status
-	err := subject.AssignPropertiesToVpnClientConfigurationStatus(&other)
+	err := copied.AssignPropertiesToVpnClientConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1383,9 +1416,12 @@ func Test_IPConfigurationBgpPeeringAddress_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForIPConfigurationBgpPeeringAddress tests if a specific instance of IPConfigurationBgpPeeringAddress can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIPConfigurationBgpPeeringAddress(subject IPConfigurationBgpPeeringAddress) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IPConfigurationBgpPeeringAddress
-	err := subject.AssignPropertiesToIPConfigurationBgpPeeringAddress(&other)
+	err := copied.AssignPropertiesToIPConfigurationBgpPeeringAddress(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1483,9 +1519,12 @@ func Test_IPConfigurationBgpPeeringAddress_Status_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForIPConfigurationBgpPeeringAddressStatus tests if a specific instance of IPConfigurationBgpPeeringAddress_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIPConfigurationBgpPeeringAddressStatus(subject IPConfigurationBgpPeeringAddress_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IPConfigurationBgpPeeringAddress_Status
-	err := subject.AssignPropertiesToIPConfigurationBgpPeeringAddressStatus(&other)
+	err := copied.AssignPropertiesToIPConfigurationBgpPeeringAddressStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1585,9 +1624,12 @@ func Test_IpsecPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForIpsecPolicy tests if a specific instance of IpsecPolicy can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIpsecPolicy(subject IpsecPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IpsecPolicy
-	err := subject.AssignPropertiesToIpsecPolicy(&other)
+	err := copied.AssignPropertiesToIpsecPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1735,9 +1777,12 @@ func Test_IpsecPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForIpsecPolicyStatus tests if a specific instance of IpsecPolicy_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIpsecPolicyStatus(subject IpsecPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IpsecPolicy_Status
-	err := subject.AssignPropertiesToIpsecPolicyStatus(&other)
+	err := copied.AssignPropertiesToIpsecPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1885,9 +1930,12 @@ func Test_RadiusServer_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForRadiusServer tests if a specific instance of RadiusServer can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForRadiusServer(subject RadiusServer) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.RadiusServer
-	err := subject.AssignPropertiesToRadiusServer(&other)
+	err := copied.AssignPropertiesToRadiusServer(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1985,9 +2033,12 @@ func Test_RadiusServer_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForRadiusServerStatus tests if a specific instance of RadiusServer_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForRadiusServerStatus(subject RadiusServer_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.RadiusServer_Status
-	err := subject.AssignPropertiesToRadiusServerStatus(&other)
+	err := copied.AssignPropertiesToRadiusServerStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2085,9 +2136,12 @@ func Test_VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClien
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRevokedCertificates tests if a specific instance of VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificates can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRevokedCertificates(subject VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificates) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificates
-	err := subject.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRevokedCertificates(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRevokedCertificates(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2186,9 +2240,12 @@ func Test_VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClien
 
 // RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRootCertificates tests if a specific instance of VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificates can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRootCertificates(subject VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificates) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificates
-	err := subject.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRootCertificates(&other)
+	err := copied.AssignPropertiesToVirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientRootCertificates(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2287,9 +2344,12 @@ func Test_VpnClientRevokedCertificate_Status_WhenPropertiesConverted_RoundTripsW
 
 // RunPropertyAssignmentTestForVpnClientRevokedCertificateStatus tests if a specific instance of VpnClientRevokedCertificate_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVpnClientRevokedCertificateStatus(subject VpnClientRevokedCertificate_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VpnClientRevokedCertificate_Status
-	err := subject.AssignPropertiesToVpnClientRevokedCertificateStatus(&other)
+	err := copied.AssignPropertiesToVpnClientRevokedCertificateStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2394,9 +2454,12 @@ func Test_VpnClientRootCertificate_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForVpnClientRootCertificateStatus tests if a specific instance of VpnClientRootCertificate_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVpnClientRootCertificateStatus(subject VpnClientRootCertificate_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VpnClientRootCertificate_Status
-	err := subject.AssignPropertiesToVpnClientRootCertificateStatus(&other)
+	err := copied.AssignPropertiesToVpnClientRootCertificateStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_network_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_VirtualNetwork_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForVirtualNetwork tests if a specific instance of VirtualNetwork can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetwork(subject VirtualNetwork) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetwork
-	err := subject.AssignPropertiesToVirtualNetwork(&other)
+	err := copied.AssignPropertiesToVirtualNetwork(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_VirtualNetwork_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForVirtualNetworkStatus tests if a specific instance of VirtualNetwork_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkStatus(subject VirtualNetwork_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetwork_Status
-	err := subject.AssignPropertiesToVirtualNetworkStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -263,9 +269,12 @@ func Test_VirtualNetworks_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForVirtualNetworksSpec tests if a specific instance of VirtualNetworks_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksSpec(subject VirtualNetworks_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworks_Spec
-	err := subject.AssignPropertiesToVirtualNetworksSpec(&other)
+	err := copied.AssignPropertiesToVirtualNetworksSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -386,9 +395,12 @@ func Test_AddressSpace_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForAddressSpace tests if a specific instance of AddressSpace can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForAddressSpace(subject AddressSpace) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.AddressSpace
-	err := subject.AssignPropertiesToAddressSpace(&other)
+	err := copied.AssignPropertiesToAddressSpace(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -484,9 +496,12 @@ func Test_AddressSpace_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForAddressSpaceStatus tests if a specific instance of AddressSpace_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForAddressSpaceStatus(subject AddressSpace_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.AddressSpace_Status
-	err := subject.AssignPropertiesToAddressSpaceStatus(&other)
+	err := copied.AssignPropertiesToAddressSpaceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -582,9 +597,12 @@ func Test_DhcpOptions_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForDhcpOptions tests if a specific instance of DhcpOptions can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForDhcpOptions(subject DhcpOptions) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.DhcpOptions
-	err := subject.AssignPropertiesToDhcpOptions(&other)
+	err := copied.AssignPropertiesToDhcpOptions(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -680,9 +698,12 @@ func Test_DhcpOptions_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForDhcpOptionsStatus tests if a specific instance of DhcpOptions_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForDhcpOptionsStatus(subject DhcpOptions_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.DhcpOptions_Status
-	err := subject.AssignPropertiesToDhcpOptionsStatus(&other)
+	err := copied.AssignPropertiesToDhcpOptionsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -778,9 +799,12 @@ func Test_Subnet_Status_VirtualNetwork_SubResourceEmbedded_WhenPropertiesConvert
 
 // RunPropertyAssignmentTestForSubnetStatusVirtualNetworkSubResourceEmbedded tests if a specific instance of Subnet_Status_VirtualNetwork_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubnetStatusVirtualNetworkSubResourceEmbedded(subject Subnet_Status_VirtualNetwork_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Subnet_Status_VirtualNetwork_SubResourceEmbedded
-	err := subject.AssignPropertiesToSubnetStatusVirtualNetworkSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSubnetStatusVirtualNetworkSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -877,9 +901,12 @@ func Test_VirtualNetworkBgpCommunities_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForVirtualNetworkBgpCommunities tests if a specific instance of VirtualNetworkBgpCommunities can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkBgpCommunities(subject VirtualNetworkBgpCommunities) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkBgpCommunities
-	err := subject.AssignPropertiesToVirtualNetworkBgpCommunities(&other)
+	err := copied.AssignPropertiesToVirtualNetworkBgpCommunities(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -976,9 +1003,12 @@ func Test_VirtualNetworkBgpCommunities_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForVirtualNetworkBgpCommunitiesStatus tests if a specific instance of VirtualNetworkBgpCommunities_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkBgpCommunitiesStatus(subject VirtualNetworkBgpCommunities_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkBgpCommunities_Status
-	err := subject.AssignPropertiesToVirtualNetworkBgpCommunitiesStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkBgpCommunitiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1076,9 +1106,12 @@ func Test_VirtualNetworkPeering_Status_SubResourceEmbedded_WhenPropertiesConvert
 
 // RunPropertyAssignmentTestForVirtualNetworkPeeringStatusSubResourceEmbedded tests if a specific instance of VirtualNetworkPeering_Status_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkPeeringStatusSubResourceEmbedded(subject VirtualNetworkPeering_Status_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkPeering_Status_SubResourceEmbedded
-	err := subject.AssignPropertiesToVirtualNetworkPeeringStatusSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToVirtualNetworkPeeringStatusSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1175,9 +1208,12 @@ func Test_VirtualNetworks_Spec_Properties_Subnets_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForVirtualNetworksSpecPropertiesSubnets tests if a specific instance of VirtualNetworks_Spec_Properties_Subnets can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksSpecPropertiesSubnets(subject VirtualNetworks_Spec_Properties_Subnets) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworks_Spec_Properties_Subnets
-	err := subject.AssignPropertiesToVirtualNetworksSpecPropertiesSubnets(&other)
+	err := copied.AssignPropertiesToVirtualNetworksSpecPropertiesSubnets(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1298,9 +1334,12 @@ func Test_VirtualNetworks_Spec_Properties_Subnets_Properties_Delegations_WhenPro
 
 // RunPropertyAssignmentTestForVirtualNetworksSpecPropertiesSubnetsPropertiesDelegations tests if a specific instance of VirtualNetworks_Spec_Properties_Subnets_Properties_Delegations can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksSpecPropertiesSubnetsPropertiesDelegations(subject VirtualNetworks_Spec_Properties_Subnets_Properties_Delegations) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworks_Spec_Properties_Subnets_Properties_Delegations
-	err := subject.AssignPropertiesToVirtualNetworksSpecPropertiesSubnetsPropertiesDelegations(&other)
+	err := copied.AssignPropertiesToVirtualNetworksSpecPropertiesSubnetsPropertiesDelegations(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_subnet_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_VirtualNetworksSubnet_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForVirtualNetworksSubnet tests if a specific instance of VirtualNetworksSubnet can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksSubnet(subject VirtualNetworksSubnet) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworksSubnet
-	err := subject.AssignPropertiesToVirtualNetworksSubnet(&other)
+	err := copied.AssignPropertiesToVirtualNetworksSubnet(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded_WhenProperties
 
 // RunPropertyAssignmentTestForSubnetStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForSubnetStatusVirtualNetworksSubnetSubResourceEmbedded(subject Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToSubnetStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSubnetStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -269,9 +275,12 @@ func Test_VirtualNetworksSubnets_Spec_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForVirtualNetworksSubnetsSpec tests if a specific instance of VirtualNetworksSubnets_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksSubnetsSpec(subject VirtualNetworksSubnets_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworksSubnets_Spec
-	err := subject.AssignPropertiesToVirtualNetworksSubnetsSpec(&other)
+	err := copied.AssignPropertiesToVirtualNetworksSubnetsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -394,9 +403,12 @@ func Test_ApplicationGatewayIPConfiguration_Status_WhenPropertiesConverted_Round
 
 // RunPropertyAssignmentTestForApplicationGatewayIPConfigurationStatus tests if a specific instance of ApplicationGatewayIPConfiguration_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForApplicationGatewayIPConfigurationStatus(subject ApplicationGatewayIPConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ApplicationGatewayIPConfiguration_Status
-	err := subject.AssignPropertiesToApplicationGatewayIPConfigurationStatus(&other)
+	err := copied.AssignPropertiesToApplicationGatewayIPConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -515,9 +527,12 @@ func Test_Delegation_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForDelegationStatus tests if a specific instance of Delegation_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForDelegationStatus(subject Delegation_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.Delegation_Status
-	err := subject.AssignPropertiesToDelegationStatus(&other)
+	err := copied.AssignPropertiesToDelegationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -623,9 +638,12 @@ func Test_IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedde
 
 // RunPropertyAssignmentTestForIPConfigurationProfileStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIPConfigurationProfileStatusVirtualNetworksSubnetSubResourceEmbedded(subject IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToIPConfigurationProfileStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToIPConfigurationProfileStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -730,9 +748,12 @@ func Test_IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded_WhenP
 
 // RunPropertyAssignmentTestForIPConfigurationStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForIPConfigurationStatusVirtualNetworksSubnetSubResourceEmbedded(subject IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToIPConfigurationStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToIPConfigurationStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -852,9 +873,12 @@ func Test_NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded_
 
 // RunPropertyAssignmentTestForNetworkSecurityGroupStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForNetworkSecurityGroupStatusVirtualNetworksSubnetSubResourceEmbedded(subject NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToNetworkSecurityGroupStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToNetworkSecurityGroupStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -951,9 +975,12 @@ func Test_PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded_WhenP
 
 // RunPropertyAssignmentTestForPrivateEndpointStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointStatusVirtualNetworksSubnetSubResourceEmbedded(subject PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1064,9 +1091,12 @@ func Test_ResourceNavigationLink_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForResourceNavigationLinkStatus tests if a specific instance of ResourceNavigationLink_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForResourceNavigationLinkStatus(subject ResourceNavigationLink_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ResourceNavigationLink_Status
-	err := subject.AssignPropertiesToResourceNavigationLinkStatus(&other)
+	err := copied.AssignPropertiesToResourceNavigationLinkStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1173,9 +1203,12 @@ func Test_RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded_WhenProper
 
 // RunPropertyAssignmentTestForRouteTableStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForRouteTableStatusVirtualNetworksSubnetSubResourceEmbedded(subject RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToRouteTableStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToRouteTableStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1272,9 +1305,12 @@ func Test_ServiceAssociationLink_Status_WhenPropertiesConverted_RoundTripsWithou
 
 // RunPropertyAssignmentTestForServiceAssociationLinkStatus tests if a specific instance of ServiceAssociationLink_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForServiceAssociationLinkStatus(subject ServiceAssociationLink_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ServiceAssociationLink_Status
-	err := subject.AssignPropertiesToServiceAssociationLinkStatus(&other)
+	err := copied.AssignPropertiesToServiceAssociationLinkStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1383,9 +1419,12 @@ func Test_ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded
 
 // RunPropertyAssignmentTestForServiceEndpointPolicyStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForServiceEndpointPolicyStatusVirtualNetworksSubnetSubResourceEmbedded(subject ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToServiceEndpointPolicyStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToServiceEndpointPolicyStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1483,9 +1522,12 @@ func Test_ServiceEndpointPropertiesFormat_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForServiceEndpointPropertiesFormat tests if a specific instance of ServiceEndpointPropertiesFormat can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForServiceEndpointPropertiesFormat(subject ServiceEndpointPropertiesFormat) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ServiceEndpointPropertiesFormat
-	err := subject.AssignPropertiesToServiceEndpointPropertiesFormat(&other)
+	err := copied.AssignPropertiesToServiceEndpointPropertiesFormat(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1583,9 +1625,12 @@ func Test_ServiceEndpointPropertiesFormat_Status_WhenPropertiesConverted_RoundTr
 
 // RunPropertyAssignmentTestForServiceEndpointPropertiesFormatStatus tests if a specific instance of ServiceEndpointPropertiesFormat_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForServiceEndpointPropertiesFormatStatus(subject ServiceEndpointPropertiesFormat_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.ServiceEndpointPropertiesFormat_Status
-	err := subject.AssignPropertiesToServiceEndpointPropertiesFormatStatus(&other)
+	err := copied.AssignPropertiesToServiceEndpointPropertiesFormatStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1688,9 +1733,12 @@ func Test_VirtualNetworksSubnets_Spec_Properties_Delegations_WhenPropertiesConve
 
 // RunPropertyAssignmentTestForVirtualNetworksSubnetsSpecPropertiesDelegations tests if a specific instance of VirtualNetworksSubnets_Spec_Properties_Delegations can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksSubnetsSpecPropertiesDelegations(subject VirtualNetworksSubnets_Spec_Properties_Delegations) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworksSubnets_Spec_Properties_Delegations
-	err := subject.AssignPropertiesToVirtualNetworksSubnetsSpecPropertiesDelegations(&other)
+	err := copied.AssignPropertiesToVirtualNetworksSubnetsSpecPropertiesDelegations(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1788,9 +1836,12 @@ func Test_PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded_WhenP
 
 // RunPropertyAssignmentTestForPublicIPAddressStatusVirtualNetworksSubnetSubResourceEmbedded tests if a specific instance of PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForPublicIPAddressStatusVirtualNetworksSubnetSubResourceEmbedded(subject PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded
-	err := subject.AssignPropertiesToPublicIPAddressStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPublicIPAddressStatusVirtualNetworksSubnetSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen_test.go
+++ b/v2/api/microsoft.network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_VirtualNetworksVirtualNetworkPeering_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForVirtualNetworksVirtualNetworkPeering tests if a specific instance of VirtualNetworksVirtualNetworkPeering can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksVirtualNetworkPeering(subject VirtualNetworksVirtualNetworkPeering) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeering
-	err := subject.AssignPropertiesToVirtualNetworksVirtualNetworkPeering(&other)
+	err := copied.AssignPropertiesToVirtualNetworksVirtualNetworkPeering(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_VirtualNetworkPeering_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForVirtualNetworkPeeringStatus tests if a specific instance of VirtualNetworkPeering_Status can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkPeeringStatus(subject VirtualNetworkPeering_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworkPeering_Status
-	err := subject.AssignPropertiesToVirtualNetworkPeeringStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkPeeringStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -261,9 +267,12 @@ func Test_VirtualNetworksVirtualNetworkPeerings_Spec_WhenPropertiesConverted_Rou
 
 // RunPropertyAssignmentTestForVirtualNetworksVirtualNetworkPeeringsSpec tests if a specific instance of VirtualNetworksVirtualNetworkPeerings_Spec can be assigned to v1alpha1api20201101storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworksVirtualNetworkPeeringsSpec(subject VirtualNetworksVirtualNetworkPeerings_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeerings_Spec
-	err := subject.AssignPropertiesToVirtualNetworksVirtualNetworkPeeringsSpec(&other)
+	err := copied.AssignPropertiesToVirtualNetworksVirtualNetworkPeeringsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespace_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_Namespace_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) 
 
 // RunPropertyAssignmentTestForNamespace tests if a specific instance of Namespace can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForNamespace(subject Namespace) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.Namespace
-	err := subject.AssignPropertiesToNamespace(&other)
+	err := copied.AssignPropertiesToNamespace(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_Namespaces_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForNamespacesSpec tests if a specific instance of Namespaces_Spec can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForNamespacesSpec(subject Namespaces_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.Namespaces_Spec
-	err := subject.AssignPropertiesToNamespacesSpec(&other)
+	err := copied.AssignPropertiesToNamespacesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -247,9 +253,12 @@ func Test_SBNamespace_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSBNamespaceStatus tests if a specific instance of SBNamespace_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForSBNamespaceStatus(subject SBNamespace_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.SBNamespace_Status
-	err := subject.AssignPropertiesToSBNamespaceStatus(&other)
+	err := copied.AssignPropertiesToSBNamespaceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -374,9 +383,12 @@ func Test_Encryption_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForEncryption tests if a specific instance of Encryption can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForEncryption(subject Encryption) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.Encryption
-	err := subject.AssignPropertiesToEncryption(&other)
+	err := copied.AssignPropertiesToEncryption(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -487,9 +499,12 @@ func Test_Encryption_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForEncryptionStatus tests if a specific instance of Encryption_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForEncryptionStatus(subject Encryption_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.Encryption_Status
-	err := subject.AssignPropertiesToEncryptionStatus(&other)
+	err := copied.AssignPropertiesToEncryptionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -600,9 +615,12 @@ func Test_Identity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForIdentity tests if a specific instance of Identity can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForIdentity(subject Identity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.Identity
-	err := subject.AssignPropertiesToIdentity(&other)
+	err := copied.AssignPropertiesToIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -702,9 +720,12 @@ func Test_Identity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForIdentityStatus tests if a specific instance of Identity_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForIdentityStatus(subject Identity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.Identity_Status
-	err := subject.AssignPropertiesToIdentityStatus(&other)
+	err := copied.AssignPropertiesToIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -820,9 +841,12 @@ func Test_PrivateEndpointConnection_Status_SubResourceEmbedded_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded tests if a specific instance of PrivateEndpointConnection_Status_SubResourceEmbedded can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded(subject PrivateEndpointConnection_Status_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.PrivateEndpointConnection_Status_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -933,9 +957,12 @@ func Test_SBSku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForSBSku tests if a specific instance of SBSku can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForSBSku(subject SBSku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.SBSku
-	err := subject.AssignPropertiesToSBSku(&other)
+	err := copied.AssignPropertiesToSBSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1033,9 +1060,12 @@ func Test_SBSku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForSBSkuStatus tests if a specific instance of SBSku_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForSBSkuStatus(subject SBSku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.SBSku_Status
-	err := subject.AssignPropertiesToSBSkuStatus(&other)
+	err := copied.AssignPropertiesToSBSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1133,9 +1163,12 @@ func Test_SystemData_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForSystemDataStatus tests if a specific instance of SystemData_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForSystemDataStatus(subject SystemData_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.SystemData_Status
-	err := subject.AssignPropertiesToSystemDataStatus(&other)
+	err := copied.AssignPropertiesToSystemDataStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1244,9 +1277,12 @@ func Test_DictionaryValue_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForDictionaryValueStatus tests if a specific instance of DictionaryValue_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForDictionaryValueStatus(subject DictionaryValue_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.DictionaryValue_Status
-	err := subject.AssignPropertiesToDictionaryValueStatus(&other)
+	err := copied.AssignPropertiesToDictionaryValueStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1344,9 +1380,12 @@ func Test_KeyVaultProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForKeyVaultProperties tests if a specific instance of KeyVaultProperties can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultProperties(subject KeyVaultProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.KeyVaultProperties
-	err := subject.AssignPropertiesToKeyVaultProperties(&other)
+	err := copied.AssignPropertiesToKeyVaultProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1458,9 +1497,12 @@ func Test_KeyVaultProperties_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForKeyVaultPropertiesStatus tests if a specific instance of KeyVaultProperties_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultPropertiesStatus(subject KeyVaultProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.KeyVaultProperties_Status
-	err := subject.AssignPropertiesToKeyVaultPropertiesStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1573,9 +1615,12 @@ func Test_UserAssignedIdentityProperties_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForUserAssignedIdentityProperties tests if a specific instance of UserAssignedIdentityProperties can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityProperties(subject UserAssignedIdentityProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.UserAssignedIdentityProperties
-	err := subject.AssignPropertiesToUserAssignedIdentityProperties(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1666,9 +1711,12 @@ func Test_UserAssignedIdentityProperties_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForUserAssignedIdentityPropertiesStatus tests if a specific instance of UserAssignedIdentityProperties_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityPropertiesStatus(subject UserAssignedIdentityProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.UserAssignedIdentityProperties_Status
-	err := subject.AssignPropertiesToUserAssignedIdentityPropertiesStatus(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NamespacesQueue_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForNamespacesQueue tests if a specific instance of NamespacesQueue can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForNamespacesQueue(subject NamespacesQueue) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.NamespacesQueue
-	err := subject.AssignPropertiesToNamespacesQueue(&other)
+	err := copied.AssignPropertiesToNamespacesQueue(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_NamespacesQueues_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForNamespacesQueuesSpec tests if a specific instance of NamespacesQueues_Spec can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForNamespacesQueuesSpec(subject NamespacesQueues_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.NamespacesQueues_Spec
-	err := subject.AssignPropertiesToNamespacesQueuesSpec(&other)
+	err := copied.AssignPropertiesToNamespacesQueuesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -245,9 +251,12 @@ func Test_SBQueue_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForSBQueueStatus tests if a specific instance of SBQueue_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForSBQueueStatus(subject SBQueue_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.SBQueue_Status
-	err := subject.AssignPropertiesToSBQueueStatus(&other)
+	err := copied.AssignPropertiesToSBQueueStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -389,9 +398,12 @@ func Test_MessageCountDetails_Status_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForMessageCountDetailsStatus tests if a specific instance of MessageCountDetails_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForMessageCountDetailsStatus(subject MessageCountDetails_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.MessageCountDetails_Status
-	err := subject.AssignPropertiesToMessageCountDetailsStatus(&other)
+	err := copied.AssignPropertiesToMessageCountDetailsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen_test.go
+++ b/v2/api/microsoft.servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_NamespacesTopic_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForNamespacesTopic tests if a specific instance of NamespacesTopic can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForNamespacesTopic(subject NamespacesTopic) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.NamespacesTopic
-	err := subject.AssignPropertiesToNamespacesTopic(&other)
+	err := copied.AssignPropertiesToNamespacesTopic(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_NamespacesTopics_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForNamespacesTopicsSpec tests if a specific instance of NamespacesTopics_Spec can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForNamespacesTopicsSpec(subject NamespacesTopics_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.NamespacesTopics_Spec
-	err := subject.AssignPropertiesToNamespacesTopicsSpec(&other)
+	err := copied.AssignPropertiesToNamespacesTopicsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -240,9 +246,12 @@ func Test_SBTopic_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForSBTopicStatus tests if a specific instance of SBTopic_Status can be assigned to v1alpha1api20210101previewstorage and back losslessly
 func RunPropertyAssignmentTestForSBTopicStatus(subject SBTopic_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210101previewstorage.SBTopic_Status
-	err := subject.AssignPropertiesToSBTopicStatus(&other)
+	err := copied.AssignPropertiesToSBTopicStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.signalrservice/v1alpha1api20211001/signal_r_types_gen_test.go
+++ b/v2/api/microsoft.signalrservice/v1alpha1api20211001/signal_r_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_SignalR_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForSignalR tests if a specific instance of SignalR can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalR(subject SignalR) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalR
-	err := subject.AssignPropertiesToSignalR(&other)
+	err := copied.AssignPropertiesToSignalR(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_SignalRResource_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForSignalRResourceStatus tests if a specific instance of SignalRResource_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRResourceStatus(subject SignalRResource_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRResource_Status
-	err := subject.AssignPropertiesToSignalRResourceStatus(&other)
+	err := copied.AssignPropertiesToSignalRResourceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -277,9 +283,12 @@ func Test_SignalR_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForSignalRSpec tests if a specific instance of SignalR_Spec can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRSpec(subject SignalR_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalR_Spec
-	err := subject.AssignPropertiesToSignalRSpec(&other)
+	err := copied.AssignPropertiesToSignalRSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -402,9 +411,12 @@ func Test_ManagedIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForManagedIdentity tests if a specific instance of ManagedIdentity can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForManagedIdentity(subject ManagedIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ManagedIdentity
-	err := subject.AssignPropertiesToManagedIdentity(&other)
+	err := copied.AssignPropertiesToManagedIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -500,9 +512,12 @@ func Test_ManagedIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForManagedIdentityStatus tests if a specific instance of ManagedIdentity_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForManagedIdentityStatus(subject ManagedIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ManagedIdentity_Status
-	err := subject.AssignPropertiesToManagedIdentityStatus(&other)
+	err := copied.AssignPropertiesToManagedIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -615,9 +630,12 @@ func Test_PrivateEndpointConnection_Status_SignalR_SubResourceEmbedded_WhenPrope
 
 // RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSignalRSubResourceEmbedded tests if a specific instance of PrivateEndpointConnection_Status_SignalR_SubResourceEmbedded can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSignalRSubResourceEmbedded(subject PrivateEndpointConnection_Status_SignalR_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.PrivateEndpointConnection_Status_SignalR_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointConnectionStatusSignalRSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointConnectionStatusSignalRSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -728,9 +746,12 @@ func Test_ResourceLogConfiguration_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForResourceLogConfiguration tests if a specific instance of ResourceLogConfiguration can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForResourceLogConfiguration(subject ResourceLogConfiguration) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ResourceLogConfiguration
-	err := subject.AssignPropertiesToResourceLogConfiguration(&other)
+	err := copied.AssignPropertiesToResourceLogConfiguration(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -827,9 +848,12 @@ func Test_ResourceLogConfiguration_Status_WhenPropertiesConverted_RoundTripsWith
 
 // RunPropertyAssignmentTestForResourceLogConfigurationStatus tests if a specific instance of ResourceLogConfiguration_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForResourceLogConfigurationStatus(subject ResourceLogConfiguration_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ResourceLogConfiguration_Status
-	err := subject.AssignPropertiesToResourceLogConfigurationStatus(&other)
+	err := copied.AssignPropertiesToResourceLogConfigurationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -926,9 +950,12 @@ func Test_ResourceSku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T
 
 // RunPropertyAssignmentTestForResourceSku tests if a specific instance of ResourceSku can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForResourceSku(subject ResourceSku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ResourceSku
-	err := subject.AssignPropertiesToResourceSku(&other)
+	err := copied.AssignPropertiesToResourceSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1030,9 +1057,12 @@ func Test_ResourceSku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForResourceSkuStatus tests if a specific instance of ResourceSku_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForResourceSkuStatus(subject ResourceSku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ResourceSku_Status
-	err := subject.AssignPropertiesToResourceSkuStatus(&other)
+	err := copied.AssignPropertiesToResourceSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1136,9 +1166,12 @@ func Test_ServerlessUpstreamSettings_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForServerlessUpstreamSettings tests if a specific instance of ServerlessUpstreamSettings can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForServerlessUpstreamSettings(subject ServerlessUpstreamSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ServerlessUpstreamSettings
-	err := subject.AssignPropertiesToServerlessUpstreamSettings(&other)
+	err := copied.AssignPropertiesToServerlessUpstreamSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1235,9 +1268,12 @@ func Test_ServerlessUpstreamSettings_Status_WhenPropertiesConverted_RoundTripsWi
 
 // RunPropertyAssignmentTestForServerlessUpstreamSettingsStatus tests if a specific instance of ServerlessUpstreamSettings_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForServerlessUpstreamSettingsStatus(subject ServerlessUpstreamSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ServerlessUpstreamSettings_Status
-	err := subject.AssignPropertiesToServerlessUpstreamSettingsStatus(&other)
+	err := copied.AssignPropertiesToServerlessUpstreamSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1334,9 +1370,12 @@ func Test_SharedPrivateLinkResource_Status_SignalR_SubResourceEmbedded_WhenPrope
 
 // RunPropertyAssignmentTestForSharedPrivateLinkResourceStatusSignalRSubResourceEmbedded tests if a specific instance of SharedPrivateLinkResource_Status_SignalR_SubResourceEmbedded can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSharedPrivateLinkResourceStatusSignalRSubResourceEmbedded(subject SharedPrivateLinkResource_Status_SignalR_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SharedPrivateLinkResource_Status_SignalR_SubResourceEmbedded
-	err := subject.AssignPropertiesToSharedPrivateLinkResourceStatusSignalRSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToSharedPrivateLinkResourceStatusSignalRSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1447,9 +1486,12 @@ func Test_SignalRCorsSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForSignalRCorsSettings tests if a specific instance of SignalRCorsSettings can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRCorsSettings(subject SignalRCorsSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRCorsSettings
-	err := subject.AssignPropertiesToSignalRCorsSettings(&other)
+	err := copied.AssignPropertiesToSignalRCorsSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1546,9 +1588,12 @@ func Test_SignalRCorsSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForSignalRCorsSettingsStatus tests if a specific instance of SignalRCorsSettings_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRCorsSettingsStatus(subject SignalRCorsSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRCorsSettings_Status
-	err := subject.AssignPropertiesToSignalRCorsSettingsStatus(&other)
+	err := copied.AssignPropertiesToSignalRCorsSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1645,9 +1690,12 @@ func Test_SignalRFeature_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForSignalRFeature tests if a specific instance of SignalRFeature can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRFeature(subject SignalRFeature) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRFeature
-	err := subject.AssignPropertiesToSignalRFeature(&other)
+	err := copied.AssignPropertiesToSignalRFeature(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1749,9 +1797,12 @@ func Test_SignalRFeature_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForSignalRFeatureStatus tests if a specific instance of SignalRFeature_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRFeatureStatus(subject SignalRFeature_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRFeature_Status
-	err := subject.AssignPropertiesToSignalRFeatureStatus(&other)
+	err := copied.AssignPropertiesToSignalRFeatureStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1854,9 +1905,12 @@ func Test_SignalRNetworkACLs_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSignalRNetworkACLs tests if a specific instance of SignalRNetworkACLs can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRNetworkACLs(subject SignalRNetworkACLs) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRNetworkACLs
-	err := subject.AssignPropertiesToSignalRNetworkACLs(&other)
+	err := copied.AssignPropertiesToSignalRNetworkACLs(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1967,9 +2021,12 @@ func Test_SignalRNetworkACLs_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForSignalRNetworkACLsStatus tests if a specific instance of SignalRNetworkACLs_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRNetworkACLsStatus(subject SignalRNetworkACLs_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRNetworkACLs_Status
-	err := subject.AssignPropertiesToSignalRNetworkACLsStatus(&other)
+	err := copied.AssignPropertiesToSignalRNetworkACLsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2081,9 +2138,12 @@ func Test_SignalRTlsSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForSignalRTlsSettings tests if a specific instance of SignalRTlsSettings can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRTlsSettings(subject SignalRTlsSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRTlsSettings
-	err := subject.AssignPropertiesToSignalRTlsSettings(&other)
+	err := copied.AssignPropertiesToSignalRTlsSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2179,9 +2239,12 @@ func Test_SignalRTlsSettings_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForSignalRTlsSettingsStatus tests if a specific instance of SignalRTlsSettings_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSignalRTlsSettingsStatus(subject SignalRTlsSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SignalRTlsSettings_Status
-	err := subject.AssignPropertiesToSignalRTlsSettingsStatus(&other)
+	err := copied.AssignPropertiesToSignalRTlsSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2278,9 +2341,12 @@ func Test_SystemData_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForSystemDataStatus tests if a specific instance of SystemData_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForSystemDataStatus(subject SystemData_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.SystemData_Status
-	err := subject.AssignPropertiesToSystemDataStatus(&other)
+	err := copied.AssignPropertiesToSystemDataStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2389,9 +2455,12 @@ func Test_NetworkACL_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForNetworkACL tests if a specific instance of NetworkACL can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForNetworkACL(subject NetworkACL) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.NetworkACL
-	err := subject.AssignPropertiesToNetworkACL(&other)
+	err := copied.AssignPropertiesToNetworkACL(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2496,9 +2565,12 @@ func Test_NetworkACL_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForNetworkACLStatus tests if a specific instance of NetworkACL_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForNetworkACLStatus(subject NetworkACL_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.NetworkACL_Status
-	err := subject.AssignPropertiesToNetworkACLStatus(&other)
+	err := copied.AssignPropertiesToNetworkACLStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2603,9 +2675,12 @@ func Test_PrivateEndpointACL_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForPrivateEndpointACL tests if a specific instance of PrivateEndpointACL can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointACL(subject PrivateEndpointACL) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.PrivateEndpointACL
-	err := subject.AssignPropertiesToPrivateEndpointACL(&other)
+	err := copied.AssignPropertiesToPrivateEndpointACL(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2711,9 +2786,12 @@ func Test_PrivateEndpointACL_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForPrivateEndpointACLStatus tests if a specific instance of PrivateEndpointACL_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointACLStatus(subject PrivateEndpointACL_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.PrivateEndpointACL_Status
-	err := subject.AssignPropertiesToPrivateEndpointACLStatus(&other)
+	err := copied.AssignPropertiesToPrivateEndpointACLStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2820,9 +2898,12 @@ func Test_ResourceLogCategory_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForResourceLogCategory tests if a specific instance of ResourceLogCategory can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForResourceLogCategory(subject ResourceLogCategory) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ResourceLogCategory
-	err := subject.AssignPropertiesToResourceLogCategory(&other)
+	err := copied.AssignPropertiesToResourceLogCategory(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2920,9 +3001,12 @@ func Test_ResourceLogCategory_Status_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForResourceLogCategoryStatus tests if a specific instance of ResourceLogCategory_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForResourceLogCategoryStatus(subject ResourceLogCategory_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ResourceLogCategory_Status
-	err := subject.AssignPropertiesToResourceLogCategoryStatus(&other)
+	err := copied.AssignPropertiesToResourceLogCategoryStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3020,9 +3104,12 @@ func Test_UpstreamTemplate_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForUpstreamTemplate tests if a specific instance of UpstreamTemplate can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForUpstreamTemplate(subject UpstreamTemplate) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.UpstreamTemplate
-	err := subject.AssignPropertiesToUpstreamTemplate(&other)
+	err := copied.AssignPropertiesToUpstreamTemplate(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3135,9 +3222,12 @@ func Test_UpstreamTemplate_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForUpstreamTemplateStatus tests if a specific instance of UpstreamTemplate_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForUpstreamTemplateStatus(subject UpstreamTemplate_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.UpstreamTemplate_Status
-	err := subject.AssignPropertiesToUpstreamTemplateStatus(&other)
+	err := copied.AssignPropertiesToUpstreamTemplateStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3251,9 +3341,12 @@ func Test_UserAssignedIdentityProperty_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForUserAssignedIdentityPropertyStatus tests if a specific instance of UserAssignedIdentityProperty_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityPropertyStatus(subject UserAssignedIdentityProperty_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.UserAssignedIdentityProperty_Status
-	err := subject.AssignPropertiesToUserAssignedIdentityPropertyStatus(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityPropertyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3351,9 +3444,12 @@ func Test_UpstreamAuthSettings_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForUpstreamAuthSettings tests if a specific instance of UpstreamAuthSettings can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForUpstreamAuthSettings(subject UpstreamAuthSettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.UpstreamAuthSettings
-	err := subject.AssignPropertiesToUpstreamAuthSettings(&other)
+	err := copied.AssignPropertiesToUpstreamAuthSettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3464,9 +3560,12 @@ func Test_UpstreamAuthSettings_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForUpstreamAuthSettingsStatus tests if a specific instance of UpstreamAuthSettings_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForUpstreamAuthSettingsStatus(subject UpstreamAuthSettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.UpstreamAuthSettings_Status
-	err := subject.AssignPropertiesToUpstreamAuthSettingsStatus(&other)
+	err := copied.AssignPropertiesToUpstreamAuthSettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3577,9 +3676,12 @@ func Test_ManagedIdentitySettings_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForManagedIdentitySettings tests if a specific instance of ManagedIdentitySettings can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForManagedIdentitySettings(subject ManagedIdentitySettings) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ManagedIdentitySettings
-	err := subject.AssignPropertiesToManagedIdentitySettings(&other)
+	err := copied.AssignPropertiesToManagedIdentitySettings(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3676,9 +3778,12 @@ func Test_ManagedIdentitySettings_Status_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForManagedIdentitySettingsStatus tests if a specific instance of ManagedIdentitySettings_Status can be assigned to v1alpha1api20211001storage and back losslessly
 func RunPropertyAssignmentTestForManagedIdentitySettingsStatus(subject ManagedIdentitySettings_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20211001storage.ManagedIdentitySettings_Status
-	err := subject.AssignPropertiesToManagedIdentitySettingsStatus(&other)
+	err := copied.AssignPropertiesToManagedIdentitySettingsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_account_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_StorageAccount_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForStorageAccount tests if a specific instance of StorageAccount can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccount(subject StorageAccount) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccount
-	err := subject.AssignPropertiesToStorageAccount(&other)
+	err := copied.AssignPropertiesToStorageAccount(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -130,9 +133,12 @@ func Test_StorageAccount_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForStorageAccountStatus tests if a specific instance of StorageAccount_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountStatus(subject StorageAccount_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccount_Status
-	err := subject.AssignPropertiesToStorageAccountStatus(&other)
+	err := copied.AssignPropertiesToStorageAccountStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -285,9 +291,12 @@ func Test_StorageAccounts_Spec_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForStorageAccountsSpec tests if a specific instance of StorageAccounts_Spec can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountsSpec(subject StorageAccounts_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccounts_Spec
-	err := subject.AssignPropertiesToStorageAccountsSpec(&other)
+	err := copied.AssignPropertiesToStorageAccountsSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -424,9 +433,12 @@ func Test_AzureFilesIdentityBasedAuthentication_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForAzureFilesIdentityBasedAuthentication tests if a specific instance of AzureFilesIdentityBasedAuthentication can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForAzureFilesIdentityBasedAuthentication(subject AzureFilesIdentityBasedAuthentication) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.AzureFilesIdentityBasedAuthentication
-	err := subject.AssignPropertiesToAzureFilesIdentityBasedAuthentication(&other)
+	err := copied.AssignPropertiesToAzureFilesIdentityBasedAuthentication(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -543,9 +555,12 @@ func Test_AzureFilesIdentityBasedAuthentication_Status_WhenPropertiesConverted_R
 
 // RunPropertyAssignmentTestForAzureFilesIdentityBasedAuthenticationStatus tests if a specific instance of AzureFilesIdentityBasedAuthentication_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForAzureFilesIdentityBasedAuthenticationStatus(subject AzureFilesIdentityBasedAuthentication_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.AzureFilesIdentityBasedAuthentication_Status
-	err := subject.AssignPropertiesToAzureFilesIdentityBasedAuthenticationStatus(&other)
+	err := copied.AssignPropertiesToAzureFilesIdentityBasedAuthenticationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -662,9 +677,12 @@ func Test_BlobRestoreStatus_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForBlobRestoreStatusStatus tests if a specific instance of BlobRestoreStatus_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForBlobRestoreStatusStatus(subject BlobRestoreStatus_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.BlobRestoreStatus_Status
-	err := subject.AssignPropertiesToBlobRestoreStatusStatus(&other)
+	err := copied.AssignPropertiesToBlobRestoreStatusStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -777,9 +795,12 @@ func Test_CustomDomain_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.
 
 // RunPropertyAssignmentTestForCustomDomain tests if a specific instance of CustomDomain can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForCustomDomain(subject CustomDomain) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.CustomDomain
-	err := subject.AssignPropertiesToCustomDomain(&other)
+	err := copied.AssignPropertiesToCustomDomain(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -876,9 +897,12 @@ func Test_CustomDomain_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *t
 
 // RunPropertyAssignmentTestForCustomDomainStatus tests if a specific instance of CustomDomain_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForCustomDomainStatus(subject CustomDomain_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.CustomDomain_Status
-	err := subject.AssignPropertiesToCustomDomainStatus(&other)
+	err := copied.AssignPropertiesToCustomDomainStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -975,9 +999,12 @@ func Test_Encryption_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForEncryption tests if a specific instance of Encryption can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryption(subject Encryption) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.Encryption
-	err := subject.AssignPropertiesToEncryption(&other)
+	err := copied.AssignPropertiesToEncryption(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1090,9 +1117,12 @@ func Test_Encryption_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForEncryptionStatus tests if a specific instance of Encryption_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionStatus(subject Encryption_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.Encryption_Status
-	err := subject.AssignPropertiesToEncryptionStatus(&other)
+	err := copied.AssignPropertiesToEncryptionStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1205,9 +1235,12 @@ func Test_Endpoints_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForEndpointsStatus tests if a specific instance of Endpoints_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEndpointsStatus(subject Endpoints_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.Endpoints_Status
-	err := subject.AssignPropertiesToEndpointsStatus(&other)
+	err := copied.AssignPropertiesToEndpointsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1323,9 +1356,12 @@ func Test_ExtendedLocation_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForExtendedLocation tests if a specific instance of ExtendedLocation can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocation(subject ExtendedLocation) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ExtendedLocation
-	err := subject.AssignPropertiesToExtendedLocation(&other)
+	err := copied.AssignPropertiesToExtendedLocation(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1422,9 +1458,12 @@ func Test_ExtendedLocation_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForExtendedLocationStatus tests if a specific instance of ExtendedLocation_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForExtendedLocationStatus(subject ExtendedLocation_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ExtendedLocation_Status
-	err := subject.AssignPropertiesToExtendedLocationStatus(&other)
+	err := copied.AssignPropertiesToExtendedLocationStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1522,9 +1561,12 @@ func Test_GeoReplicationStats_Status_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForGeoReplicationStatsStatus tests if a specific instance of GeoReplicationStats_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForGeoReplicationStatsStatus(subject GeoReplicationStats_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.GeoReplicationStats_Status
-	err := subject.AssignPropertiesToGeoReplicationStatsStatus(&other)
+	err := copied.AssignPropertiesToGeoReplicationStatsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1623,9 +1665,12 @@ func Test_Identity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForIdentity tests if a specific instance of Identity can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForIdentity(subject Identity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.Identity
-	err := subject.AssignPropertiesToIdentity(&other)
+	err := copied.AssignPropertiesToIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1725,9 +1770,12 @@ func Test_Identity_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForIdentityStatus tests if a specific instance of Identity_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForIdentityStatus(subject Identity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.Identity_Status
-	err := subject.AssignPropertiesToIdentityStatus(&other)
+	err := copied.AssignPropertiesToIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1843,9 +1891,12 @@ func Test_KeyCreationTime_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t
 
 // RunPropertyAssignmentTestForKeyCreationTimeStatus tests if a specific instance of KeyCreationTime_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForKeyCreationTimeStatus(subject KeyCreationTime_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.KeyCreationTime_Status
-	err := subject.AssignPropertiesToKeyCreationTimeStatus(&other)
+	err := copied.AssignPropertiesToKeyCreationTimeStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1943,9 +1994,12 @@ func Test_KeyPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) 
 
 // RunPropertyAssignmentTestForKeyPolicy tests if a specific instance of KeyPolicy can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForKeyPolicy(subject KeyPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.KeyPolicy
-	err := subject.AssignPropertiesToKeyPolicy(&other)
+	err := copied.AssignPropertiesToKeyPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2041,9 +2095,12 @@ func Test_KeyPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForKeyPolicyStatus tests if a specific instance of KeyPolicy_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForKeyPolicyStatus(subject KeyPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.KeyPolicy_Status
-	err := subject.AssignPropertiesToKeyPolicyStatus(&other)
+	err := copied.AssignPropertiesToKeyPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2139,9 +2196,12 @@ func Test_NetworkRuleSet_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testin
 
 // RunPropertyAssignmentTestForNetworkRuleSet tests if a specific instance of NetworkRuleSet can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForNetworkRuleSet(subject NetworkRuleSet) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.NetworkRuleSet
-	err := subject.AssignPropertiesToNetworkRuleSet(&other)
+	err := copied.AssignPropertiesToNetworkRuleSet(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2258,9 +2318,12 @@ func Test_NetworkRuleSet_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForNetworkRuleSetStatus tests if a specific instance of NetworkRuleSet_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForNetworkRuleSetStatus(subject NetworkRuleSet_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.NetworkRuleSet_Status
-	err := subject.AssignPropertiesToNetworkRuleSetStatus(&other)
+	err := copied.AssignPropertiesToNetworkRuleSetStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2378,9 +2441,12 @@ func Test_PrivateEndpointConnection_Status_SubResourceEmbedded_WhenPropertiesCon
 
 // RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded tests if a specific instance of PrivateEndpointConnection_Status_SubResourceEmbedded can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForPrivateEndpointConnectionStatusSubResourceEmbedded(subject PrivateEndpointConnection_Status_SubResourceEmbedded) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.PrivateEndpointConnection_Status_SubResourceEmbedded
-	err := subject.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
+	err := copied.AssignPropertiesToPrivateEndpointConnectionStatusSubResourceEmbedded(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2477,9 +2543,12 @@ func Test_RoutingPreference_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForRoutingPreference tests if a specific instance of RoutingPreference can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForRoutingPreference(subject RoutingPreference) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.RoutingPreference
-	err := subject.AssignPropertiesToRoutingPreference(&other)
+	err := copied.AssignPropertiesToRoutingPreference(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2577,9 +2646,12 @@ func Test_RoutingPreference_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForRoutingPreferenceStatus tests if a specific instance of RoutingPreference_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForRoutingPreferenceStatus(subject RoutingPreference_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.RoutingPreference_Status
-	err := subject.AssignPropertiesToRoutingPreferenceStatus(&other)
+	err := copied.AssignPropertiesToRoutingPreferenceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2678,9 +2750,12 @@ func Test_SasPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) 
 
 // RunPropertyAssignmentTestForSasPolicy tests if a specific instance of SasPolicy can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForSasPolicy(subject SasPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.SasPolicy
-	err := subject.AssignPropertiesToSasPolicy(&other)
+	err := copied.AssignPropertiesToSasPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2777,9 +2852,12 @@ func Test_SasPolicy_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForSasPolicyStatus tests if a specific instance of SasPolicy_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForSasPolicyStatus(subject SasPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.SasPolicy_Status
-	err := subject.AssignPropertiesToSasPolicyStatus(&other)
+	err := copied.AssignPropertiesToSasPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2876,9 +2954,12 @@ func Test_Sku_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForSku tests if a specific instance of Sku can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForSku(subject Sku) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.Sku
-	err := subject.AssignPropertiesToSku(&other)
+	err := copied.AssignPropertiesToSku(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -2983,9 +3064,12 @@ func Test_Sku_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForSkuStatus tests if a specific instance of Sku_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForSkuStatus(subject Sku_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.Sku_Status
-	err := subject.AssignPropertiesToSkuStatus(&other)
+	err := copied.AssignPropertiesToSkuStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3090,9 +3174,12 @@ func Test_ActiveDirectoryProperties_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForActiveDirectoryProperties tests if a specific instance of ActiveDirectoryProperties can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForActiveDirectoryProperties(subject ActiveDirectoryProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ActiveDirectoryProperties
-	err := subject.AssignPropertiesToActiveDirectoryProperties(&other)
+	err := copied.AssignPropertiesToActiveDirectoryProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3194,9 +3281,12 @@ func Test_ActiveDirectoryProperties_Status_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForActiveDirectoryPropertiesStatus tests if a specific instance of ActiveDirectoryProperties_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForActiveDirectoryPropertiesStatus(subject ActiveDirectoryProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ActiveDirectoryProperties_Status
-	err := subject.AssignPropertiesToActiveDirectoryPropertiesStatus(&other)
+	err := copied.AssignPropertiesToActiveDirectoryPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3298,9 +3388,12 @@ func Test_BlobRestoreParameters_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForBlobRestoreParametersStatus tests if a specific instance of BlobRestoreParameters_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForBlobRestoreParametersStatus(subject BlobRestoreParameters_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.BlobRestoreParameters_Status
-	err := subject.AssignPropertiesToBlobRestoreParametersStatus(&other)
+	err := copied.AssignPropertiesToBlobRestoreParametersStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3411,9 +3504,12 @@ func Test_EncryptionIdentity_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForEncryptionIdentity tests if a specific instance of EncryptionIdentity can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionIdentity(subject EncryptionIdentity) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.EncryptionIdentity
-	err := subject.AssignPropertiesToEncryptionIdentity(&other)
+	err := copied.AssignPropertiesToEncryptionIdentity(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3503,9 +3599,12 @@ func Test_EncryptionIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForEncryptionIdentityStatus tests if a specific instance of EncryptionIdentity_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionIdentityStatus(subject EncryptionIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.EncryptionIdentity_Status
-	err := subject.AssignPropertiesToEncryptionIdentityStatus(&other)
+	err := copied.AssignPropertiesToEncryptionIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3602,9 +3701,12 @@ func Test_EncryptionServices_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForEncryptionServices tests if a specific instance of EncryptionServices can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionServices(subject EncryptionServices) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.EncryptionServices
-	err := subject.AssignPropertiesToEncryptionServices(&other)
+	err := copied.AssignPropertiesToEncryptionServices(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3703,9 +3805,12 @@ func Test_EncryptionServices_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForEncryptionServicesStatus tests if a specific instance of EncryptionServices_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionServicesStatus(subject EncryptionServices_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.EncryptionServices_Status
-	err := subject.AssignPropertiesToEncryptionServicesStatus(&other)
+	err := copied.AssignPropertiesToEncryptionServicesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3805,9 +3910,12 @@ func Test_IPRule_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForIPRule tests if a specific instance of IPRule can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForIPRule(subject IPRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.IPRule
-	err := subject.AssignPropertiesToIPRule(&other)
+	err := copied.AssignPropertiesToIPRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -3904,9 +4012,12 @@ func Test_IPRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing
 
 // RunPropertyAssignmentTestForIPRuleStatus tests if a specific instance of IPRule_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForIPRuleStatus(subject IPRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.IPRule_Status
-	err := subject.AssignPropertiesToIPRuleStatus(&other)
+	err := copied.AssignPropertiesToIPRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4003,9 +4114,12 @@ func Test_KeyVaultProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForKeyVaultProperties tests if a specific instance of KeyVaultProperties can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultProperties(subject KeyVaultProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.KeyVaultProperties
-	err := subject.AssignPropertiesToKeyVaultProperties(&other)
+	err := copied.AssignPropertiesToKeyVaultProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4103,9 +4217,12 @@ func Test_KeyVaultProperties_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForKeyVaultPropertiesStatus tests if a specific instance of KeyVaultProperties_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForKeyVaultPropertiesStatus(subject KeyVaultProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.KeyVaultProperties_Status
-	err := subject.AssignPropertiesToKeyVaultPropertiesStatus(&other)
+	err := copied.AssignPropertiesToKeyVaultPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4206,9 +4323,12 @@ func Test_ResourceAccessRule_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForResourceAccessRule tests if a specific instance of ResourceAccessRule can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForResourceAccessRule(subject ResourceAccessRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ResourceAccessRule
-	err := subject.AssignPropertiesToResourceAccessRule(&other)
+	err := copied.AssignPropertiesToResourceAccessRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4304,9 +4424,12 @@ func Test_ResourceAccessRule_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForResourceAccessRuleStatus tests if a specific instance of ResourceAccessRule_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForResourceAccessRuleStatus(subject ResourceAccessRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ResourceAccessRule_Status
-	err := subject.AssignPropertiesToResourceAccessRuleStatus(&other)
+	err := copied.AssignPropertiesToResourceAccessRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4404,9 +4527,12 @@ func Test_StorageAccountInternetEndpoints_Status_WhenPropertiesConverted_RoundTr
 
 // RunPropertyAssignmentTestForStorageAccountInternetEndpointsStatus tests if a specific instance of StorageAccountInternetEndpoints_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountInternetEndpointsStatus(subject StorageAccountInternetEndpoints_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccountInternetEndpoints_Status
-	err := subject.AssignPropertiesToStorageAccountInternetEndpointsStatus(&other)
+	err := copied.AssignPropertiesToStorageAccountInternetEndpointsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4506,9 +4632,12 @@ func Test_StorageAccountMicrosoftEndpoints_Status_WhenPropertiesConverted_RoundT
 
 // RunPropertyAssignmentTestForStorageAccountMicrosoftEndpointsStatus tests if a specific instance of StorageAccountMicrosoftEndpoints_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountMicrosoftEndpointsStatus(subject StorageAccountMicrosoftEndpoints_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccountMicrosoftEndpoints_Status
-	err := subject.AssignPropertiesToStorageAccountMicrosoftEndpointsStatus(&other)
+	err := copied.AssignPropertiesToStorageAccountMicrosoftEndpointsStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4610,9 +4739,12 @@ func Test_UserAssignedIdentity_Status_WhenPropertiesConverted_RoundTripsWithoutL
 
 // RunPropertyAssignmentTestForUserAssignedIdentityStatus tests if a specific instance of UserAssignedIdentity_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForUserAssignedIdentityStatus(subject UserAssignedIdentity_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.UserAssignedIdentity_Status
-	err := subject.AssignPropertiesToUserAssignedIdentityStatus(&other)
+	err := copied.AssignPropertiesToUserAssignedIdentityStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4710,9 +4842,12 @@ func Test_VirtualNetworkRule_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForVirtualNetworkRule tests if a specific instance of VirtualNetworkRule can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkRule(subject VirtualNetworkRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.VirtualNetworkRule
-	err := subject.AssignPropertiesToVirtualNetworkRule(&other)
+	err := copied.AssignPropertiesToVirtualNetworkRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4814,9 +4949,12 @@ func Test_VirtualNetworkRule_Status_WhenPropertiesConverted_RoundTripsWithoutLos
 
 // RunPropertyAssignmentTestForVirtualNetworkRuleStatus tests if a specific instance of VirtualNetworkRule_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForVirtualNetworkRuleStatus(subject VirtualNetworkRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.VirtualNetworkRule_Status
-	err := subject.AssignPropertiesToVirtualNetworkRuleStatus(&other)
+	err := copied.AssignPropertiesToVirtualNetworkRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -4920,9 +5058,12 @@ func Test_BlobRestoreRange_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForBlobRestoreRangeStatus tests if a specific instance of BlobRestoreRange_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForBlobRestoreRangeStatus(subject BlobRestoreRange_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.BlobRestoreRange_Status
-	err := subject.AssignPropertiesToBlobRestoreRangeStatus(&other)
+	err := copied.AssignPropertiesToBlobRestoreRangeStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5020,9 +5161,12 @@ func Test_EncryptionService_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForEncryptionService tests if a specific instance of EncryptionService can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionService(subject EncryptionService) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.EncryptionService
-	err := subject.AssignPropertiesToEncryptionService(&other)
+	err := copied.AssignPropertiesToEncryptionService(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -5119,9 +5263,12 @@ func Test_EncryptionService_Status_WhenPropertiesConverted_RoundTripsWithoutLoss
 
 // RunPropertyAssignmentTestForEncryptionServiceStatus tests if a specific instance of EncryptionService_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForEncryptionServiceStatus(subject EncryptionService_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.EncryptionService_Status
-	err := subject.AssignPropertiesToEncryptionServiceStatus(&other)
+	err := copied.AssignPropertiesToEncryptionServiceStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_StorageAccountsBlobService_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForStorageAccountsBlobService tests if a specific instance of StorageAccountsBlobService can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountsBlobService(subject StorageAccountsBlobService) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccountsBlobService
-	err := subject.AssignPropertiesToStorageAccountsBlobService(&other)
+	err := copied.AssignPropertiesToStorageAccountsBlobService(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_BlobServiceProperties_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForBlobServicePropertiesStatus tests if a specific instance of BlobServiceProperties_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForBlobServicePropertiesStatus(subject BlobServiceProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.BlobServiceProperties_Status
-	err := subject.AssignPropertiesToBlobServicePropertiesStatus(&other)
+	err := copied.AssignPropertiesToBlobServicePropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -255,9 +261,12 @@ func Test_StorageAccountsBlobServices_Spec_WhenPropertiesConverted_RoundTripsWit
 
 // RunPropertyAssignmentTestForStorageAccountsBlobServicesSpec tests if a specific instance of StorageAccountsBlobServices_Spec can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountsBlobServicesSpec(subject StorageAccountsBlobServices_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccountsBlobServices_Spec
-	err := subject.AssignPropertiesToStorageAccountsBlobServicesSpec(&other)
+	err := copied.AssignPropertiesToStorageAccountsBlobServicesSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -377,9 +386,12 @@ func Test_ChangeFeed_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T)
 
 // RunPropertyAssignmentTestForChangeFeed tests if a specific instance of ChangeFeed can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForChangeFeed(subject ChangeFeed) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ChangeFeed
-	err := subject.AssignPropertiesToChangeFeed(&other)
+	err := copied.AssignPropertiesToChangeFeed(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -476,9 +488,12 @@ func Test_ChangeFeed_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *tes
 
 // RunPropertyAssignmentTestForChangeFeedStatus tests if a specific instance of ChangeFeed_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForChangeFeedStatus(subject ChangeFeed_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ChangeFeed_Status
-	err := subject.AssignPropertiesToChangeFeedStatus(&other)
+	err := copied.AssignPropertiesToChangeFeedStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -575,9 +590,12 @@ func Test_CorsRules_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) 
 
 // RunPropertyAssignmentTestForCorsRules tests if a specific instance of CorsRules can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForCorsRules(subject CorsRules) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.CorsRules
-	err := subject.AssignPropertiesToCorsRules(&other)
+	err := copied.AssignPropertiesToCorsRules(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -673,9 +691,12 @@ func Test_CorsRules_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *test
 
 // RunPropertyAssignmentTestForCorsRulesStatus tests if a specific instance of CorsRules_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForCorsRulesStatus(subject CorsRules_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.CorsRules_Status
-	err := subject.AssignPropertiesToCorsRulesStatus(&other)
+	err := copied.AssignPropertiesToCorsRulesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -771,9 +792,12 @@ func Test_DeleteRetentionPolicy_WhenPropertiesConverted_RoundTripsWithoutLoss(t 
 
 // RunPropertyAssignmentTestForDeleteRetentionPolicy tests if a specific instance of DeleteRetentionPolicy can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForDeleteRetentionPolicy(subject DeleteRetentionPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.DeleteRetentionPolicy
-	err := subject.AssignPropertiesToDeleteRetentionPolicy(&other)
+	err := copied.AssignPropertiesToDeleteRetentionPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -871,9 +895,12 @@ func Test_DeleteRetentionPolicy_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForDeleteRetentionPolicyStatus tests if a specific instance of DeleteRetentionPolicy_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForDeleteRetentionPolicyStatus(subject DeleteRetentionPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.DeleteRetentionPolicy_Status
-	err := subject.AssignPropertiesToDeleteRetentionPolicyStatus(&other)
+	err := copied.AssignPropertiesToDeleteRetentionPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -971,9 +998,12 @@ func Test_LastAccessTimeTrackingPolicy_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForLastAccessTimeTrackingPolicy tests if a specific instance of LastAccessTimeTrackingPolicy can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForLastAccessTimeTrackingPolicy(subject LastAccessTimeTrackingPolicy) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.LastAccessTimeTrackingPolicy
-	err := subject.AssignPropertiesToLastAccessTimeTrackingPolicy(&other)
+	err := copied.AssignPropertiesToLastAccessTimeTrackingPolicy(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1073,9 +1103,12 @@ func Test_LastAccessTimeTrackingPolicy_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForLastAccessTimeTrackingPolicyStatus tests if a specific instance of LastAccessTimeTrackingPolicy_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForLastAccessTimeTrackingPolicyStatus(subject LastAccessTimeTrackingPolicy_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.LastAccessTimeTrackingPolicy_Status
-	err := subject.AssignPropertiesToLastAccessTimeTrackingPolicyStatus(&other)
+	err := copied.AssignPropertiesToLastAccessTimeTrackingPolicyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1175,9 +1208,12 @@ func Test_RestorePolicyProperties_WhenPropertiesConverted_RoundTripsWithoutLoss(
 
 // RunPropertyAssignmentTestForRestorePolicyProperties tests if a specific instance of RestorePolicyProperties can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForRestorePolicyProperties(subject RestorePolicyProperties) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.RestorePolicyProperties
-	err := subject.AssignPropertiesToRestorePolicyProperties(&other)
+	err := copied.AssignPropertiesToRestorePolicyProperties(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1275,9 +1311,12 @@ func Test_RestorePolicyProperties_Status_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForRestorePolicyPropertiesStatus tests if a specific instance of RestorePolicyProperties_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForRestorePolicyPropertiesStatus(subject RestorePolicyProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.RestorePolicyProperties_Status
-	err := subject.AssignPropertiesToRestorePolicyPropertiesStatus(&other)
+	err := copied.AssignPropertiesToRestorePolicyPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1377,9 +1416,12 @@ func Test_CorsRule_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
 
 // RunPropertyAssignmentTestForCorsRule tests if a specific instance of CorsRule can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForCorsRule(subject CorsRule) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.CorsRule
-	err := subject.AssignPropertiesToCorsRule(&other)
+	err := copied.AssignPropertiesToCorsRule(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -1486,9 +1528,12 @@ func Test_CorsRule_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testi
 
 // RunPropertyAssignmentTestForCorsRuleStatus tests if a specific instance of CorsRule_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForCorsRuleStatus(subject CorsRule_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.CorsRule_Status
-	err := subject.AssignPropertiesToCorsRuleStatus(&other)
+	err := copied.AssignPropertiesToCorsRuleStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen_test.go
+++ b/v2/api/microsoft.storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen_test.go
@@ -31,9 +31,12 @@ func Test_StorageAccountsBlobServicesContainer_WhenPropertiesConverted_RoundTrip
 
 // RunPropertyAssignmentTestForStorageAccountsBlobServicesContainer tests if a specific instance of StorageAccountsBlobServicesContainer can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountsBlobServicesContainer(subject StorageAccountsBlobServicesContainer) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccountsBlobServicesContainer
-	err := subject.AssignPropertiesToStorageAccountsBlobServicesContainer(&other)
+	err := copied.AssignPropertiesToStorageAccountsBlobServicesContainer(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -131,9 +134,12 @@ func Test_BlobContainer_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *
 
 // RunPropertyAssignmentTestForBlobContainerStatus tests if a specific instance of BlobContainer_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForBlobContainerStatus(subject BlobContainer_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.BlobContainer_Status
-	err := subject.AssignPropertiesToBlobContainerStatus(&other)
+	err := copied.AssignPropertiesToBlobContainerStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -268,9 +274,12 @@ func Test_StorageAccountsBlobServicesContainers_Spec_WhenPropertiesConverted_Rou
 
 // RunPropertyAssignmentTestForStorageAccountsBlobServicesContainersSpec tests if a specific instance of StorageAccountsBlobServicesContainers_Spec can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForStorageAccountsBlobServicesContainersSpec(subject StorageAccountsBlobServicesContainers_Spec) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.StorageAccountsBlobServicesContainers_Spec
-	err := subject.AssignPropertiesToStorageAccountsBlobServicesContainersSpec(&other)
+	err := copied.AssignPropertiesToStorageAccountsBlobServicesContainersSpec(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -387,9 +396,12 @@ func Test_ImmutabilityPolicyProperties_Status_WhenPropertiesConverted_RoundTrips
 
 // RunPropertyAssignmentTestForImmutabilityPolicyPropertiesStatus tests if a specific instance of ImmutabilityPolicyProperties_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForImmutabilityPolicyPropertiesStatus(subject ImmutabilityPolicyProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ImmutabilityPolicyProperties_Status
-	err := subject.AssignPropertiesToImmutabilityPolicyPropertiesStatus(&other)
+	err := copied.AssignPropertiesToImmutabilityPolicyPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -503,9 +515,12 @@ func Test_ImmutableStorageWithVersioning_WhenPropertiesConverted_RoundTripsWitho
 
 // RunPropertyAssignmentTestForImmutableStorageWithVersioning tests if a specific instance of ImmutableStorageWithVersioning can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForImmutableStorageWithVersioning(subject ImmutableStorageWithVersioning) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ImmutableStorageWithVersioning
-	err := subject.AssignPropertiesToImmutableStorageWithVersioning(&other)
+	err := copied.AssignPropertiesToImmutableStorageWithVersioning(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -602,9 +617,12 @@ func Test_ImmutableStorageWithVersioning_Status_WhenPropertiesConverted_RoundTri
 
 // RunPropertyAssignmentTestForImmutableStorageWithVersioningStatus tests if a specific instance of ImmutableStorageWithVersioning_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForImmutableStorageWithVersioningStatus(subject ImmutableStorageWithVersioning_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.ImmutableStorageWithVersioning_Status
-	err := subject.AssignPropertiesToImmutableStorageWithVersioningStatus(&other)
+	err := copied.AssignPropertiesToImmutableStorageWithVersioningStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -703,9 +721,12 @@ func Test_LegalHoldProperties_Status_WhenPropertiesConverted_RoundTripsWithoutLo
 
 // RunPropertyAssignmentTestForLegalHoldPropertiesStatus tests if a specific instance of LegalHoldProperties_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForLegalHoldPropertiesStatus(subject LegalHoldProperties_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.LegalHoldProperties_Status
-	err := subject.AssignPropertiesToLegalHoldPropertiesStatus(&other)
+	err := copied.AssignPropertiesToLegalHoldPropertiesStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -816,9 +837,12 @@ func Test_TagProperty_Status_WhenPropertiesConverted_RoundTripsWithoutLoss(t *te
 
 // RunPropertyAssignmentTestForTagPropertyStatus tests if a specific instance of TagProperty_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForTagPropertyStatus(subject TagProperty_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.TagProperty_Status
-	err := subject.AssignPropertiesToTagPropertyStatus(&other)
+	err := copied.AssignPropertiesToTagPropertyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}
@@ -918,9 +942,12 @@ func Test_UpdateHistoryProperty_Status_WhenPropertiesConverted_RoundTripsWithout
 
 // RunPropertyAssignmentTestForUpdateHistoryPropertyStatus tests if a specific instance of UpdateHistoryProperty_Status can be assigned to v1alpha1api20210401storage and back losslessly
 func RunPropertyAssignmentTestForUpdateHistoryPropertyStatus(subject UpdateHistoryProperty_Status) string {
+	// Copy subject to make sure assignment doesn't modify it
+	copied := subject.DeepCopy()
+
 	// Use AssignPropertiesTo() for the first stage of conversion
 	var other v1alpha1api20210401storage.UpdateHistoryProperty_Status
-	err := subject.AssignPropertiesToUpdateHistoryPropertyStatus(&other)
+	err := copied.AssignPropertiesToUpdateHistoryPropertyStatus(&other)
 	if err != nil {
 		return err.Error()
 	}

--- a/v2/tools/generator/internal/testcases/testdata/TestGolden_PropertyAssignmentTestCase_AsFunc/person_test_test.golden
+++ b/v2/tools/generator/internal/testcases/testdata/TestGolden_PropertyAssignmentTestCase_AsFunc/person_test_test.golden
@@ -27,9 +27,12 @@
 +
 +// RunPropertyAssignmentTestForPersonSpec tests if a specific instance of Person_Spec can be assigned to v20211231 and back losslessly
 +func RunPropertyAssignmentTestForPersonSpec(subject Person_Spec) string {
++	// Copy subject to make sure assignment doesn't modify it
++	copied := subject.DeepCopy()
++
 +	// Use AssignPropertiesTo() for the first stage of conversion
 +	var other person.Person_Spec
-+	err := subject.AssignPropertiesToPersonSpec(&other)
++	err := copied.AssignPropertiesToPersonSpec(&other)
 +	if err != nil {
 +		return err.Error()
 +	}

--- a/v2/tools/generator/internal/testcases/testdata/TestGolden_ResourceConversionTestCase_AsFunc/person_test.golden
+++ b/v2/tools/generator/internal/testcases/testdata/TestGolden_ResourceConversionTestCase_AsFunc/person_test.golden
@@ -28,9 +28,12 @@
 +
 +// RunResourceConversionTestForPerson tests if a specific instance of Person round trips to the hub storage version and back losslessly
 +func RunResourceConversionTestForPerson(subject Person) string {
++	// Copy subject to make sure conversion doesn't modify it
++	copied := subject.DeepCopy()
++
 +	// Convert to our hub version
 +	var hub person.Person
-+	err := subject.ConvertTo(&hub)
++	err := copied.ConvertTo(&hub)
 +	if err != nil {
 +		return err.Error()
 +	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Copy the subject before converting or assigning properties to be sure that the operation isn't inadvertently modifying the source. We saw what could be a bug in the property assignment generation code that would result in the source object being updated, rather than the destination - that might not be revealed by the generated tests since the source and destination are still equal.

Running the updated tests didn't generate any failures in conversion or property assignment tests, so it might be that the bug wasn't real or that specific complex property type doesn't appear in any of our resources, but the check's still worth having.

**Special notes for your reviewer**:
The first commit has the actual generator change, the second commit is just updated tests.

**How does this PR make you feel**:
![gif](https://c.tenor.com/ry6gQ8oBbUgAAAAC/bts-kpop.gif)

**If applicable**:
- [X] this PR contains tests
