### PR TITLE
Support secret rollover

### DIFF
--- a/v2/api/resources/v1alpha1api20200601/resourcegroup_types.go
+++ b/v2/api/resources/v1alpha1api20200601/resourcegroup_types.go
@@ -18,6 +18,7 @@ import (
 // directory.
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 // +kubebuilder:rbac:groups=resources.azure.com,resources=resourcegroups,verbs=get;list;watch;create;update;patch;delete

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/benbjohnson/clock v1.1.0
 	github.com/dnaeon/go-vcr v1.2.0
 	github.com/go-logr/logr v0.4.0
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.3.0
 	github.com/kr/pretty v0.2.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -23,7 +23,6 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0 h1:KQgdWmEOmaJKxaUUZwHAYh12t+b+ZJf8q3friycK1kA=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0/go.mod h1:ZPW/Z0kLCTdDZaDbYTetxc9Cxl/2lNqxYHYNOF2bti0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.0 h1:8wVJL0HUP5yDFXvotdewORTw7Yu88JbreWN/mobSvsQ=
@@ -35,6 +34,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0/go.mod h1:GJzjM4SR9T0Ky
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0 h1:bLRntPH25SkY1uZ/YZW+dmxNky9r1fAHvDFrzluo+4Q=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.0/go.mod h1:TmXReXZ9yPp5D5TBRMTAtyz+UyOl15Py4hL5E5p6igQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0 h1:VBvHGLJbaY0+c66NZHdS9cgjHVYSH6DDa0XJMyrblsI=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0/go.mod h1:GJzjM4SR9T0KyX5gKCVyz1ytD8FeWeUPCwtFCt1AyfE=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1 h1:BUYIbDf/mMZ8945v3QkG3OuqGVyS4Iek0AOLwdRAYoc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.3/go.mod h1:KLF4gFr6DcKFZwSuH8w8yEK6DpFl3LP5rhdvAb7Yz5I=
@@ -162,6 +163,8 @@ github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL9
 github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE69AqPYEJeo/TWfEeg=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -354,7 +357,6 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=

--- a/v2/internal/controllers/controller_resources.go
+++ b/v2/internal/controllers/controller_resources.go
@@ -6,16 +6,31 @@ Licensed under the MIT license.
 package controllers
 
 import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	resources "github.com/Azure/azure-service-operator/v2/api/resources/v1alpha1api20200601"
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
+	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/registration"
 )
 
-func GetKnownStorageTypes() []client.Object {
+func GetKnownStorageTypes() []registration.StorageType {
 	knownTypes := getKnownStorageTypes()
 
-	knownTypes = append(knownTypes, new(resources.ResourceGroup))
+	knownTypes = append(
+		knownTypes,
+		registration.MakeStorageType(new(resources.ResourceGroup)))
 
 	return knownTypes
 }
@@ -33,4 +48,72 @@ func CreateScheme() *runtime.Scheme {
 	_ = resources.AddToScheme(scheme)
 
 	return scheme
+}
+
+// watchSecretsFactory is used to register an EventHandlerFactory for watching secret mutations.
+func watchSecretsFactory(keys []string, objList client.ObjectList) registration.EventHandlerFactory {
+	return func(client client.Client, log logr.Logger) handler.EventHandler {
+		return handler.EnqueueRequestsFromMapFunc(watchSecrets(client, log, keys, objList))
+	}
+}
+
+// TODO: It may be possible where we construct the ctrl.Manager to limit what secrets we watch with
+// TODO: this feature: https://github.com/kubernetes-sigs/controller-runtime/blob/master/designs/use-selectors-at-cache.md,
+// TODO: likely scoped by a label selector?
+func watchSecrets(c client.Client, log logr.Logger, keys []string, objList client.ObjectList) handler.MapFunc {
+	listType := reflect.TypeOf(objList).Elem()
+
+	return func(o client.Object) []reconcile.Request {
+		// Safety check that we're looking at a secret
+		if _, ok := o.(*corev1.Secret); !ok {
+			log.V(Status).Info("Unexpected non-secret", "namespace", o.GetNamespace(), "name", o.GetName(), "actual", fmt.Sprintf("%T", o))
+			return nil
+		}
+
+		// This should be fast since the list of items it's going through should always be cached
+		// locally with the shared informer.
+		// Unfortunately we don't have a ctx we can use here, see https://github.com/kubernetes-sigs/controller-runtime/issues/1628
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		var allMatches []client.Object
+
+		for _, key := range keys {
+			matchingResources, castOk := reflect.New(listType).Interface().(client.ObjectList)
+			if !castOk {
+				log.V(Status).Info("Somehow reflect.New() returned non client.ObjectList", "actual", fmt.Sprintf("%T", o))
+				continue
+			}
+
+			err := c.List(ctx, matchingResources, client.MatchingFields{key: o.GetName()})
+			if err != nil {
+				// According to https://github.com/kubernetes/kubernetes/issues/51046, APIServer itself
+				// doesn't actually support this. In our envtest tests, since we use a real client that
+				// goes directly to APIServer, we'll never actually detect these changes
+				log.Error(err, "couldn't list resources using secret", "kind", "TODO", "field", key, "value", o.GetName())
+				continue
+			}
+
+			items, err := reflecthelpers.GetObjectListItems(matchingResources)
+			if err != nil {
+				log.Error(err, "failed to get list items")
+				continue
+			}
+
+			allMatches = append(allMatches, items...)
+		}
+
+		var result []reconcile.Request
+
+		for _, matchingResource := range allMatches {
+			result = append(result, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: matchingResource.GetNamespace(),
+					Name:      matchingResource.GetName(),
+				},
+			})
+		}
+
+		return result
+	}
 }

