### PR TITLE
Fix link for GitHub triage search

### DIFF
--- a/docs/issue-management.md
+++ b/docs/issue-management.md
@@ -2,7 +2,7 @@
 
 ## New Issue Triage
 
-On a regular basis (target: weekly) the development team will triage new issues matching the following [GitHub search](https://github.com/Azure/azure-service-operator/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-triage+label%3A%22needs-triage+%3Amag%3A%22):
+On a regular basis (target: weekly) the development team will triage new issues matching the following [GitHub search](https://github.com/Azure/azure-service-operator/issues?q=is%3Aissue+is%3Aopen+label%3A%22needs-triage+%3Amag%3A%22+sort%3Aupdated-desc+):
 
 ```
 is:issue is:open label:needs-triage label:"needs-triage :mag:" 


### PR DESCRIPTION
**What this PR does / why we need it**:

Our current link is wrong - it includes the needs-triage label twice, in two different forms.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/lQfiQeN2LM1SFaYdgJ/giphy.gif)
