### PR TITLE
Add PrivateDNSZone resource

### DIFF
--- a/v2/api/network/versions_matrix.md
+++ b/v2/api/network/versions_matrix.md
@@ -1,254 +1,260 @@
-| Types defined in package "network"                                                               | v1alpha1api20201101 |
-|--------------------------------------------------------------------------------------------------|---------------------|
-| AddressSpace                                                                                     | v1alpha1api20201101 |
-| AddressSpace_Status                                                                              | v1alpha1api20201101 |
-| ApplicationGatewayBackendAddressPoolPropertiesFormat_Status_NetworkInterface_SubResourceEmbedded | v1alpha1api20201101 |
-| ApplicationGatewayBackendAddressPool_Status_NetworkInterface_SubResourceEmbedded                 | v1alpha1api20201101 |
-| ApplicationGatewayBackendAddress_Status                                                          | v1alpha1api20201101 |
-| ApplicationGatewayIPConfigurationPropertiesFormat_Status                                         | v1alpha1api20201101 |
-| ApplicationGatewayIPConfiguration_Status                                                         | v1alpha1api20201101 |
-| ApplicationSecurityGroup_Status_NetworkInterface_SubResourceEmbedded                             | v1alpha1api20201101 |
-| ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded            | v1alpha1api20201101 |
-| BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded                                       | v1alpha1api20201101 |
-| BackendAddressPool_Status_NetworkInterface_SubResourceEmbedded                                   | v1alpha1api20201101 |
-| BgpSettings                                                                                      | v1alpha1api20201101 |
-| BgpSettings_Status                                                                               | v1alpha1api20201101 |
-| DdosSettings                                                                                     | v1alpha1api20201101 |
-| DdosSettingsProtectionCoverage                                                                   | v1alpha1api20201101 |
-| DdosSettingsStatusProtectionCoverage                                                             | v1alpha1api20201101 |
-| DdosSettings_Status                                                                              | v1alpha1api20201101 |
-| Delegation_Status                                                                                | v1alpha1api20201101 |
-| DhGroup_Status                                                                                   | v1alpha1api20201101 |
-| DhcpOptions                                                                                      | v1alpha1api20201101 |
-| DhcpOptions_Status                                                                               | v1alpha1api20201101 |
-| ExtendedLocation                                                                                 | v1alpha1api20201101 |
-| ExtendedLocationType                                                                             | v1alpha1api20201101 |
-| ExtendedLocationType_Status                                                                      | v1alpha1api20201101 |
-| ExtendedLocation_Status                                                                          | v1alpha1api20201101 |
-| FlowLog_Status_SubResourceEmbedded                                                               | v1alpha1api20201101 |
-| FrontendIPConfigurationPropertiesFormat                                                          | v1alpha1api20201101 |
-| FrontendIPConfigurationPropertiesFormatPrivateIPAddressVersion                                   | v1alpha1api20201101 |
-| FrontendIPConfigurationPropertiesFormatPrivateIPAllocationMethod                                 | v1alpha1api20201101 |
-| FrontendIPConfigurationPropertiesFormat_Status_LoadBalancer_SubResourceEmbedded                  | v1alpha1api20201101 |
-| FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded                                  | v1alpha1api20201101 |
-| IPAllocationMethod_Status                                                                        | v1alpha1api20201101 |
-| IPConfigurationBgpPeeringAddress                                                                 | v1alpha1api20201101 |
-| IPConfigurationBgpPeeringAddress_Status                                                          | v1alpha1api20201101 |
-| IPConfigurationProfilePropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbedded          | v1alpha1api20201101 |
-| IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded                          | v1alpha1api20201101 |
-| IPConfigurationPropertiesFormat_Status_PublicIPAddress_SubResourceEmbedded                       | v1alpha1api20201101 |
-| IPConfigurationPropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbedded                 | v1alpha1api20201101 |
-| IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded                                       | v1alpha1api20201101 |
-| IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded                                 | v1alpha1api20201101 |
-| IPVersion_Status                                                                                 | v1alpha1api20201101 |
-| IkeEncryption_Status                                                                             | v1alpha1api20201101 |
-| IkeIntegrity_Status                                                                              | v1alpha1api20201101 |
-| InboundNatPoolPropertiesFormat                                                                   | v1alpha1api20201101 |
-| InboundNatPoolPropertiesFormatProtocol                                                           | v1alpha1api20201101 |
-| InboundNatPoolPropertiesFormat_Status                                                            | v1alpha1api20201101 |
-| InboundNatPool_Status                                                                            | v1alpha1api20201101 |
-| InboundNatRule_Status_LoadBalancer_SubResourceEmbedded                                           | v1alpha1api20201101 |
-| InboundNatRule_Status_NetworkInterface_SubResourceEmbedded                                       | v1alpha1api20201101 |
-| IpTag                                                                                            | v1alpha1api20201101 |
-| IpTag_Status                                                                                     | v1alpha1api20201101 |
-| IpsecEncryption_Status                                                                           | v1alpha1api20201101 |
-| IpsecIntegrity_Status                                                                            | v1alpha1api20201101 |
-| IpsecPolicy                                                                                      | v1alpha1api20201101 |
-| IpsecPolicyDhGroup                                                                               | v1alpha1api20201101 |
-| IpsecPolicyIkeEncryption                                                                         | v1alpha1api20201101 |
-| IpsecPolicyIkeIntegrity                                                                          | v1alpha1api20201101 |
-| IpsecPolicyIpsecEncryption                                                                       | v1alpha1api20201101 |
-| IpsecPolicyIpsecIntegrity                                                                        | v1alpha1api20201101 |
-| IpsecPolicyPfsGroup                                                                              | v1alpha1api20201101 |
-| IpsecPolicy_Status                                                                               | v1alpha1api20201101 |
-| LoadBalancer                                                                                     | v1alpha1api20201101 |
-| LoadBalancerBackendAddressPropertiesFormat                                                       | v1alpha1api20201101 |
-| LoadBalancerPropertiesFormat_Status                                                              | v1alpha1api20201101 |
-| LoadBalancerSku                                                                                  | v1alpha1api20201101 |
-| LoadBalancerSkuName                                                                              | v1alpha1api20201101 |
-| LoadBalancerSkuStatusName                                                                        | v1alpha1api20201101 |
-| LoadBalancerSkuStatusTier                                                                        | v1alpha1api20201101 |
-| LoadBalancerSkuTier                                                                              | v1alpha1api20201101 |
-| LoadBalancerSku_Status                                                                           | v1alpha1api20201101 |
-| LoadBalancer_Status                                                                              | v1alpha1api20201101 |
-| LoadBalancersSpecAPIVersion                                                                      | v1alpha1api20201101 |
-| LoadBalancers_Spec                                                                               | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties                                                                    | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_BackendAddressPools                                                | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_BackendAddressPools_Properties                                     | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddresses        | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_FrontendIPConfigurations                                           | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_InboundNatPools                                                    | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_LoadBalancingRules                                                 | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_OutboundRules                                                      | v1alpha1api20201101 |
-| LoadBalancers_Spec_Properties_Probes                                                             | v1alpha1api20201101 |
-| LoadBalancingRulePropertiesFormat                                                                | v1alpha1api20201101 |
-| LoadBalancingRulePropertiesFormatLoadDistribution                                                | v1alpha1api20201101 |
-| LoadBalancingRulePropertiesFormatProtocol                                                        | v1alpha1api20201101 |
-| LoadBalancingRulePropertiesFormatStatusLoadDistribution                                          | v1alpha1api20201101 |
-| LoadBalancingRulePropertiesFormat_Status                                                         | v1alpha1api20201101 |
-| LoadBalancingRule_Status                                                                         | v1alpha1api20201101 |
-| NatGatewaySkuStatusName                                                                          | v1alpha1api20201101 |
-| NatGatewaySku_Status                                                                             | v1alpha1api20201101 |
-| NatGateway_Status_PublicIPAddress_SubResourceEmbedded                                            | v1alpha1api20201101 |
-| NetworkInterface                                                                                 | v1alpha1api20201101 |
-| NetworkInterfaceDnsSettings                                                                      | v1alpha1api20201101 |
-| NetworkInterfaceDnsSettings_Status                                                               | v1alpha1api20201101 |
-| NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_Status                            | v1alpha1api20201101 |
-| NetworkInterfaceIPConfigurationPropertiesFormat                                                  | v1alpha1api20201101 |
-| NetworkInterfaceIPConfigurationPropertiesFormatPrivateIPAddressVersion                           | v1alpha1api20201101 |
-| NetworkInterfaceIPConfigurationPropertiesFormatPrivateIPAllocationMethod                         | v1alpha1api20201101 |
-| NetworkInterfaceIPConfigurationPropertiesFormat_Status_NetworkInterface_SubResourceEmbedded      | v1alpha1api20201101 |
-| NetworkInterfaceIPConfiguration_Status_NetworkInterface_SubResourceEmbedded                      | v1alpha1api20201101 |
-| NetworkInterfacePropertiesFormatStatusMigrationPhase                                             | v1alpha1api20201101 |
-| NetworkInterfacePropertiesFormatStatusNicType                                                    | v1alpha1api20201101 |
-| NetworkInterfacePropertiesFormat_Status                                                          | v1alpha1api20201101 |
-| NetworkInterfaceTapConfiguration_Status_NetworkInterface_SubResourceEmbedded                     | v1alpha1api20201101 |
-| NetworkInterface_Status_NetworkInterface_SubResourceEmbedded                                     | v1alpha1api20201101 |
-| NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded                                 | v1alpha1api20201101 |
-| NetworkInterfacesSpecAPIVersion                                                                  | v1alpha1api20201101 |
-| NetworkInterfaces_Spec                                                                           | v1alpha1api20201101 |
-| NetworkInterfaces_Spec_Properties                                                                | v1alpha1api20201101 |
-| NetworkInterfaces_Spec_Properties_IpConfigurations                                               | v1alpha1api20201101 |
-| NetworkSecurityGroup                                                                             | v1alpha1api20201101 |
-| NetworkSecurityGroupPropertiesFormat_Status                                                      | v1alpha1api20201101 |
-| NetworkSecurityGroup_Status_NetworkInterface_SubResourceEmbedded                                 | v1alpha1api20201101 |
-| NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded                             | v1alpha1api20201101 |
-| NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded                            | v1alpha1api20201101 |
-| NetworkSecurityGroupsSecurityRule                                                                | v1alpha1api20201101 |
-| NetworkSecurityGroupsSecurityRulesSpecAPIVersion                                                 | v1alpha1api20201101 |
-| NetworkSecurityGroupsSecurityRules_Spec                                                          | v1alpha1api20201101 |
-| NetworkSecurityGroupsSpecAPIVersion                                                              | v1alpha1api20201101 |
-| NetworkSecurityGroups_Spec                                                                       | v1alpha1api20201101 |
-| OutboundRulePropertiesFormat                                                                     | v1alpha1api20201101 |
-| OutboundRulePropertiesFormatProtocol                                                             | v1alpha1api20201101 |
-| OutboundRulePropertiesFormatStatusProtocol                                                       | v1alpha1api20201101 |
-| OutboundRulePropertiesFormat_Status                                                              | v1alpha1api20201101 |
-| OutboundRule_Status                                                                              | v1alpha1api20201101 |
-| PfsGroup_Status                                                                                  | v1alpha1api20201101 |
-| PrivateEndpoint_Status_NetworkInterface_SubResourceEmbedded                                      | v1alpha1api20201101 |
-| PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded                                 | v1alpha1api20201101 |
-| PrivateLinkService_Status_NetworkInterface_SubResourceEmbedded                                   | v1alpha1api20201101 |
-| ProbePropertiesFormat                                                                            | v1alpha1api20201101 |
-| ProbePropertiesFormatProtocol                                                                    | v1alpha1api20201101 |
-| ProbePropertiesFormatStatusProtocol                                                              | v1alpha1api20201101 |
-| ProbePropertiesFormat_Status                                                                     | v1alpha1api20201101 |
-| Probe_Status                                                                                     | v1alpha1api20201101 |
-| ProvisioningState_Status                                                                         | v1alpha1api20201101 |
-| PublicIPAddress                                                                                  | v1alpha1api20201101 |
-| PublicIPAddressDnsSettings                                                                       | v1alpha1api20201101 |
-| PublicIPAddressDnsSettings_Status                                                                | v1alpha1api20201101 |
-| PublicIPAddressPropertiesFormat                                                                  | v1alpha1api20201101 |
-| PublicIPAddressPropertiesFormatPublicIPAddressVersion                                            | v1alpha1api20201101 |
-| PublicIPAddressPropertiesFormatPublicIPAllocationMethod                                          | v1alpha1api20201101 |
-| PublicIPAddressPropertiesFormatStatusMigrationPhase                                              | v1alpha1api20201101 |
-| PublicIPAddressPropertiesFormat_Status                                                           | v1alpha1api20201101 |
-| PublicIPAddressSku                                                                               | v1alpha1api20201101 |
-| PublicIPAddressSkuName                                                                           | v1alpha1api20201101 |
-| PublicIPAddressSkuStatusName                                                                     | v1alpha1api20201101 |
-| PublicIPAddressSkuStatusTier                                                                     | v1alpha1api20201101 |
-| PublicIPAddressSkuTier                                                                           | v1alpha1api20201101 |
-| PublicIPAddressSku_Status                                                                        | v1alpha1api20201101 |
-| PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded                                          | v1alpha1api20201101 |
-| PublicIPAddress_Status_NetworkInterface_SubResourceEmbedded                                      | v1alpha1api20201101 |
-| PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded                                       | v1alpha1api20201101 |
-| PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded                                 | v1alpha1api20201101 |
-| PublicIPAddressesSpecAPIVersion                                                                  | v1alpha1api20201101 |
-| PublicIPAddresses_Spec                                                                           | v1alpha1api20201101 |
-| RadiusServer                                                                                     | v1alpha1api20201101 |
-| RadiusServer_Status                                                                              | v1alpha1api20201101 |
-| ResourceNavigationLinkFormat_Status                                                              | v1alpha1api20201101 |
-| ResourceNavigationLink_Status                                                                    | v1alpha1api20201101 |
-| RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded                                      | v1alpha1api20201101 |
-| SecurityRuleAccess_Status                                                                        | v1alpha1api20201101 |
-| SecurityRuleDirection_Status                                                                     | v1alpha1api20201101 |
-| SecurityRulePropertiesFormat                                                                     | v1alpha1api20201101 |
-| SecurityRulePropertiesFormatAccess                                                               | v1alpha1api20201101 |
-| SecurityRulePropertiesFormatDirection                                                            | v1alpha1api20201101 |
-| SecurityRulePropertiesFormatProtocol                                                             | v1alpha1api20201101 |
-| SecurityRulePropertiesFormatStatusProtocol                                                       | v1alpha1api20201101 |
-| SecurityRulePropertiesFormat_Status                                                              | v1alpha1api20201101 |
-| SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded                                     | v1alpha1api20201101 |
-| SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded                        | v1alpha1api20201101 |
-| ServiceAssociationLinkPropertiesFormat_Status                                                    | v1alpha1api20201101 |
-| ServiceAssociationLink_Status                                                                    | v1alpha1api20201101 |
-| ServiceDelegationPropertiesFormat                                                                | v1alpha1api20201101 |
-| ServiceDelegationPropertiesFormat_Status                                                         | v1alpha1api20201101 |
-| ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded                           | v1alpha1api20201101 |
-| ServiceEndpointPropertiesFormat                                                                  | v1alpha1api20201101 |
-| ServiceEndpointPropertiesFormat_Status                                                           | v1alpha1api20201101 |
-| SubResource                                                                                      | v1alpha1api20201101 |
-| SubResource_Status                                                                               | v1alpha1api20201101 |
-| SubnetPropertiesFormatStatusPrivateEndpointNetworkPolicies                                       | v1alpha1api20201101 |
-| SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPolicies                                    | v1alpha1api20201101 |
-| SubnetPropertiesFormat_Status                                                                    | v1alpha1api20201101 |
-| Subnet_Status_LoadBalancer_SubResourceEmbedded                                                   | v1alpha1api20201101 |
-| Subnet_Status_NetworkInterface_SubResourceEmbedded                                               | v1alpha1api20201101 |
-| Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded                                           | v1alpha1api20201101 |
-| Subnet_Status_PublicIPAddress_SubResourceEmbedded                                                | v1alpha1api20201101 |
-| Subnet_Status_VirtualNetwork_SubResourceEmbedded                                                 | v1alpha1api20201101 |
-| Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded                                          | v1alpha1api20201101 |
-| TransportProtocol_Status                                                                         | v1alpha1api20201101 |
-| VirtualNetwork                                                                                   | v1alpha1api20201101 |
-| VirtualNetworkBgpCommunities                                                                     | v1alpha1api20201101 |
-| VirtualNetworkBgpCommunities_Status                                                              | v1alpha1api20201101 |
-| VirtualNetworkGateway                                                                            | v1alpha1api20201101 |
-| VirtualNetworkGatewayIPConfigurationPropertiesFormat                                             | v1alpha1api20201101 |
-| VirtualNetworkGatewayIPConfigurationPropertiesFormatPrivateIPAllocationMethod                    | v1alpha1api20201101 |
-| VirtualNetworkGatewayIPConfigurationPropertiesFormat_Status                                      | v1alpha1api20201101 |
-| VirtualNetworkGatewayIPConfiguration_Status                                                      | v1alpha1api20201101 |
-| VirtualNetworkGatewayPropertiesFormatStatusGatewayType                                           | v1alpha1api20201101 |
-| VirtualNetworkGatewayPropertiesFormatStatusVpnGatewayGeneration                                  | v1alpha1api20201101 |
-| VirtualNetworkGatewayPropertiesFormatStatusVpnType                                               | v1alpha1api20201101 |
-| VirtualNetworkGatewayPropertiesFormat_Status                                                     | v1alpha1api20201101 |
-| VirtualNetworkGatewaySku                                                                         | v1alpha1api20201101 |
-| VirtualNetworkGatewaySkuName                                                                     | v1alpha1api20201101 |
-| VirtualNetworkGatewaySkuStatusName                                                               | v1alpha1api20201101 |
-| VirtualNetworkGatewaySkuStatusTier                                                               | v1alpha1api20201101 |
-| VirtualNetworkGatewaySkuTier                                                                     | v1alpha1api20201101 |
-| VirtualNetworkGatewaySku_Status                                                                  | v1alpha1api20201101 |
-| VirtualNetworkGateway_Status                                                                     | v1alpha1api20201101 |
-| VirtualNetworkGatewaysSpecAPIVersion                                                             | v1alpha1api20201101 |
-| VirtualNetworkGatewaysSpecPropertiesGatewayType                                                  | v1alpha1api20201101 |
-| VirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnAuthenticationTypes                 | v1alpha1api20201101 |
-| VirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientProtocols                     | v1alpha1api20201101 |
-| VirtualNetworkGatewaysSpecPropertiesVpnGatewayGeneration                                         | v1alpha1api20201101 |
-| VirtualNetworkGatewaysSpecPropertiesVpnType                                                      | v1alpha1api20201101 |
-| VirtualNetworkGateways_Spec                                                                      | v1alpha1api20201101 |
-| VirtualNetworkGateways_Spec_Properties                                                           | v1alpha1api20201101 |
-| VirtualNetworkGateways_Spec_Properties_IpConfigurations                                          | v1alpha1api20201101 |
-| VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration                                    | v1alpha1api20201101 |
-| VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificates       | v1alpha1api20201101 |
-| VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificates          | v1alpha1api20201101 |
-| VirtualNetworkPeeringPropertiesFormat                                                            | v1alpha1api20201101 |
-| VirtualNetworkPeeringPropertiesFormatPeeringState                                                | v1alpha1api20201101 |
-| VirtualNetworkPeeringPropertiesFormatStatusPeeringState                                          | v1alpha1api20201101 |
-| VirtualNetworkPeeringPropertiesFormat_Status                                                     | v1alpha1api20201101 |
-| VirtualNetworkPeering_Status                                                                     | v1alpha1api20201101 |
-| VirtualNetworkPeering_Status_SubResourceEmbedded                                                 | v1alpha1api20201101 |
-| VirtualNetworkPropertiesFormat_Status                                                            | v1alpha1api20201101 |
-| VirtualNetworkTap_Status_NetworkInterface_SubResourceEmbedded                                    | v1alpha1api20201101 |
-| VirtualNetwork_Status                                                                            | v1alpha1api20201101 |
-| VirtualNetworksSpecAPIVersion                                                                    | v1alpha1api20201101 |
-| VirtualNetworksSubnet                                                                            | v1alpha1api20201101 |
-| VirtualNetworksSubnetsSpecAPIVersion                                                             | v1alpha1api20201101 |
-| VirtualNetworksSubnets_Spec                                                                      | v1alpha1api20201101 |
-| VirtualNetworksSubnets_Spec_Properties                                                           | v1alpha1api20201101 |
-| VirtualNetworksSubnets_Spec_Properties_Delegations                                               | v1alpha1api20201101 |
-| VirtualNetworksVirtualNetworkPeering                                                             | v1alpha1api20201101 |
-| VirtualNetworksVirtualNetworkPeeringsSpecAPIVersion                                              | v1alpha1api20201101 |
-| VirtualNetworksVirtualNetworkPeerings_Spec                                                       | v1alpha1api20201101 |
-| VirtualNetworks_Spec                                                                             | v1alpha1api20201101 |
-| VirtualNetworks_Spec_Properties                                                                  | v1alpha1api20201101 |
-| VirtualNetworks_Spec_Properties_Subnets                                                          | v1alpha1api20201101 |
-| VirtualNetworks_Spec_Properties_Subnets_Properties                                               | v1alpha1api20201101 |
-| VirtualNetworks_Spec_Properties_Subnets_Properties_Delegations                                   | v1alpha1api20201101 |
-| VpnClientConfigurationStatusVpnAuthenticationTypes                                               | v1alpha1api20201101 |
-| VpnClientConfigurationStatusVpnClientProtocols                                                   | v1alpha1api20201101 |
-| VpnClientConfiguration_Status                                                                    | v1alpha1api20201101 |
-| VpnClientRevokedCertificatePropertiesFormat                                                      | v1alpha1api20201101 |
-| VpnClientRevokedCertificatePropertiesFormat_Status                                               | v1alpha1api20201101 |
-| VpnClientRevokedCertificate_Status                                                               | v1alpha1api20201101 |
-| VpnClientRootCertificatePropertiesFormat                                                         | v1alpha1api20201101 |
-| VpnClientRootCertificatePropertiesFormat_Status                                                  | v1alpha1api20201101 |
-| VpnClientRootCertificate_Status                                                                  | v1alpha1api20201101 |
+| Types defined in package "network"                                                               | v1alpha1api20180901 | v1alpha1api20201101 |
+|--------------------------------------------------------------------------------------------------|---------------------|---------------------|
+| AddressSpace                                                                                     |                     | v1alpha1api20201101 |
+| AddressSpace_Status                                                                              |                     | v1alpha1api20201101 |
+| ApplicationGatewayBackendAddressPoolPropertiesFormat_Status_NetworkInterface_SubResourceEmbedded |                     | v1alpha1api20201101 |
+| ApplicationGatewayBackendAddressPool_Status_NetworkInterface_SubResourceEmbedded                 |                     | v1alpha1api20201101 |
+| ApplicationGatewayBackendAddress_Status                                                          |                     | v1alpha1api20201101 |
+| ApplicationGatewayIPConfigurationPropertiesFormat_Status                                         |                     | v1alpha1api20201101 |
+| ApplicationGatewayIPConfiguration_Status                                                         |                     | v1alpha1api20201101 |
+| ApplicationSecurityGroup_Status_NetworkInterface_SubResourceEmbedded                             |                     | v1alpha1api20201101 |
+| ApplicationSecurityGroup_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded            |                     | v1alpha1api20201101 |
+| BackendAddressPool_Status_LoadBalancer_SubResourceEmbedded                                       |                     | v1alpha1api20201101 |
+| BackendAddressPool_Status_NetworkInterface_SubResourceEmbedded                                   |                     | v1alpha1api20201101 |
+| BgpSettings                                                                                      |                     | v1alpha1api20201101 |
+| BgpSettings_Status                                                                               |                     | v1alpha1api20201101 |
+| DdosSettings                                                                                     |                     | v1alpha1api20201101 |
+| DdosSettingsProtectionCoverage                                                                   |                     | v1alpha1api20201101 |
+| DdosSettingsStatusProtectionCoverage                                                             |                     | v1alpha1api20201101 |
+| DdosSettings_Status                                                                              |                     | v1alpha1api20201101 |
+| Delegation_Status                                                                                |                     | v1alpha1api20201101 |
+| DhGroup_Status                                                                                   |                     | v1alpha1api20201101 |
+| DhcpOptions                                                                                      |                     | v1alpha1api20201101 |
+| DhcpOptions_Status                                                                               |                     | v1alpha1api20201101 |
+| ExtendedLocation                                                                                 |                     | v1alpha1api20201101 |
+| ExtendedLocationType                                                                             |                     | v1alpha1api20201101 |
+| ExtendedLocationType_Status                                                                      |                     | v1alpha1api20201101 |
+| ExtendedLocation_Status                                                                          |                     | v1alpha1api20201101 |
+| FlowLog_Status_SubResourceEmbedded                                                               |                     | v1alpha1api20201101 |
+| FrontendIPConfigurationPropertiesFormat                                                          |                     | v1alpha1api20201101 |
+| FrontendIPConfigurationPropertiesFormatPrivateIPAddressVersion                                   |                     | v1alpha1api20201101 |
+| FrontendIPConfigurationPropertiesFormatPrivateIPAllocationMethod                                 |                     | v1alpha1api20201101 |
+| FrontendIPConfigurationPropertiesFormat_Status_LoadBalancer_SubResourceEmbedded                  |                     | v1alpha1api20201101 |
+| FrontendIPConfiguration_Status_LoadBalancer_SubResourceEmbedded                                  |                     | v1alpha1api20201101 |
+| IPAllocationMethod_Status                                                                        |                     | v1alpha1api20201101 |
+| IPConfigurationBgpPeeringAddress                                                                 |                     | v1alpha1api20201101 |
+| IPConfigurationBgpPeeringAddress_Status                                                          |                     | v1alpha1api20201101 |
+| IPConfigurationProfilePropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbedded          |                     | v1alpha1api20201101 |
+| IPConfigurationProfile_Status_VirtualNetworksSubnet_SubResourceEmbedded                          |                     | v1alpha1api20201101 |
+| IPConfigurationPropertiesFormat_Status_PublicIPAddress_SubResourceEmbedded                       |                     | v1alpha1api20201101 |
+| IPConfigurationPropertiesFormat_Status_VirtualNetworksSubnet_SubResourceEmbedded                 |                     | v1alpha1api20201101 |
+| IPConfiguration_Status_PublicIPAddress_SubResourceEmbedded                                       |                     | v1alpha1api20201101 |
+| IPConfiguration_Status_VirtualNetworksSubnet_SubResourceEmbedded                                 |                     | v1alpha1api20201101 |
+| IPVersion_Status                                                                                 |                     | v1alpha1api20201101 |
+| IkeEncryption_Status                                                                             |                     | v1alpha1api20201101 |
+| IkeIntegrity_Status                                                                              |                     | v1alpha1api20201101 |
+| InboundNatPoolPropertiesFormat                                                                   |                     | v1alpha1api20201101 |
+| InboundNatPoolPropertiesFormatProtocol                                                           |                     | v1alpha1api20201101 |
+| InboundNatPoolPropertiesFormat_Status                                                            |                     | v1alpha1api20201101 |
+| InboundNatPool_Status                                                                            |                     | v1alpha1api20201101 |
+| InboundNatRule_Status_LoadBalancer_SubResourceEmbedded                                           |                     | v1alpha1api20201101 |
+| InboundNatRule_Status_NetworkInterface_SubResourceEmbedded                                       |                     | v1alpha1api20201101 |
+| IpTag                                                                                            |                     | v1alpha1api20201101 |
+| IpTag_Status                                                                                     |                     | v1alpha1api20201101 |
+| IpsecEncryption_Status                                                                           |                     | v1alpha1api20201101 |
+| IpsecIntegrity_Status                                                                            |                     | v1alpha1api20201101 |
+| IpsecPolicy                                                                                      |                     | v1alpha1api20201101 |
+| IpsecPolicyDhGroup                                                                               |                     | v1alpha1api20201101 |
+| IpsecPolicyIkeEncryption                                                                         |                     | v1alpha1api20201101 |
+| IpsecPolicyIkeIntegrity                                                                          |                     | v1alpha1api20201101 |
+| IpsecPolicyIpsecEncryption                                                                       |                     | v1alpha1api20201101 |
+| IpsecPolicyIpsecIntegrity                                                                        |                     | v1alpha1api20201101 |
+| IpsecPolicyPfsGroup                                                                              |                     | v1alpha1api20201101 |
+| IpsecPolicy_Status                                                                               |                     | v1alpha1api20201101 |
+| LoadBalancer                                                                                     |                     | v1alpha1api20201101 |
+| LoadBalancerBackendAddressPropertiesFormat                                                       |                     | v1alpha1api20201101 |
+| LoadBalancerPropertiesFormat_Status                                                              |                     | v1alpha1api20201101 |
+| LoadBalancerSku                                                                                  |                     | v1alpha1api20201101 |
+| LoadBalancerSkuName                                                                              |                     | v1alpha1api20201101 |
+| LoadBalancerSkuStatusName                                                                        |                     | v1alpha1api20201101 |
+| LoadBalancerSkuStatusTier                                                                        |                     | v1alpha1api20201101 |
+| LoadBalancerSkuTier                                                                              |                     | v1alpha1api20201101 |
+| LoadBalancerSku_Status                                                                           |                     | v1alpha1api20201101 |
+| LoadBalancer_Status                                                                              |                     | v1alpha1api20201101 |
+| LoadBalancersSpecAPIVersion                                                                      |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec                                                                               |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties                                                                    |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_BackendAddressPools                                                |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_BackendAddressPools_Properties                                     |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddresses        |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_FrontendIPConfigurations                                           |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_InboundNatPools                                                    |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_LoadBalancingRules                                                 |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_OutboundRules                                                      |                     | v1alpha1api20201101 |
+| LoadBalancers_Spec_Properties_Probes                                                             |                     | v1alpha1api20201101 |
+| LoadBalancingRulePropertiesFormat                                                                |                     | v1alpha1api20201101 |
+| LoadBalancingRulePropertiesFormatLoadDistribution                                                |                     | v1alpha1api20201101 |
+| LoadBalancingRulePropertiesFormatProtocol                                                        |                     | v1alpha1api20201101 |
+| LoadBalancingRulePropertiesFormatStatusLoadDistribution                                          |                     | v1alpha1api20201101 |
+| LoadBalancingRulePropertiesFormat_Status                                                         |                     | v1alpha1api20201101 |
+| LoadBalancingRule_Status                                                                         |                     | v1alpha1api20201101 |
+| NatGatewaySkuStatusName                                                                          |                     | v1alpha1api20201101 |
+| NatGatewaySku_Status                                                                             |                     | v1alpha1api20201101 |
+| NatGateway_Status_PublicIPAddress_SubResourceEmbedded                                            |                     | v1alpha1api20201101 |
+| NetworkInterface                                                                                 |                     | v1alpha1api20201101 |
+| NetworkInterfaceDnsSettings                                                                      |                     | v1alpha1api20201101 |
+| NetworkInterfaceDnsSettings_Status                                                               |                     | v1alpha1api20201101 |
+| NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties_Status                            |                     | v1alpha1api20201101 |
+| NetworkInterfaceIPConfigurationPropertiesFormat                                                  |                     | v1alpha1api20201101 |
+| NetworkInterfaceIPConfigurationPropertiesFormatPrivateIPAddressVersion                           |                     | v1alpha1api20201101 |
+| NetworkInterfaceIPConfigurationPropertiesFormatPrivateIPAllocationMethod                         |                     | v1alpha1api20201101 |
+| NetworkInterfaceIPConfigurationPropertiesFormat_Status_NetworkInterface_SubResourceEmbedded      |                     | v1alpha1api20201101 |
+| NetworkInterfaceIPConfiguration_Status_NetworkInterface_SubResourceEmbedded                      |                     | v1alpha1api20201101 |
+| NetworkInterfacePropertiesFormatStatusMigrationPhase                                             |                     | v1alpha1api20201101 |
+| NetworkInterfacePropertiesFormatStatusNicType                                                    |                     | v1alpha1api20201101 |
+| NetworkInterfacePropertiesFormat_Status                                                          |                     | v1alpha1api20201101 |
+| NetworkInterfaceTapConfiguration_Status_NetworkInterface_SubResourceEmbedded                     |                     | v1alpha1api20201101 |
+| NetworkInterface_Status_NetworkInterface_SubResourceEmbedded                                     |                     | v1alpha1api20201101 |
+| NetworkInterface_Status_NetworkSecurityGroup_SubResourceEmbedded                                 |                     | v1alpha1api20201101 |
+| NetworkInterfacesSpecAPIVersion                                                                  |                     | v1alpha1api20201101 |
+| NetworkInterfaces_Spec                                                                           |                     | v1alpha1api20201101 |
+| NetworkInterfaces_Spec_Properties                                                                |                     | v1alpha1api20201101 |
+| NetworkInterfaces_Spec_Properties_IpConfigurations                                               |                     | v1alpha1api20201101 |
+| NetworkSecurityGroup                                                                             |                     | v1alpha1api20201101 |
+| NetworkSecurityGroupPropertiesFormat_Status                                                      |                     | v1alpha1api20201101 |
+| NetworkSecurityGroup_Status_NetworkInterface_SubResourceEmbedded                                 |                     | v1alpha1api20201101 |
+| NetworkSecurityGroup_Status_NetworkSecurityGroup_SubResourceEmbedded                             |                     | v1alpha1api20201101 |
+| NetworkSecurityGroup_Status_VirtualNetworksSubnet_SubResourceEmbedded                            |                     | v1alpha1api20201101 |
+| NetworkSecurityGroupsSecurityRule                                                                |                     | v1alpha1api20201101 |
+| NetworkSecurityGroupsSecurityRulesSpecAPIVersion                                                 |                     | v1alpha1api20201101 |
+| NetworkSecurityGroupsSecurityRules_Spec                                                          |                     | v1alpha1api20201101 |
+| NetworkSecurityGroupsSpecAPIVersion                                                              |                     | v1alpha1api20201101 |
+| NetworkSecurityGroups_Spec                                                                       |                     | v1alpha1api20201101 |
+| OutboundRulePropertiesFormat                                                                     |                     | v1alpha1api20201101 |
+| OutboundRulePropertiesFormatProtocol                                                             |                     | v1alpha1api20201101 |
+| OutboundRulePropertiesFormatStatusProtocol                                                       |                     | v1alpha1api20201101 |
+| OutboundRulePropertiesFormat_Status                                                              |                     | v1alpha1api20201101 |
+| OutboundRule_Status                                                                              |                     | v1alpha1api20201101 |
+| PfsGroup_Status                                                                                  |                     | v1alpha1api20201101 |
+| PrivateDnsZone                                                                                   | v1alpha1api20180901 |                     |
+| PrivateDnsZonesSpecAPIVersion                                                                    | v1alpha1api20180901 |                     |
+| PrivateDnsZones_Spec                                                                             | v1alpha1api20180901 |                     |
+| PrivateEndpoint_Status_NetworkInterface_SubResourceEmbedded                                      |                     | v1alpha1api20201101 |
+| PrivateEndpoint_Status_VirtualNetworksSubnet_SubResourceEmbedded                                 |                     | v1alpha1api20201101 |
+| PrivateLinkService_Status_NetworkInterface_SubResourceEmbedded                                   |                     | v1alpha1api20201101 |
+| PrivateZonePropertiesStatusProvisioningState                                                     | v1alpha1api20180901 |                     |
+| PrivateZoneProperties_Status                                                                     | v1alpha1api20180901 |                     |
+| PrivateZone_Status                                                                               | v1alpha1api20180901 |                     |
+| ProbePropertiesFormat                                                                            |                     | v1alpha1api20201101 |
+| ProbePropertiesFormatProtocol                                                                    |                     | v1alpha1api20201101 |
+| ProbePropertiesFormatStatusProtocol                                                              |                     | v1alpha1api20201101 |
+| ProbePropertiesFormat_Status                                                                     |                     | v1alpha1api20201101 |
+| Probe_Status                                                                                     |                     | v1alpha1api20201101 |
+| ProvisioningState_Status                                                                         |                     | v1alpha1api20201101 |
+| PublicIPAddress                                                                                  |                     | v1alpha1api20201101 |
+| PublicIPAddressDnsSettings                                                                       |                     | v1alpha1api20201101 |
+| PublicIPAddressDnsSettings_Status                                                                |                     | v1alpha1api20201101 |
+| PublicIPAddressPropertiesFormat                                                                  |                     | v1alpha1api20201101 |
+| PublicIPAddressPropertiesFormatPublicIPAddressVersion                                            |                     | v1alpha1api20201101 |
+| PublicIPAddressPropertiesFormatPublicIPAllocationMethod                                          |                     | v1alpha1api20201101 |
+| PublicIPAddressPropertiesFormatStatusMigrationPhase                                              |                     | v1alpha1api20201101 |
+| PublicIPAddressPropertiesFormat_Status                                                           |                     | v1alpha1api20201101 |
+| PublicIPAddressSku                                                                               |                     | v1alpha1api20201101 |
+| PublicIPAddressSkuName                                                                           |                     | v1alpha1api20201101 |
+| PublicIPAddressSkuStatusName                                                                     |                     | v1alpha1api20201101 |
+| PublicIPAddressSkuStatusTier                                                                     |                     | v1alpha1api20201101 |
+| PublicIPAddressSkuTier                                                                           |                     | v1alpha1api20201101 |
+| PublicIPAddressSku_Status                                                                        |                     | v1alpha1api20201101 |
+| PublicIPAddress_Status_LoadBalancer_SubResourceEmbedded                                          |                     | v1alpha1api20201101 |
+| PublicIPAddress_Status_NetworkInterface_SubResourceEmbedded                                      |                     | v1alpha1api20201101 |
+| PublicIPAddress_Status_PublicIPAddress_SubResourceEmbedded                                       |                     | v1alpha1api20201101 |
+| PublicIPAddress_Status_VirtualNetworksSubnet_SubResourceEmbedded                                 |                     | v1alpha1api20201101 |
+| PublicIPAddressesSpecAPIVersion                                                                  |                     | v1alpha1api20201101 |
+| PublicIPAddresses_Spec                                                                           |                     | v1alpha1api20201101 |
+| RadiusServer                                                                                     |                     | v1alpha1api20201101 |
+| RadiusServer_Status                                                                              |                     | v1alpha1api20201101 |
+| ResourceNavigationLinkFormat_Status                                                              |                     | v1alpha1api20201101 |
+| ResourceNavigationLink_Status                                                                    |                     | v1alpha1api20201101 |
+| RouteTable_Status_VirtualNetworksSubnet_SubResourceEmbedded                                      |                     | v1alpha1api20201101 |
+| SecurityRuleAccess_Status                                                                        |                     | v1alpha1api20201101 |
+| SecurityRuleDirection_Status                                                                     |                     | v1alpha1api20201101 |
+| SecurityRulePropertiesFormat                                                                     |                     | v1alpha1api20201101 |
+| SecurityRulePropertiesFormatAccess                                                               |                     | v1alpha1api20201101 |
+| SecurityRulePropertiesFormatDirection                                                            |                     | v1alpha1api20201101 |
+| SecurityRulePropertiesFormatProtocol                                                             |                     | v1alpha1api20201101 |
+| SecurityRulePropertiesFormatStatusProtocol                                                       |                     | v1alpha1api20201101 |
+| SecurityRulePropertiesFormat_Status                                                              |                     | v1alpha1api20201101 |
+| SecurityRule_Status_NetworkSecurityGroup_SubResourceEmbedded                                     |                     | v1alpha1api20201101 |
+| SecurityRule_Status_NetworkSecurityGroupsSecurityRule_SubResourceEmbedded                        |                     | v1alpha1api20201101 |
+| ServiceAssociationLinkPropertiesFormat_Status                                                    |                     | v1alpha1api20201101 |
+| ServiceAssociationLink_Status                                                                    |                     | v1alpha1api20201101 |
+| ServiceDelegationPropertiesFormat                                                                |                     | v1alpha1api20201101 |
+| ServiceDelegationPropertiesFormat_Status                                                         |                     | v1alpha1api20201101 |
+| ServiceEndpointPolicy_Status_VirtualNetworksSubnet_SubResourceEmbedded                           |                     | v1alpha1api20201101 |
+| ServiceEndpointPropertiesFormat                                                                  |                     | v1alpha1api20201101 |
+| ServiceEndpointPropertiesFormat_Status                                                           |                     | v1alpha1api20201101 |
+| SubResource                                                                                      |                     | v1alpha1api20201101 |
+| SubResource_Status                                                                               |                     | v1alpha1api20201101 |
+| SubnetPropertiesFormatStatusPrivateEndpointNetworkPolicies                                       |                     | v1alpha1api20201101 |
+| SubnetPropertiesFormatStatusPrivateLinkServiceNetworkPolicies                                    |                     | v1alpha1api20201101 |
+| SubnetPropertiesFormat_Status                                                                    |                     | v1alpha1api20201101 |
+| Subnet_Status_LoadBalancer_SubResourceEmbedded                                                   |                     | v1alpha1api20201101 |
+| Subnet_Status_NetworkInterface_SubResourceEmbedded                                               |                     | v1alpha1api20201101 |
+| Subnet_Status_NetworkSecurityGroup_SubResourceEmbedded                                           |                     | v1alpha1api20201101 |
+| Subnet_Status_PublicIPAddress_SubResourceEmbedded                                                |                     | v1alpha1api20201101 |
+| Subnet_Status_VirtualNetwork_SubResourceEmbedded                                                 |                     | v1alpha1api20201101 |
+| Subnet_Status_VirtualNetworksSubnet_SubResourceEmbedded                                          |                     | v1alpha1api20201101 |
+| TransportProtocol_Status                                                                         |                     | v1alpha1api20201101 |
+| VirtualNetwork                                                                                   |                     | v1alpha1api20201101 |
+| VirtualNetworkBgpCommunities                                                                     |                     | v1alpha1api20201101 |
+| VirtualNetworkBgpCommunities_Status                                                              |                     | v1alpha1api20201101 |
+| VirtualNetworkGateway                                                                            |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayIPConfigurationPropertiesFormat                                             |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayIPConfigurationPropertiesFormatPrivateIPAllocationMethod                    |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayIPConfigurationPropertiesFormat_Status                                      |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayIPConfiguration_Status                                                      |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayPropertiesFormatStatusGatewayType                                           |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayPropertiesFormatStatusVpnGatewayGeneration                                  |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayPropertiesFormatStatusVpnType                                               |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewayPropertiesFormat_Status                                                     |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaySku                                                                         |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaySkuName                                                                     |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaySkuStatusName                                                               |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaySkuStatusTier                                                               |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaySkuTier                                                                     |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaySku_Status                                                                  |                     | v1alpha1api20201101 |
+| VirtualNetworkGateway_Status                                                                     |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaysSpecAPIVersion                                                             |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaysSpecPropertiesGatewayType                                                  |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnAuthenticationTypes                 |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaysSpecPropertiesVpnClientConfigurationVpnClientProtocols                     |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaysSpecPropertiesVpnGatewayGeneration                                         |                     | v1alpha1api20201101 |
+| VirtualNetworkGatewaysSpecPropertiesVpnType                                                      |                     | v1alpha1api20201101 |
+| VirtualNetworkGateways_Spec                                                                      |                     | v1alpha1api20201101 |
+| VirtualNetworkGateways_Spec_Properties                                                           |                     | v1alpha1api20201101 |
+| VirtualNetworkGateways_Spec_Properties_IpConfigurations                                          |                     | v1alpha1api20201101 |
+| VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration                                    |                     | v1alpha1api20201101 |
+| VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificates       |                     | v1alpha1api20201101 |
+| VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificates          |                     | v1alpha1api20201101 |
+| VirtualNetworkPeeringPropertiesFormat                                                            |                     | v1alpha1api20201101 |
+| VirtualNetworkPeeringPropertiesFormatPeeringState                                                |                     | v1alpha1api20201101 |
+| VirtualNetworkPeeringPropertiesFormatStatusPeeringState                                          |                     | v1alpha1api20201101 |
+| VirtualNetworkPeeringPropertiesFormat_Status                                                     |                     | v1alpha1api20201101 |
+| VirtualNetworkPeering_Status                                                                     |                     | v1alpha1api20201101 |
+| VirtualNetworkPeering_Status_SubResourceEmbedded                                                 |                     | v1alpha1api20201101 |
+| VirtualNetworkPropertiesFormat_Status                                                            |                     | v1alpha1api20201101 |
+| VirtualNetworkTap_Status_NetworkInterface_SubResourceEmbedded                                    |                     | v1alpha1api20201101 |
+| VirtualNetwork_Status                                                                            |                     | v1alpha1api20201101 |
+| VirtualNetworksSpecAPIVersion                                                                    |                     | v1alpha1api20201101 |
+| VirtualNetworksSubnet                                                                            |                     | v1alpha1api20201101 |
+| VirtualNetworksSubnetsSpecAPIVersion                                                             |                     | v1alpha1api20201101 |
+| VirtualNetworksSubnets_Spec                                                                      |                     | v1alpha1api20201101 |
+| VirtualNetworksSubnets_Spec_Properties                                                           |                     | v1alpha1api20201101 |
+| VirtualNetworksSubnets_Spec_Properties_Delegations                                               |                     | v1alpha1api20201101 |
+| VirtualNetworksVirtualNetworkPeering                                                             |                     | v1alpha1api20201101 |
+| VirtualNetworksVirtualNetworkPeeringsSpecAPIVersion                                              |                     | v1alpha1api20201101 |
+| VirtualNetworksVirtualNetworkPeerings_Spec                                                       |                     | v1alpha1api20201101 |
+| VirtualNetworks_Spec                                                                             |                     | v1alpha1api20201101 |
+| VirtualNetworks_Spec_Properties                                                                  |                     | v1alpha1api20201101 |
+| VirtualNetworks_Spec_Properties_Subnets                                                          |                     | v1alpha1api20201101 |
+| VirtualNetworks_Spec_Properties_Subnets_Properties                                               |                     | v1alpha1api20201101 |
+| VirtualNetworks_Spec_Properties_Subnets_Properties_Delegations                                   |                     | v1alpha1api20201101 |
+| VpnClientConfigurationStatusVpnAuthenticationTypes                                               |                     | v1alpha1api20201101 |
+| VpnClientConfigurationStatusVpnClientProtocols                                                   |                     | v1alpha1api20201101 |
+| VpnClientConfiguration_Status                                                                    |                     | v1alpha1api20201101 |
+| VpnClientRevokedCertificatePropertiesFormat                                                      |                     | v1alpha1api20201101 |
+| VpnClientRevokedCertificatePropertiesFormat_Status                                               |                     | v1alpha1api20201101 |
+| VpnClientRevokedCertificate_Status                                                               |                     | v1alpha1api20201101 |
+| VpnClientRootCertificatePropertiesFormat                                                         |                     | v1alpha1api20201101 |
+| VpnClientRootCertificatePropertiesFormat_Status                                                  |                     | v1alpha1api20201101 |
+| VpnClientRootCertificate_Status                                                                  |                     | v1alpha1api20201101 |

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -51,10 +51,14 @@ typeFilters:
   - action: prune
     group: web
     because: Some types (SitesSlotsConfig) use OneOf in a way we don't currently handle. Exclude the whole set for now.