--- a/v2/internal/controllers/controller_resources_gen.go
+++ b/v2/internal/controllers/controller_resources_gen.go
@@ -44,77 +44,667 @@ import (
 	signalrservicev1alpha1api20211001storage "github.com/Azure/azure-service-operator/v2/api/signalrservice/v1alpha1api20211001storage"
 	storagev1alpha1api20210401 "github.com/Azure/azure-service-operator/v2/api/storage/v1alpha1api20210401"
 	storagev1alpha1api20210401storage "github.com/Azure/azure-service-operator/v2/api/storage/v1alpha1api20210401storage"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/registration"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // getKnownStorageTypes returns the list of storage types which can be reconciled.
-func getKnownStorageTypes() []client.Object {
-	var result []client.Object
-	result = append(result, new(authorizationv1alpha1api20200801previewstorage.RoleAssignment))
-	result = append(result, new(batchv1alpha1api20210101storage.BatchAccount))
-	result = append(result, new(cachev1alpha1api20201201storage.Redis))
-	result = append(result, new(cachev1alpha1api20201201storage.RedisFirewallRule))
-	result = append(result, new(cachev1alpha1api20201201storage.RedisLinkedServer))
-	result = append(result, new(cachev1alpha1api20201201storage.RedisPatchSchedule))
-	result = append(result, new(cachev1alpha1api20210301storage.RedisEnterprise))
-	result = append(result, new(cachev1alpha1api20210301storage.RedisEnterpriseDatabase))
-	result = append(result, new(computev1alpha1api20200930storage.Disk))
-	result = append(result, new(computev1alpha1api20201201storage.VirtualMachine))
-	result = append(result, new(computev1alpha1api20201201storage.VirtualMachineScaleSet))
-	result = append(result, new(containerservicev1alpha1api20210501storage.ManagedCluster))
-	result = append(result, new(containerservicev1alpha1api20210501storage.ManagedClustersAgentPool))
-	result = append(result, new(dbformysqlv1alpha1api20210501storage.FlexibleServer))
-	result = append(result, new(dbformysqlv1alpha1api20210501storage.FlexibleServersDatabase))
-	result = append(result, new(dbformysqlv1alpha1api20210501storage.FlexibleServersFirewallRule))
-	result = append(result, new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServer))
-	result = append(result, new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersConfiguration))
-	result = append(result, new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersDatabase))
-	result = append(result, new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersFirewallRule))
-	result = append(result, new(documentdbv1alpha1api20210515storage.DatabaseAccount))
-	result = append(result, new(documentdbv1alpha1api20210515storage.MongodbDatabase))
-	result = append(result, new(documentdbv1alpha1api20210515storage.MongodbDatabaseCollection))
-	result = append(result, new(documentdbv1alpha1api20210515storage.MongodbDatabaseCollectionThroughputSetting))
-	result = append(result, new(documentdbv1alpha1api20210515storage.MongodbDatabaseThroughputSetting))
-	result = append(result, new(documentdbv1alpha1api20210515storage.SqlDatabase))
-	result = append(result, new(documentdbv1alpha1api20210515storage.SqlDatabaseContainer))
-	result = append(result, new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerStoredProcedure))
-	result = append(result, new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerThroughputSetting))
-	result = append(result, new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerTrigger))
-	result = append(result, new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerUserDefinedFunction))
-	result = append(result, new(documentdbv1alpha1api20210515storage.SqlDatabaseThroughputSetting))
-	result = append(result, new(eventgridv1alpha1api20200601storage.Domain))
-	result = append(result, new(eventgridv1alpha1api20200601storage.DomainsTopic))
-	result = append(result, new(eventgridv1alpha1api20200601storage.EventSubscription))
-	result = append(result, new(eventgridv1alpha1api20200601storage.Topic))
-	result = append(result, new(eventhubv1alpha1api20211101storage.Namespace))
-	result = append(result, new(eventhubv1alpha1api20211101storage.NamespacesAuthorizationRule))
-	result = append(result, new(eventhubv1alpha1api20211101storage.NamespacesEventhub))
-	result = append(result, new(eventhubv1alpha1api20211101storage.NamespacesEventhubsAuthorizationRule))
-	result = append(result, new(eventhubv1alpha1api20211101storage.NamespacesEventhubsConsumerGroup))
-	result = append(result, new(insightsv1alpha1api20180501previewstorage.Webtest))
-	result = append(result, new(insightsv1alpha1api20200202storage.Component))
-	result = append(result, new(managedidentityv1alpha1api20181130storage.UserAssignedIdentity))
-	result = append(result, new(networkv1alpha1api20201101storage.LoadBalancer))
-	result = append(result, new(networkv1alpha1api20201101storage.NetworkInterface))
-	result = append(result, new(networkv1alpha1api20201101storage.NetworkSecurityGroup))
-	result = append(result, new(networkv1alpha1api20201101storage.NetworkSecurityGroupsSecurityRule))
-	result = append(result, new(networkv1alpha1api20201101storage.PublicIPAddress))
-	result = append(result, new(networkv1alpha1api20201101storage.VirtualNetwork))
-	result = append(result, new(networkv1alpha1api20201101storage.VirtualNetworkGateway))
-	result = append(result, new(networkv1alpha1api20201101storage.VirtualNetworksSubnet))
-	result = append(result, new(networkv1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeering))
-	result = append(result, new(operationalinsightsv1alpha1api20210601storage.Workspace))
-	result = append(result, new(servicebusv1alpha1api20210101previewstorage.Namespace))
-	result = append(result, new(servicebusv1alpha1api20210101previewstorage.NamespacesQueue))
-	result = append(result, new(servicebusv1alpha1api20210101previewstorage.NamespacesTopic))
-	result = append(result, new(signalrservicev1alpha1api20211001storage.SignalR))
-	result = append(result, new(storagev1alpha1api20210401storage.StorageAccount))
-	result = append(result, new(storagev1alpha1api20210401storage.StorageAccountsBlobService))
-	result = append(result, new(storagev1alpha1api20210401storage.StorageAccountsBlobServicesContainer))
-	result = append(result, new(storagev1alpha1api20210401storage.StorageAccountsQueueService))
-	result = append(result, new(storagev1alpha1api20210401storage.StorageAccountsQueueServicesQueue))
+func getKnownStorageTypes() []registration.StorageType {
+	var result []registration.StorageType
+	result = append(result, registration.StorageType{
+		Obj:     new(authorizationv1alpha1api20200801previewstorage.RoleAssignment),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &authorizationv1alpha1api20200801previewstorage.RoleAssignmentList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(batchv1alpha1api20210101storage.BatchAccount),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &batchv1alpha1api20210101storage.BatchAccountList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(cachev1alpha1api20201201storage.Redis),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &cachev1alpha1api20201201storage.RedisList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(cachev1alpha1api20201201storage.RedisFirewallRule),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &cachev1alpha1api20201201storage.RedisFirewallRuleList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(cachev1alpha1api20201201storage.RedisLinkedServer),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &cachev1alpha1api20201201storage.RedisLinkedServerList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(cachev1alpha1api20201201storage.RedisPatchSchedule),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &cachev1alpha1api20201201storage.RedisPatchScheduleList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(cachev1alpha1api20210301storage.RedisEnterprise),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &cachev1alpha1api20210301storage.RedisEnterpriseList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(cachev1alpha1api20210301storage.RedisEnterpriseDatabase),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &cachev1alpha1api20210301storage.RedisEnterpriseDatabaseList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(computev1alpha1api20200930storage.Disk),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &computev1alpha1api20200930storage.DiskList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj: new(computev1alpha1api20201201storage.VirtualMachine),
+		Indexes: []registration.Index{
+			registration.Index{
+				Key:  ".spec.osProfile.adminPassword",
+				Func: indexComputeVirtualMachineAdminPassword,
+			},
+		},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{".spec.osProfile.adminPassword"}, &computev1alpha1api20201201storage.VirtualMachineList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj: new(computev1alpha1api20201201storage.VirtualMachineScaleSet),
+		Indexes: []registration.Index{
+			registration.Index{
+				Key:  ".spec.virtualMachineProfile.osProfile.adminPassword",
+				Func: indexComputeVirtualMachineScaleSetAdminPassword,
+			},
+		},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{".spec.virtualMachineProfile.osProfile.adminPassword"}, &computev1alpha1api20201201storage.VirtualMachineScaleSetList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(containerservicev1alpha1api20210501storage.ManagedCluster),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &containerservicev1alpha1api20210501storage.ManagedClusterList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(containerservicev1alpha1api20210501storage.ManagedClustersAgentPool),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &containerservicev1alpha1api20210501storage.ManagedClustersAgentPoolList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj: new(dbformysqlv1alpha1api20210501storage.FlexibleServer),
+		Indexes: []registration.Index{
+			registration.Index{
+				Key:  ".spec.administratorLoginPassword",
+				Func: indexDbformysqlFlexibleServerAdministratorLoginPassword,
+			},
+		},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{".spec.administratorLoginPassword"}, &dbformysqlv1alpha1api20210501storage.FlexibleServerList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(dbformysqlv1alpha1api20210501storage.FlexibleServersDatabase),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &dbformysqlv1alpha1api20210501storage.FlexibleServersDatabaseList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(dbformysqlv1alpha1api20210501storage.FlexibleServersFirewallRule),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &dbformysqlv1alpha1api20210501storage.FlexibleServersFirewallRuleList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj: new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServer),
+		Indexes: []registration.Index{
+			registration.Index{
+				Key:  ".spec.administratorLoginPassword",
+				Func: indexDbforpostgresqlFlexibleServerAdministratorLoginPassword,
+			},
+		},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{".spec.administratorLoginPassword"}, &dbforpostgresqlv1alpha1api20210601storage.FlexibleServerList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersConfiguration),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &dbforpostgresqlv1alpha1api20210601storage.FlexibleServersConfigurationList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersDatabase),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &dbforpostgresqlv1alpha1api20210601storage.FlexibleServersDatabaseList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersFirewallRule),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &dbforpostgresqlv1alpha1api20210601storage.FlexibleServersFirewallRuleList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.DatabaseAccount),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.DatabaseAccountList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabase),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.MongodbDatabaseList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabaseCollection),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.MongodbDatabaseCollectionList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabaseCollectionThroughputSetting),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.MongodbDatabaseCollectionThroughputSettingList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabaseThroughputSetting),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.MongodbDatabaseThroughputSettingList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabase),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.SqlDatabaseList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainer),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.SqlDatabaseContainerList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerStoredProcedure),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.SqlDatabaseContainerStoredProcedureList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerThroughputSetting),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.SqlDatabaseContainerThroughputSettingList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerTrigger),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.SqlDatabaseContainerTriggerList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerUserDefinedFunction),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.SqlDatabaseContainerUserDefinedFunctionList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseThroughputSetting),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &documentdbv1alpha1api20210515storage.SqlDatabaseThroughputSettingList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventgridv1alpha1api20200601storage.Domain),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventgridv1alpha1api20200601storage.DomainList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventgridv1alpha1api20200601storage.DomainsTopic),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventgridv1alpha1api20200601storage.DomainsTopicList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventgridv1alpha1api20200601storage.EventSubscription),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventgridv1alpha1api20200601storage.EventSubscriptionList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventgridv1alpha1api20200601storage.Topic),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventgridv1alpha1api20200601storage.TopicList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventhubv1alpha1api20211101storage.Namespace),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventhubv1alpha1api20211101storage.NamespaceList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesAuthorizationRule),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventhubv1alpha1api20211101storage.NamespacesAuthorizationRuleList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesEventhub),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventhubv1alpha1api20211101storage.NamespacesEventhubList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesEventhubsAuthorizationRule),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventhubv1alpha1api20211101storage.NamespacesEventhubsAuthorizationRuleList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesEventhubsConsumerGroup),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &eventhubv1alpha1api20211101storage.NamespacesEventhubsConsumerGroupList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(insightsv1alpha1api20180501previewstorage.Webtest),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &insightsv1alpha1api20180501previewstorage.WebtestList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(insightsv1alpha1api20200202storage.Component),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &insightsv1alpha1api20200202storage.ComponentList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(managedidentityv1alpha1api20181130storage.UserAssignedIdentity),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &managedidentityv1alpha1api20181130storage.UserAssignedIdentityList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.LoadBalancer),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.LoadBalancerList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.NetworkInterface),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.NetworkInterfaceList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.NetworkSecurityGroup),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.NetworkSecurityGroupList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.NetworkSecurityGroupsSecurityRule),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.NetworkSecurityGroupsSecurityRuleList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.PublicIPAddress),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.PublicIPAddressList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.VirtualNetwork),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.VirtualNetworkList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.VirtualNetworkGateway),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.VirtualNetworkGatewayList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.VirtualNetworksSubnet),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.VirtualNetworksSubnetList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(networkv1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeering),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &networkv1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeeringList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(operationalinsightsv1alpha1api20210601storage.Workspace),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &operationalinsightsv1alpha1api20210601storage.WorkspaceList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(servicebusv1alpha1api20210101previewstorage.Namespace),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &servicebusv1alpha1api20210101previewstorage.NamespaceList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(servicebusv1alpha1api20210101previewstorage.NamespacesQueue),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &servicebusv1alpha1api20210101previewstorage.NamespacesQueueList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(servicebusv1alpha1api20210101previewstorage.NamespacesTopic),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &servicebusv1alpha1api20210101previewstorage.NamespacesTopicList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(signalrservicev1alpha1api20211001storage.SignalR),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &signalrservicev1alpha1api20211001storage.SignalRList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(storagev1alpha1api20210401storage.StorageAccount),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &storagev1alpha1api20210401storage.StorageAccountList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsBlobService),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &storagev1alpha1api20210401storage.StorageAccountsBlobServiceList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsBlobServicesContainer),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &storagev1alpha1api20210401storage.StorageAccountsBlobServicesContainerList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsQueueService),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &storagev1alpha1api20210401storage.StorageAccountsQueueServiceList{}),
+			},
+		},
+	})
+	result = append(result, registration.StorageType{
+		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsQueueServicesQueue),
+		Indexes: []registration.Index{},
+		Watches: []registration.Watch{
+			registration.Watch{
+				Src:              &source.Kind{Type: &v1.Secret{}},
+				MakeEventHandler: watchSecretsFactory([]string{}, &storagev1alpha1api20210401storage.StorageAccountsQueueServicesQueueList{}),
+			},
+		},
+	})
 	return result
 }
 
