### PR TITLE
CodeGenerationContext implements ReadonlyTypes too

### DIFF
--- a/v2/tools/generator/internal/armconversion/shared.go
+++ b/v2/tools/generator/internal/armconversion/shared.go
@@ -88,11 +88,7 @@ func GetAzureNameProperty(idFactory astmodel.IdentifierFactory) *astmodel.Proper
 
 func getReceiverObjectType(codeGenerationContext *astmodel.CodeGenerationContext, receiver astmodel.TypeName) *astmodel.ObjectType {
 	// Determine the type we're operating on
-	rt, err := codeGenerationContext.GetImportedDefinition(receiver)
-	if err != nil {
-		panic(err)
-	}
-
+	rt := codeGenerationContext.MustGetDefinition(receiver)
 	receiverType, ok := rt.Type().(*astmodel.ObjectType)
 	if !ok {
 		// Don't expect to have any wrapper types left at this point

--- a/v2/tools/generator/internal/codegen/embeddedresources/remover.go
+++ b/v2/tools/generator/internal/codegen/embeddedresources/remover.go
@@ -387,7 +387,11 @@ func findAllResourceStatusTypes(definitions astmodel.TypeDefinitionSet) astmodel
 }
 
 func extractPropertiesType(definitions astmodel.TypeDefinitionSet, typeName astmodel.TypeName) (*astmodel.TypeName, error) {
-	resolved := definitions.Get(typeName)
+	resolved, err := definitions.GetDefinition(typeName)
+	if err != nil {
+		return nil, err
+	}
+
 	ot, ok := astmodel.AsObjectType(resolved.Type())
 	if !ok {
 		return nil, errors.Errorf("couldn't find object type %q", typeName)

--- a/v2/tools/generator/internal/codegen/pipeline/status_augment.go
+++ b/v2/tools/generator/internal/codegen/pipeline/status_augment.go
@@ -95,7 +95,7 @@ func newDefaultMerger(allTypes astmodel.ReadonlyTypes) *astmodel.TypeMerger {
 			return spec, nil
 		}
 
-		specType := allTypes.Get(spec).Type()
+		specType := allTypes.MustGetDefinition(spec).Type()
 
 		newSpec, err := merger.Merge(specType, status)
 		if err != nil {
@@ -112,7 +112,7 @@ func newDefaultMerger(allTypes astmodel.ReadonlyTypes) *astmodel.TypeMerger {
 
 	// handle (Type, TypeName) by resolving RHS
 	merger.Add(func(spec astmodel.Type, status astmodel.TypeName) (astmodel.Type, error) {
-		return merger.Merge(spec, allTypes.Get(status).Type())
+		return merger.Merge(spec, allTypes.MustGetDefinition(status).Type())
 	})
 
 	// handle (Optional, Type)

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -81,7 +81,7 @@ func (graph *ConversionGraph) FindNextType(name astmodel.TypeName, definitions a
 
 	// With no configured rename, we can return nextTypeName, as long as it exists
 	if !haveRename {
-		if _, found := definitions.TryGet(nextTypeName); found {
+		if _, err := definitions.GetDefinition(nextTypeName); err == nil {
 			return nextTypeName, nil
 		}
 
@@ -91,7 +91,7 @@ func (graph *ConversionGraph) FindNextType(name astmodel.TypeName, definitions a
 	// Validity check on the type-rename we found - ensure it specifies a type that's known
 	// If we don't find the type, the configured rename is invalid
 	renamedTypeName := astmodel.MakeTypeName(nextPackage, rename)
-	if _, found := definitions.TryGet(renamedTypeName); !found {
+	if _, err := definitions.GetDefinition(renamedTypeName); err != nil {
 		return astmodel.EmptyTypeName, errors.Errorf(
 			"rename of %s invalid because specified type %s does not exist",
 			name,
@@ -100,7 +100,7 @@ func (graph *ConversionGraph) FindNextType(name astmodel.TypeName, definitions a
 
 	// Validity check that the type-rename doesn't conflict
 	// if v1.Foo and v2.Foo both exist, it's illegal to specify a type-rename on v1.Foo
-	if _, found := definitions.TryGet(nextTypeName); found {
+	if _, err := definitions.GetDefinition(nextTypeName); err == nil {
 		return astmodel.EmptyTypeName, errors.Errorf(
 			"configured rename of %s to %s conflicts with existing type %s",
 			name,


### PR DESCRIPTION
This is useful for an upcoming PR where I wanted to have a single method that could operator on a `Types` and a `CodeGenerationContext`.

Once early in the process to pick out what types to add a function to, and then in the actual implementation of that function in order to examine some of the types in more detail.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/9S706ievhjXVfG9s9Q/giphy.gif)

