### PR TITLE
Clean up distinction between package reference types

### DIFF
--- a/v2/tools/generator/internal/astmodel/code_generation_context.go
+++ b/v2/tools/generator/internal/astmodel/code_generation_context.go
@@ -110,13 +110,7 @@ func (codeGenContext *CodeGenerationContext) GetImportedDefinition(typeName Type
 
 // GetTypesInPackage returns the actual definitions from a specific package
 func (codeGenContext *CodeGenerationContext) GetTypesInPackage(packageRef PackageReference) (Types, bool) {
-	ref := packageRef
-	if local, ok := ref.AsLocalPackage(); ok {
-		// Resolve to a local reference if possible
-		ref = local
-	}
-
-	def, ok := codeGenContext.generatedPackages[ref]
+	def, ok := codeGenContext.generatedPackages[packageRef]
 	if !ok {
 		// Package reference not found
 		return nil, false

--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -58,3 +58,8 @@ func (pr ExternalPackageReference) IsPreview() bool {
 func (pr ExternalPackageReference) String() string {
 	return pr.packagePath
 }
+
+// GroupVersion returns the group and version of this local reference.
+func (pr ExternalPackageReference) GroupVersion() (string, string, bool) {
+	return "", "", false
+}

--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -23,12 +23,6 @@ func MakeExternalPackageReference(packagePath string) ExternalPackageReference {
 	return ExternalPackageReference{packagePath: packagePath}
 }
 
-// AsLocalPackage returns an empty local reference and false to indicate that library packages
-// are not local
-func (pr ExternalPackageReference) AsLocalPackage() (LocalPackageReference, bool) {
-	return LocalPackageReference{}, false
-}
-
 // PackageName returns the package name of this reference
 func (pr ExternalPackageReference) PackageName() string {
 	l := strings.Split(pr.packagePath, "/")

--- a/v2/tools/generator/internal/astmodel/external_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference_test.go
@@ -52,9 +52,6 @@ func TestExternalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			ref := MakeExternalPackageReference(c.path)
-			_, ok := ref.AsLocalPackage()
-
-			g.Expect(ok).To(BeFalse())
 			g.Expect(ref.PackagePath()).To(Equal(c.path))
 			g.Expect(ref.String()).To(Equal(c.path))
 		})

--- a/v2/tools/generator/internal/astmodel/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/astmodel/kubernetes_admissions_defaulter.go
@@ -52,7 +52,7 @@ func (d *DefaulterBuilder) AddDefault(f *resourceFunction) {
 func (d *DefaulterBuilder) ToInterfaceImplementation() *InterfaceImplementation {
 	group, version, ok := d.resourceName.PackageReference.GroupVersion()
 	if !ok {
-		panic(fmt.Sprintf("expected resource name %s to not have an external package reference", d.resourceName))
+		panic(fmt.Sprintf("unexpected external package reference for resource name %s", d.resourceName))
 	}
 
 	// e.g. group = "microsoft.network.azure.com"

--- a/v2/tools/generator/internal/astmodel/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/astmodel/kubernetes_admissions_defaulter.go
@@ -50,14 +50,16 @@ func (d *DefaulterBuilder) AddDefault(f *resourceFunction) {
 // as well as helper functions that allow additional handcrafted defaults to be injected by
 // implementing the genruntime.Defaulter interface.
 func (d *DefaulterBuilder) ToInterfaceImplementation() *InterfaceImplementation {
-	lpr, ok := d.resourceName.PackageReference.AsLocalPackage()
+	group, version, ok := d.resourceName.PackageReference.GroupVersion()
 	if !ok {
-		panic(fmt.Sprintf("expected resource name %s to be a local package reference", d.resourceName.String()))
+		panic(fmt.Sprintf("expected resource name %s to not have an external package reference", d.resourceName))
 	}
 
-	group := lpr.group                // e.g. "microsoft.network.azure.com"
-	resource := d.resourceName.Name() // e.g. "backendaddresspools"
-	version := lpr.version            // e.g. "v1"
+	// e.g. group = "microsoft.network.azure.com"
+	// e.g. resource = "backendaddresspools"
+	// e.g. version = "v1"
+
+	resource := d.resourceName.Name()
 
 	group = strings.ToLower(group + GroupSuffix)
 	nonPluralResource := strings.ToLower(resource)

--- a/v2/tools/generator/internal/astmodel/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/astmodel/kubernetes_admissions_validator.go
@@ -67,7 +67,7 @@ func (v *ValidatorBuilder) AddValidation(kind ValidationKind, f *resourceFunctio
 func (v *ValidatorBuilder) ToInterfaceImplementation() *InterfaceImplementation {
 	group, version, ok := v.resourceName.PackageReference.GroupVersion()
 	if !ok {
-		panic(fmt.Sprintf("expected resource name %s to not have an external package reference", v.resourceName))
+		panic(fmt.Sprintf("unexpected external package reference for resource name %s", v.resourceName))
 	}
 
 	// e.g. group = "microsoft.network.azure.com"

--- a/v2/tools/generator/internal/astmodel/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/astmodel/kubernetes_admissions_validator.go
@@ -65,14 +65,16 @@ func (v *ValidatorBuilder) AddValidation(kind ValidationKind, f *resourceFunctio
 // as well as helper functions that allow additional handcrafted validations to be injected by
 // implementing the genruntime.Validator interface.
 func (v *ValidatorBuilder) ToInterfaceImplementation() *InterfaceImplementation {
-	lpr, ok := v.resourceName.PackageReference.AsLocalPackage()
+	group, version, ok := v.resourceName.PackageReference.GroupVersion()
 	if !ok {
-		panic(fmt.Sprintf("expected resource name %s to be a local package reference", v.resourceName.String()))
+		panic(fmt.Sprintf("expected resource name %s to not have an external package reference", v.resourceName))
 	}
 
-	group := lpr.group                // e.g. "microsoft.network.azure.com"
-	resource := v.resourceName.Name() // e.g. "backendaddresspools"
-	version := lpr.version            // e.g. "v1"
+	// e.g. group = "microsoft.network.azure.com"
+	// e.g. resource = "backendaddresspools"
+	// e.g. version = "v1"
+
+	resource := v.resourceName.Name()
 
 	group = strings.ToLower(group + GroupSuffix)
 	nonPluralResource := strings.ToLower(resource)

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -53,11 +53,6 @@ func sanitizePackageName(input string) string {
 	return string(builder)
 }
 
-// AsLocalPackage returns this instance and true
-func (pr LocalPackageReference) AsLocalPackage() (LocalPackageReference, bool) {
-	return pr, true
-}
-
 // LocalPathPrefix returns the prefix (everything up to the group name)
 func (pr LocalPackageReference) LocalPathPrefix() string {
 	return pr.localPathPrefix

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -114,3 +114,8 @@ func IsLocalPackageReference(ref PackageReference) bool {
 	_, ok := ref.(LocalPackageReference)
 	return ok
 }
+
+// GroupVersion returns the group and version of this local reference.
+func (pr LocalPackageReference) GroupVersion() (string, string, bool) {
+	return pr.group, pr.version, true
+}

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -90,7 +90,7 @@ func (pr LocalPackageReference) Equals(ref PackageReference) bool {
 		return false
 	}
 
-	if other, ok := ref.AsLocalPackage(); ok {
+	if other, ok := ref.(LocalPackageReference); ok {
 		return pr.localPathPrefix == other.localPathPrefix &&
 			pr.version == other.version &&
 			pr.group == other.group

--- a/v2/tools/generator/internal/astmodel/local_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference_test.go
@@ -79,9 +79,6 @@ func TestLocalPackageReferences_ReturnExpectedProperties(t *testing.T) {
 
 			ref := makeTestLocalPackageReference(c.group, c.pkg)
 			grp := ref.Group()
-			_, ok := ref.AsLocalPackage()
-
-			g.Expect(ok).To(BeTrue())
 			g.Expect(ref.PackageName()).To(Equal(c.pkg))
 			g.Expect(ref.PackagePath()).To(Equal(c.expectedPath))
 			g.Expect(ref.String()).To(Equal(c.expectedPath))

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -34,6 +34,9 @@ type PackageReference interface {
 	// IsPreview returns true if this package reference has a suffix indicating it's a preview
 	// release, false otherwise
 	IsPreview() bool
+	// GroupVersion returns the group and version of this reference.
+	// Returns true if the reference has a group and version, false otherwise.
+	GroupVersion() (string, string, bool)
 }
 
 // IsExternalPackageReference returns true if the provided reference is external

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -9,8 +9,6 @@ import (
 	"sort"
 	"strings"
 	"unicode"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -43,15 +41,6 @@ type PackageReference interface {
 func IsExternalPackageReference(ref PackageReference) bool {
 	_, result := ref.(ExternalPackageReference)
 	return result
-}
-
-// PackageAsLocalPackage converts the given PackageReference into a LocalPackageReference if possible.
-// If the provided PackageReference does not represent a local package an error is returned.
-func PackageAsLocalPackage(pkg PackageReference) (LocalPackageReference, error) {
-	if localPkg, ok := pkg.AsLocalPackage(); ok {
-		return localPkg, nil
-	}
-	return LocalPackageReference{}, errors.Errorf("%q is not a local package", pkg.PackagePath())
 }
 
 func SortPackageReferencesByPathAndVersion(packages []PackageReference) {

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -19,8 +19,6 @@ const (
 var MetaV1PackageReference = MakeExternalPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
 
 type PackageReference interface {
-	// AsLocalPackage attempts conversion to a LocalPackageReference
-	AsLocalPackage() (LocalPackageReference, bool)
 	// PackageName returns the package name of this reference
 	PackageName() string
 	// PackagePath returns the fully qualified package path

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -36,6 +36,12 @@ type PackageReference interface {
 	IsPreview() bool
 }
 
+// IsExternalPackageReference returns true if the provided reference is external
+func IsExternalPackageReference(ref PackageReference) bool {
+	_, result := ref.(ExternalPackageReference)
+	return result
+}
+
 // PackageAsLocalPackage converts the given PackageReference into a LocalPackageReference if possible.
 // If the provided PackageReference does not represent a local package an error is returned.
 func PackageAsLocalPackage(pkg PackageReference) (LocalPackageReference, error) {

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -571,11 +571,11 @@ func (resource *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerati
 
 	// Add required RBAC annotations, only on storage version
 	if resource.isStorageVersion {
-		lpr, ok := declContext.Name.PackageReference.AsLocalPackage()
+		group, _, ok := declContext.Name.PackageReference.GroupVersion()
 		if !ok {
 			panic(fmt.Sprintf("expected resource package reference to be local: %q", declContext.Name))
 		}
-		group := strings.ToLower(lpr.Group() + GroupSuffix)
+		group = strings.ToLower(group + GroupSuffix)
 		resourceName := strings.ToLower(declContext.Name.Plural().Name())
 
 		astbuilder.AddComment(&comments, fmt.Sprintf("// +kubebuilder:rbac:groups=%s,resources=%s,verbs=get;list;watch;create;update;patch;delete", group, resourceName))

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -29,11 +29,6 @@ func MakeStoragePackageReference(local LocalPackageReference) StoragePackageRefe
 	}
 }
 
-// AsLocalPackage returns the local package wrapped by this storage package
-func (s StoragePackageReference) AsLocalPackage() (LocalPackageReference, bool) {
-	return s.inner, true
-}
-
 // PackageName returns the package name of this reference
 func (s StoragePackageReference) PackageName() string {
 	return s.version

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -70,3 +70,8 @@ func IsStoragePackageReference(reference PackageReference) bool {
 	_, ok := reference.(StoragePackageReference)
 	return ok
 }
+
+// GroupVersion returns the group and version of this local reference.
+func (s StoragePackageReference) GroupVersion() (string, string, bool) {
+	return s.inner.group, s.inner.version + StoragePackageSuffix, true
+}

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -15,8 +15,8 @@ const (
 )
 
 type StoragePackageReference struct {
-	inner   LocalPackageReference
-	version string
+	inner   LocalPackageReference // a reference to the API package this storage package mirrors
+	version string                // our version has the suffix "storage" (see StoragePackageSuffix)
 }
 
 var _ PackageReference = StoragePackageReference{}

--- a/v2/tools/generator/internal/astmodel/type_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_test.go
@@ -31,11 +31,11 @@ func Test_MakeTypeDefinition_GivenValues_InitializesProperties(t *testing.T) {
 	g.Expect(objectDefinition.Name().name).To(Equal(name))
 	g.Expect(objectDefinition.Type()).To(Equal(objectType))
 
-	localRef, ok := objectDefinition.Name().PackageReference.AsLocalPackage()
+	actualGroup, actualVersion, ok := objectDefinition.Name().PackageReference.GroupVersion()
 	g.Expect(ok).To(BeTrue())
+	g.Expect(actualGroup).To(Equal(group))
+	g.Expect(actualVersion).To(Equal(version))
 
-	g.Expect(localRef.Group()).To(Equal(group))
-	g.Expect(localRef.Version()).To(Equal(version))
 	g.Expect(objectDefinition.Type().(*ObjectType).properties).To(HaveLen(3))
 }
 

--- a/v2/tools/generator/internal/astmodel/type_name.go
+++ b/v2/tools/generator/internal/astmodel/type_name.go
@@ -74,7 +74,7 @@ func (typeName TypeName) AsType(codeGenerationContext *CodeGenerationContext) ds
 // AsZero renders an expression for the "zero" value of the type.
 // The exact thing we need to generate depends on the actual type we reference
 func (typeName TypeName) AsZero(types Types, ctx *CodeGenerationContext) dst.Expr {
-	if _, isLocal := typeName.PackageReference.AsLocalPackage(); !isLocal {
+	if IsExternalPackageReference(typeName.PackageReference) {
 		// TypeName is external, zero value is a qualified empty struct
 		// (we might not actually use this, if the property is optional, but we still need to generate the right thing)
 
@@ -201,7 +201,7 @@ func (typeName TypeName) WriteDebugDescription(builder *strings.Builder, types T
 	builder.WriteString(typeName.name)
 
 	if typeName.PackageReference != nil {
-		if _, ok := typeName.PackageReference.AsLocalPackage(); ok {
+		if !IsExternalPackageReference(typeName.PackageReference) {
 			builder.WriteString(":")
 			if definition, ok := types[typeName]; ok {
 				definition.Type().WriteDebugDescription(builder, types)

--- a/v2/tools/generator/internal/astmodel/type_walker.go
+++ b/v2/tools/generator/internal/astmodel/type_walker.go
@@ -80,7 +80,7 @@ func (t *TypeWalker) visitTypeName(this *TypeVisitor, it TypeName, ctx interface
 		panic(fmt.Sprintf("TypeWalker visitor visitTypeName must return a TypeName, instead returned %T", visitedTypeName))
 	}
 
-	if _, isLocal := it.PackageReference.AsLocalPackage(); !isLocal {
+	if IsExternalPackageReference(it.PackageReference) {
 		// Non-local type names are fine, we can exit early
 		return it, nil
 	}

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -242,20 +242,24 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) pipeline.Sta
 				t.Fatalf("defs was empty")
 			}
 
-			var pr astmodel.LocalPackageReference
+			var pr astmodel.PackageReference
+			var group string
+			var version string
+			var found bool
 			var ds []astmodel.TypeDefinition
 			for _, def := range defs {
 				ds = append(ds, def)
-				if ref, ok := def.Name().PackageReference.AsLocalPackage(); ok {
+				ref := def.Name().PackageReference
+				if !found {
 					pr = ref
+					group, version, found = ref.GroupVersion()
 				}
-
 			}
 
 			// Fabricate a single package definition
 			pkgs := make(map[astmodel.PackageReference]*astmodel.PackageDefinition)
 
-			packageDefinition := astmodel.NewPackageDefinition(pr.Group(), pr.PackageName())
+			packageDefinition := astmodel.NewPackageDefinition(group, version)
 			for _, def := range defs {
 				packageDefinition.AddDefinition(def)
 			}

--- a/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
@@ -247,12 +247,13 @@ func (c *armConversionApplier) createOwnerProperty(ownerTypeName *astmodel.TypeN
 		c.idFactory.CreateIdentifier(astmodel.OwnerProperty, astmodel.NotExported),
 		astmodel.KnownResourceReferenceType)
 
-	if localRef, ok := ownerTypeName.PackageReference.AsLocalPackage(); ok {
-		group := localRef.Group() + astmodel.GroupSuffix
-		prop = prop.WithTag("group", group).WithTag("kind", ownerTypeName.Name())
+	ref := ownerTypeName.PackageReference
+	if group, _, ok := ref.GroupVersion(); ok {
+		prop = prop.WithTag("group", group+astmodel.GroupSuffix)
+		prop = prop.WithTag("kind", ownerTypeName.Name())
 		prop = prop.MakeRequired() // Owner is always required
 	} else {
-		return nil, errors.New("owners from external packages not currently supported")
+		return nil, errors.Errorf("owners from external package %s not currently supported", ref)
 	}
 
 	return prop, nil

--- a/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
+++ b/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
@@ -96,10 +96,7 @@ func containsAnyType(theType astmodel.Type) bool {
 }
 
 func packageName(name astmodel.TypeName) string {
-	if localRef, ok := name.PackageReference.AsLocalPackage(); ok {
-		group := localRef.Group()
-		version := localRef.Version()
-
+	if group, version, ok := name.PackageReference.GroupVersion(); ok {
 		return group + "/" + version
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -51,22 +51,20 @@ func ExportPackages(outputPath string) Stage {
 func CreatePackagesForDefinitions(definitions astmodel.Types) (map[astmodel.PackageReference]*astmodel.PackageDefinition, error) {
 	packages := make(map[astmodel.PackageReference]*astmodel.PackageDefinition)
 	for _, def := range definitions {
-		defName := def.Name()
-		pkgRef, ok := defName.PackageReference.AsLocalPackage()
+		name := def.Name()
+		ref := name.PackageReference
+		group, version, ok := ref.GroupVersion()
 		if !ok {
-			klog.Errorf("Definition %s from external package %s skipped", defName.Name(), defName.PackageReference)
+			klog.Errorf("Definition %s from external package %s skipped", name.Name(), ref)
 			continue
 		}
 
-		groupName := pkgRef.Group()
-		pkgName := pkgRef.PackageName()
-
-		if pkg, ok := packages[pkgRef]; ok {
+		if pkg, ok := packages[ref]; ok {
 			pkg.AddDefinition(def)
 		} else {
-			pkg = astmodel.NewPackageDefinition(groupName, pkgName)
+			pkg = astmodel.NewPackageDefinition(group, version)
 			pkg.AddDefinition(def)
-			packages[pkgRef] = pkg
+			packages[ref] = pkg
 		}
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -110,7 +110,7 @@ func getUnversionedName(name astmodel.TypeName) (unversionedName, error) {
 		return unversionedName{}, errors.Errorf("cannot get unversioned name for external reference %s", ref)
 	}
 
-		return unversionedName{group, name.Name()}, nil
+	return unversionedName{group, name.Name()}, nil
 }
 
 type unversionedName struct {

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -104,12 +104,13 @@ func groupResourcesByVersion(types astmodel.Types) (map[unversionedName][]astmod
 }
 
 func getUnversionedName(name astmodel.TypeName) (unversionedName, error) {
-	pkg, err := astmodel.PackageAsLocalPackage(name.PackageReference)
-	if err != nil {
-		return unversionedName{}, errors.Wrapf(err, "cannot get unversioned name")
+	ref := name.PackageReference
+	group, _, ok := ref.GroupVersion()
+	if !ok {
+		return unversionedName{}, errors.Errorf("cannot get unversioned name for external reference %s", ref)
 	}
 
-	return unversionedName{pkg.Group(), name.Name()}, nil
+		return unversionedName{group, name.Name()}, nil
 }
 
 type unversionedName struct {

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -21,12 +21,11 @@ type ConversionGraph struct {
 // Returns the end and true if it's found, or nil and false if not.
 func (graph *ConversionGraph) LookupTransition(start astmodel.PackageReference) (astmodel.PackageReference, bool) {
 	// Expect to get either a local or a storage reference, not an external one
-	local, ok := start.AsLocalPackage()
+	group, _, ok := ref.GroupVersion()
 	if !ok {
 		panic(fmt.Sprintf("cannot use external package reference %s with a conversion graph", start))
 	}
 
-	group := local.Group()
 	subgraph, ok := graph.subGraphs[group]
 	if !ok {
 		return nil, false

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -19,11 +19,11 @@ type ConversionGraph struct {
 
 // LookupTransition looks for a link and find out where it ends, given the starting reference.
 // Returns the end and true if it's found, or nil and false if not.
-func (graph *ConversionGraph) LookupTransition(start astmodel.PackageReference) (astmodel.PackageReference, bool) {
+func (graph *ConversionGraph) LookupTransition(ref astmodel.PackageReference) (astmodel.PackageReference, bool) {
 	// Expect to get either a local or a storage reference, not an external one
 	group, _, ok := ref.GroupVersion()
 	if !ok {
-		panic(fmt.Sprintf("cannot use external package reference %s with a conversion graph", start))
+		panic(fmt.Sprintf("cannot use external package reference %s with a conversion graph", ref))
 	}
 
 	subgraph, ok := graph.subGraphs[group]
@@ -31,7 +31,7 @@ func (graph *ConversionGraph) LookupTransition(start astmodel.PackageReference) 
 		return nil, false
 	}
 
-	return subgraph.LookupTransition(start)
+	return subgraph.LookupTransition(ref)
 }
 
 // FindNext returns the type name of the next closest type on the path to the hub type.

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
@@ -61,12 +61,11 @@ func (b *ConversionGraphBuilder) Build() (*ConversionGraph, error) {
 // getSubBuilder finds the relevant builder for the group of the provided reference, creating one if necessary
 func (b *ConversionGraphBuilder) getSubBuilder(ref astmodel.PackageReference) *GroupConversionGraphBuilder {
 	// Expect to get either a local or a storage reference, not an external one
-	local, ok := ref.AsLocalPackage()
+	group, _, ok := ref.GroupVersion()
 	if !ok {
 		panic(fmt.Sprintf("cannot use external package reference %s with a conversion graph", ref))
 	}
 
-	group := local.Group()
 	subBuilder, ok := b.subBuilders[group]
 	if !ok {
 		subBuilder = NewGroupConversionGraphBuilder(group)

--- a/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/group_conversion_graph_builder.go
@@ -42,7 +42,7 @@ func (b *GroupConversionGraphBuilder) Build() (*GroupConversionGraph, error) {
 
 	// For each original API reference, create a storage variant reference to match
 	for index, ref := range sortedApiReferences {
-		localRef, ok := ref.AsLocalPackage()
+		localRef, ok := ref.(astmodel.LocalPackageReference)
 		if !ok {
 			// Shouldn't have any non-local references, if we do, abort
 			return nil, errors.Errorf("expected all API references to be local references, but %s was not", ref)

--- a/v2/tools/generator/internal/codegen/storage/property_converter.go
+++ b/v2/tools/generator/internal/codegen/storage/property_converter.go
@@ -90,7 +90,7 @@ func (p *PropertyConverter) shortCircuitNamesOfSimpleTypes(
 	tv *astmodel.TypeVisitor, tn astmodel.TypeName, ctx interface{}) (astmodel.Type, error) {
 
 	// for nonlocal packages, preserve the name as is
-	if _, ok := tn.PackageReference.AsLocalPackage(); !ok {
+	if astmodel.IsExternalPackageReference(tn.PackageReference) {
 		return tn, nil
 	}
 

--- a/v2/tools/generator/internal/codegen/storage/property_converter.go
+++ b/v2/tools/generator/internal/codegen/storage/property_converter.go
@@ -119,7 +119,7 @@ func (p *PropertyConverter) shortCircuitNamesOfSimpleTypes(
 
 func (_ *PropertyConverter) tryConvertToStoragePackage(name astmodel.TypeName) (astmodel.TypeName, bool) {
 	// Map the type name into our storage package
-	localRef, ok := name.PackageReference.AsLocalPackage()
+	localRef, ok := name.PackageReference.(astmodel.LocalPackageReference)
 	if !ok {
 		return astmodel.TypeName{}, false
 	}

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -82,12 +82,11 @@ func (omc *ObjectModelConfiguration) Add(group *GroupConfiguration) *ObjectModel
 
 // findGroup uses the provided TypeName to work out which nested GroupConfiguration should be used
 func (omc *ObjectModelConfiguration) findGroup(name astmodel.TypeName) (*GroupConfiguration, bool) {
-	localRef, ok := name.PackageReference.AsLocalPackage()
+	group, _, ok := name.PackageReference.GroupVersion()
 	if !ok {
 		return nil, false
 	}
 
-	group := strings.ToLower(localRef.Group())
 	g, ok := omc.groups[group]
 	if !ok {
 		return nil, false

--- a/v2/tools/generator/internal/config/type_matcher.go
+++ b/v2/tools/generator/internal/config/type_matcher.go
@@ -84,7 +84,7 @@ func (t *TypeMatcher) AppliesToType(typeName astmodel.TypeName) bool {
 			t.versionMatches(version) &&
 			t.nameMatches(typeName.Name())
 
-		// Track this match so we can later report if we didn't match anything
+		// Track this match, so we can later report if we didn't match anything
 		if result {
 			if t.matchedTypes == nil {
 				t.matchedTypes = astmodel.NewTypeNameSet(typeName)
@@ -152,7 +152,7 @@ func createGlobbingRegex(globbing string) *regexp.Regexp {
 		regexes = append(regexes, g)
 	}
 
-	// (?i) forces case insensitive matches
+	// (?i) forces case-insensitive matches
 	regex := "(?i)" + strings.Join(regexes, "|")
 	return regexp.MustCompile(regex)
 }

--- a/v2/tools/generator/internal/config/type_matcher.go
+++ b/v2/tools/generator/internal/config/type_matcher.go
@@ -78,9 +78,7 @@ func (t *TypeMatcher) matches(glob string, regex **regexp.Regexp, name string) b
 
 // AppliesToType indicates whether this filter should be applied to the supplied type definition
 func (t *TypeMatcher) AppliesToType(typeName astmodel.TypeName) bool {
-	if localRef, ok := typeName.PackageReference.AsLocalPackage(); ok {
-		group := localRef.Group()
-		version := localRef.Version()
+	if group, version, ok := typeName.PackageReference.GroupVersion(); ok {
 
 		result := t.groupMatches(group) &&
 			t.versionMatches(version) &&

--- a/v2/tools/generator/internal/test/asserts.go
+++ b/v2/tools/generator/internal/test/asserts.go
@@ -28,12 +28,13 @@ func AssertPackagesGenerateExpectedCode(t *testing.T, types astmodel.Types, opti
 	// Write a file for each package
 	for _, defs := range groups {
 		ref := defs[0].Name().PackageReference
-		local, ok := ref.AsLocalPackage()
+		group, version, ok := ref.GroupVersion()
 		if !ok {
-			panic("Must only have types from local packages - fix your test")
+			msg := fmt.Sprintf("May not have types from external package %s - fix your test", ref)
+			panic(msg)
 		}
 
-		fileName := fmt.Sprintf("%s-%s", local.Group(), local.Version())
+		fileName := fmt.Sprintf("%s-%s", group, version)
 		AssertTypeDefinitionsGenerateExpectedCode(t, fileName, defs, options...)
 	}
 }

--- a/v2/tools/generator/internal/test/file_definition.go
+++ b/v2/tools/generator/internal/test/file_definition.go
@@ -14,13 +14,13 @@ import (
 func CreateFileDefinition(definitions ...astmodel.TypeDefinition) *astmodel.FileDefinition {
 	packages := make(map[astmodel.PackageReference]*astmodel.PackageDefinition)
 
-	// Use the package reference of the first definition for the whole file
-	ref, err := astmodel.PackageAsLocalPackage(definitions[0].Name().PackageReference)
-	if err != nil {
-		panic(errors.Wrap(err, "Expected first definition to have a local package reference - fix your test!"))
+	ref := definitions[0].Name().PackageReference
+	group, version, ok := ref.GroupVersion()
+	if !ok {
+		panic(errors.Errorf("Expected first definition not to have external package reference %s - fix your test!", ref))
 	}
 
-	pkgDefinition := astmodel.NewPackageDefinition(ref.Group(), ref.PackageName())
+	pkgDefinition := astmodel.NewPackageDefinition(group, version)
 	for _, def := range definitions {
 		pkgDefinition.AddDefinition(def)
 	}
@@ -37,12 +37,14 @@ func CreateTestFileDefinition(definitions ...astmodel.TypeDefinition) *astmodel.
 	packages := make(map[astmodel.PackageReference]*astmodel.PackageDefinition)
 
 	// Use the package reference of the first definition for the whole file
-	ref, err := astmodel.PackageAsLocalPackage(definitions[0].Name().PackageReference)
-	if err != nil {
-		panic(errors.Wrap(err, "Expected first definition to have a local package reference - fix your test!"))
+	ref := definitions[0].Name().PackageReference
+
+	group, version, ok := ref.GroupVersion()
+	if !ok {
+		panic(errors.Errorf("Expected first definition not to have external package reference %s - fix your test!", ref))
 	}
 
-	pkgDefinition := astmodel.NewPackageDefinition(ref.Group(), ref.PackageName())
+	pkgDefinition := astmodel.NewPackageDefinition(group, version)
 	for _, def := range definitions {
 		pkgDefinition.AddDefinition(def)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We've been handwaving along with the illusion that a `StoragePackageReference` was effectively a `LocalPackageReference` and could be treated as such for all intents and purposes ... this illusion broke down as I was implementing object renaming.

Upon inspection, it became clear that most (if not all) use of `AsLocalPackageReference` was interested in getting the `Group`, `Version` or both values from the reference.

By adding `GroupVersion()` to the interface definition, I was able to replace almost all calls to `AsLocalPackageReference` with cleaner code.

The few remaining references were easily refactored, allowing the removal of both the interface member `AsLocalPackageReference` and the helper method `PackageAsLocalPackage`.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/l0HlHJGHe3yAMhdQY/giphy.gif)

**If applicable**:
- [x] this PR contains tests