@@ -295,4 +885,61 @@ func createScheme() *runtime.Scheme {
 	_ = storagev1alpha1api20210401.AddToScheme(scheme)
 	_ = storagev1alpha1api20210401storage.AddToScheme(scheme)
 	return scheme
+}
+
+// indexComputeVirtualMachineAdminPassword an index function for computev1alpha1api20201201storage.VirtualMachine .spec.osProfile.adminPassword
+func indexComputeVirtualMachineAdminPassword(rawObj client.Object) []string {
+	obj, ok := rawObj.(*computev1alpha1api20201201storage.VirtualMachine)
+	if !ok {
+		return nil
+	}
+	if obj.Spec.OsProfile == nil {
+		return nil
+	}
+	if obj.Spec.OsProfile.AdminPassword == nil {
+		return nil
+	}
+	return []string{obj.Spec.OsProfile.AdminPassword.Name}
+}
+
+// indexComputeVirtualMachineScaleSetAdminPassword an index function for computev1alpha1api20201201storage.VirtualMachineScaleSet .spec.virtualMachineProfile.osProfile.adminPassword
+func indexComputeVirtualMachineScaleSetAdminPassword(rawObj client.Object) []string {
+	obj, ok := rawObj.(*computev1alpha1api20201201storage.VirtualMachineScaleSet)
+	if !ok {
+		return nil
+	}
+	if obj.Spec.VirtualMachineProfile == nil {
+		return nil
+	}
+	if obj.Spec.VirtualMachineProfile.OsProfile == nil {
+		return nil
+	}
+	if obj.Spec.VirtualMachineProfile.OsProfile.AdminPassword == nil {
+		return nil
+	}
+	return []string{obj.Spec.VirtualMachineProfile.OsProfile.AdminPassword.Name}
+}
+
+// indexDbformysqlFlexibleServerAdministratorLoginPassword an index function for dbformysqlv1alpha1api20210501storage.FlexibleServer .spec.administratorLoginPassword
+func indexDbformysqlFlexibleServerAdministratorLoginPassword(rawObj client.Object) []string {
+	obj, ok := rawObj.(*dbformysqlv1alpha1api20210501storage.FlexibleServer)
+	if !ok {
+		return nil
+	}
+	if obj.Spec.AdministratorLoginPassword == nil {
+		return nil
+	}
+	return []string{obj.Spec.AdministratorLoginPassword.Name}
+}
+
+// indexDbforpostgresqlFlexibleServerAdministratorLoginPassword an index function for dbforpostgresqlv1alpha1api20210601storage.FlexibleServer .spec.administratorLoginPassword
+func indexDbforpostgresqlFlexibleServerAdministratorLoginPassword(rawObj client.Object) []string {
+	obj, ok := rawObj.(*dbforpostgresqlv1alpha1api20210601storage.FlexibleServer)
+	if !ok {
+		return nil
+	}
+	if obj.Spec.AdministratorLoginPassword == nil {
+		return nil
+	}
+	return []string{obj.Spec.AdministratorLoginPassword.Name}
 }

--- a/v2/internal/reflecthelpers/reflect_helpers.go
+++ b/v2/internal/reflecthelpers/reflect_helpers.go
@@ -90,3 +90,47 @@ func FindSecretReferences(obj interface{}) (map[genruntime.SecretReference]struc
 
 	return result, nil
 }
+
+// GetObjectListItems gets the list of items from an ObjectList
+func GetObjectListItems(listPtr client.ObjectList) ([]client.Object, error) {
+	val := reflect.ValueOf(listPtr)
+
+	if val.Kind() != reflect.Ptr {
+		return nil, errors.Errorf("provided list was not a pointer, was %s", val.Kind())
+	}
+
+	list := val.Elem()
+
+	if list.Kind() != reflect.Struct {
+		return nil, errors.Errorf("provided list was not a struct, was %s", val.Kind())
+	}
+
+	itemsField := list.FieldByName("Items")
+	if (itemsField == reflect.Value{}) {
+		return nil, errors.Errorf("provided list has no field \"Items\"")
+	}
+	if itemsField.Kind() != reflect.Slice {
+		return nil, errors.Errorf("provided list \"Items\" field was not of type slice")
+	}
+
+	var result []client.Object
+	for i := 0; i < itemsField.Len(); i++ {
+		item := itemsField.Index(i)
+
+		if item.Kind() == reflect.Struct {
+			if !item.CanAddr() {
+				return nil, errors.Errorf("provided list elements were not pointers, but cannot be addressed")
+			}
+			item = item.Addr()
+		}
+
+		typedItem, ok := item.Interface().(client.Object)
+		if !ok {
+			return nil, errors.Errorf("provided list elements did not implement client.Object interface")
+		}
+
+		result = append(result, typedItem)
+	}
+
+	return result, nil
+}

--- a/v2/internal/reflecthelpers/reflect_helpers_test.go
+++ b/v2/internal/reflecthelpers/reflect_helpers_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	//nolint:staticcheck // ignoring deprecation (SA1019) to unblock CI builds
 	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