+  - action: include
+    group: network
+    version: '*api20180901*'
+    because: Include networking api versions with PrivateDNSZone types
   - action: prune
     group: network
     version: '*api201*'
-    because: Pruning all older networking api versions types since we don't use them anyway
+    because: Pruning all other older networking api versions types since we don't use them anyway
   - action: prune
     group: compute
     version: '*api201*'
@@ -809,6 +813,9 @@ objectModelConfiguration:
       UserAssignedIdentity:
         $export: true
   network:
+    2018-09-01:
+      PrivateDNSZone:
+        $export: true
     2020-11-01:
       LoadBalancer:
         $export: true


### PR DESCRIPTION
Signed-off-by: vaspahomov <vas2142553@gmail.com>

**What this PR does / why we need it**:

I want to add PrivateDNSZone resource and their PrivateDNSZone/VirtualNetworkLink dependency. 
This can help us to create [PostgreSQL connected with private network](https://github.com/Azure/azure-service-operator/blob/main/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go#L2299) without az cli or others.

**Special notes for your reviewer**:

I've found that `'*api201*'` versions of network are excluded. I think we need explicitly add PrivateDnsZones and VirtualNetworkLinks (but I can not find right resource name) resources.

After this manipulations I'm receiving: 
```
E0211 14:19:54.561995   27841 gen_kustomize.go:111] Error during code generation:
failed during pipeline stage 23/57: Verify there are no ErroredType's containing errors: "github.com/Azure/azure-service-operator/v2/api/network/v1alpha1api20180901/PrivateDnsZone" has property "Status" with errors: "missing status information for github.com/Azure/azure-service-operator/v2/api/network/v1alpha1api20180901/PrivateDnsZones"
```

I've tried to add this in status section, but it did not help:

```
    {
      # give the privations types their own namespace
      basePath: 'privatedns/resource-management',
      namespace: 'Microsoft.Network'
    },
```

Can you tell me what I'm doing wrong?

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/iJQDeXvfJ5TnSgMiRU/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
