### PR TITLE
Add preamble to report

### DIFF
--- a/hack/crossplane/apis/resources.md
+++ b/hack/crossplane/apis/resources.md
@@ -1,16 +1,20 @@
-### cache
+# Supported Resources
+
+These are the resources with Azure Service Operator support committed to our **main** branch, grouped by the originating ARM service. (Newly supported resources will appear in this list prior to inclusion in any ASO release.)
+
+## cache
 
 
-#### ARM version: 2020-06-01
+### ARM version 2020-06-01
 
 - github.com/Azure/azure-service-operator/hack/crossplane/apis/cache/v1alpha1api20200601/Redis
 
 Use CRD version `v1alpha1api20200601`
 
-### sql
+## sql
 
 
-#### ARM version: 2020-11-01-preview
+### ARM version 2020-11-01-preview
 
 - github.com/Azure/azure-service-operator/hack/crossplane/apis/sql/v1alpha1api20201101preview/Server
 - github.com/Azure/azure-service-operator/hack/crossplane/apis/sql/v1alpha1api20201101preview/ServersDatabase

--- a/v2/api/resources.md
+++ b/v2/api/resources.md
@@ -1,6 +1,6 @@
 # Supported Resources
 
-This page lists all resources currently supported by Azure Service Operator, grouped by the originating ARM service.
+These are the resources with Azure Service Operator support committed to our **main** branch, grouped by the originating ARM service. (Newly supported resources will appear in this list prior to inclusion in any ASO release.)
 
 ## authorization
 

--- a/v2/api/resources.md
+++ b/v2/api/resources.md
@@ -1,25 +1,29 @@
-### authorization
+# Supported Resources
+
+This page lists all resources currently supported by Azure Service Operator, grouped by the originating ARM service.
+
+## authorization
 
 
-#### ARM version: 2020-08-01-preview
+### ARM version 2020-08-01-preview
 
 - RoleAssignment ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/authorization/v1alpha1api20200801preview_roleassignment.yaml))
 
 Use CRD version `v1alpha1api20200801preview`
 
-### batch
+## batch
 
 
-#### ARM version: 2021-01-01
+### ARM version 2021-01-01
 
 - BatchAccount ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/batch/v1alpha1api20210101_batchaccount.yaml))
 
 Use CRD version `v1alpha1api20210101`
 
-### cache
+## cache
 
 
-#### ARM version: 2020-12-01
+### ARM version 2020-12-01
 
 - Redis ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/cache/v1alpha1api20201201_redis.yaml))
 - RedisFirewallRule ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/cache/v1alpha1api20201201_redisfirewallrule.yaml))
@@ -29,44 +33,44 @@ Use CRD version `v1alpha1api20210101`
 Use CRD version `v1alpha1api20201201`
 
 
-#### ARM version: 2021-03-01
+### ARM version 2021-03-01
 
 - RedisEnterprise ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/cache/v1alpha1api20210301_redisenterprise.yaml))
 - RedisEnterpriseDatabase ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/cache/v1alpha1api20210301_redisenterprisedatabase.yaml))
 
 Use CRD version `v1alpha1api20210301`
 
-### compute
+## compute
 
 
-#### ARM version: 2020-09-30
+### ARM version 2020-09-30
 
 - Disk ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/compute/v1alpha1api20200930_disk.yaml))
 
 Use CRD version `v1alpha1api20200930`
 
 
-#### ARM version: 2020-12-01
+### ARM version 2020-12-01
 
 - VirtualMachine ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/compute/v1alpha1api20201201_virtualmachine.yaml))
 - VirtualMachineScaleSet ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/compute/v1alpha1api20201201_virtualmachinescaleset.yaml))
 
 Use CRD version `v1alpha1api20201201`
 
-### containerservice
+## containerservice
 
 
-#### ARM version: 2021-05-01
+### ARM version 2021-05-01
 
 - ManagedCluster ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/containerservice/v1alpha1api20210501_managedcluster.yaml))
 - ManagedClustersAgentPool ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/containerservice/v1alpha1api20210501_managedclustersagentpool.yaml))
 
 Use CRD version `v1alpha1api20210501`
 