@@ -20,6 +23,65 @@ type ResourceWithReferences struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              ResourceWithReferencesSpec `json:"spec,omitempty"`
+}
+
+var _ client.Object = &ResourceWithReferences{}
+
+func (in *ResourceWithReferences) DeepCopyInto(out *ResourceWithReferences) {
+	// TODO: This isn't a full impelmentation, but that's ok we don't need it
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+}
+
+func (in *ResourceWithReferences) DeepCopy() *ResourceWithReferences {
+	if in == nil {
+		return nil
+	}
+	out := new(ResourceWithReferences)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ResourceWithReferences) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+type ResourceWithReferencesList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ResourceWithReferences `json:"items"`
+}
+
+func (in *ResourceWithReferencesList) DeepCopyInto(out *ResourceWithReferencesList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]ResourceWithReferences, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *ResourceWithReferencesList) DeepCopy() *ResourceWithReferencesList {
+	if in == nil {
+		return nil
+	}
+	out := new(ResourceWithReferencesList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *ResourceWithReferencesList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
 }
 
 type ResourceWithReferencesSpec struct {
@@ -90,4 +152,33 @@ func Test_FindSecrets(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(refs).To(HaveLen(1))
 	g.Expect(refs).To(HaveKey(ref))
+}
+
+func Test_GetObjectListItems(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	res := ResourceWithReferences{
+		Spec: ResourceWithReferencesSpec{
+			AzureName: "azureName",
+			Location:  "westus",
+			Owner: genruntime.KnownResourceReference{
+				Name: "myrg",
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-group",
+			Namespace: "test-namespace",
+		},
+	}
+
+	list := &ResourceWithReferencesList{
+		Items: []ResourceWithReferences{
+			res,
+		},
+	}
+
+	items, err := reflecthelpers.GetObjectListItems(list)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(items).To(HaveLen(1))
+	g.Expect(items[0].GetName()).To(Equal("test-group"))
 }

--- a/v2/pkg/genruntime/registration/registration.go
+++ b/v2/pkg/genruntime/registration/registration.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package registration
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Index describes an index registration.
+// See controller-runtime mgr.GetFieldIndexer().IndexField() for more details.
+type Index struct {
+	Key  string
+	Func func(rawObj client.Object) []string
+}
+
+type EventHandlerFactory func(client client.Client, log logr.Logger) handler.EventHandler
+
+// Watch describes a watch registration.
+// See controller-runtime builder.Watches() for more details.
+type Watch struct {
+	Src              source.Source
+	MakeEventHandler EventHandlerFactory
+}
+
+// StorageType describes a storage type to register, as well as any additional
+// indexes or watches required.
+// Obj is the object whose Kind should be registered as the storage type.
+type StorageType struct {
+	Obj     client.Object
+	Indexes []Index
+	Watches []Watch
+}
+
+// MakeStorageType makes a new storage type for the specified object
+func MakeStorageType(obj client.Object) StorageType {
+	return StorageType{
+		Obj: obj,
+	}
+}

--- a/v2/test/mysql_secret_update_test.go
+++ b/v2/test/mysql_secret_update_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	_ "github.com/go-sql-driver/mysql" //sql drive link
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+
+	mysql "github.com/Azure/azure-service-operator/v2/api/dbformysql/v1alpha1api20210501"
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+)
+
+// Test_MySQL_Secret_Updated ensures that when a secret is modified, the modified value
+// is sent to Azure. This cannot be tested in the recording tests because they do not use
+// a cached client. The index functionality used to check if a secret is being used by an
+// ASO resource requires the cached client (the indexes are local to the cache).
+func Test_MySQL_Secret_Updated(t *testing.T) {
+	t.Parallel()
+	tc := globalTestContext.ForTest(t)
+
+	rg := tc.CreateTestResourceGroupAndWait()
+
+	adminUsername := "myadmin"
+	adminPasswordKey := "adminPassword"
+	adminPassword := tc.Namer.GeneratePassword()
+	secret := &v1.Secret{
+		ObjectMeta: tc.MakeObjectMeta("mysqlsecret"),
+		StringData: map[string]string{
+			adminPasswordKey: adminPassword,
+		},
+	}
+
+	tc.CreateResource(secret)
+
+	version := mysql.ServerPropertiesVersion8021
+	secretRef := genruntime.SecretReference{
+		Name: secret.Name,
+		Key:  adminPasswordKey,
+	}
+	flexibleServer := &mysql.FlexibleServer{
+		ObjectMeta: tc.MakeObjectMeta("mysql"),
+		Spec: mysql.FlexibleServers_Spec{
+			Location: tc.AzureRegion,
+			Owner:    testcommon.AsOwner(rg),
+			Version:  &version,
+			Sku: &mysql.Sku{
+				Name: "Standard_D4ds_v4",
+				Tier: mysql.SkuTierGeneralPurpose,
+			},
+			AdministratorLogin:         to.StringPtr(adminUsername),
+			AdministratorLoginPassword: &secretRef,
+			Storage: &mysql.Storage{
+				StorageSizeGB: to.IntPtr(128),
+			},
+		},
+	}
+
+	tc.CreateResourceAndWait(flexibleServer)
+
+	// This rule opens access to the public internet. Safe in this case
+	// because there's no data in the database anyway
+	firewallRule := &mysql.FlexibleServersFirewallRule{
+		ObjectMeta: tc.MakeObjectMeta("firewall"),
+		Spec: mysql.FlexibleServersFirewallRules_Spec{
+			Owner:          testcommon.AsOwner(flexibleServer),
+			StartIpAddress: "0.0.0.0",
+			EndIpAddress:   "255.255.255.255",
+		},
+	}
+
+	tc.CreateResourceAndWait(firewallRule)
+
+	tc.Expect(flexibleServer.Status.FullyQualifiedDomainName).ToNot(BeNil())
+	fqdn := *flexibleServer.Status.FullyQualifiedDomainName
+
+	// Connect to the DB
+	conn, err := ConnectToMySQLDB(
+		context.Background(),
+		fqdn,
+		MySQLSystemDatabase,
+		MySQLServerPort,
+		adminUsername,
+		adminPassword)
+	tc.Expect(err).ToNot(HaveOccurred())
+	// Close the connection
+	tc.Expect(conn.Close()).To(Succeed())
+
+	// Update the secret
+	newAdminPassword := tc.Namer.GeneratePasswordOfLength(40)
+
+	newSecret := &v1.Secret{
+		ObjectMeta: secret.ObjectMeta,
+		StringData: map[string]string{
+			adminPasswordKey: newAdminPassword,
+		},
+	}
+	tc.UpdateResource(newSecret)
+
+	// Connect to the DB - this may fail initially as reconcile runs and MySQL
+	// performs the update
+	tc.G.Eventually(
+		func() error {
+			conn, err = ConnectToMySQLDB(
+				context.Background(),
+				fqdn,
+				MySQLSystemDatabase,
+				MySQLServerPort,
+				adminUsername,
+				newAdminPassword)
+			if err != nil {
+				return err
+			}
+
+			return conn.Close()
+		},
+		2*time.Minute, // We expect this to pass pretty quickly
+	).Should(Succeed())
+}
+
+const MySQLServerPort = 3306
+const MySQLDriver = "mysql"
+const MySQLSystemDatabase = "mysql"
+
+// TODO: This will probably one day need to be put into a non-test package, but for now not bothering as we only use it to test
+func ConnectToMySQLDB(ctx context.Context, fullServer string, database string, port int, user string, password string) (*sql.DB, error) {
+	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=true&interpolateParams=true", user, password, fullServer, port, database)
+
+	db, err := sql.Open(MySQLDriver, connString)
+	if err != nil {
+		return db, err
+	}
+
+	err = db.PingContext(ctx)
+	if err != nil {
+		return db, errors.Wrapf(err, "error pinging the mysql db (%s:%d/%s)", fullServer, port, database)
+	}
+
+	return db, err
+}

--- a/v2/tools/generator/internal/astmodel/package_definition.go
+++ b/v2/tools/generator/internal/astmodel/package_definition.go
@@ -41,7 +41,7 @@ func (p *PackageDefinition) GetDefinition(typeName TypeName) (TypeDefinition, er
 		}
 	}
 
-	return TypeDefinition{}, errors.Errorf("no error with name %s found", typeName)
+	return TypeDefinition{}, errors.Errorf("no type with name %s found", typeName)
 }
 
 // AddDefinition adds a Definition to the PackageDefinition

--- a/v2/tools/generator/internal/astmodel/property_definition.go
+++ b/v2/tools/generator/internal/astmodel/property_definition.go
@@ -273,6 +273,16 @@ func (property *PropertyDefinition) Tag(key string) ([]string, bool) {
 	return result, ok
 }
 
+// JSONName returns the JSON name of the property, or false if there is no json name
+func (property *PropertyDefinition) JSONName() (string, bool) {
+	jsonTag, ok := property.Tag("json")
+	if !ok {
+		return "", false
+	}
+
+	return jsonTag[0], true
+}
+
 func (property *PropertyDefinition) hasJsonOmitEmpty() bool {
 	return property.HasTagValue("json", "omitempty")
 }

