### PR TITLE
Flexible error formats

### DIFF
--- a/v2/api/cache/customizations/redis_extension_types.go
+++ b/v2/api/cache/customizations/redis_extension_types.go
@@ -6,9 +6,6 @@ Licensed under the MIT license.
 package customizations
 
 import (
-	"strings"
-
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
@@ -36,7 +33,7 @@ func (e *RedisExtension) ClassifyError(
 	}
 
 	// Override is to treat Conflict as retryable for Redis, if the message contains "try again later"
-	if isRetryableConflict(cloudError.InnerError) {
+	if isRetryableConflict(cloudError) {
 		details.Classification = core.ErrorRetryable
 	}
 
@@ -44,11 +41,10 @@ func (e *RedisExtension) ClassifyError(
 }
 
 // isRetryableConflict checks the passed error to see if it is a retryable conflict, returning true if it is.
-func isRetryableConflict(err *genericarmclient.ErrorResponse) bool {
-	if err == nil || err.Message == nil {
+func isRetryableConflict(err *genericarmclient.CloudError) bool {
+	if err == nil  {
 		return false
 	}
 
-	return to.String(err.Code) == "Conflict" &&
-		strings.Contains(strings.ToLower(*err.Message), "try again later")
+	return err.ErrorCode() == "Conflict"
 }

--- a/v2/api/cache/customizations/redis_extension_types.go
+++ b/v2/api/cache/customizations/redis_extension_types.go
@@ -42,9 +42,9 @@ func (e *RedisExtension) ClassifyError(
 
 // isRetryableConflict checks the passed error to see if it is a retryable conflict, returning true if it is.
 func isRetryableConflict(err *genericarmclient.CloudError) bool {
-	if err == nil  {
+	if err == nil {
 		return false
 	}
 
-	return err.ErrorCode() == "Conflict"
+	return err.Code() == "Conflict"
 }

--- a/v2/api/cache/customizations/redis_firewall_rule_extension_types.go.go
+++ b/v2/api/cache/customizations/redis_firewall_rule_extension_types.go.go
@@ -33,7 +33,7 @@ func (e *RedisFirewallRuleExtension) ClassifyError(
 	}
 
 	// Override is to treat Conflict as retryable for RedisFirewallRules, if the message contains "try again later"
-	if isRetryableConflict(cloudError.InnerError) {
+	if isRetryableConflict(cloudError) {
 		details.Classification = core.ErrorRetryable
 	}
 

--- a/v2/api/cache/customizations/redis_linked_server_extension_types.go
+++ b/v2/api/cache/customizations/redis_linked_server_extension_types.go
@@ -33,7 +33,7 @@ func (e *RedisLinkedServerExtension) ClassifyError(
 	}
 
 	// Override is to treat Conflict as retryable for RedisLinkedServers, if the message contains "try again later"
-	if isRetryableConflict(cloudError.InnerError) {
+	if isRetryableConflict(cloudError) {
 		details.Classification = core.ErrorRetryable
 	}
 

--- a/v2/api/cache/customizations/redis_patch_schedule_extension_types.go
+++ b/v2/api/cache/customizations/redis_patch_schedule_extension_types.go
@@ -33,7 +33,7 @@ func (e *RedisPatchScheduleExtension) ClassifyError(
 	}
 
 	// Override is to treat Conflict as retryable for RedisPatchSchedules, if the message contains "try again later"
-	if isRetryableConflict(cloudError.InnerError) {
+	if isRetryableConflict(cloudError) {
 		details.Classification = core.ErrorRetryable
 	}
 

--- a/v2/internal/duration/duration_test.go
+++ b/v2/internal/duration/duration_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 type (
@@ -58,8 +58,8 @@ func TestDuration_String(t *testing.T) {
 		t.Run(c.Expected, func(t *testing.T) {
 			t.Parallel()
 			d := ISO8601{Duration: c.Duration}
-			g := gomega.NewGomegaWithT(t)
-			g.Expect(d.String()).To(gomega.Equal(c.Expected))
+			g := NewGomegaWithT(t)
+			g.Expect(d.String()).To(Equal(c.Expected))
 		})
 	}
 }
@@ -97,12 +97,12 @@ func TestDuration_JSON(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
 			var testStruct DurationTest
-			g := gomega.NewGomegaWithT(t)
-			g.Expect(json.Unmarshal([]byte(c.JSON), &testStruct))
-			g.Expect(testStruct).To(gomega.Equal(c.Struct))
+			g := NewGomegaWithT(t)
+			g.Expect(json.Unmarshal([]byte(c.JSON), &testStruct)).To(Succeed())
+			g.Expect(testStruct).To(Equal(c.Struct))
 			bits, err := json.Marshal(testStruct)
-			g.Expect(err).ToNot(gomega.HaveOccurred())
-			g.Expect(string(bits)).To(gomega.Equal(c.JSON))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(string(bits)).To(Equal(c.JSON))
 		})
 	}
 }

--- a/v2/internal/genericarmclient/cloud_error.go
+++ b/v2/internal/genericarmclient/cloud_error.go
@@ -90,6 +90,10 @@ func (e CloudError) ErrorTarget() string {
 		return *e.InnerError.Target
 	}
 
+	if e.Target != nil && *e.Target != "" {
+		return *e.Target
+	}
+
 	return ""
 }
 

--- a/v2/internal/genericarmclient/cloud_error.go
+++ b/v2/internal/genericarmclient/cloud_error.go
@@ -5,12 +5,34 @@ Licensed under the MIT license.
 
 package genericarmclient
 
-// CloudError - An error response for a resource management request.
+import (
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+)
+
+// CloudError - An error response for a resource management request
+// We have to support two different formats for the error as some services do things differently.
+//
+// The ARM spec says that error details should be nested inside an `error` element.
+// See https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#error-response-content
+//
+// However, some services put the code & message at the top level instead.
+// This is common enough that the Azure Python SDK has specific handling to promote a nested error to the top level.
+// See https://github.com/Azure/azure-sdk-for-python/blob/9791fb5bc4cb6001768e6e1fb986b8d8f8326c43/sdk/core/azure-core/azure/core/exceptions.py#L153
+//
 type CloudError struct {
 	error error
 
-	// Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response
-	// format.)
+	// READ-ONLY; The error code.
+	Code *string `json:"code,omitempty" azure:"ro"`
+
+	// READ-ONLY; The error message.
+	Message *string `json:"message,omitempty" azure:"ro"`
+
+	// READ-ONLY; The error target.
+	Target *string `json:"target,omitempty" azure:"ro"`
+
+	// Common error response for all Azure Resource Manager APIs to return error details for failed operations.
+	// (This also follows the OData error response format.)
 	InnerError *ErrorResponse `json:"error,omitempty"`
 }
 
@@ -27,4 +49,50 @@ func (e CloudError) Error() string {
 	return e.error.Error()
 }
 
-func (e CloudError) Unwrap() error { return e.error }
+// ErrorCode returns the error code from the message.
+// If InnerError is present, we have an ARM compliant error (our preferred kind), so we use that code if present.
+// If InnerError is not present, we return the outer error code if present.
+// If neither is present, we return UnknownErrorCode
+func (e CloudError) ErrorCode() string {
+	if e.InnerError != nil && e.InnerError.Code != nil && *e.InnerError.Code != "" {
+		return *e.InnerError.Code
+	}
+
+	if e.Code != nil && *e.Code != "" {
+		return *e.Code
+	}
+
+	return core.UnknownErrorCode
+}
+
+// ErrorMessage returns the message from the error.
+// If InnerError is present, we have an ARM compliant error (our preferred kind), so we use that message if present.
+// If InnerError is not present, we return the outer message if present.
+// If neither is present, we return UnknownErrorCode
+func (e CloudError) ErrorMessage() string {
+	if e.InnerError != nil && e.InnerError.Message != nil && *e.InnerError.Message != "" {
+		return *e.InnerError.Message
+	}
+
+	if e.Message != nil && *e.Message != "" {
+		return *e.Message
+	}
+
+	return core.UnknownErrorMessage
+}
+
+// ErrorTarget returns the target of the error.
+// If InnerError is present, we have an ARM compliant error (our preferred kind), so we use that target if present.
+// If InnerError is not present, we return the outer target if present.
+// If neither is present, we return an empty string
+func (e CloudError) ErrorTarget() string {
+	if e.InnerError != nil && e.InnerError.Target != nil {
+		return *e.InnerError.Target
+	}
+
+	return ""
+}
+
+func (e CloudError) Unwrap() error {
+	return e.error
+}

--- a/v2/internal/genericarmclient/cloud_error.go
+++ b/v2/internal/genericarmclient/cloud_error.go
@@ -6,6 +6,10 @@ Licensed under the MIT license.
 package genericarmclient
 
 import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 )
 
@@ -22,18 +26,10 @@ import (
 type CloudError struct {
 	error error
 
-	// READ-ONLY; The error code.
-	Code *string `json:"code,omitempty" azure:"ro"`
-
-	// READ-ONLY; The error message.
-	Message *string `json:"message,omitempty" azure:"ro"`
-
-	// READ-ONLY; The error target.
-	Target *string `json:"target,omitempty" azure:"ro"`
-
-	// Common error response for all Azure Resource Manager APIs to return error details for failed operations.
-	// (This also follows the OData error response format.)
-	InnerError *ErrorResponse `json:"error,omitempty"`
+	code    *string
+	message *string
+	target  *string
+	details []*ErrorResponse
 }
 
 // NewCloudError returns a new CloudError
@@ -43,58 +39,83 @@ func NewCloudError(err error) CloudError {
 	}
 }
 
+func NewTestCloudError(code string, message string) *CloudError {
+	return &CloudError{
+		code:    &code,
+		message: &message,
+	}
+}
+
 // Error implements the error interface for type CloudError.
 // The contents of the error text are not contractual and subject to change.
 func (e CloudError) Error() string {
 	return e.error.Error()
 }
 
-// ErrorCode returns the error code from the message.
-// If InnerError is present, we have an ARM compliant error (our preferred kind), so we use that code if present.
-// If InnerError is not present, we return the outer error code if present.
-// If neither is present, we return UnknownErrorCode
-func (e CloudError) ErrorCode() string {
-	if e.InnerError != nil && e.InnerError.Code != nil && *e.InnerError.Code != "" {
-		return *e.InnerError.Code
-	}
-
-	if e.Code != nil && *e.Code != "" {
-		return *e.Code
+// Code returns the error code from the message, if present, or UnknownErrorCode if not.
+func (e CloudError) Code() string {
+	if e.code != nil && *e.code != "" {
+		return *e.code
 	}
 
 	return core.UnknownErrorCode
 }
 
-// ErrorMessage returns the message from the error.
-// If InnerError is present, we have an ARM compliant error (our preferred kind), so we use that message if present.
-// If InnerError is not present, we return the outer message if present.
-// If neither is present, we return UnknownErrorCode
-func (e CloudError) ErrorMessage() string {
-	if e.InnerError != nil && e.InnerError.Message != nil && *e.InnerError.Message != "" {
-		return *e.InnerError.Message
-	}
-
-	if e.Message != nil && *e.Message != "" {
-		return *e.Message
+// Message returns the message from the error, if present, or UnknownErrorMessage if not.
+func (e CloudError) Message() string {
+	if e.message != nil && *e.message != "" {
+		return *e.message
 	}
 
 	return core.UnknownErrorMessage
 }
 
-// ErrorTarget returns the target of the error.
-// If InnerError is present, we have an ARM compliant error (our preferred kind), so we use that target if present.
-// If InnerError is not present, we return the outer target if present.
-// If neither is present, we return an empty string
-func (e CloudError) ErrorTarget() string {
-	if e.InnerError != nil && e.InnerError.Target != nil {
-		return *e.InnerError.Target
-	}
-
-	if e.Target != nil && *e.Target != "" {
-		return *e.Target
+// Target returns the target of the error, if present, or an empty string if not.
+func (e CloudError) Target() string {
+	if e.target != nil && *e.target != "" {
+		return *e.target
 	}
 
 	return ""
+}
+
+// Details returns the details of the error, if present, or an empty slice if not
+func (e CloudError) Details() []*ErrorResponse {
+	return e.details
+}
+
+func (e *CloudError) UnmarshalJSON(data []byte) error {
+	var content struct {
+		Code       *string          `json:"code,omitempty"`
+		Message    *string          `json:"message,omitempty"`
+		Target     *string          `json:"target,omitempty"`
+		Details    []*ErrorResponse `json:"details,omitempty"`
+		InnerError *struct {
+			Code    *string          `json:"code,omitempty"`
+			Message *string          `json:"message,omitempty"`
+			Target  *string          `json:"target,omitempty"`
+			Details []*ErrorResponse `json:"details,omitempty"`
+		} `json:"error,omitempty"`
+	}
+
+	err := json.Unmarshal(data, &content)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling JSON for CloudError")
+	}
+
+	if content.InnerError != nil {
+		e.code = content.InnerError.Code
+		e.message = content.InnerError.Message
+		e.target = content.InnerError.Target
+		e.details = content.InnerError.Details
+	} else {
+		e.code = content.Code
+		e.message = content.Message
+		e.target = content.Target
+		e.details = content.Details
+	}
+
+	return nil
 }
 
 func (e CloudError) Unwrap() error {

--- a/v2/internal/genericarmclient/cloud_error_test.go
+++ b/v2/internal/genericarmclient/cloud_error_test.go
@@ -1,3 +1,8 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
 package genericarmclient
 
 import (
@@ -8,6 +13,7 @@ import (
 )
 
 func TestCloudError_WhenLoadedFromJSON_ReturnsExpectedResults(t *testing.T) {
+	t.Parallel()
 
 	cases := []struct {
 		Name            string
@@ -61,9 +67,9 @@ func TestCloudError_WhenLoadedFromJSON_ReturnsExpectedResults(t *testing.T) {
 			g := NewGomegaWithT(t)
 			g.Expect(json.Unmarshal([]byte(c.JSON), &cloudError)).To(Succeed())
 
-			g.Expect(cloudError.ErrorCode()).To(Equal(c.ExpectedCode))
-			g.Expect(cloudError.ErrorMessage()).To(Equal(c.ExpectedMessage))
-			g.Expect(cloudError.ErrorTarget()).To(Equal(c.ExpectedTarget))
+			g.Expect(cloudError.Code()).To(Equal(c.ExpectedCode))
+			g.Expect(cloudError.Message()).To(Equal(c.ExpectedMessage))
+			g.Expect(cloudError.Target()).To(Equal(c.ExpectedTarget))
 		})
 	}
 }

--- a/v2/internal/genericarmclient/cloud_error_test.go
+++ b/v2/internal/genericarmclient/cloud_error_test.go
@@ -24,11 +24,32 @@ func TestCloudError_WhenLoadedFromJSON_ReturnsExpectedResults(t *testing.T) {
 			ExpectedTarget:  "Janus VI",
 		},
 		{
+			Name:            "ARM style, code missing",
+			JSON:            `{"error": { "message": "It's dead, Jim", "target": "Janus VI" } }`,
+			ExpectedCode:    "UnknownError",
+			ExpectedMessage: "It's dead, Jim",
+			ExpectedTarget:  "Janus VI",
+		},
+		{
 			Name:            "Simple style",
 			JSON:            `{ "code": "broken", "message": "It's dead, Jim", "target": "Janus VI" }`,
 			ExpectedCode:    "broken",
 			ExpectedMessage: "It's dead, Jim",
 			ExpectedTarget:  "Janus VI",
+		},
+		{
+			Name:            "Simple style, code missing",
+			JSON:            `{ "message": "It's dead, Jim", "target": "Janus VI" }`,
+			ExpectedCode:    "UnknownError",
+			ExpectedMessage: "It's dead, Jim",
+			ExpectedTarget:  "Janus VI",
+		},
+		{
+			Name:            "CosmosDB Actual",
+			JSON:            `{"code":"BadRequest","message":"The requested operation cannot be performed because the database account asotestdbiosaow is in the process of being created."}`,
+			ExpectedCode:    "BadRequest",
+			ExpectedMessage: "The requested operation cannot be performed because the database account asotestdbiosaow is in the process of being created.",
+			ExpectedTarget:  "",
 		},
 	}
 

--- a/v2/internal/genericarmclient/cloud_error_test.go
+++ b/v2/internal/genericarmclient/cloud_error_test.go
@@ -1,0 +1,48 @@
+package genericarmclient
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCloudError_WhenLoadedFromJSON_ReturnsExpectedResults(t *testing.T) {
+
+	cases := []struct {
+		Name            string
+		JSON            string
+		ExpectedCode    string
+		ExpectedMessage string
+		ExpectedTarget  string
+	}{
+		{
+			Name:            "ARM style",
+			JSON:            `{"error": { "code": "broken", "message": "It's dead, Jim", "target": "Janus VI" } }`,
+			ExpectedCode:    "broken",
+			ExpectedMessage: "It's dead, Jim",
+			ExpectedTarget:  "Janus VI",
+		},
+		{
+			Name:            "Simple style",
+			JSON:            `{ "code": "broken", "message": "It's dead, Jim", "target": "Janus VI" }`,
+			ExpectedCode:    "broken",
+			ExpectedMessage: "It's dead, Jim",
+			ExpectedTarget:  "Janus VI",
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			var cloudError CloudError
+			g := NewGomegaWithT(t)
+			g.Expect(json.Unmarshal([]byte(c.JSON), &cloudError)).To(Succeed())
+
+			g.Expect(cloudError.ErrorCode()).To(Equal(c.ExpectedCode))
+			g.Expect(cloudError.ErrorMessage()).To(Equal(c.ExpectedMessage))
+			g.Expect(cloudError.ErrorTarget()).To(Equal(c.ExpectedTarget))
+		})
+	}
+}

--- a/v2/internal/genericarmclient/generic_client_test.go
+++ b/v2/internal/genericarmclient/generic_client_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,5 +103,5 @@ func Test_NewResourceGroup_Error(t *testing.T) {
 	// nolint:bodyclose
 	g.Expect(httpErr.RawResponse.StatusCode).To(Equal(http.StatusBadRequest))
 	g.Expect(httpErr.StatusCode).To(Equal(http.StatusBadRequest))
-	g.Expect(to.String(cloudError.InnerError.Code)).To(Equal("LocationNotAvailableForResourceGroup"))
+	g.Expect(cloudError.Code()).To(Equal("LocationNotAvailableForResourceGroup"))
 }

--- a/v2/internal/reconcilers/error_classifier.go
+++ b/v2/internal/reconcilers/error_classifier.go
@@ -12,11 +12,6 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 )
 
-const (
-	UnknownErrorCode    = "UnknownError"
-	UnknownErrorMessage = "There was an unknown deployment error"
-)
-
 func stringOrDefault(str string, def string) string {
 	if str == "" {
 		return def
@@ -30,8 +25,8 @@ func ClassifyCloudError(err *genericarmclient.CloudError) (core.CloudErrorDetail
 		// Default to retrying if we're asked to classify a nil error
 		result := core.CloudErrorDetails{
 			Classification: core.ErrorRetryable,
-			Code:           UnknownErrorCode,
-			Message:        UnknownErrorMessage,
+			Code:           core.UnknownErrorCode,
+			Message:        core.UnknownErrorMessage,
 		}
 		return result, nil
 	}

--- a/v2/internal/reconcilers/error_classifier.go
+++ b/v2/internal/reconcilers/error_classifier.go
@@ -21,11 +21,11 @@ func ClassifyCloudError(err *genericarmclient.CloudError) (core.CloudErrorDetail
 		return result, nil
 	}
 
-	classification := classifyCloudErrorCode(err.ErrorCode())
+	classification := classifyCloudErrorCode(err.Code())
 	result := core.CloudErrorDetails{
 		Classification: classification,
-		Code:           err.ErrorCode(),
-		Message:        err.ErrorMessage(),
+		Code:           err.Code(),
+		Message:        err.Message(),
 	}
 	return result, nil
 }

--- a/v2/internal/reconcilers/error_classifier.go
+++ b/v2/internal/reconcilers/error_classifier.go
@@ -6,22 +6,12 @@
 package reconcilers
 
 import (
-	"github.com/Azure/go-autorest/autorest/to"
-
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 )
 
-func stringOrDefault(str string, def string) string {
-	if str == "" {
-		return def
-	}
-
-	return str
-}
-
 func ClassifyCloudError(err *genericarmclient.CloudError) (core.CloudErrorDetails, error) {
-	if err == nil || err.InnerError == nil {
+	if err == nil {
 		// Default to retrying if we're asked to classify a nil error
 		result := core.CloudErrorDetails{
 			Classification: core.ErrorRetryable,
@@ -31,21 +21,20 @@ func ClassifyCloudError(err *genericarmclient.CloudError) (core.CloudErrorDetail
 		return result, nil
 	}
 
-	classification := classifyInnerCloudError(err.InnerError)
+	classification := classifyCloudErrorCode(err.ErrorCode())
 	result := core.CloudErrorDetails{
 		Classification: classification,
-		Code:           stringOrDefault(to.String(err.InnerError.Code), UnknownErrorCode),
-		Message:        stringOrDefault(to.String(err.InnerError.Message), UnknownErrorMessage),
+		Code:           err.ErrorCode(),
+		Message:        err.ErrorMessage(),
 	}
 	return result, nil
 }
 
-func classifyInnerCloudError(err *genericarmclient.ErrorResponse) core.ErrorClassification {
+func classifyCloudErrorCode(code string) core.ErrorClassification {
 	// See https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
 	// for a breakdown of common deployment error codes. Note that the error codes documented there are
 	// the inner error codes we're parsing here.
 
-	code := to.String(err.Code)
 	if code == "" {
 		// If there's no code, assume we can retry on it
 		return core.ErrorRetryable

--- a/v2/internal/reconcilers/error_classifier_test.go
+++ b/v2/internal/reconcilers/error_classifier_test.go
@@ -49,8 +49,8 @@ func Test_NilError_IsRetryable(t *testing.T) {
 	g := NewGomegaWithT(t)
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorRetryable,
-		Code:           reconcilers.UnknownErrorCode,
-		Message:        reconcilers.UnknownErrorMessage,
+		Code:           core.UnknownErrorCode,
+		Message:        core.UnknownErrorMessage,
 	}
 	g.Expect(reconcilers.ClassifyCloudError(nil)).To(Equal(expected))
 }

--- a/v2/internal/reconcilers/error_classifier_test.go
+++ b/v2/internal/reconcilers/error_classifier_test.go
@@ -52,6 +52,7 @@ func Test_NilError_IsRetryable(t *testing.T) {
 		Code:           core.UnknownErrorCode,
 		Message:        core.UnknownErrorMessage,
 	}
+	
 	g.Expect(reconcilers.ClassifyCloudError(nil)).To(Equal(expected))
 }
 
@@ -61,9 +62,10 @@ func Test_Conflict_IsNotRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorFatal,
-		Code:           to.String(conflictError.InnerError.Code),
-		Message:        to.String(conflictError.InnerError.Message),
+		Code:           conflictError.ErrorCode(),
+		Message:        conflictError.ErrorMessage(),
 	}
+
 	g.Expect(reconcilers.ClassifyCloudError(conflictError)).To(Equal(expected))
 }
 
@@ -73,9 +75,10 @@ func Test_BadRequest_IsRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorRetryable,
-		Code:           to.String(badRequestError.InnerError.Code),
-		Message:        to.String(badRequestError.InnerError.Message),
+		Code:           badRequestError.ErrorCode(),
+		Message:        badRequestError.ErrorMessage(),
 	}
+
 	g.Expect(reconcilers.ClassifyCloudError(badRequestError)).To(Equal(expected))
 }
 
@@ -85,9 +88,10 @@ func Test_ResourceGroupNotFound_IsRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorRetryable,
-		Code:           to.String(resourceGroupNotFoundError.InnerError.Code),
-		Message:        to.String(resourceGroupNotFoundError.InnerError.Message),
+		Code:           resourceGroupNotFoundError.ErrorCode(),
+		Message:        resourceGroupNotFoundError.ErrorMessage(),
 	}
+
 	g.Expect(reconcilers.ClassifyCloudError(resourceGroupNotFoundError)).To(Equal(expected))
 }
 
@@ -97,8 +101,9 @@ func Test_UnknownError_IsRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorRetryable,
-		Code:           to.String(unknownError.InnerError.Code),
-		Message:        to.String(unknownError.InnerError.Message),
+		Code:           unknownError.ErrorCode(),
+		Message:        unknownError.ErrorMessage(),
 	}
+
 	g.Expect(reconcilers.ClassifyCloudError(unknownError)).To(Equal(expected))
 }

--- a/v2/internal/reconcilers/error_classifier_test.go
+++ b/v2/internal/reconcilers/error_classifier_test.go
@@ -8,7 +8,6 @@ package reconcilers_test
 import (
 	"testing"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
@@ -16,33 +15,13 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 )
 
-var badRequestError = &genericarmclient.CloudError{
-	InnerError: &genericarmclient.ErrorResponse{
-		Code:    to.StringPtr("BadRequest"),
-		Message: to.StringPtr("That was not a good request"),
-	},
-}
+var badRequestError = genericarmclient.NewTestCloudError("BadRequest", "That was not a good request")
 
-var conflictError = &genericarmclient.CloudError{
-	InnerError: &genericarmclient.ErrorResponse{
-		Code:    to.StringPtr("Conflict"),
-		Message: to.StringPtr("That doesn't match what I have"),
-	},
-}
+var conflictError = genericarmclient.NewTestCloudError("Conflict", "That doesn't match what I have")
 
-var resourceGroupNotFoundError = &genericarmclient.CloudError{
-	InnerError: &genericarmclient.ErrorResponse{
-		Code:    to.StringPtr("ResourceGroupNotFound"),
-		Message: to.StringPtr("The resource group was not found"),
-	},
-}
+var resourceGroupNotFoundError = genericarmclient.NewTestCloudError("ResourceGroupNotFound", "The resource group was not found")
 
-var unknownError = &genericarmclient.CloudError{
-	InnerError: &genericarmclient.ErrorResponse{
-		Code:    to.StringPtr("ThisCodeIsNotACodeUnderstoodByTheClassifier"),
-		Message: to.StringPtr("No idea what went wrong"),
-	},
-}
+var unknownError = genericarmclient.NewTestCloudError("ThisCodeIsNotACodeUnderstoodByTheClassifier", "No idea what went wrong")
 
 func Test_NilError_IsRetryable(t *testing.T) {
 	t.Parallel()
@@ -52,7 +31,7 @@ func Test_NilError_IsRetryable(t *testing.T) {
 		Code:           core.UnknownErrorCode,
 		Message:        core.UnknownErrorMessage,
 	}
-	
+
 	g.Expect(reconcilers.ClassifyCloudError(nil)).To(Equal(expected))
 }
 
@@ -62,8 +41,8 @@ func Test_Conflict_IsNotRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorFatal,
-		Code:           conflictError.ErrorCode(),
-		Message:        conflictError.ErrorMessage(),
+		Code:           conflictError.Code(),
+		Message:        conflictError.Message(),
 	}
 
 	g.Expect(reconcilers.ClassifyCloudError(conflictError)).To(Equal(expected))
@@ -75,8 +54,8 @@ func Test_BadRequest_IsRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorRetryable,
-		Code:           badRequestError.ErrorCode(),
-		Message:        badRequestError.ErrorMessage(),
+		Code:           badRequestError.Code(),
+		Message:        badRequestError.Message(),
 	}
 
 	g.Expect(reconcilers.ClassifyCloudError(badRequestError)).To(Equal(expected))
@@ -88,8 +67,8 @@ func Test_ResourceGroupNotFound_IsRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorRetryable,
-		Code:           resourceGroupNotFoundError.ErrorCode(),
-		Message:        resourceGroupNotFoundError.ErrorMessage(),
+		Code:           resourceGroupNotFoundError.Code(),
+		Message:        resourceGroupNotFoundError.Message(),
 	}
 
 	g.Expect(reconcilers.ClassifyCloudError(resourceGroupNotFoundError)).To(Equal(expected))
@@ -101,8 +80,8 @@ func Test_UnknownError_IsRetryable(t *testing.T) {
 
 	expected := core.CloudErrorDetails{
 		Classification: core.ErrorRetryable,
-		Code:           unknownError.ErrorCode(),
-		Message:        unknownError.ErrorMessage(),
+		Code:           unknownError.Code(),
+		Message:        unknownError.Message(),
 	}
 
 	g.Expect(reconcilers.ClassifyCloudError(unknownError)).To(Equal(expected))

--- a/v2/pkg/genruntime/core/error_constants.go
+++ b/v2/pkg/genruntime/core/error_constants.go
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package core
+
+const (
+	UnknownErrorCode    = "UnknownError"
+	UnknownErrorMessage = "There was an unknown deployment error"
+)

--- a/v2/pkg/genruntime/extensions/error_classifier.go
+++ b/v2/pkg/genruntime/extensions/error_classifier.go
@@ -44,9 +44,9 @@ func CreateErrorClassifier(
 	return func(cloudError *genericarmclient.CloudError) (core.CloudErrorDetails, error) {
 		log.V(Info).Info(
 			"Classifying cloud error",
-			"Message", cloudError.InnerError.Message,
-			"Code", cloudError.InnerError.Code,
-			"Target", cloudError.InnerError.Target)
+			"Message", cloudError.ErrorMessage(),
+			"Code", cloudError.ErrorCode(),
+			"Target", cloudError.ErrorTarget())
 
 		result, err := impl.ClassifyError(cloudError, apiVersion, log, classifier)
 

--- a/v2/pkg/genruntime/extensions/error_classifier.go
+++ b/v2/pkg/genruntime/extensions/error_classifier.go
@@ -44,9 +44,9 @@ func CreateErrorClassifier(
 	return func(cloudError *genericarmclient.CloudError) (core.CloudErrorDetails, error) {
 		log.V(Info).Info(
 			"Classifying cloud error",
-			"Message", cloudError.ErrorMessage(),
-			"Code", cloudError.ErrorCode(),
-			"Target", cloudError.ErrorTarget())
+			"Message", cloudError.Message(),
+			"Code", cloudError.Code(),
+			"Target", cloudError.Target())
 
 		result, err := impl.ClassifyError(cloudError, apiVersion, log, classifier)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We have to support two different formats for the error as some services do things differently.

The [ARM spec](https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#error-response-content) says that error details should be nested inside an `error` element.

However, some services put the code & message at the top level instead.
This is common enough that the [Azure Python SDK](https://github.com/Azure/azure-sdk-for-python/blob/9791fb5bc4cb6001768e6e1fb986b8d8f8326c43/sdk/core/azure-core/azure/core/exceptions.py#L153) has specific handling to promote a nested error to the top level.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/bKnEnd65zqxfq/giphy.gif)

**If applicable**:
- [x] this PR contains tests