-### dbformysql
+## dbformysql
 
 
-#### ARM version: 2021-05-01
+### ARM version 2021-05-01
 
 - FlexibleServer ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/dbformysql/v1alpha1api20210501_flexibleserver.yaml))
 - FlexibleServersDatabase ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/dbformysql/v1alpha1api20210501_flexibleserversdatabase.yaml))
@@ -74,10 +78,10 @@ Use CRD version `v1alpha1api20210501`
 
 Use CRD version `v1alpha1api20210501`
 
-### dbforpostgresql
+## dbforpostgresql
 
 
-#### ARM version: 2021-06-01
+### ARM version 2021-06-01
 
 - FlexibleServer ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/dbforpostgresql/v1alpha1api20210601_flexibleserver.yaml))
 - FlexibleServersConfiguration ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/dbforpostgresql/v1alpha1api20210601_flexibleserversconfiguration.yaml))
@@ -86,10 +90,10 @@ Use CRD version `v1alpha1api20210501`
 
 Use CRD version `v1alpha1api20210601`
 
-### documentdb
+## documentdb
 
 
-#### ARM version: 2021-05-15
+### ARM version 2021-05-15
 
 - DatabaseAccount ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/documentdb/v1alpha1api20210515_databaseaccount.yaml))
 - MongodbDatabase ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/documentdb/v1alpha1api20210515_mongodbdatabase.yaml))
@@ -106,10 +110,10 @@ Use CRD version `v1alpha1api20210601`
 
 Use CRD version `v1alpha1api20210515`
 
-### eventgrid
+## eventgrid
 
 
-#### ARM version: 2020-06-01
+### ARM version 2020-06-01
 
 - Domain ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/eventgrid/v1alpha1api20200601_domain.yaml))
 - DomainsTopic ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/eventgrid/v1alpha1api20200601_domainstopic.yaml))
@@ -118,10 +122,10 @@ Use CRD version `v1alpha1api20210515`
 
 Use CRD version `v1alpha1api20200601`
 
-### eventhub
+## eventhub
 
 
-#### ARM version: 2021-11-01
+### ARM version 2021-11-01
 
 - Namespace ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/eventhub/v1alpha1api20211101_namespace.yaml))
 - NamespacesAuthorizationRule ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/eventhub/v1alpha1api20211101_namespacesauthorizationrule.yaml))
@@ -131,35 +135,35 @@ Use CRD version `v1alpha1api20200601`
 
 Use CRD version `v1alpha1api20211101`
 
-### insights
+## insights
 
 
-#### ARM version: 2018-05-01-preview
+### ARM version 2018-05-01-preview
 
 - Webtest ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/insights/v1alpha1api20180501preview_webtest.yaml))
 
 Use CRD version `v1alpha1api20180501preview`
 
 
-#### ARM version: 2020-02-02
+### ARM version 2020-02-02
 
 - Component ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/insights/v1alpha1api20200202_component.yaml))
 
 Use CRD version `v1alpha1api20200202`
 
-### managedidentity
+## managedidentity
 
 
-#### ARM version: 2018-11-30
+### ARM version 2018-11-30
 
 - UserAssignedIdentity ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/managedidentity/v1alpha1api20181130_userassignedidentity.yaml))
 
 Use CRD version `v1alpha1api20181130`
 
-### network
+## network
 
 
-#### ARM version: 2020-11-01
+### ARM version 2020-11-01
 
 - LoadBalancer ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/network/v1alpha1api20201101_loadbalancer.yaml))
 - NetworkInterface ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/network/v1alpha1api20201101_networkinterface.yaml))
@@ -173,19 +177,19 @@ Use CRD version `v1alpha1api20181130`
 
 Use CRD version `v1alpha1api20201101`
 
-### operationalinsights
+## operationalinsights
 
 
-#### ARM version: 2021-06-01
+### ARM version 2021-06-01
 
 - Workspace ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/operationalinsights/v1alpha1api20210601_workspace.yaml))
 
 Use CRD version `v1alpha1api20210601`
 
-### servicebus
+## servicebus
 
 
-#### ARM version: 2021-01-01-preview
+### ARM version 2021-01-01-preview
 
 - Namespace ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/servicebus/v1alpha1api20210101preview_namespace.yaml))
 - NamespacesQueue ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/servicebus/v1alpha1api20210101preview_namespacesqueue.yaml))