--- a/v2/tools/generator/internal/astmodel/std_references.go
+++ b/v2/tools/generator/internal/astmodel/std_references.go
@@ -19,9 +19,10 @@ var (
 	TestingReference = MakeExternalPackageReference("testing")
 
 	// References to our Libraries
-	GenRuntimeReference           = MakeExternalPackageReference(genRuntimePathPrefix)
-	GenRuntimeConditionsReference = MakeExternalPackageReference(genRuntimePathPrefix + "/conditions")
-	ReflectHelpersReference       = MakeExternalPackageReference(reflectHelpersPath)
+	GenRuntimeReference             = MakeExternalPackageReference(genRuntimePathPrefix)
+	GenRuntimeConditionsReference   = MakeExternalPackageReference(genRuntimePathPrefix + "/conditions")
+	GenRuntimeRegistrationReference = MakeExternalPackageReference(genRuntimePathPrefix + "/registration")
+	ReflectHelpersReference         = MakeExternalPackageReference(reflectHelpersPath)
 
 	// References to other libraries
 	APIExtensionsReference       = MakeExternalPackageReference("k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1")
@@ -30,12 +31,14 @@ var (
 	APIMachineryRuntimeReference = MakeExternalPackageReference("k8s.io/apimachinery/pkg/runtime")
 	APIMachinerySchemaReference  = MakeExternalPackageReference("k8s.io/apimachinery/pkg/runtime/schema")
 	MetaV1Reference              = MakeExternalPackageReference("k8s.io/apimachinery/pkg/apis/meta/v1")
+	CoreV1Reference              = MakeExternalPackageReference("k8s.io/api/core/v1")
 
 	ClientGoSchemeReference     = MakeExternalPackageReference("k8s.io/client-go/kubernetes/scheme")
 	ControllerRuntimeAdmission  = MakeExternalPackageReference("sigs.k8s.io/controller-runtime/pkg/webhook/admission")
 	ControllerRuntimeConversion = MakeExternalPackageReference("sigs.k8s.io/controller-runtime/pkg/conversion")
 	ControllerSchemeReference   = MakeExternalPackageReference("sigs.k8s.io/controller-runtime/pkg/scheme")
 	ControllerRuntimeClient     = MakeExternalPackageReference("sigs.k8s.io/controller-runtime/pkg/client")
+	ControllerRuntimeSource     = MakeExternalPackageReference("sigs.k8s.io/controller-runtime/pkg/source")
 	GitHubErrorsReference       = MakeExternalPackageReference("github.com/pkg/errors")
 
 	// References to libraries used for testing
@@ -66,6 +69,11 @@ var (
 	ConvertToARMResolvedDetailsType = MakeTypeName(GenRuntimeReference, "ConvertToARMResolvedDetails")
 	SecretReferenceType             = MakeTypeName(GenRuntimeReference, "SecretReference")
 
+	// Type names - Registration
+	StorageTypeRegistrationType = MakeTypeName(GenRuntimeRegistrationReference, "StorageType")
+	IndexRegistrationType       = MakeTypeName(GenRuntimeRegistrationReference, "Index")
+	WatchRegistrationType       = MakeTypeName(GenRuntimeRegistrationReference, "Watch")
+
 	ConditionType   = MakeTypeName(GenRuntimeConditionsReference, "Condition")
 	ConditionsType  = MakeTypeName(GenRuntimeConditionsReference, "Conditions")
 	ConditionerType = MakeTypeName(GenRuntimeConditionsReference, "Conditioner")
@@ -77,6 +85,11 @@ var (
 	ObjectMetaType       = MakeTypeName(MetaV1Reference, "ObjectMeta")
 
 	// Type names - Controller Runtime
-	ConvertibleInterface = MakeTypeName(ControllerRuntimeConversion, "Convertible")
-	HubInterface         = MakeTypeName(ControllerRuntimeConversion, "Hub")
+	ConvertibleInterface            = MakeTypeName(ControllerRuntimeConversion, "Convertible")
+	HubInterface                    = MakeTypeName(ControllerRuntimeConversion, "Hub")
+	ControllerRuntimeObjectType     = MakeTypeName(ControllerRuntimeClient, "Object")
+	ControllerRuntimeSourceKindType = MakeTypeName(ControllerRuntimeSource, "Kind")
+
+	// Type names - Core types
+	SecretType = MakeTypeName(CoreV1Reference, "Secret")
 )

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -199,7 +199,7 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		pipeline.DeleteGeneratedCode(configuration.FullTypesOutputPath()),
 		pipeline.ExportPackages(configuration.FullTypesOutputPath()),
 
-		pipeline.ExportControllerResourceRegistrations(configuration.FullTypesRegistrationOutputFilePath()).UsedFor(pipeline.ARMTarget),
+		pipeline.ExportControllerResourceRegistrations(idFactory, configuration.FullTypesRegistrationOutputFilePath()).UsedFor(pipeline.ARMTarget),
 
 		pipeline.ReportResourceVersions(configuration),
 	}

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -8,15 +8,17 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
 )
 
 // ExportControllerResourceRegistrations creates a Stage to generate type registrations
 // for resources.
-func ExportControllerResourceRegistrations(outputPath string) Stage {
+func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory, outputPath string) Stage {
 	return MakeLegacyStage(
 		"exportControllerResourceRegistrations",
 		fmt.Sprintf("Export resource registrations to %q", outputPath),
@@ -28,6 +30,8 @@ func ExportControllerResourceRegistrations(outputPath string) Stage {
 
 			var resources []astmodel.TypeName
 			var storageVersionResources []astmodel.TypeName
+			indexFunctions := make(map[astmodel.TypeName][]*functions.IndexRegistrationFunction)
+			secretPropertyKeys := make(map[astmodel.TypeName][]string)
 
 			// We need to register each version
 			for _, def := range types {
@@ -38,12 +42,20 @@ func ExportControllerResourceRegistrations(outputPath string) Stage {
 
 				if resource.IsStorageVersion() {
 					storageVersionResources = append(storageVersionResources, def.Name())
-				}
 
+					chains, err := catalogSecretPropertyChains(def, types)
+					if err != nil {
+						return nil, errors.Wrapf(err, "failed to catalog %s property chains", def.Name())
+					}
+
+					resourceIndexFunctions, resourceSecretPropertyKeys := handleSecretPropertyChains(chains, idFactory, def)
+					indexFunctions[def.Name()] = resourceIndexFunctions
+					secretPropertyKeys[def.Name()] = resourceSecretPropertyKeys
+				}
 				resources = append(resources, def.Name())
 			}
 
-			file := NewResourceRegistrationFile(resources, storageVersionResources)
+			file := NewResourceRegistrationFile(resources, storageVersionResources, indexFunctions, secretPropertyKeys)
 			fileWriter := astmodel.NewGoSourceFileWriter(file)
 
 			err := fileWriter.SaveToFile(outputPath)
@@ -53,4 +65,119 @@ func ExportControllerResourceRegistrations(outputPath string) Stage {
 
 			return types, nil
 		})
+}
+
+func handleSecretPropertyChains(
+	chains [][]*astmodel.PropertyDefinition,
+	idFactory astmodel.IdentifierFactory,
+	def astmodel.TypeDefinition) ([]*functions.IndexRegistrationFunction, []string) {
+
+	var indexFunctions []*functions.IndexRegistrationFunction
+	var secretPropertyKeys []string
+
+	for _, chain := range chains {
+		secretPropertyKey := makeIndexPropertyKey(chain)
+		indexFunction := functions.NewIndexRegistrationFunction(
+			makeUniqueIndexMethodName(idFactory, def.Name(), chain),
+			def.Name(),
+			secretPropertyKey,
+			chain)
+		indexFunctions = append(indexFunctions, indexFunction)
+		secretPropertyKeys = append(secretPropertyKeys, secretPropertyKey)
+	}
+
+	return indexFunctions, secretPropertyKeys
+}
+
+func catalogSecretPropertyChains(def astmodel.TypeDefinition, allTypes astmodel.Types) ([][]*astmodel.PropertyDefinition, error) {
+	indexBuilder := &indexFunctionBuilder{}
+
+	visitor := astmodel.TypeVisitorBuilder{
+		VisitObjectType: indexBuilder.catalogSecretProperties,
+	}.Build()
+
+	walker := astmodel.NewTypeWalker(allTypes, visitor)
+	walker.MakeContext = func(it astmodel.TypeName, ctx interface{}) (interface{}, error) {
+		if ctx != nil {
+			return ctx, nil
+		}
+
+		return indexFunctionBuilderContext{}, nil
+	}
+
+	_, err := walker.Walk(def)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error cataloging secret properties")
+	}
+
+	return indexBuilder.propChains, nil
+}
+
+type indexFunctionBuilder struct {
+	propChains [][]*astmodel.PropertyDefinition
+}
+
+type indexFunctionBuilderContext struct {
+	props []*astmodel.PropertyDefinition
+}
+
+func (ctx indexFunctionBuilderContext) clone() indexFunctionBuilderContext {
+	duplicate := append([]*astmodel.PropertyDefinition(nil), ctx.props...)
+	return indexFunctionBuilderContext{props: duplicate}
+}
+
+func preservePropertyContext(_ *astmodel.ObjectType, prop *astmodel.PropertyDefinition, ctx interface{}) (interface{}, error) {
+	typedCtx := ctx.(indexFunctionBuilderContext)
+	newCtx := typedCtx.clone()
+	newCtx.props = append(newCtx.props, prop)
+	return newCtx, nil
+}
+
+func (b *indexFunctionBuilder) catalogSecretProperties(this *astmodel.TypeVisitor, it *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
+	typedCtx := ctx.(indexFunctionBuilderContext)
+
+	for _, prop := range it.Properties() {
+		if prop.IsSecret() {
+			newCtx := typedCtx.clone()
+			newCtx.props = append(newCtx.props, prop)
+			b.propChains = append(b.propChains, newCtx.props)
+		}
+	}
+
+	identityVisit := astmodel.MakeIdentityVisitOfObjectType(preservePropertyContext)
+	return identityVisit(this, it, ctx)
+}
+
+func makeUniqueIndexMethodName(
+	idFactory astmodel.IdentifierFactory,
+	resourceTypeName astmodel.TypeName,
+	propertyChain []*astmodel.PropertyDefinition) string {
+
+	// TODO: Technically speaking it's still possible to generate names that clash here, although it's pretty
+	// TODO: unlikely. Do we need to do more?
+
+	lastProp := propertyChain[len(propertyChain)-1]
+
+	group, _, ok := resourceTypeName.PackageReference.GroupVersion()
+	if !ok {
+		panic(fmt.Sprintf("cannot generate index method for type %s", resourceTypeName.String()))
+	}
+	return fmt.Sprintf("index%s%s%s",
+		idFactory.CreateIdentifier(group, astmodel.Exported),
+		resourceTypeName.Name(),
+		lastProp.PropertyName())
+}
+
+func makeIndexPropertyKey(propertyChain []*astmodel.PropertyDefinition) string {
+	values := []string{
+		".spec",
+	}
+	for _, prop := range propertyChain {
+		name, ok := prop.JSONName()
+		if !ok {
+			panic(fmt.Sprintf("property %s has no JSON name", prop.PropertyName()))
+		}
+		values = append(values, name)
+	}
+	return strings.Join(values, ".")
 }

--- a/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
 )
 
 // ResourceRegistrationFile is a file containing functions that assist in registering resources
