### PR TITLE
BREAKING: Rename annotations to match prefix/name

### DIFF
--- a/v2/internal/controllers/generic_controller.go
+++ b/v2/internal/controllers/generic_controller.go
@@ -201,7 +201,7 @@ func MakeResourceGVKLookup(mgr ctrl.Manager, objs []client.Object) (map[schema.G
 
 // NamespaceAnnotation defines the annotation name to use when marking
 // a resource with the namespace of the managing operator.
-const NamespaceAnnotation = "azure.microsoft.com/operator-namespace"
+const NamespaceAnnotation = "serviceoperator.azure.com/operator-namespace"
 
 // Reconcile will take state in K8s and apply it to Azure
 func (gr *GenericReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/v2/internal/reconcilers/azure_generic_arm_reconciler.go
+++ b/v2/internal/reconcilers/azure_generic_arm_reconciler.go
@@ -40,9 +40,9 @@ import (
 
 const (
 	// TODO: Delete these later in favor of something in status?
-	PollerResumeTokenAnnotation = "poller-resume-token.azure.com"
-	PollerResumeIDAnnotation    = "poller-resume-id.azure.com"
-	ResourceSigAnnotationKey    = "resource-sig.azure.com"
+	PollerResumeTokenAnnotation = "serviceoperator.azure.com/poller-resume-token"
+	PollerResumeIDAnnotation    = "serviceoperator.azure.com/poller-resume-id"
+	ResourceSigAnnotationKey    = "serviceoperator.azure.com/resource-sig"
 )
 
 // TODO: Do we actually want this at the controller level or this level?


### PR DESCRIPTION
* Renamed "poller-resume-token.azure.com" to "serviceoperator.azure.com/poller-resume-token".
* Renamed "poller-resume-id.azure.com" to "serviceoperator.azure.com/poller-resume-id".
* Renamed "resource-sig.azure.com" to "serviceoperator.azure.com/resource-sig".
* Renamed "azure.microsoft.com/operator-namespace" to "serviceoperator.azure.com/operator-namespace".

This fixes #1970.