@@ -193,19 +197,19 @@ Use CRD version `v1alpha1api20210601`
 
 Use CRD version `v1alpha1api20210101preview`
 
-### signalrservice
+## signalrservice
 
 
-#### ARM version: 2021-10-01
+### ARM version 2021-10-01
 
 - SignalR ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/signalrservice/v1alpha1api20211001_signalr.yaml))
 
 Use CRD version `v1alpha1api20211001`
 
-### storage
+## storage
 
 
-#### ARM version: 2021-04-01
+### ARM version 2021-04-01
 
 - StorageAccount ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/storage/v1alpha1api20210401_storageaccount.yaml))
 - StorageAccountsBlobService ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/storage/v1alpha1api20210401_storageaccountsblobservice.yaml))

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -77,6 +77,11 @@ func (r *ResourceVersionsReport) WriteTo(outputPath string, samplesURL string) e
 
 // WriteToBuffer creates the report in the provided buffer
 func (r *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder, samplesURL string) {
+
+	buffer.WriteString("# Supported Resources\n\n")
+	buffer.WriteString("This page lists all resources currently supported by Azure Service Operator, grouped by the originating ARM service.\n\n")
+
+
 	// Sort packages into increasing order
 	// Skip storage versions
 	var packages []astmodel.PackageReference
@@ -94,7 +99,7 @@ func (r *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder, samplesU
 		// Write a header for each service
 		svc := r.serviceName(pkg)
 		if lastService != svc {
-			buffer.WriteString(fmt.Sprintf("### %s\n\n", svc))
+			buffer.WriteString(fmt.Sprintf("## %s\n\n", svc))
 			lastService = svc
 		}
 
@@ -117,7 +122,7 @@ func (r *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder, samplesU
 
 		buffer.WriteString(
 			fmt.Sprintf(
-				"\n#### ARM version: %s\n\n",
+				"\n### ARM version %s\n\n",
 				armVersion))
 
 		// write an alphabetical list of resources

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -79,7 +79,9 @@ func (r *ResourceVersionsReport) WriteTo(outputPath string, samplesURL string) e
 func (r *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder, samplesURL string) {
 
 	buffer.WriteString("# Supported Resources\n\n")
-	buffer.WriteString("This page lists all resources currently supported by Azure Service Operator, grouped by the originating ARM service.\n\n")
+	buffer.WriteString("These are the resources with Azure Service Operator support committed to our **main** branch, ")
+	buffer.WriteString("grouped by the originating ARM service. ")
+	buffer.WriteString("(Newly supported resources will appear in this list prior to inclusion in any ASO release.)\n\n")
 
 	// Sort packages into increasing order
 	// Skip storage versions

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -81,7 +81,6 @@ func (r *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder, samplesU
 	buffer.WriteString("# Supported Resources\n\n")
 	buffer.WriteString("This page lists all resources currently supported by Azure Service Operator, grouped by the originating ARM service.\n\n")
 
-
 	// Sort packages into increasing order
 	// Skip storage versions
 	var packages []astmodel.PackageReference

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_ReportResourceVersions.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_ReportResourceVersions.golden
@@ -1,7 +1,11 @@
-### person
+# Supported Resources
+
+These are the resources with Azure Service Operator support committed to our **main** branch, grouped by the originating ARM service. (Newly supported resources will appear in this list prior to inclusion in any ASO release.)
+
+## person
 
 
-#### ARM version: v20200101
+### ARM version v20200101
 
 - Address ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/person/v20200101_address.yaml))
 - Person ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/person/v20200101_person.yaml))
@@ -9,7 +13,7 @@
 Use CRD version `v20200101`
 
 
-#### ARM version: v20211231
+### ARM version v20211231
 
 - Address ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/person/v20211231_address.yaml))
 - Person ([sample](https://github.com/Azure/azure-service-operator/tree/main/v2/config/samples/person/v20211231_person.yaml))


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a preamble to our supported resources report to make it work better as a page in our documentation.

Also tweaks formatting; previously we were using level 3 & 4 headers, now uses level 2 & 3.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/6k5aYgBKTxe3C/giphy.gif)

The result looks like this:
![image](https://user-images.githubusercontent.com/1272094/150039673-3d235f3e-84f3-4e6d-9619-016dcb3e09a8.png)