@@ -20,16 +21,25 @@ import (
 type ResourceRegistrationFile struct {
 	resources               []astmodel.TypeName
 	storageVersionResources []astmodel.TypeName
+	indexFunctions          map[astmodel.TypeName][]*functions.IndexRegistrationFunction
+	secretPropertyKeys      map[astmodel.TypeName][]string
 }
 
 var _ astmodel.GoSourceFile = &ResourceRegistrationFile{}
 
 // NewResourceRegistrationFile returns a ResourceRegistrationFile for registering all of the specified resources
 // with a controller
-func NewResourceRegistrationFile(resources []astmodel.TypeName, storageVersionResources []astmodel.TypeName) *ResourceRegistrationFile {
+func NewResourceRegistrationFile(
+	resources []astmodel.TypeName,
+	storageVersionResources []astmodel.TypeName,
+	indexFunctions map[astmodel.TypeName][]*functions.IndexRegistrationFunction,
+	secretPropertyKeys map[astmodel.TypeName][]string) *ResourceRegistrationFile {
+
 	return &ResourceRegistrationFile{
 		resources:               resources,
 		storageVersionResources: storageVersionResources,
+		indexFunctions:          indexFunctions,
+		secretPropertyKeys:      secretPropertyKeys,
 	}
 }
 
@@ -59,24 +69,31 @@ func (r *ResourceRegistrationFile) AsAst() (*dst.File, error) {
 		})
 	}
 
-	knownStorageTypes, err := r.createGetKnownStorageTypesFunc(codeGenContext)
-	if err != nil {
-		return nil, err
-	}
+	// getKnownStorageTypes() function
+	knownStorageTypes := createGetKnownStorageTypesFunc(
+		codeGenContext,
+		r.storageVersionResources,
+		r.indexFunctions,
+		r.secretPropertyKeys)
 	decls = append(decls, knownStorageTypes)
 
-	// Create KnownTypes collection
-	knownTypes, err := r.createGetKnownTypesFunc(codeGenContext)
+	// getKnownTypes() function
+	knownTypes, err := createGetKnownTypesFunc(codeGenContext, r.resources)
 	if err != nil {
 		return nil, err
 	}
 	decls = append(decls, knownTypes)
 
+	// createScheme() function
 	createSchemeFunc, err := r.createCreateSchemeFunc(codeGenContext)
 	if err != nil {
 		return nil, err
 	}
 	decls = append(decls, createSchemeFunc)
+
+	// All the index functions
+	indexFunctionDecls := r.defineIndexFunctions(codeGenContext)
+	decls = append(decls, indexFunctionDecls...)
 
 	// TODO: Common func?
 	var header []string
@@ -116,69 +133,17 @@ func (r *ResourceRegistrationFile) generateImports() *astmodel.PackageImportSet 
 	// We require these imports
 	clientGoSchemeImport := astmodel.NewPackageImport(astmodel.ClientGoSchemeReference).WithName("clientgoscheme")
 	requiredImports.AddImport(clientGoSchemeImport)
-
-	runtimeImport := astmodel.NewPackageImport(astmodel.APIMachineryRuntimeReference)
-	requiredImports.AddImport(runtimeImport)
-
-	clientImport := astmodel.NewPackageImport(astmodel.ControllerRuntimeClient)
-	requiredImports.AddImport(clientImport)
+	requiredImports.AddImport(astmodel.NewPackageImport(astmodel.APIMachineryRuntimeReference))
+	requiredImports.AddImport(astmodel.NewPackageImport(astmodel.ControllerRuntimeClient))
+	requiredImports.AddImport(astmodel.NewPackageImport(astmodel.ControllerRuntimeSource))
+	requiredImports.AddImport(astmodel.NewPackageImport(astmodel.GenRuntimeRegistrationReference))
+	requiredImports.AddImport(astmodel.NewPackageImport(astmodel.CoreV1Reference))
 
 	return requiredImports
 }
 
