### PR TITLE
Add `inject-ca-from` annotation to generated CRD patches

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -296,7 +296,7 @@ tasks:
     cmds:
       # This timeout is purposefully low - if we find that this job is taking a long time we may need to think of other ways
       # to keep CI fast
-      - go test -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./test
+      - go test -timeout 15m -v -run '{{default ".*" .TEST_FILTER}}' ./test
 
   controller:test-integration-ci:
     desc: Run integration tests for CI

--- a/v2/test/managedidentity_test.go
+++ b/v2/test/managedidentity_test.go
@@ -23,9 +23,9 @@ func Test_ManagedIdentity_ResourceCanBeCreated(t *testing.T) {
 
 	rg := tc.CreateTestResourceGroupAndWait()
 
-	// Test creating another resource as well - resource group is the
-	// only one that without multiple versions (and so no conversion
-	// webhooks).
+	// Test creating another resource to ensure conversion webhooks
+	// are working - resource group is the only one without multiple
+	// versions (and so no conversion webhooks).
 	vnet := network.VirtualNetwork{
 		ObjectMeta: tc.MakeObjectMetaWithName(tc.Namer.GenerateName("vn")),
 		Spec: network.VirtualNetworks_Spec{

--- a/v2/test/managedidentity_test.go
+++ b/v2/test/managedidentity_test.go
@@ -7,16 +7,36 @@ package test
 
 import (
 	"testing"
+
+	network "github.com/Azure/azure-service-operator/v2/api/network/v1alpha1api20201101"
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
 )
 
 func Test_ManagedIdentity_ResourceCanBeCreated(t *testing.T) {
 	t.Parallel()
 
-	// The identity used by this test is always based on AAD Pod Identity, so all we need to do is
-	// create and delete a resource group and ensure that it works.
+	// The identity used by this test is always based on AAD Pod
+	// Identity, so all we need to do is create and delete a resource
+	// group and ensure that it works.
 
 	tc := globalTestContext.ForTest(t)
 
 	rg := tc.CreateTestResourceGroupAndWait()
-	tc.DeleteResourceAndWait(rg)
+
+	// Test creating another resource as well - resource group is the
+	// only one that without multiple versions (and so no conversion
+	// webhooks).
+	vnet := network.VirtualNetwork{
+		ObjectMeta: tc.MakeObjectMetaWithName(tc.Namer.GenerateName("vn")),
+		Spec: network.VirtualNetworks_Spec{
+			Owner:    testcommon.AsOwner(rg),
+			Location: testcommon.DefaultTestRegion,
+			AddressSpace: network.AddressSpace{
+				AddressPrefixes: []string{"10.0.0.0/8"},
+			},
+		},
+	}
+	tc.CreateResourceAndWait(&vnet)
+
+	tc.DeleteResourcesAndWait(&vnet, rg)
 }

--- a/v2/tools/generator/internal/kustomization/conversion_patch_file.go
+++ b/v2/tools/generator/internal/kustomization/conversion_patch_file.go
@@ -20,6 +20,8 @@ import (
 // kind: CustomResourceDefinition
 // metadata:
 //     name: roleassignments.microsoft.authorization.azure.com
+//     annotations:
+//         cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 // spec:
 //     preserveUnknownFields: false
 //     conversion:
@@ -47,6 +49,9 @@ func NewConversionPatchFile(resourceName string) *ConversionPatchFile {
 		Kind:       "CustomResourceDefinition",
 		Metadata: conversionPatchMetadata{
 			Name: resourceName,
+			Annotations: map[string]string{
+				certManagerInjectKey: certManagerInjectValue,
+			},
 		},
 		Spec: conversionPatchSpec{
 			PreserveUnknownFields: false,
@@ -84,8 +89,20 @@ func (p *ConversionPatchFile) Save(destination string) error {
 	return nil
 }
 
+const (
+	// This annotation instructs the cert-manager webhooks to inject
+	// the CA bundle from a certificate into the client config of this
+	// CRD's conversion webhook.
+	certManagerInjectKey = "cert-manager.io/inject-ca-from"
+
+	// The values here will be substituted by kusomization vars when
+	// this kustomize directory is built.
+	certManagerInjectValue = "$(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)"
+)
+
 type conversionPatchMetadata struct {
-	Name string `yaml:"name"`
+	Name        string            `yaml:"name"`
+	Annotations map[string]string `yaml:"annotations"`
 }
 
 type conversionPatchSpec struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
The `cert-manager.io/inject-ca-from` annotation on a CRD tells the cert-manager webhooks to add the CA bundle to the conversion webhook client config. Without this the conversion webhooks will fail and the only resource that will be able to be created will be resource groups (since they don't have multiple versions). This was missed because our integration test and manual post-release check only tested resource groups 😢. This has now been rectified! 

Envtests were working because they manage the CA bundle themselves when the CRD is being installed.

**How does this PR make you feel**:
![gif](https://c.tenor.com/ZAHC50FvopkAAAAC/futurama-fry.gif)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
