### PR TITLE
Stop using specHash optimization - reconcile should always PUT to Azure

### DIFF
--- a/v2/cmd/controller/main.go
+++ b/v2/cmd/controller/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/config"
 	"github.com/Azure/azure-service-operator/v2/internal/controllers"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/internal/version"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
@@ -82,6 +83,8 @@ func main() {
 	}
 
 	log := ctrl.Log.WithName("controllers")
+	log.V(Status).Info("Configuration details", "config", cfg.String())
+
 	if cfg.OperatorMode.IncludesWatchers() {
 		if errs := controllers.RegisterAll(mgr, clientFactory, controllers.GetKnownStorageTypes(), makeControllerOptions(log, cfg)); errs != nil {
 			setupLog.Error(err, "failed to register gvks")

--- a/v2/config/manager/manager_image_patch.yaml
+++ b/v2/config/manager/manager_image_patch.yaml
@@ -46,6 +46,12 @@ spec:
                   name: aso-controller-settings
                   key: AZURE_OPERATOR_MODE
                   optional: true
+            - name: AZURE_SYNC_PERIOD
+              valueFrom:
+                secretKeyRef:
+                  name: aso-controller-settings
+                  key: AZURE_SYNC_PERIOD
+                  optional: true
             # Used for setting the operator-namespace annotation (and
             # for aad-pod-identity once we support it).
             - name: POD_NAMESPACE

--- a/v2/internal/config/vars.go
+++ b/v2/internal/config/vars.go
@@ -6,6 +6,7 @@ package config
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -14,6 +15,7 @@ const (
 	SubscriptionIDVar   = "AZURE_SUBSCRIPTION_ID"
 	targetNamespacesVar = "AZURE_TARGET_NAMESPACES"
 	operatorModeVar     = "AZURE_OPERATOR_MODE"
+	syncPeriodVar       = "AZURE_SYNC_PERIOD"
 	podNamespaceVar     = "POD_NAMESPACE"
 )
 
@@ -34,6 +36,17 @@ type Values struct {
 	// for Azure resources (if the mode includes running watchers). If
 	// it's empty the operator will watch all namespaces.
 	TargetNamespaces []string
+
+	// SyncPeriod is the frequency at which resources are re-reconciled with Azure
+	// when there have been no triggering changes in the Kubernetes resources. This sync
+	// exists to detect and correct changes that happened in Azure that Kubernetes is not
+	// aware about. BE VERY CAREFUL setting this value low - even a modest number of resources
+	// can cause subscription level throttling if they are re-synced frequently.
+	// If nil, no sync is performed.
+	//
+	// This can be set to nil by specifying empty string for AZURE_SYNC_PERIOD explicitly in
+	// the config.
+	SyncPeriod *time.Duration
 }
 
 // ReadFromEnvironment loads configuration values from the AZURE_*
@@ -51,9 +64,17 @@ func ReadFromEnvironment() (Values, error) {
 		result.OperatorMode = mode
 	}
 
+	var err error
+
 	result.SubscriptionID = os.Getenv(SubscriptionIDVar)
 	result.PodNamespace = os.Getenv(podNamespaceVar)
 	result.TargetNamespaces = parseTargetNamespaces(os.Getenv(targetNamespacesVar))
+	result.SyncPeriod, err = parseSyncPeriod()
+
+	if err != nil {
+		return result, errors.Wrapf(err, "parsing %q", syncPeriodVar)
+	}
+
 	// Not calling validate here to support using from tests where we
 	// don't require consistent settings.
 	return result, nil
@@ -99,4 +120,29 @@ func parseTargetNamespaces(fromEnv string) []string {
 		items[i] = strings.TrimSpace(item)
 	}
 	return items
+}
+
+// parseSyncPeriod parses the sync period from the environment
+func parseSyncPeriod() (*time.Duration, error) {
+	syncPeriodStr := envOrDefault(syncPeriodVar, "15m")
+	if syncPeriodStr == "" {
+		return nil, nil
+	}
+
+	syncPeriod, err := time.ParseDuration(syncPeriodStr)
+	if err != nil {
+		return nil, err
+	}
+	return &syncPeriod, nil
+}
+
+// envOrDefault returns the value of the specified env variable or the default value if
+// the env variable was not set.
+func envOrDefault(env string, def string) string {
+	result, specified := os.LookupEnv(env)
+	if !specified {
+		return def
+	}
+
+	return result
 }

--- a/v2/internal/config/vars.go
+++ b/v2/internal/config/vars.go
@@ -43,7 +43,8 @@ type Values struct {
 	// exists to detect and correct changes that happened in Azure that Kubernetes is not
 	// aware about. BE VERY CAREFUL setting this value low - even a modest number of resources
 	// can cause subscription level throttling if they are re-synced frequently.
-	// If nil, no sync is performed.
+	// If nil, no sync is performed. Durations are specified as "1h", "15m", or "60s". See
+	// https://pkg.go.dev/time#ParseDuration for more details.
 	//
 	// This can be set to nil by specifying empty string for AZURE_SYNC_PERIOD explicitly in
 	// the config.

--- a/v2/internal/config/vars.go
+++ b/v2/internal/config/vars.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -47,6 +48,19 @@ type Values struct {
 	// This can be set to nil by specifying empty string for AZURE_SYNC_PERIOD explicitly in
 	// the config.
 	SyncPeriod *time.Duration
+}
+
+var _ fmt.Stringer = Values{}
+
+// Returns the configuration as a string
+func (v Values) String() string {
+	return fmt.Sprintf(
+		"SubscriptionID:%s/PodNamespace:%s/OperatorMode:%s/TargetNamespaces:%s/SyncPeriod:%s",
+		v.SubscriptionID,
+		v.PodNamespace,
+		v.OperatorMode,
+		strings.Join(v.TargetNamespaces, "|"),
+		v.SyncPeriod)
 }
 
 // ReadFromEnvironment loads configuration values from the AZURE_*

--- a/v2/internal/config/vars_test.go
+++ b/v2/internal/config/vars_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package config_test
+
+import (
+	"reflect"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/internal/config"
+)
+
+func Test_String_HasAllKeys(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// This makes sure that if config.Values or testConfig changes
+	// then cfgToKey is updated to match.
+	s := config.Values{}.String()
+
+	testConfigType := reflect.TypeOf(config.Values{})
+
+	for _, field := range reflect.VisibleFields(testConfigType) {
+		g.Expect(s).To(ContainSubstring(field.Name + ":"))
+	}
+}

--- a/v2/internal/controllers/generic_controller.go
+++ b/v2/internal/controllers/generic_controller.go
@@ -263,7 +263,8 @@ func (gr *GenericReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		gr.Recorder,
 		gr.KubeClient,
 		gr.ResourceResolver,
-		gr.PositiveConditions)
+		gr.PositiveConditions,
+		gr.Config)
 
 	result, err := reconciler.Reconcile(ctx)
 	if err != nil {

--- a/v2/internal/reconcilers/azure_generic_arm_reconciler.go
+++ b/v2/internal/reconcilers/azure_generic_arm_reconciler.go
@@ -7,8 +7,6 @@ package reconcilers
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -19,7 +17,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,7 +39,6 @@ const (
 	// TODO: Delete these later in favor of something in status?
 	PollerResumeTokenAnnotation = "serviceoperator.azure.com/poller-resume-token"
 	PollerResumeIDAnnotation    = "serviceoperator.azure.com/poller-resume-id"
-	ResourceSigAnnotationKey    = "serviceoperator.azure.com/resource-sig"
 )
 
 // TODO: Do we actually want this at the controller level or this level?
@@ -221,57 +217,6 @@ func (r *AzureDeploymentReconciler) SetPollerResumeToken(id string, token string
 	genruntime.AddAnnotation(r.obj, PollerResumeIDAnnotation, id)
 }
 
-func (r *AzureDeploymentReconciler) SetResourceSignature(sig string) {
-	genruntime.AddAnnotation(r.obj, ResourceSigAnnotationKey, sig)
-}
-
-func (r *AzureDeploymentReconciler) GetResourceSignature() (string, bool) {
-	sig, hasSig := r.obj.GetAnnotations()[ResourceSigAnnotationKey]
-	return sig, hasSig
-}
-
-func (r *AzureDeploymentReconciler) HasResourceSpecHashChanged() (bool, error) {
-	oldSig, exists := r.obj.GetAnnotations()[ResourceSigAnnotationKey]
-	if !exists {
-		// signature does not exist, so yes, it has changed
-		return true, nil
-	}
-
-	newSig, err := r.SpecSignature()
-	if err != nil {
-		return false, err
-	}
-	// check if the last signature matches the new signature
-	return oldSig != newSig, nil
-}
-
-// SpecSignature calculates the hash of a spec. This can be used to compare specs and determine
-// if there has been a change
-func (r *AzureDeploymentReconciler) SpecSignature() (string, error) {
-	// Convert the resource to unstructured for easier comparison later.
-	unObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(r.obj)
-	if err != nil {
-		return "", err
-	}
-
-	spec, ok, err := unstructured.NestedMap(unObj, "spec")
-	if err != nil {
-		return "", err
-	}
-
-	if !ok {
-		return "", errors.New("unable to find spec within unstructured MetaObject")
-	}
-
-	bits, err := json.Marshal(spec)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to marshal spec of unstructured MetaObject")
-	}
-
-	hash := sha256.Sum256(bits)
-	return hex.EncodeToString(hash[:]), nil
-}
-
 func (r *AzureDeploymentReconciler) makeReadyConditionFromError(cloudError *genericarmclient.CloudError) conditions.Condition {
 	var severity conditions.ConditionSeverity
 	errorDetails := ClassifyCloudError(cloudError)
@@ -290,11 +235,6 @@ func (r *AzureDeploymentReconciler) makeReadyConditionFromError(cloudError *gene
 }
 
 func (r *AzureDeploymentReconciler) AddInitialResourceState(resourceID string) error {
-	sig, err := r.SpecSignature() // nolint:govet
-	if err != nil {
-		return errors.Wrap(err, "failed to compute resource spec hash")
-	}
-	r.SetResourceSignature(sig)
 	conditions.SetCondition(r.obj, r.PositiveConditions.Ready.Reconciling(r.obj.GetGeneration()))
 	genruntime.SetResourceID(r.obj, resourceID) // TODO: This is sorta weird because we can actually just get it via resolver... so this is a cached value only?
 
@@ -313,12 +253,6 @@ func (r *AzureDeploymentReconciler) DetermineDeleteAction() (DeleteAction, Delet
 
 func (r *AzureDeploymentReconciler) DetermineCreateOrUpdateAction() (CreateOrUpdateAction, CreateOrUpdateActionFunc, error) {
 	ready := r.GetReadyCondition()
-
-	hasChanged, err := r.HasResourceSpecHashChanged()
-	if err != nil {
-		return CreateOrUpdateActionNoAction, NoAction, errors.Wrap(err, "comparing resource hash")
-	}
-
 	pollerID, pollerResumeToken, hasPollerResumeToken := r.GetPollerResumeToken()
 
 	conditionString := "<nil>"
@@ -328,15 +262,8 @@ func (r *AzureDeploymentReconciler) DetermineCreateOrUpdateAction() (CreateOrUpd
 	r.log.V(Verbose).Info(
 		"DetermineCreateOrUpdateAction",
 		"condition", conditionString,
-		"hasChanged", hasChanged,
 		"pollerID", pollerID,
 		"resumeToken", pollerResumeToken)
-
-	if !hasChanged && r.InTerminalState() {
-		msg := fmt.Sprintf("Nothing to do. Spec has not changed and resource has terminal Ready condition: %q.", ready)
-		r.log.V(Info).Info(msg)
-		return CreateOrUpdateActionNoAction, NoAction, nil
-	}
 
 	if ready != nil && ready.Reason == conditions.ReasonDeleting {
 		return CreateOrUpdateActionNoAction, NoAction, errors.Errorf("resource is currently deleting; it can not be applied")
@@ -520,9 +447,11 @@ func (r *AzureDeploymentReconciler) handlePollerFailed(ctx context.Context, err 
 		"resourceID", genruntime.GetResourceIDOrDefault(r.obj),
 		"error", err.Error())
 
+	isFatal := false
 	if isCloudErr {
 		ready := r.makeReadyConditionFromError(cloudError)
 		conditions.SetCondition(r.obj, ready)
+		isFatal = ready.Severity == conditions.ConditionSeverityError
 	}
 
 	r.SetPollerResumeToken("", "")
@@ -534,7 +463,7 @@ func (r *AzureDeploymentReconciler) handlePollerFailed(ctx context.Context, err 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{Requeue: !isFatal}, nil
 }
 
 func (r *AzureDeploymentReconciler) handlePollerSuccess(ctx context.Context) (ctrl.Result, error) {

--- a/v2/internal/testcommon/kube_per_test_context.go
+++ b/v2/internal/testcommon/kube_per_test_context.go
@@ -113,6 +113,10 @@ func (ctx KubeGlobalContext) ForTest(t *testing.T) *KubePerTestContext {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Test configs never want SyncPeriod set as it introduces jitter
+	cfg.SyncPeriod = nil
+
 	return ctx.ForTestWithConfig(t, cfg)
 }
 

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -194,7 +194,7 @@ type testConfig struct {
 func cfgToKey(cfg testConfig) string {
 	return fmt.Sprintf(
 		"%s/Replaying:%t",
-		cfg.Values.String(),
+		cfg.Values,
 		cfg.Replaying)
 }
 

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"time"
 
@@ -194,13 +193,9 @@ type testConfig struct {
 
 func cfgToKey(cfg testConfig) string {
 	return fmt.Sprintf(
-		"SubscriptionID:%s/PodNamespace:%s/OperatorMode:%s/Replaying:%t/TargetNamespaces:%s/SyncPeriod:%s",
-		cfg.SubscriptionID,
-		cfg.PodNamespace,
-		cfg.OperatorMode,
-		cfg.Replaying,
-		strings.Join(cfg.TargetNamespaces, "|"),
-		cfg.SyncPeriod)
+		"%s/Replaying:%t",
+		cfg.Values.String(),
+		cfg.Replaying)
 }
 
 func (set *sharedEnvTests) stopAll() {

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -194,12 +194,13 @@ type testConfig struct {
 
 func cfgToKey(cfg testConfig) string {
 	return fmt.Sprintf(
-		"SubscriptionID:%s/PodNamespace:%s/OperatorMode:%s/Replaying:%t/TargetNamespaces:%s",
+		"SubscriptionID:%s/PodNamespace:%s/OperatorMode:%s/Replaying:%t/TargetNamespaces:%s/SyncPeriod:%s",
 		cfg.SubscriptionID,
 		cfg.PodNamespace,
 		cfg.OperatorMode,
 		cfg.Replaying,
-		strings.Join(cfg.TargetNamespaces, "|"))
+		strings.Join(cfg.TargetNamespaces, "|"),
+		cfg.SyncPeriod)
 }
 
 func (set *sharedEnvTests) stopAll() {

--- a/v2/internal/util/lockedrand/rand.go
+++ b/v2/internal/util/lockedrand/rand.go
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package lockedrand
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// LockedSource is a simple locked random source, similar to the one implemented but
+// not exported in math/rand.
+type LockedSource struct {
+	lock sync.Mutex
+	src  rand.Source64
+}
+
+var _ rand.Source = &LockedSource{}
+var _ rand.Source64 = &LockedSource{}
+
+func (l *LockedSource) Int63() int64 {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return l.src.Int63()
+}
+
+func (l *LockedSource) Uint64() uint64 {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return l.src.Uint64()
+}
+
+func (l *LockedSource) Seed(seed int64) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.src.Seed(seed)
+}
+
+// NewSource returns a new LockedSource
+func NewSource(seed int64) rand.Source {
+	return &LockedSource{
+		src: rand.NewSource(seed).(rand.Source64),
+	}
+}

--- a/v2/internal/util/randextensions/time.go
+++ b/v2/internal/util/randextensions/time.go
@@ -4,20 +4,27 @@
 package randextensions
 
 import (
+	"math"
 	"math/rand"
 	"time"
 )
 
 // Jitter returns the provided duration, scaled by a jitter factor.
 // jitter must be between 0 and 1.
-// After jitter is applied the result will be in the range: [(1-jitter)t, (1+jitter)t]
-// UNLESS (1+jitter)*t overflows int64. Overflows are not checked by this function so
-// use with caution.
+// After jitter is applied the result will be in the range: [(1-jitter)t, (1+jitter)t],
+// UNLESS (1+jitter)t is larger than MaxInt64, in which case the range will be [(1-jitter)t, math.MaxInt64]
 func Jitter(r *rand.Rand, t time.Duration, jitter float64) time.Duration {
 	if jitter <= 0 || jitter > 1 {
 		panic("jitter must be in the range (0, 1]")
 	}
-	low := 1 - jitter
-	val := low + r.Float64()*(2*jitter)
-	return time.Duration(float64(t) * val)
+	halfRange := int64(float64(t) * jitter)
+	min := int64(t) - halfRange
+	fullRange := 2 * halfRange
+	// check for possible overflow and limit range if so
+	if int64(t) > math.MaxInt64-halfRange {
+		fullRange = math.MaxInt64 - int64(t) + halfRange
+	}
+
+	val := min + int64(r.Float64()*float64(fullRange))
+	return time.Duration(val)
 }

--- a/v2/internal/util/randextensions/time.go
+++ b/v2/internal/util/randextensions/time.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package randextensions
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Jitter returns the provided duration, scaled by a jitter factor.
+// jitter must be between 0 and 1.
+// After jitter is applied the result will be in the range: [(1-jitter)t, (1+jitter)t]
+// UNLESS (1+jitter)*t overflows int64. Overflows are not checked by this function so
+// use with caution.
+func Jitter(r *rand.Rand, t time.Duration, jitter float64) time.Duration {
+	if jitter <= 0 || jitter > 1 {
+		panic("jitter must be in the range (0, 1]")
+	}
+	low := 1 - jitter
+	val := low + r.Float64()*(2*jitter)
+	return time.Duration(float64(t) * val)
+}

--- a/v2/internal/util/randextensions/time_test.go
+++ b/v2/internal/util/randextensions/time_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package randextensions_test
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+
+	"github.com/Azure/azure-service-operator/v2/internal/util/lockedrand"
+	"github.com/Azure/azure-service-operator/v2/internal/util/randextensions"
+)
+
+func Test_Jitter(t *testing.T) {
+	t.Parallel()
+
+	seed := time.Now().UnixNano()
+	//nolint:gosec // do not want cryptographic randomness here
+	r := rand.New(lockedrand.NewSource(seed))
+	properties := gopter.NewProperties(gopter.DefaultTestParametersWithSeed(seed))
+
+	properties.Property(
+		"Is in expected jitter range",
+		prop.ForAll(
+			func(t int64, jitter float64) bool {
+				result := randextensions.Jitter(r, time.Duration(t), jitter)
+
+				expectedLow := time.Duration((1 - jitter) * float64(t))
+				expectedHigh := time.Duration((1 + jitter) * float64(t))
+				return result >= expectedLow && result <= expectedHigh
+			},
+			gen.Int64Range(0, math.MaxInt64/2-1), // Ensure we don't overflow... TODO: Maybe method should test for that?
+			gen.Float64Range(0.001, 1)))
+
+	properties.TestingRun(t)
+}

--- a/v2/internal/util/randextensions/time_test.go
+++ b/v2/internal/util/randextensions/time_test.go
@@ -32,10 +32,15 @@ func Test_Jitter(t *testing.T) {
 				result := randextensions.Jitter(r, time.Duration(t), jitter)
 
 				expectedLow := time.Duration((1 - jitter) * float64(t))
-				expectedHigh := time.Duration((1 + jitter) * float64(t))
+
+				halfRange := int64(jitter * float64(t))
+				expectedHigh := time.Duration((1 + jitter) * float64(t)) // This could overflow -- check is below
+				if math.MaxInt64-halfRange < t {
+					expectedHigh = math.MaxInt64
+				}
 				return result >= expectedLow && result <= expectedHigh
 			},
-			gen.Int64Range(0, math.MaxInt64/2-1), // Ensure we don't overflow... TODO: Maybe method should test for that?
+			gen.Int64Range(0, math.MaxInt64),
 			gen.Float64Range(0.001, 1)))
 
 	properties.TestingRun(t)


### PR DESCRIPTION
* Stop using SpecHash to prevent issuing a PUT to Azure. 

  The use of SpecHash prevented us from detecting changes in Azure 
  and resolving them, which is one of the primary deliverables of an
  operator.
* Perform a re-sync with Azure every 15m.
* Add Jitter helper method and associated lockedrand module.

This is related to #1491

**If applicable**:
- [x] this PR contains tests
