### PR TITLE
Custom error classification for CosmosDB

### DIFF
--- a/v2/api/documentdb/customizations/mongodb_database_extension.go
+++ b/v2/api/documentdb/customizations/mongodb_database_extension.go
@@ -1,0 +1,39 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.ErrorClassifier = &MongodbDatabaseExtension{}
+
+// ClassifyError evaluates the provided error, returning whether it is fatal or can be retried.
+// A BadRequest (400) is normally fatal, but Mongodb Databases may return 400 if database creation is attempted while
+// the parent account is still being created, so we make BadRequest retryable for this case.
+// cloudError is the error returned from ARM.
+// next is the next implementation to call.
+func (extension *MongodbDatabaseExtension) ClassifyError(
+	cloudError *genericarmclient.CloudError,
+	_ string,
+	_ logr.Logger,
+	next extensions.ErrorClassifierFunc) (core.CloudErrorDetails, error) {
+	details, err := next(cloudError)
+	if err != nil {
+		return core.CloudErrorDetails{}, err
+	}
+
+	// Override is to treat BadRequest as retryable for Mongodb Databases
+	if isRetryableBadRequest(cloudError) {
+		details.Classification = core.ErrorRetryable
+	}
+
+	return details, nil
+}

--- a/v2/api/documentdb/customizations/sql_database_extension_types.go
+++ b/v2/api/documentdb/customizations/sql_database_extension_types.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.ErrorClassifier = &SqlDatabaseExtension{}
+
+// ClassifyError evaluates the provided error, returning whether it is fatal or can be retried.
+// A BadRequest (400) is normally fatal, but CosmosDB Databases may return 400 if database creation is attempted while
+// the parent account is still being created, so we make BadRequest retryable for this case.
+// cloudError is the error returned from ARM.
+// apiVersion is the ARM API version used for the request.
+// log is a logger than can be used for telemetry.
+// next is the next implementation to call.
+func (extension *SqlDatabaseExtension) ClassifyError(
+	cloudError *genericarmclient.CloudError,
+	_ string,
+	_ logr.Logger,
+	next extensions.ErrorClassifierFunc) (core.CloudErrorDetails, error) {
+	details, err := next(cloudError)
+	if err != nil {
+		return core.CloudErrorDetails{}, err
+	}
+
+	// Override is to treat BadRequest as retryable for SqlDatabases
+	if isRetryableBadRequest(cloudError) {
+		details.Classification = core.ErrorRetryable
+	}
+
+	return details, nil
+}
+
+// isRetryableConflict checks the passed error to see if it is a retryable conflict, returning true if it is.
+func isRetryableBadRequest(err *genericarmclient.CloudError) bool {
+	if err == nil {
+		return false
+	}
+
+	return err.Code() == "BadRequest"
+}

--- a/v2/api/documentdb/customizations/sql_database_extension_types.go
+++ b/v2/api/documentdb/customizations/sql_database_extension_types.go
@@ -19,8 +19,6 @@ var _ extensions.ErrorClassifier = &SqlDatabaseExtension{}
 // A BadRequest (400) is normally fatal, but CosmosDB Databases may return 400 if database creation is attempted while
 // the parent account is still being created, so we make BadRequest retryable for this case.
 // cloudError is the error returned from ARM.
-// apiVersion is the ARM API version used for the request.
-// log is a logger than can be used for telemetry.
 // next is the next implementation to call.
 func (extension *SqlDatabaseExtension) ClassifyError(
 	cloudError *genericarmclient.CloudError,

--- a/v2/internal/reconcilers/error_classifier.go
+++ b/v2/internal/reconcilers/error_classifier.go
@@ -62,8 +62,7 @@ func classifyCloudErrorCode(code string) core.ErrorClassification {
 		return core.ErrorRetryable
 	case "BadRequestFormat",
 		"Conflict",
-		// TODO: See https://github.com/Azure/azure-service-operator/issues/1997 for why this is commented out
-		// "BadRequest",
+		"BadRequest",
 		"PublicIpForGatewayIsRequired", // TODO: There's not a great way to look at an arbitrary error returned by this API and determine if it's a 4xx or 5xx level... ugh
 		"InvalidParameter",
 		"InvalidParameterValue",

--- a/v2/internal/reconcilers/error_classifier_test.go
+++ b/v2/internal/reconcilers/error_classifier_test.go
@@ -48,12 +48,12 @@ func Test_Conflict_IsNotRetryable(t *testing.T) {
 	g.Expect(reconcilers.ClassifyCloudError(conflictError)).To(Equal(expected))
 }
 
-func Test_BadRequest_IsRetryable(t *testing.T) {
+func Test_BadRequest_IsFatal(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	expected := core.CloudErrorDetails{
-		Classification: core.ErrorRetryable,
+		Classification: core.ErrorFatal,
 		Code:           badRequestError.Code(),
 		Message:        badRequestError.Message(),
 	}

--- a/v2/pkg/genruntime/extensions/error_classifier.go
+++ b/v2/pkg/genruntime/extensions/error_classifier.go
@@ -42,19 +42,27 @@ func CreateErrorClassifier(
 	}
 
 	return func(cloudError *genericarmclient.CloudError) (core.CloudErrorDetails, error) {
-		log.V(Info).Info(
-			"Classifying cloud error",
+		log.V(Status).Info(
+			"Classifying CloudError",
 			"Message", cloudError.Message(),
 			"Code", cloudError.Code(),
 			"Target", cloudError.Target())
 
 		result, err := impl.ClassifyError(cloudError, apiVersion, log, classifier)
+		if err != nil {
+			log.V(Status).Info(
+				"CloudError classification failed",
+				"Error", err.Error())
 
-		log.V(Info).Info(
-			"Cloud error classified",
+			return core.CloudErrorDetails{}, err
+		}
+
+		log.V(Status).Info(
+			"CloudError classified",
 			"Classification", result.Classification,
 			"Code", result.Code,
 			"Message", result.Message)
-		return result, err
+
+		return result, nil
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Closes #[issue number]

**What this PR does / why we need it**:

Moves CosmosDB and MongoDB specific error handling into specific extensions.

Closes #2106 

Update 24 Feb: Now that PR #2112 has been merged, I was able to make our CI fail by disabling the extensions, which gives me much more confidence that this works.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/8OrESzoMlIUrC/giphy.gif)

**If applicable**:
- [x] this PR contains tests