-// createGetKnownStorageTypesFunc creates a getKnownStorageTypes function that returns all storage types:
-//		func getKnownStorageTypes() []client.Object {
-//			var result []client.Object
-//			result = append(result, new(<package>.<resource>))
-//			result = append(result, new(<package>.<resource>))
-//			result = append(result, new(<package>.<resource>))
-//			...
-//			return result
-//		}
-func (r *ResourceRegistrationFile) createGetKnownStorageTypesFunc(codeGenerationContext *astmodel.CodeGenerationContext) (dst.Decl, error) {
-	return createKnownTypesFuncImpl(
-		codeGenerationContext,
-		r.storageVersionResources,
-		"getKnownStorageTypes",
-		"returns the list of storage types which can be reconciled.")
-}
-
-// createGetKnownTypesFunc creates a getKnownTypes function that returns all known types:
-//		func getKnownTypes() []client.Object {
-//			var result []client.Object
-//			result = append(result, new(<package>.<resource>))
-//			result = append(result, new(<package>.<resource>))
-//			result = append(result, new(<package>.<resource>))
-//			...
-//			return result
-//		}
-func (r *ResourceRegistrationFile) createGetKnownTypesFunc(codeGenerationContext *astmodel.CodeGenerationContext) (dst.Decl, error) {
-	return createKnownTypesFuncImpl(
-		codeGenerationContext,
-		r.resources,
-		"getKnownTypes",
-		"returns the list of all types.")
-}
-
-func createKnownTypesFuncImpl(codeGenerationContext *astmodel.CodeGenerationContext, resources []astmodel.TypeName, funcName string, funcComment string) (dst.Decl, error) {
-	client, err := codeGenerationContext.GetImportedPackageName(astmodel.ControllerRuntimeClient)
-	if err != nil {
-		return nil, err
-	}
-
-	resultIdent := dst.NewIdent("result")
-	resultVar := astbuilder.LocalVariableDeclaration(
-		resultIdent.String(),
-		&dst.ArrayType{
-			Elt: &dst.SelectorExpr{
-				X:   dst.NewIdent(client),
-				Sel: dst.NewIdent("Object"),
-			},
-		},
-		"")
-
-	// Sort the resources for a deterministic file layout
-	sort.Slice(resources, func(i, j int) bool {
+func orderByImportedTypeName(codeGenerationContext *astmodel.CodeGenerationContext, resources []astmodel.TypeName) func(i, j int) bool {
+	return func(i, j int) bool {
 		iVal := resources[i]
 		jVal := resources[j]
 
@@ -192,18 +157,52 @@ func createKnownTypesFuncImpl(codeGenerationContext *astmodel.CodeGenerationCont
 		}
 
 		return iPkgName < jPkgName || iPkgName == jPkgName && iVal.Name() < jVal.Name()
-	})
+	}
+}
+
+func orderByFunctionName(functions []*functions.IndexRegistrationFunction) func(i, j int) bool {
+	return func(i, j int) bool {
+		iVal := functions[i]
+		jVal := functions[j]
+
+		return iVal.Name() < jVal.Name()
+	}
+}
+
+// createGetKnownTypesFunc creates a getKnownTypes function that returns all known types:
+//		func getKnownTypes() []client.Object {
+//			var result []client.Object
+//			result = append(result, new(<package>.<resource>))
+//			result = append(result, new(<package>.<resource>))
+//			result = append(result, new(<package>.<resource>))
+//			...
+//			return result
+//		}
+func createGetKnownTypesFunc(codeGenerationContext *astmodel.CodeGenerationContext, resources []astmodel.TypeName) (dst.Decl, error) {
+	funcName := "getKnownTypes"
+	funcComment := "returns the list of all types."
+
+	client, err := codeGenerationContext.GetImportedPackageName(astmodel.ControllerRuntimeClient)
+	if err != nil {
+		return nil, err
+	}
+
+	resultIdent := dst.NewIdent("result")
+	resultVar := astbuilder.LocalVariableDeclaration(
+		resultIdent.String(),
+		&dst.ArrayType{
+			Elt: astbuilder.Selector(dst.NewIdent(client), "Object"),
+		},
+		"")
+
+	// Sort the resources for a deterministic file layout
+	sort.Slice(resources, orderByImportedTypeName(codeGenerationContext, resources))
 
 	var resourceAppendStatements []dst.Stmt
 	for _, typeName := range resources {
 		appendStmt := astbuilder.AppendSlice(
 			resultIdent,
-			&dst.CallExpr{
-				Fun: dst.NewIdent("new"),
-				Args: []dst.Expr{
-					typeName.AsType(codeGenerationContext),
-				},
-			})
+			astbuilder.CallFunc("new", typeName.AsType(codeGenerationContext)))
 		resourceAppendStatements = append(resourceAppendStatements, appendStmt)
 	}
 
@@ -225,10 +224,7 @@ func createKnownTypesFuncImpl(codeGenerationContext *astmodel.CodeGenerationCont
 		Returns: []*dst.Field{
 			{
 				Type: &dst.ArrayType{
-					Elt: &dst.SelectorExpr{
-						X:   dst.NewIdent(client),
-						Sel: dst.NewIdent("Object"),
-					},
+					Elt: astbuilder.Selector(dst.NewIdent(client), "Object"),
 				},
 			},
 		},
@@ -236,6 +232,150 @@ func createKnownTypesFuncImpl(codeGenerationContext *astmodel.CodeGenerationCont
 	f.AddComments(funcComment)
 
 	return f.DefineFunc(), nil
+}
+
+// createGetKnownStorageTypesFunc creates a getKnownStorageTypes function that returns all storage types:
+//		func getKnownStorageTypes() []registration.StorageType {
+//			var result []registration.StorageType
+//			result = append(result, registration.StorageType{
+//				Obj: new(<package>.<resource>),
+//				Indexes: []registration.IndexRegistration{
+//					registration.IndexRegistration{
+//						Key: <key>,
+//						Func: <func>,
+//				},
+//				Watches: []registration.WatchRegistration{
+//					registration.WatchRegistration{
+//						Src: <source> (usually corev1.Secret{}),
+//
+//					},
+//			})
+//			result = append(result, registration.StorageType{Obj: new(<package>.<resource>)})
+//			result = append(result, registration.StorageType{Obj: new(<package>.<resource>)})
+//			...
+//			return result
+//		}
+func createGetKnownStorageTypesFunc(
+	codeGenerationContext *astmodel.CodeGenerationContext,
+	resources []astmodel.TypeName,
+	indexFunctions map[astmodel.TypeName][]*functions.IndexRegistrationFunction,
+	secretPropertyKeys map[astmodel.TypeName][]string) dst.Decl {
+
+	funcName := "getKnownStorageTypes"
+	funcComment := "returns the list of storage types which can be reconciled."
+
+	resultIdent := dst.NewIdent("result")
+	resultVar := astbuilder.LocalVariableDeclaration(
+		resultIdent.String(),
+		&dst.ArrayType{
+			Elt: astmodel.StorageTypeRegistrationType.AsType(codeGenerationContext),
+		},
+		"")
+
+	sort.Slice(resources, orderByImportedTypeName(codeGenerationContext, resources))
+
+	var resourceAppendStatements []dst.Stmt
+	for _, typeName := range resources {
+		newStorageTypeBuilder := astbuilder.NewCompositeLiteralBuilder(astmodel.StorageTypeRegistrationType.AsType(codeGenerationContext))
+		newStorageTypeBuilder.AddField("Obj", astbuilder.CallFunc("new", typeName.AsType(codeGenerationContext)))
+
+		// Register index functions (if needed):
+		// Indexes: []registration.IndexRegistration{
+		//		registration.IndexRegistration{
+		//			Key: <key>,
+		//			Func: <func>,
+		//		}
+		//	}
+		if indexFuncs, ok := indexFunctions[typeName]; ok {
+			sliceBuilder := astbuilder.NewSliceLiteralBuilder(astmodel.IndexRegistrationType.AsType(codeGenerationContext), true)
+
+			for _, indexFunc := range indexFuncs {
+				newIndexFunctionBuilder := astbuilder.NewCompositeLiteralBuilder(astmodel.IndexRegistrationType.AsType(codeGenerationContext))
+				newIndexFunctionBuilder.AddField("Key", astbuilder.StringLiteral(indexFunc.IndexKey()))
+				newIndexFunctionBuilder.AddField("Func", dst.NewIdent(indexFunc.Name()))
+				sliceBuilder.AddElement(newIndexFunctionBuilder.Build())
+			}
+			// astbuilder.SliceLiteral(astmodel.IndexRegistrationType.AsType(codeGenerationContext), indexRegistrations...)
+			newStorageTypeBuilder.AddField("Indexes", sliceBuilder.Build())
+		}
+
+		// Register additional watches (if needed):
+		// Watches: []registration.WatchRegistration{
+		//		registration.WatchRegistration{
+		//			Src: <event source>,
+		//			MakeEventHandler: <func>,
+		//		}
+		//	}
+		if secretKeys, ok := secretPropertyKeys[typeName]; ok {
+			newWatchBuilder := astbuilder.NewCompositeLiteralBuilder(astmodel.WatchRegistrationType.AsType(codeGenerationContext))
+			// Not using astbuilder here because we want this to go onto a single line
+			source := &dst.CompositeLit{
+				Type: astmodel.ControllerRuntimeSourceKindType.AsType(codeGenerationContext),
+				Elts: []dst.Expr{
+					&dst.KeyValueExpr{
+						Key: dst.NewIdent("Type"),
+						Value: astbuilder.AddrOf(
+							&dst.CompositeLit{
+								Type: astmodel.SecretType.AsType(codeGenerationContext),
+							}),
+					},
+				},
+			}
+			newWatchBuilder.AddField("Src", astbuilder.AddrOf(source))
+
+			// This is so messy and could be done much cleaner with select, if there was one
+			var secretKeyParams []dst.Expr
+			for _, secretKey := range secretKeys {
+				secretKeyParams = append(secretKeyParams, astbuilder.StringLiteral(secretKey))
+			}
+
+			// This is a bit hacky
+			listTypeName := typeName.WithName(typeName.Name() + "List").AsType(codeGenerationContext)
+
+			eventHandler := astbuilder.CallFunc(
+				"watchSecretsFactory",
+				astbuilder.SliceLiteral(dst.NewIdent("string"), secretKeyParams...),
+				astbuilder.AddrOf(astbuilder.NewCompositeLiteralBuilder(listTypeName).Build()))
+			newWatchBuilder.AddField("MakeEventHandler", eventHandler)
+
+			sliceBuilder := astbuilder.NewSliceLiteralBuilder(astmodel.WatchRegistrationType.AsType(codeGenerationContext), true)
+			sliceBuilder.AddElement(newWatchBuilder.Build())
+
+			newStorageTypeBuilder.AddField("Watches", sliceBuilder.Build())
+		}
+
+		appendStmt := astbuilder.AppendSlice(
+			resultIdent,
+			newStorageTypeBuilder.Build())
+		resourceAppendStatements = append(resourceAppendStatements, appendStmt)
+	}
+
+	returnStmt := &dst.ReturnStmt{
+		Results: []dst.Expr{
+			resultIdent,
+		},
+	}
+
+	var body []dst.Stmt
+	body = append(body, resultVar)
+	body = append(body, resourceAppendStatements...)
+	body = append(body, returnStmt)
+
+	f := &astbuilder.FuncDetails{
+		Name:   funcName,
+		Body:   body,
+		Params: []*dst.Field{},
+		Returns: []*dst.Field{
+			{
+				Type: &dst.ArrayType{
+					Elt: astmodel.StorageTypeRegistrationType.AsType(codeGenerationContext),
+				},
+			},
+		},
+	}
+	f.AddComments(funcComment)
+
+	return f.DefineFunc()
 }
 
 // createCreateSchemeFunc creates a createScheme() function like:
@@ -315,6 +455,22 @@ func (r *ResourceRegistrationFile) createCreateSchemeFunc(codeGenerationContext 
 	f.AddComments("creates a Scheme containing the clientgo types and all of the custom types returned by getKnownTypes")
 
 	return f.DefineFunc(), nil
+}
+
+func (r *ResourceRegistrationFile) defineIndexFunctions(codeGenerationContext *astmodel.CodeGenerationContext) []dst.Decl {
+	var result []dst.Decl
+	var indexFunctions []*functions.IndexRegistrationFunction
+
+	for _, funcs := range r.indexFunctions {
+		indexFunctions = append(indexFunctions, funcs...)
+	}
+	sort.Slice(indexFunctions, orderByFunctionName(indexFunctions))
+
+	for _, f := range indexFunctions {
+		result = append(result, f.AsFunc(codeGenerationContext, astmodel.TypeName{}))
+	}
+
+	return result
 }
 
 func (r *ResourceRegistrationFile) getImportedPackages() map[astmodel.PackageReference]struct{} {

--- a/v2/tools/generator/internal/functions/index_registration_function.go
+++ b/v2/tools/generator/internal/functions/index_registration_function.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package functions
+
+import (
+	"fmt"
+
+	"github.com/dave/dst"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astbuilder"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+)
+
+type IndexRegistrationFunction struct {
+	name             string
+	resourceTypeName astmodel.TypeName
+	propertyChain    []*astmodel.PropertyDefinition
+	indexKey         string
+}
+
+// NewIndexRegistrationFunction returns a new index registration function
+func NewIndexRegistrationFunction(
+	name string,
+	resourceTypeName astmodel.TypeName,
+	indexKey string,
+	propertyChain []*astmodel.PropertyDefinition) *IndexRegistrationFunction {
+	return &IndexRegistrationFunction{
+		name:             name,
+		resourceTypeName: resourceTypeName,
+		// TODO: Technically you can derive the key from the chain so maybe should just pass one
+		indexKey:      indexKey,
+		propertyChain: propertyChain,
+	}
+}
+
+// Ensure IndexRegistrationFunction implements Function interface correctly
+var _ astmodel.Function = &IndexRegistrationFunction{}
+
+func (f *IndexRegistrationFunction) Name() string {
+	return f.name
+}
+
+// IndexKey returns the index key used in the index function
+func (f *IndexRegistrationFunction) IndexKey() string {
+	return f.indexKey
+}
+
+// Equals determines if this function is equal to the passed in function
+func (f *IndexRegistrationFunction) Equals(other astmodel.Function, overrides astmodel.EqualityOverrides) bool {
+	if o, ok := other.(*IndexRegistrationFunction); ok {
+		return f.resourceTypeName.Equals(o.resourceTypeName, overrides)
+	}
+
+	return false
+}
+
+// References returns the set of types to which this function refers.
+// SHOULD include any types which this function references but its receiver doesn't.
+// SHOULD NOT include the receiver of this function.
+func (f *IndexRegistrationFunction) References() astmodel.TypeNameSet {
+	return nil
+}
+
+// RequiredPackageReferences returns a set of references to packages required by this
+func (f *IndexRegistrationFunction) RequiredPackageReferences() *astmodel.PackageReferenceSet {
+	return astmodel.NewPackageReferenceSet(astmodel.ControllerRuntimeClient)
+}
+
+// AsFunc returns the function as a go dst
+func (f *IndexRegistrationFunction) AsFunc(
+	genContext *astmodel.CodeGenerationContext,
+	_ astmodel.TypeName) *dst.FuncDecl {
+
+	rawObjName := "rawObj"
+	objName := "obj"
+
+	// obj, ok := rawObj.(*<type>)
+	cast := astbuilder.TypeAssert(
+		dst.NewIdent(objName),
+		dst.NewIdent(rawObjName),
+		astbuilder.Dereference(f.resourceTypeName.AsType(genContext)))
+
+	// if !ok { return nil }
+	checkAssert := astbuilder.ReturnIfNotOk(astbuilder.Nil())
+	specSelector := astbuilder.Selector(dst.NewIdent(objName), "Spec")
+
+	// Create a series of guards to protect against the possibility of a nil dereference
+	// if obj.Spec.AdministratorLoginPassword == nil {
+	//	return nil
+	// }
+	var propNames []string
+	var nilGuards []dst.Stmt
+	for _, prop := range f.propertyChain {
+		propNames = append(propNames, prop.PropertyName().String())
+		intermediateSelector := astbuilder.Selector(specSelector, propNames...)
+		nilGuards = append(nilGuards, astbuilder.ReturnIfNil(intermediateSelector, astbuilder.Nil()))
+	}
+
+	// return []string{obj.Spec.<property>}
+	propNames = append(propNames, "Name") // Add the ".Name" selector to select the secrets name field
+	finalSelector := astbuilder.Selector(specSelector, propNames...)
+	ret := astbuilder.Returns(astbuilder.SliceLiteral(dst.NewIdent("string"), finalSelector))
+
+	fn := &astbuilder.FuncDetails{
+		Name: f.Name(),
+		Body: astbuilder.Statements(
+			cast,
+			checkAssert,
+			nilGuards,
+			ret),
+	}
+
+	fn.AddParameter(rawObjName, astmodel.ControllerRuntimeObjectType.AsType(genContext))
+
+	fn.AddReturn(&dst.ArrayType{Elt: dst.NewIdent("string")})
+
+	pkg := genContext.MustGetImportedPackageName(f.resourceTypeName.PackageReference)
+
+	fn.AddComments(fmt.Sprintf("an index function for %s.%s %s", pkg, f.resourceTypeName.Name(), f.indexKey))
+	return fn.DefineFunc()
+}

--- a/v2/tools/generator/internal/functions/pure_function.go
+++ b/v2/tools/generator/internal/functions/pure_function.go
@@ -11,24 +11,24 @@ import (
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
 
-// ObjectFunction is a simple helper that implements the Function interface. It is intended for use for functions
-// that only need information about the object they are operating on
-type ObjectFunction struct {
+// StandaloneFunction is a simple helper that implements the Function interface. It is intended for use
+// for pure functions
+type PureFunction struct {
 	name             string
 	idFactory        astmodel.IdentifierFactory
-	asFunc           ObjectFunctionHandler
+	asFunc           PureFunctionHandler
 	requiredPackages *astmodel.PackageReferenceSet
 	referencedTypes  astmodel.TypeNameSet
 }
 
-var _ astmodel.Function = &ObjectFunction{}
+var _ astmodel.Function = &PureFunction{}
 
-// NewObjectFunction creates a new object function
-func NewObjectFunction(
+// NewPureFunction creates a new pure function
+func NewPureFunction(
 	name string,
 	idFactory astmodel.IdentifierFactory,
-	asFunc ObjectFunctionHandler) *ObjectFunction {
-	return &ObjectFunction{
+	asFunc PureFunctionHandler) *PureFunction {
+	return &PureFunction{
 		name:             name,
 		asFunc:           asFunc,
 		requiredPackages: astmodel.NewPackageReferenceSet(),
@@ -37,38 +37,37 @@ func NewObjectFunction(
 	}
 }
 
-type ObjectFunctionHandler func(f *ObjectFunction, codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName, methodName string) *dst.FuncDecl
+type PureFunctionHandler func(f *PureFunction, codeGenerationContext *astmodel.CodeGenerationContext, methodName string) *dst.FuncDecl
 
 // Name returns the unique name of this function
-// (You can't have two functions with the same name on the same object or resource)
-func (fn *ObjectFunction) Name() string {
+func (fn *PureFunction) Name() string {
 	return fn.name
 }
 
-func (fn *ObjectFunction) IdFactory() astmodel.IdentifierFactory {
+func (fn *PureFunction) IdFactory() astmodel.IdentifierFactory {
 	return fn.idFactory
 }
 
 // RequiredPackageReferences returns the set of required packages for this function
-func (fn *ObjectFunction) RequiredPackageReferences() *astmodel.PackageReferenceSet {
+func (fn *PureFunction) RequiredPackageReferences() *astmodel.PackageReferenceSet {
 	return fn.requiredPackages
 }
 
 // References returns the set of types to which this function refers.
 // SHOULD include any types which this function references but its receiver doesn't.
 // SHOULD NOT include the receiver of this function.
-func (fn *ObjectFunction) References() astmodel.TypeNameSet {
+func (fn *PureFunction) References() astmodel.TypeNameSet {
 	return fn.referencedTypes
 }
 
 // AsFunc renders the current instance as a Go abstract syntax tree
-func (fn *ObjectFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *dst.FuncDecl {
-	return fn.asFunc(fn, codeGenerationContext, receiver, fn.name)
+func (fn *PureFunction) AsFunc(codeGenerationContext *astmodel.CodeGenerationContext, _ astmodel.TypeName) *dst.FuncDecl {
+	return fn.asFunc(fn, codeGenerationContext, fn.name)
 }
 
 // Equals checks if this function is equal to the passed in function
-func (fn *ObjectFunction) Equals(f astmodel.Function, _ astmodel.EqualityOverrides) bool {
-	typedF, ok := f.(*ObjectFunction)
+func (fn *PureFunction) Equals(f astmodel.Function, _ astmodel.EqualityOverrides) bool {
+	typedF, ok := f.(*PureFunction)
 	if !ok {
 		return false
 	}
@@ -79,7 +78,7 @@ func (fn *ObjectFunction) Equals(f astmodel.Function, _ astmodel.EqualityOverrid
 }
 
 // AddPackageReference adds one or more required package references
-func (fn *ObjectFunction) AddPackageReference(refs ...astmodel.PackageReference) {
+func (fn *PureFunction) AddPackageReference(refs ...astmodel.PackageReference) {
 	for _, ref := range refs {
 		fn.requiredPackages.AddReference(ref)
 	}
@@ -87,7 +86,7 @@ func (fn *ObjectFunction) AddPackageReference(refs ...astmodel.PackageReference)
 
 // AddReferencedTypes adds one or more types that are required
 // Their packages are automatically included as well.
-func (fn *ObjectFunction) AddReferencedTypes(types ...astmodel.TypeName) {
+func (fn *PureFunction) AddReferencedTypes(types ...astmodel.TypeName) {
 	for _, t := range types {
 		fn.referencedTypes.Add(t)
 		fn.requiredPackages.AddReference(t.PackageReference)


### PR DESCRIPTION
 * Add index in client-go for resources that support secrets, indexed on
   the property containing the secret.
 * Trigger reconcile for resources that have a secret reference by watching
   secret modifications and using the resource specific indexes to
   see if that secret is in use by a resource.
 * Add tests to ensure that this whole dance works. The test cannot run
   in the recording tests because they do not use a cached client and
   the custom indexing is all client-side.

**If applicable**:
- [x] this PR contains tests
