### PR TITLE
Create default merger helper method for status merging

### DIFF
--- a/v2/tools/generator/internal/astmodel/type_merger.go
+++ b/v2/tools/generator/internal/astmodel/type_merger.go
@@ -37,8 +37,8 @@ type mergerRegistration struct {
 
 type MergerFunc func(ctx interface{}, left, right Type) (Type, error)
 
-func NewTypeMerger(fallback MergerFunc) TypeMerger {
-	return TypeMerger{fallback: fallback}
+func NewTypeMerger(fallback MergerFunc) *TypeMerger {
+	return &TypeMerger{fallback: fallback}
 }
 
 var typeInterface reflect.Type = reflect.TypeOf((*Type)(nil)).Elem() // yuck

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -339,7 +339,7 @@ func (s synthesizer) intersectTypes(left astmodel.Type, right astmodel.Type) (as
 	return intersector.MergeWithContext(s, left, right)
 }
 
-var intersector astmodel.TypeMerger
+var intersector *astmodel.TypeMerger
 
 func init() {
 	i := astmodel.NewTypeMerger(func(_ctx interface{}, left, right astmodel.Type) (astmodel.Type, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/status_augment.go
+++ b/v2/tools/generator/internal/codegen/pipeline/status_augment.go
@@ -62,11 +62,131 @@ func fuseAugmenters(augments ...augmenter) augmenter {
 	}
 }
 
+// newDefaultMerger returns a default merger that deals with the following common cases:
+// (TypeName, Type) - by resolving LHS
+// (Type, TypeName) - by resolving RHS
+// (Optional, Type) - by ignoring optionality
+// (Type, Optional) - by ignoring optionality
+// (FlaggedType, Type) - by ignoring flags
+// Note: (Type, FlaggedType) is not handled as the Status types are not expected to be flagged
+// (Map, Map)  - by matching up the keys and values
+// (Array, Array) - by matching up the inner types
+// (AllOf, AllOf) - panics
+// (OneOf, OneOf) - panics
+// (Resource, Resource) - panics
+func newDefaultMerger(allTypes astmodel.ReadonlyTypes) *astmodel.TypeMerger {
+	merger := astmodel.NewTypeMerger(func(ctx interface{}, left, right astmodel.Type) (astmodel.Type, error) {
+		// as a fallback, return left (= main type) if we have nothing else to do
+		return left, nil
+	})
+
+	// handle (TypeName, Type) by resolving LHS
+	merger.Add(func(spec astmodel.TypeName, status astmodel.Type) (astmodel.Type, error) {
+		// Connascence alert! This is in coöperation with the code in
+		// determine_resource_ownership.go:updateChildResourceDefinitionsWithOwner
+		// which requires the typenames to identify which ChildResources match
+		// which Resources. The ChildResource types should never actually be
+		// used, so it's okay that we don't visit them here.
+		if strings.HasSuffix(spec.Name(), ChildResourceNameSuffix) {
+			// don't touch child resources!
+			return spec, nil
+		}
+
+		specType := allTypes.Get(spec).Type()
+
+		newSpec, err := merger.Merge(specType, status)
+		if err != nil {
+			return nil, err
+		}
+
+		// return original typename if not changed
+		if astmodel.TypeEquals(newSpec, specType) {
+			return spec, nil
+		}
+
+		return newSpec, nil
+	})
+
+	// handle (Type, TypeName) by resolving RHS
+	merger.Add(func(spec astmodel.Type, status astmodel.TypeName) (astmodel.Type, error) {
+		return merger.Merge(spec, allTypes.Get(status).Type())
+	})
+
+	// handle (Optional, Type)
+	merger.Add(func(spec *astmodel.OptionalType, status astmodel.Type) (astmodel.Type, error) {
+		// we ignore optionality when matching things up, since there are
+		// discordances between the JSON Schema/Swagger as some teams have handcrafted them
+		newElement, err := merger.Merge(spec.Element(), status)
+		if err != nil {
+			return nil, err
+		}
+
+		return spec.WithElement(newElement), nil
+	})
+
+	// handle (Type, Optional)
+	merger.Add(func(spec astmodel.Type, status *astmodel.OptionalType) (astmodel.Type, error) {
+		// we ignore optionality when matching things up, since there are
+		// discordances between the JSON Schema/Swagger as some teams have handcrafted them
+		return merger.Merge(spec, status.Element())
+	})
+
+	// handle (FlaggedType, Type); there is no need to handle the opposite direction
+	// as the swagger types won’t be flagged
+	merger.Add(func(spec *astmodel.FlaggedType, status astmodel.Type) (astmodel.Type, error) {
+		newElement, err := merger.Merge(spec.Element(), status)
+		if err != nil {
+			return nil, err
+		}
+
+		return spec.WithElement(newElement), nil
+	})
+
+	// handle (Map, Map) by matching up the keys and values
+	merger.Add(func(spec, status *astmodel.MapType) (astmodel.Type, error) {
+		keyResult, err := merger.Merge(spec.KeyType(), status.KeyType())
+		if err != nil {
+			return nil, err
+		}
+
+		valueResult, err := merger.Merge(spec.ValueType(), status.ValueType())
+		if err != nil {
+			return nil, err
+		}
+
+		return spec.WithKeyType(keyResult).WithValueType(valueResult), nil
+	})
+
+	// handle (Array, Array) by matching up the inner types
+	merger.Add(func(spec, status *astmodel.ArrayType) (astmodel.Type, error) {
+		newElement, err := merger.Merge(spec.Element(), status.Element())
+		if err != nil {
+			return nil, err
+		}
+
+		return spec.WithElement(newElement), nil
+	})
+
+	// safety check, (AllOf, AllOf) should not occur
+	merger.Add(func(_, _ *astmodel.AllOfType) (astmodel.Type, error) {
+		panic("allofs should have been removed")
+	})
+
+	// safety check, (OneOf, OneOf) should not occur
+	merger.Add(func(_, _ *astmodel.OneOfType) (astmodel.Type, error) {
+		panic("oneofs should have been removed")
+	})
+
+	// this shouldn't ever happen, I think, (Resource, Resource)
+	merger.Add(func(_, _ *astmodel.ResourceType) (astmodel.Type, error) {
+		panic("unexpected Resource in Status type")
+	})
+
+	return merger
+}
+
 // flattenAugmenter copies across the "flatten" property from Swagger
 func flattenAugmenter(allTypes astmodel.ReadonlyTypes) augmenter {
-	/* TODO: there is a lot here that should be pulled into a "default augmenter" value that can be reused,
-	but at the moment we only have one augmenter */
-
 	return func(spec astmodel.Type, status astmodel.Type) (astmodel.Type, error) {
 		// reminder: merger is invoked with a pair of Types and invokes the first
 		// Added function that matches those types
@@ -75,17 +195,11 @@ func flattenAugmenter(allTypes astmodel.ReadonlyTypes) augmenter {
 		// (SpecType, StatusType),  to copy the StatusType’s “flatten” property
 		// across, if present (this is only provided on the Swagger = Status side)
 		//
-		// most of the cases are only recursively invoking the merger/matcher on
-		// “inner” types; the (Object, Object) case is where the work is done
-		//
 		// note that we do a small optimization where we don’t return a new type
 		// if nothing was changed; this allows us to keep the same TypeNames
 		// if no alterations were made
 
-		merger := astmodel.NewTypeMerger(func(ctx interface{}, left, right astmodel.Type) (astmodel.Type, error) {
-			// as a fallback, return left (= main type) if we have nothing else to do
-			return left, nil
-		})
+		merger := newDefaultMerger(allTypes)
 
 		// this is the main part of the merging, we want to match up (Object, Object)
 		// based on their properties and copy across “flatten” when present, and
@@ -122,108 +236,6 @@ func flattenAugmenter(allTypes astmodel.ReadonlyTypes) augmenter {
 			}
 
 			return spec.WithProperties(props...), nil
-		})
-
-		// handle (TypeName, Type) by resolving LHS
-		merger.Add(func(spec astmodel.TypeName, status astmodel.Type) (astmodel.Type, error) {
-			// Connascence alert! This is in coöperation with the code in
-			// determine_resource_ownership.go:updateChildResourceDefinitionsWithOwner
-			// which requires the typenames to identify which ChildResources match
-			// which Resources. The ChildResource types should never actually be
-			// used, so it's okay that we don't visit them here.
-			if strings.HasSuffix(spec.Name(), ChildResourceNameSuffix) {
-				// don't touch child resources!
-				return spec, nil
-			}
-
-			specType := allTypes.Get(spec).Type()
-
-			newSpec, err := merger.Merge(specType, status)
-			if err != nil {
-				return nil, err
-			}
-
-			// return original typename if not changed
-			if astmodel.TypeEquals(newSpec, specType) {
-				return spec, nil
-			}
-
-			return newSpec, nil
-		})
-
-		// handle (Type, TypeName) by resolving RHS
-		merger.Add(func(spec astmodel.Type, status astmodel.TypeName) (astmodel.Type, error) {
-			return merger.Merge(spec, allTypes.Get(status).Type())
-		})
-
-		// handle (Optional, Type)
-		merger.Add(func(spec *astmodel.OptionalType, status astmodel.Type) (astmodel.Type, error) {
-			// we ignore optionality when matching things up, since there are
-			// discordances between the JSON Schema/Swagger as some teams have handcrafted them
-			newElement, err := merger.Merge(spec.Element(), status)
-			if err != nil {
-				return nil, err
-			}
-
-			return spec.WithElement(newElement), nil
-		})
-
-		// handle (Type, Optional)
-		merger.Add(func(spec astmodel.Type, status *astmodel.OptionalType) (astmodel.Type, error) {
-			// we ignore optionality when matching things up, since there are
-			// discordances between the JSON Schema/Swagger as some teams have handcrafted them
-			return merger.Merge(spec, status.Element())
-		})
-
-		// handle (FlaggedType, Type); there is no need to handle the opposite direction
-		// as the swagger types won’t be flagged
-		merger.Add(func(spec *astmodel.FlaggedType, status astmodel.Type) (astmodel.Type, error) {
-			newElement, err := merger.Merge(spec.Element(), status)
-			if err != nil {
-				return nil, err
-			}
-
-			return spec.WithElement(newElement), nil
-		})
-
-		// handle (Map, Map) by matching up the keys and values
-		merger.Add(func(spec, status *astmodel.MapType) (astmodel.Type, error) {
-			keyResult, err := merger.Merge(spec.KeyType(), status.KeyType())
-			if err != nil {
-				return nil, err
-			}
-
-			valueResult, err := merger.Merge(spec.ValueType(), status.ValueType())
-			if err != nil {
-				return nil, err
-			}
-
-			return spec.WithKeyType(keyResult).WithValueType(valueResult), nil
-		})
-
-		// handle (Array, Array) by matching up the inner types
-		merger.Add(func(spec, status *astmodel.ArrayType) (astmodel.Type, error) {
-			newElement, err := merger.Merge(spec.Element(), status.Element())
-			if err != nil {
-				return nil, err
-			}
-
-			return spec.WithElement(newElement), nil
-		})
-
-		// safety check, (AllOf, AllOf) should not occur
-		merger.Add(func(_, _ *astmodel.AllOfType) (astmodel.Type, error) {
-			panic("allofs should have been removed")
-		})
-
-		// safety check, (OneOf, OneOf) should not occur
-		merger.Add(func(_, _ *astmodel.OneOfType) (astmodel.Type, error) {
-			panic("oneofs should have been removed")
-		})
-
-		// this shouldn't ever happen, I think, (Resource, Resource)
-		merger.Add(func(_, _ *astmodel.ResourceType) (astmodel.Type, error) {
-			return astmodel.NewErroredType(nil, []string{"unsupported"}, nil), nil
 		})
 
 		// now go!


### PR DESCRIPTION
The default merger deals with the common cases so that augmenters can
focus on the specific cases they want to handle.