### PR TITLE
Fix up stage pre/post-requisite enforcement

### DIFF
--- a/v2/tools/generator/internal/astmodel/string_set.go
+++ b/v2/tools/generator/internal/astmodel/string_set.go
@@ -5,21 +5,34 @@
 
 package astmodel
 
+// StringSet provides a standard way to have a set of distinct strings with no sort applied
 type StringSet map[string]struct{}
 
-func MakeStringSet() StringSet {
-	return make(StringSet)
+// MakeStringSet creates a new set with the supplied strings
+func MakeStringSet(strings ...string) StringSet {
+	result := make(StringSet)
+
+	for _, s := range strings {
+		result.Add(s)
+	}
+
+	return result
 }
 
+// Contains does a case-sensitive check to see if the provided string is in the set
 func (set StringSet) Contains(s string) bool {
 	_, ok := set[s]
 	return ok
 }
 
+// Add adds the provided string into the set
+// Nothing happens if the string is already present
 func (set StringSet) Add(s string) {
 	set[s] = struct{}{}
 }
 
+// Remove deletes the provided string from the set
+// Nothing happens if the string is not present
 func (set StringSet) Remove(s string) {
 	delete(set, s)
 }

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -193,11 +193,11 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 
 		pipeline.InjectHubFunction(idFactory).UsedFor(pipeline.ARMTarget),
 		pipeline.ImplementConvertibleInterface(idFactory).UsedFor(pipeline.ARMTarget),
-		pipeline.InjectResourceConversionTestCases(idFactory).UsedFor(pipeline.ARMTarget),
 
 		// Inject test cases
 		pipeline.InjectJsonSerializationTests(idFactory).UsedFor(pipeline.ARMTarget),
 		pipeline.InjectPropertyAssignmentTests(idFactory).UsedFor(pipeline.ARMTarget),
+		pipeline.InjectResourceConversionTestCases(idFactory).UsedFor(pipeline.ARMTarget),
 
 		pipeline.SimplifyDefinitions(),
 

--- a/v2/tools/generator/internal/codegen/code_generator_test.go
+++ b/v2/tools/generator/internal/codegen/code_generator_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/codegen/pipeline"
 
 	. "github.com/onsi/gomega"
@@ -68,9 +67,11 @@ func TestRemoveStages_PanicsForUnknownStage(t *testing.T) {
 }
 
 func MakeFakePipelineStage(id string) *pipeline.Stage {
-	return pipeline.NewLegacyStage(
-		id, "Stage "+id, func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
-			return defs, nil
+	return pipeline.NewStage(
+		id,
+		"Stage "+id,
+		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
+			return state, nil
 		})
 }
 

--- a/v2/tools/generator/internal/codegen/code_generator_test.go
+++ b/v2/tools/generator/internal/codegen/code_generator_test.go
@@ -35,7 +35,7 @@ func TestRemoveStages_RemovesSpecifiedStages(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			bazStage,
@@ -52,7 +52,7 @@ func TestRemoveStages_PanicsForUnknownStage(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			bazStage,
@@ -67,8 +67,8 @@ func TestRemoveStages_PanicsForUnknownStage(t *testing.T) {
 	gen.RemoveStages("foo", "baz")
 }
 
-func MakeFakePipelineStage(id string) pipeline.Stage {
-	return pipeline.MakeLegacyStage(
+func MakeFakePipelineStage(id string) *pipeline.Stage {
+	return pipeline.NewLegacyStage(
 		id, "Stage "+id, func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
 			return defs, nil
 		})
@@ -83,7 +83,7 @@ func TestReplaceStage_ReplacesSpecifiedStage(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			bazStage,
@@ -101,7 +101,7 @@ func TestReplaceStage_PanicsForUnknownStage(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			bazStage,
@@ -123,7 +123,7 @@ func TestInjectStageAfter_InjectsSpecifiedStage(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			bazStage,
@@ -141,7 +141,7 @@ func TestInjectStageAfter_PanicsForUnknownStage(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			bazStage,
@@ -163,7 +163,7 @@ func TestVerifyPipeline_GivenNoPrerequisites_ReturnsNoError(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			bazStage,
@@ -177,10 +177,10 @@ func TestVerifyPipeline_GivenSatisfiedPrerequisites_ReturnsNoError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			stage,
@@ -195,10 +195,10 @@ func TestVerifyPipeline_GivenUnsatisfiedPrerequisites_ReturnsError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			stage,
 			bazStage,
@@ -215,10 +215,10 @@ func TestVerifyPipeline_GivenOutOfOrderPrerequisites_ReturnsError(t *testing.T) 
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			stage,
 			barStage,
@@ -236,10 +236,10 @@ func TestVerifyPipeline_GivenSatisfiedPostrequisites_ReturnsNoError(t *testing.T
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPostrequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage").WithRequiredPostrequisites(barStage.Id())
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			stage,
 			barStage,
@@ -255,10 +255,10 @@ func TestVerifyPipeline_GivenUnsatisfiedPostrequisites_ReturnsError(t *testing.T
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			stage,
 			bazStage,
@@ -275,10 +275,10 @@ func TestVerifyPipeline_GivenOutOfOrderPostrequisites_ReturnsError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPostrequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage").WithRequiredPostrequisites(barStage.Id())
 
 	gen := &CodeGenerator{
-		pipeline: []pipeline.Stage{
+		pipeline: []*pipeline.Stage{
 			fooStage,
 			barStage,
 			stage,

--- a/v2/tools/generator/internal/codegen/code_generator_test.go
+++ b/v2/tools/generator/internal/codegen/code_generator_test.go
@@ -177,7 +177,7 @@ func TestVerifyPipeline_GivenSatisfiedPrerequisites_ReturnsNoError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
+	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -195,7 +195,7 @@ func TestVerifyPipeline_GivenUnsatisfiedPrerequisites_ReturnsError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
+	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -215,7 +215,7 @@ func TestVerifyPipeline_GivenOutOfOrderPrerequisites_ReturnsError(t *testing.T) 
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
+	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -236,7 +236,7 @@ func TestVerifyPipeline_GivenSatisfiedPostrequisites_ReturnsNoError(t *testing.T
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").WithRequiredPostrequisites(barStage.Id())
+	stage := MakeFakePipelineStage("stage").RequiresPostrequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -255,7 +255,7 @@ func TestVerifyPipeline_GivenUnsatisfiedPostrequisites_ReturnsError(t *testing.T
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").WithRequiredPrerequisites(barStage.Id())
+	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -275,7 +275,7 @@ func TestVerifyPipeline_GivenOutOfOrderPostrequisites_ReturnsError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").WithRequiredPostrequisites(barStage.Id())
+	stage := MakeFakePipelineStage("stage").RequiresPostrequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{

--- a/v2/tools/generator/internal/codegen/code_generator_test.go
+++ b/v2/tools/generator/internal/codegen/code_generator_test.go
@@ -177,7 +177,8 @@ func TestVerifyPipeline_GivenSatisfiedPrerequisites_ReturnsNoError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage")
+	stage.RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -195,7 +196,8 @@ func TestVerifyPipeline_GivenUnsatisfiedPrerequisites_ReturnsError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage")
+	stage.RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -215,7 +217,8 @@ func TestVerifyPipeline_GivenOutOfOrderPrerequisites_ReturnsError(t *testing.T) 
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage")
+	stage.RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -236,7 +239,8 @@ func TestVerifyPipeline_GivenSatisfiedPostrequisites_ReturnsNoError(t *testing.T
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPostrequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage")
+	stage.RequiresPostrequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -255,7 +259,8 @@ func TestVerifyPipeline_GivenUnsatisfiedPostrequisites_ReturnsError(t *testing.T
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPrerequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage")
+	stage.RequiresPrerequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{
@@ -275,7 +280,8 @@ func TestVerifyPipeline_GivenOutOfOrderPostrequisites_ReturnsError(t *testing.T)
 	t.Parallel()
 	g := NewGomegaWithT(t)
 
-	stage := MakeFakePipelineStage("stage").RequiresPostrequisiteStages(barStage.Id())
+	stage := MakeFakePipelineStage("stage")
+	stage.RequiresPostrequisiteStages(barStage.Id())
 
 	gen := &CodeGenerator{
 		pipeline: []*pipeline.Stage{

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -201,10 +201,11 @@ func NewTestCodeGenerator(
 		pipeline.ApplyExportFiltersStageID, // Don't want any filtering of resources during tests
 	)
 
+	//TODO: Enable this check once we fix up the test pipeline so that all the dependencies pass
 	//if err := codegen.verifyPipeline(); err != nil {
 	//	return nil, err
 	//}
-	//
+
 	return codegen, nil
 }
 

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -71,8 +71,8 @@ func makeEmbeddedTestTypeDefinition() astmodel.TypeDefinition {
 	return astmodel.MakeTypeDefinition(name, t)
 }
 
-func injectEmbeddedStructType() pipeline.Stage {
-	return pipeline.MakeLegacyStage(
+func injectEmbeddedStructType() *pipeline.Stage {
+	return pipeline.NewLegacyStage(
 		"injectEmbeddedStructType",
 		"Injects an embedded struct into each object",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -129,7 +129,12 @@ func runGoldenTest(t *testing.T, path string, testConfig GoldenTestConfig) {
 	}
 }
 
-func NewTestCodeGenerator(testName string, path string, t *testing.T, testConfig GoldenTestConfig, genPipeline config.GenerationPipeline) (*CodeGenerator, error) {
+func NewTestCodeGenerator(
+	testName string,
+	path string,
+	t *testing.T,
+	testConfig GoldenTestConfig,
+	genPipeline config.GenerationPipeline) (*CodeGenerator, error) {
 	idFactory := astmodel.NewIdentifierFactory()
 	cfg := config.NewConfiguration()
 	cfg.GoModulePath = test.GoModulePrefix
@@ -196,16 +201,20 @@ func NewTestCodeGenerator(testName string, path string, t *testing.T, testConfig
 		pipeline.ApplyExportFiltersStageID, // Don't want any filtering of resources during tests
 	)
 
+	//if err := codegen.verifyPipeline(); err != nil {
+	//	return nil, err
+	//}
+	//
 	return codegen, nil
 }
 
 func loadTestSchemaIntoTypes(
 	idFactory astmodel.IdentifierFactory,
 	configuration *config.Configuration,
-	path string) pipeline.Stage {
+	path string) *pipeline.Stage {
 	source := configuration.SchemaURL
 
-	return pipeline.MakeLegacyStage(
+	return pipeline.NewLegacyStage(
 		"loadTestSchema",
 		"Load and walk schema (test)",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -236,10 +245,10 @@ func loadTestSchemaIntoTypes(
 		})
 }
 
-func exportPackagesTestPipelineStage(t *testing.T, testName string) pipeline.Stage {
+func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.Stage {
 	g := goldie.New(t)
 
-	return pipeline.MakeLegacyStage(
+	return pipeline.NewLegacyStage(
 		"exportTestPackages",
 		"Export packages for test",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -287,8 +296,8 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) pipeline.Sta
 		})
 }
 
-func stripUnusedTypesPipelineStage() pipeline.Stage {
-	return pipeline.MakeLegacyStage(
+func stripUnusedTypesPipelineStage() *pipeline.Stage {
+	return pipeline.NewLegacyStage(
 		"stripUnused",
 		"Strip unused types for test",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -310,8 +319,8 @@ func stripUnusedTypesPipelineStage() pipeline.Stage {
 // TODO: Ideally we wouldn't need a test specific function here, but currently
 // TODO: we're hard-coding references, and even if we were sourcing them from Swagger
 // TODO: we have no way to give Swagger to the golden files tests currently.
-func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) pipeline.Stage {
-	return pipeline.MakeLegacyStage(
+func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) *pipeline.Stage {
+	return pipeline.NewLegacyStage(
 		pipeline.AddCrossResourceReferencesStageID,
 		"Add cross resource references for test",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -72,13 +72,13 @@ func makeEmbeddedTestTypeDefinition() astmodel.TypeDefinition {
 }
 
 func injectEmbeddedStructType() *pipeline.Stage {
-	return pipeline.NewLegacyStage(
+	return pipeline.NewStage(
 		"injectEmbeddedStructType",
 		"Injects an embedded struct into each object",
-		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
-			results := make(astmodel.TypeDefinitionSet)
+		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
+			defs := make(astmodel.TypeDefinitionSet)
 			embeddedTypeDef := makeEmbeddedTestTypeDefinition()
-			for _, def := range defs {
+			for _, def := range state.Definitions() {
 				if astmodel.IsObjectDefinition(def) {
 					result, err := def.ApplyObjectTransformation(func(objectType *astmodel.ObjectType) (astmodel.Type, error) {
 						prop := astmodel.NewPropertyDefinition(
@@ -90,15 +90,15 @@ func injectEmbeddedStructType() *pipeline.Stage {
 					if err != nil {
 						return nil, err
 					}
-					results.Add(result)
+					defs.Add(result)
 				} else {
-					results.Add(def)
+					defs.Add(def)
 				}
 			}
 
-			results.Add(embeddedTypeDef)
+			defs.Add(embeddedTypeDef)
 
-			return results, nil
+			return state.WithDefinitions(defs), nil
 		})
 }
 
@@ -214,10 +214,10 @@ func loadTestSchemaIntoTypes(
 	path string) *pipeline.Stage {
 	source := configuration.SchemaURL
 
-	return pipeline.NewLegacyStage(
+	return pipeline.NewStage(
 		"loadTestSchema",
 		"Load and walk schema (test)",
-		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
+		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
 			klog.V(0).Infof("Loading JSON schema %q", source)
 
 			inputFile, err := ioutil.ReadFile(path)
@@ -241,18 +241,18 @@ func loadTestSchemaIntoTypes(
 				return nil, errors.Wrapf(err, "failed to walk JSON schema")
 			}
 
-			return scanner.Definitions(), nil
+			return state.WithDefinitions(scanner.Definitions()), nil
 		})
 }
 
 func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.Stage {
 	g := goldie.New(t)
 
-	return pipeline.NewLegacyStage(
+	return pipeline.NewStage(
 		"exportTestPackages",
 		"Export packages for test",
-		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
-			if len(defs) == 0 {
+		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
+			if len(state.Definitions()) == 0 {
 				t.Fatalf("defs was empty")
 			}
 
@@ -261,7 +261,7 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.St
 			var version string
 			var found bool
 			var ds []astmodel.TypeDefinition
-			for _, def := range defs {
+			for _, def := range state.Definitions() {
 				ds = append(ds, def)
 				ref := def.Name().PackageReference
 				if !found {
@@ -274,9 +274,10 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.St
 			pkgs := make(map[astmodel.PackageReference]*astmodel.PackageDefinition)
 
 			packageDefinition := astmodel.NewPackageDefinition(group, version)
-			for _, def := range defs {
+			for _, def := range state.Definitions() {
 				packageDefinition.AddDefinition(def)
 			}
+
 			pkgs[pr] = packageDefinition
 
 			// put all definitions in one file, regardless.
@@ -292,27 +293,27 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.St
 
 			g.Assert(t, testName, buf.Bytes())
 
-			return nil, nil
+			return state, nil
 		})
 }
 
 func stripUnusedTypesPipelineStage() *pipeline.Stage {
-	return pipeline.NewLegacyStage(
+	return pipeline.NewStage(
 		"stripUnused",
 		"Strip unused types for test",
-		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
+		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
 			// The golden files always generate a top-level Test type - mark
 			// that as the root.
 			roots := astmodel.NewTypeNameSet(astmodel.MakeTypeName(
 				test.MakeLocalPackageReference("test", "v1alpha1api20200101"),
 				"Test",
 			))
-			defs, err := pipeline.StripUnusedDefinitions(roots, defs)
+			defs, err := pipeline.StripUnusedDefinitions(roots, state.Definitions())
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not strip unused types")
 			}
 
-			return defs, nil
+			return state.WithDefinitions(defs), nil
 		})
 }
 
@@ -320,21 +321,21 @@ func stripUnusedTypesPipelineStage() *pipeline.Stage {
 // TODO: we're hard-coding references, and even if we were sourcing them from Swagger
 // TODO: we have no way to give Swagger to the golden files tests currently.
 func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) *pipeline.Stage {
-	return pipeline.NewLegacyStage(
+	return pipeline.NewStage(
 		pipeline.AddCrossResourceReferencesStageID,
 		"Add cross resource references for test",
-		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
-			result := make(astmodel.TypeDefinitionSet)
+		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
+			defs := make(astmodel.TypeDefinitionSet)
 			isCrossResourceReference := func(_ astmodel.TypeName, prop *astmodel.PropertyDefinition) bool {
 				return pipeline.DoesPropertyLookLikeARMReference(prop)
 			}
 			visitor := pipeline.MakeCrossResourceReferenceTypeVisitor(idFactory, isCrossResourceReference)
 
-			for _, def := range defs {
+			for _, def := range state.Definitions() {
 				// Skip Status types
 				// TODO: we need flags
 				if strings.Contains(def.Name().Name(), "_Status") {
-					result.Add(def)
+					defs.Add(def)
 					continue
 				}
 
@@ -342,10 +343,10 @@ func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) *pi
 				if err != nil {
 					return nil, errors.Wrapf(err, "visiting %q", def.Name())
 				}
-				result.Add(def.WithType(t))
+				defs.Add(def.WithType(t))
 			}
 
-			return result, nil
+			return state.WithDefinitions(defs), nil
 		})
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
@@ -21,8 +21,8 @@ const ApplyARMConversionInterfaceStageID = "applyArmConversionInterface"
 // ApplyARMConversionInterface adds the genruntime.ARMTransformer interface and the Owner property
 // to all Kubernetes types.
 // The genruntime.ARMTransformer interface is used to convert from the Kubernetes type to the corresponding ARM type and back.
-func ApplyARMConversionInterface(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func ApplyARMConversionInterface(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		ApplyARMConversionInterfaceStageID,
 		"Add ARM conversion interfaces to Kubernetes types",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
@@ -26,8 +26,8 @@ var armIDDescriptionRegex = regexp.MustCompile("(?i)(.*/subscriptions/.*?/resour
 // TODO: For now not supporting array or map of references. Unsure if it actually ever happens in practice.
 
 // AddCrossResourceReferences replaces cross resource references with genruntime.ResourceReference.
-func AddCrossResourceReferences(configuration *config.Configuration, idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func AddCrossResourceReferences(configuration *config.Configuration, idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		AddCrossResourceReferencesStageID,
 		"Replace cross-resource references with genruntime.ResourceReference",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_operator_spec.go
@@ -17,8 +17,8 @@ import (
 
 const AddOperatorSpecStageID = "addOperatorSpec"
 
-func AddOperatorSpec(configuration *config.Configuration, idFactory astmodel.IdentifierFactory) Stage {
-	return MakeStage(
+func AddOperatorSpec(configuration *config.Configuration, idFactory astmodel.IdentifierFactory) *Stage {
+	return NewStage(
 		AddOperatorSpecStageID,
 		"Adds the property 'OperatorSpec' to all Spec types that require it",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_secrets.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_secrets.go
@@ -18,8 +18,8 @@ import (
 const AddSecretsStageID = "addSecrets"
 
 // AddSecrets replaces properties flagged as secret with genruntime.SecretReference
-func AddSecrets(config *config.Configuration) Stage {
-	stage := MakeStage(
+func AddSecrets(config *config.Configuration) *Stage {
+	stage := NewStage(
 		AddSecretsStageID,
 		"Replace properties flagged as secret with genruntime.SecretReference",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -43,9 +43,8 @@ func AddSecrets(config *config.Configuration) Stage {
 			return state.WithDefinitions(result), nil
 		})
 
-	return stage.
-		RequiresPrerequisiteStages(AugmentSpecWithStatusStageID).
-		RequiresPostrequisiteStages(CreateARMTypesStageID)
+	return stage.WithRequiredPrerequisites(AugmentSpecWithStatusStageID).
+		WithRequiredPostrequisites(CreateARMTypesStageID)
 }
 
 func applyConfigSecretOverrides(config *config.Configuration, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_secrets.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_secrets.go
@@ -43,8 +43,10 @@ func AddSecrets(config *config.Configuration) *Stage {
 			return state.WithDefinitions(result), nil
 		})
 
-	return stage.WithRequiredPrerequisites(AugmentSpecWithStatusStageID).
-		WithRequiredPostrequisites(CreateARMTypesStageID)
+	stage.RequiresPrerequisiteStages(AugmentSpecWithStatusStageID)
+	stage.RequiresPostrequisiteStages(CreateARMTypesStageID)
+
+	return stage
 }
 
 func applyConfigSecretOverrides(config *config.Configuration, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/add_status_conditions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_status_conditions.go
@@ -16,8 +16,8 @@ import (
 
 const AddStatusConditionsStageID = "addStatusConditions"
 
-func AddStatusConditions(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeStage(
+func AddStatusConditions(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewStage(
 		AddStatusConditionsStageID,
 		"Add the property 'Conditions' to all status types and implements genruntime.Conditioner on all resources",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_defaulter_and_validator_interfaces.go
@@ -15,8 +15,8 @@ import (
 const ApplyDefaulterAndValidatorInterfaceStageID = "applyDefaulterAndValidatorInterfaces"
 
 // ApplyDefaulterAndValidatorInterfaces add the admission.Defaulter and admission.Validator interfaces to each resource that requires them
-func ApplyDefaulterAndValidatorInterfaces(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func ApplyDefaulterAndValidatorInterfaces(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		ApplyDefaulterAndValidatorInterfaceStageID,
 		"Add the admission.Defaulter and admission.Validator interfaces to each resource that requires them",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -40,5 +40,6 @@ func ApplyDefaulterAndValidatorInterfaces(idFactory astmodel.IdentifierFactory) 
 			return state.WithDefinitions(defs.OverlayWith(updatedDefs)), nil
 		})
 
-	return stage.RequiresPrerequisiteStages(ApplyKubernetesResourceInterfaceStageID)
+	stage.RequiresPrerequisiteStages(ApplyKubernetesResourceInterfaceStageID)
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
@@ -18,13 +18,15 @@ import (
 const ApplyExportFiltersStageID = "filterTypes"
 
 // ApplyExportFilters creates a Stage to reduce our set of types for export
-func ApplyExportFilters(configuration *config.Configuration) Stage {
-	return MakeStage(
+func ApplyExportFilters(configuration *config.Configuration) *Stage {
+	stage := NewStage(
 		ApplyExportFiltersStageID,
 		"Apply export filters to reduce the number of generated types",
 		func(ctx context.Context, state *State) (*State, error) {
 			return filterTypes(configuration, state)
 		})
+
+	return stage.WithRequiredPostrequisites(VerifyNoErroredTypesStageID)
 }
 
 // filterTypes applies the configuration include/exclude filters to the generated definitions

--- a/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_export_filters.go
@@ -26,7 +26,8 @@ func ApplyExportFilters(configuration *config.Configuration) *Stage {
 			return filterTypes(configuration, state)
 		})
 
-	return stage.WithRequiredPostrequisites(VerifyNoErroredTypesStageID)
+	stage.RequiresPostrequisiteStages(VerifyNoErroredTypesStageID)
+	return stage
 }
 
 // filterTypes applies the configuration include/exclude filters to the generated definitions

--- a/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
@@ -17,8 +17,8 @@ import (
 const ApplyKubernetesResourceInterfaceStageID = "applyKubernetesResourceInterface"
 
 // ApplyKubernetesResourceInterface ensures that every Resource implements the KubernetesResource interface
-func ApplyKubernetesResourceInterface(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeStage(
+func ApplyKubernetesResourceInterface(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		ApplyKubernetesResourceInterfaceStageID,
 		"Add the KubernetesResource interface to every resource",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_kubernetes_resource_interface.go
@@ -18,7 +18,7 @@ const ApplyKubernetesResourceInterfaceStageID = "applyKubernetesResourceInterfac
 
 // ApplyKubernetesResourceInterface ensures that every Resource implements the KubernetesResource interface
 func ApplyKubernetesResourceInterface(idFactory astmodel.IdentifierFactory) *Stage {
-	return NewLegacyStage(
+	return NewStage(
 		ApplyKubernetesResourceInterfaceStageID,
 		"Add the KubernetesResource interface to every resource",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/apply_property_rewrites.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_property_rewrites.go
@@ -17,8 +17,8 @@ import (
 // ApplyPropertyRewrites applies any typeTransformers for properties.
 // It is its own pipeline stage so that we can apply it after the allOf/oneOf types have
 // been "lowered" to objects.
-func ApplyPropertyRewrites(config *config.Configuration) Stage {
-	return MakeLegacyStage(
+func ApplyPropertyRewrites(config *config.Configuration) *Stage {
+	stage := NewLegacyStage(
 		"propertyRewrites",
 		"Modify property types using configured transforms",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -47,4 +47,6 @@ func ApplyPropertyRewrites(config *config.Configuration) Stage {
 
 			return newDefinitions, nil
 		})
+
+	return stage.WithRequiredPrerequisites("nameTypes", "allof-anyof-objects")
 }

--- a/v2/tools/generator/internal/codegen/pipeline/apply_property_rewrites.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_property_rewrites.go
@@ -48,5 +48,7 @@ func ApplyPropertyRewrites(config *config.Configuration) *Stage {
 			return newDefinitions, nil
 		})
 
-	return stage.WithRequiredPrerequisites("nameTypes", "allof-anyof-objects")
+	stage.RequiresPrerequisiteStages("nameTypes", "allof-anyof-objects")
+	
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/apply_property_rewrites.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_property_rewrites.go
@@ -49,6 +49,6 @@ func ApplyPropertyRewrites(config *config.Configuration) *Stage {
 		})
 
 	stage.RequiresPrerequisiteStages("nameTypes", "allof-anyof-objects")
-	
+
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/assert_types_collection_valid.go
+++ b/v2/tools/generator/internal/codegen/pipeline/assert_types_collection_valid.go
@@ -14,8 +14,8 @@ import (
 // AssertTypesCollectionValid creates a Stage that ensures that each reachable type in the types collection
 // has TypeName's that are all reachable as well. This check fails if there is any TypeName that refers to a type that doesn't
 // exist.
-func AssertTypesCollectionValid() Stage {
-	return MakeLegacyStage(
+func AssertTypesCollectionValid() *Stage {
+	return NewLegacyStage(
 		"assertTypesStructureValid",
 		"Verify that all local TypeNames refer to a type",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
+++ b/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
@@ -26,24 +26,24 @@ const CheckForAnyTypeStageID = "rogueCheck"
 // error. The stage will also return an error if there are packages that we expect
 // to have AnyTypes but turn out not to, ensuring that we clean up our configuration
 // as the schemas are fixed and our handling improves.
-func FilterOutDefinitionsUsingAnyType(packages []string) Stage {
+func FilterOutDefinitionsUsingAnyType(packages []string) *Stage {
 	return checkForAnyType("Filter out rogue definitions using AnyTypes", packages)
 }
 
 // ensureDefinitionsDoNotUseAnyTypes returns a stage that will check for any
 // definitions containing AnyTypes. The stage will return errors for each type
 // found that uses an AnyType.
-func EnsureDefinitionsDoNotUseAnyTypes() Stage {
+func EnsureDefinitionsDoNotUseAnyTypes() *Stage {
 	return checkForAnyType("Check for rogue definitions using AnyTypes", []string{})
 }
 
-func checkForAnyType(description string, packages []string) Stage {
+func checkForAnyType(description string, packages []string) *Stage {
 	expectedPackages := astmodel.MakeStringSet()
 	for _, p := range packages {
 		expectedPackages.Add(p)
 	}
 
-	return MakeLegacyStage(
+	return NewLegacyStage(
 		CheckForAnyTypeStageID,
 		description,
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/collapse_cross_group_refs.go
+++ b/v2/tools/generator/internal/codegen/pipeline/collapse_cross_group_refs.go
@@ -18,8 +18,8 @@ const CollapseCrossGroupReferencesStageID = "collapseCrossGroupReferences"
 
 // CollapseCrossGroupReferences finds and removes references between API groups. This isn't particularly common
 // but does occur in a few instances, for example from Microsoft.Compute -> Microsoft.Compute.Extensions.
-func CollapseCrossGroupReferences() Stage {
-	return MakeLegacyStage(
+func CollapseCrossGroupReferences() *Stage {
+	return NewLegacyStage(
 		CollapseCrossGroupReferencesStageID,
 		"Find and remove cross group references",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
+++ b/v2/tools/generator/internal/codegen/pipeline/convert_allof_and_oneof_to_objects.go
@@ -29,8 +29,8 @@ var (
 )
 
 // ConvertAllOfAndOneOfToObjects reduces the AllOfType and OneOfType to ObjectType
-func ConvertAllOfAndOneOfToObjects(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func ConvertAllOfAndOneOfToObjects(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		"allof-anyof-objects",
 		"Convert allOf and oneOf to object types",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types.go
@@ -22,8 +22,8 @@ const CreateARMTypesStageID = "createArmTypes"
 
 // CreateARMTypes walks the type graph and builds new types for communicating
 // with ARM
-func CreateARMTypes(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func CreateARMTypes(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		CreateARMTypesStageID,
 		"Create types for interaction with ARM",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -20,8 +20,8 @@ const CreateConversionGraphStageId = "createConversionGraph"
 
 // CreateConversionGraph walks the set of available types and creates a graph of conversions that will be used to
 // convert resources to/from the designated storage (or hub) version
-func CreateConversionGraph(configuration *config.Configuration) Stage {
-	stage := MakeStage(
+func CreateConversionGraph(configuration *config.Configuration) *Stage {
+	stage := NewStage(
 		CreateConversionGraphStageId,
 		"Create the graph of conversions between versions of each resource group",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -42,5 +42,6 @@ func CreateConversionGraph(configuration *config.Configuration) Stage {
 			return state.WithConversionGraph(graph), nil
 		})
 
-	return stage
+	return stage.WithRequiredPrerequisites(
+		CreateStorageTypesStageID) // We need storage types created before we construct the graph
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -42,8 +42,5 @@ func CreateConversionGraph(configuration *config.Configuration) *Stage {
 			return state.WithConversionGraph(graph), nil
 		})
 
-	stage.RequiresPrerequisiteStages(
-		CreateStorageTypesStageID) // We need storage types created before we construct the graph
-
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_conversion_graph.go
@@ -42,6 +42,8 @@ func CreateConversionGraph(configuration *config.Configuration) *Stage {
 			return state.WithConversionGraph(graph), nil
 		})
 
-	return stage.WithRequiredPrerequisites(
+	stage.RequiresPrerequisiteStages(
 		CreateStorageTypesStageID) // We need storage types created before we construct the graph
+
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
@@ -56,5 +56,7 @@ func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFac
 	// We don't want tests to be generated for resourceExtensions, since these are not the actual resource types.
 	// Therefore, we want to make sure that 'createResourceExtensions' stage only runs when these prerequisite
 	// stages have completed.
-	return stage.WithRequiredPrerequisites(InjectJsonSerializationTestsID, InjectPropertyAssignmentTestsID)
+	stage.RequiresPrerequisiteStages(InjectJsonSerializationTestsID, InjectPropertyAssignmentTestsID)
+
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
@@ -17,8 +17,8 @@ const (
 	CreateResourceExtensionsStageID = "createResourceExtensions"
 )
 
-func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		CreateResourceExtensionsStageID,
 		"Create Resource Extensions for each resource type",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -56,5 +56,5 @@ func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFac
 	// We don't want tests to be generated for resourceExtensions, since these are not the actual resource types.
 	// Therefore, we want to make sure that 'createResourceExtensions' stage only runs when these prerequisite
 	// stages have completed.
-	return stage.RequiresPrerequisiteStages(InjectJsonSerializationTestsID, InjectPropertyAssignmentTestsID)
+	return stage.WithRequiredPrerequisites(InjectJsonSerializationTestsID, InjectPropertyAssignmentTestsID)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
@@ -58,6 +58,8 @@ func CreateStorageTypes() *Stage {
 			return state.WithDefinitions(defs), nil
 		})
 
-	return stage.WithRequiredPrerequisites(InjectOriginalVersionFunctionStageID).
-		WithRequiredPostrequisites(CreateConversionGraphStageId)
+	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID)
+	stage.RequiresPostrequisiteStages(CreateConversionGraphStageId)
+
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
@@ -58,8 +58,7 @@ func CreateStorageTypes() *Stage {
 			return state.WithDefinitions(defs), nil
 		})
 
-	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID)
-	stage.RequiresPostrequisiteStages(CreateConversionGraphStageId)
+	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID, CreateConversionGraphStageId)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_storage_types.go
@@ -19,8 +19,8 @@ const CreateStorageTypesStageID = "createStorageTypes"
 // CreateStorageTypes returns a pipeline stage that creates dedicated storage types for each resource and nested object.
 // Storage versions are created for *all* API versions to allow users of older versions of the operator to easily
 // upgrade. This is of course a bit odd for the first release, but defining the approach from day one is useful.
-func CreateStorageTypes() Stage {
-	stage := MakeStage(
+func CreateStorageTypes() *Stage {
+	stage := NewStage(
 		CreateStorageTypesStageID,
 		"Create storage versions of CRD types",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -58,6 +58,6 @@ func CreateStorageTypes() Stage {
 			return state.WithDefinitions(defs), nil
 		})
 
-	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID, CreateConversionGraphStageId)
-	return stage
+	return stage.WithRequiredPrerequisites(InjectOriginalVersionFunctionStageID).
+		WithRequiredPostrequisites(CreateConversionGraphStageId)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_at_provider.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_at_provider.go
@@ -15,8 +15,8 @@ import (
 )
 
 // AddCrossplaneAtProvider adds an "AtProvider" property as the sole property in every resource status
-func AddCrossplaneAtProvider(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func AddCrossplaneAtProvider(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		"addCrossplaneAtProviderProperty",
 		"Add an 'AtProvider' property on every status",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_spec.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_spec.go
@@ -16,8 +16,8 @@ import (
 var CrossplaneRuntimeV1Alpha1Package = astmodel.MakeExternalPackageReference("github.com/crossplane/crossplane-runtime/apis/core/v1alpha1")
 
 // AddCrossplaneEmbeddedResourceSpec puts an embedded runtimev1alpha1.ResourceSpec on every spec type
-func AddCrossplaneEmbeddedResourceSpec(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func AddCrossplaneEmbeddedResourceSpec(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		"addCrossplaneEmbeddedResourceSpec",
 		"Add an embedded runtimev1alpha1.ResourceSpec to every spec type",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_status.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_embedded_resource_status.go
@@ -14,8 +14,8 @@ import (
 )
 
 // AddCrossplaneEmbeddedResourceStatus puts an embedded runtimev1alpha1.ResourceStatus on every spec type
-func AddCrossplaneEmbeddedResourceStatus(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func AddCrossplaneEmbeddedResourceStatus(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		"addCrossplaneEmbeddedResourceStatus",
 		"Add an embedded runtimev1alpha1.ResourceStatus to every status type",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_for_provider.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_for_provider.go
@@ -16,8 +16,8 @@ import (
 
 // AddCrossplaneForProvider adds a "ForProvider" property as the sole property in every resource spec
 // and moves everything that was at the spec level down a level into the ForProvider type
-func AddCrossplaneForProvider(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func AddCrossplaneForProvider(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		"addCrossplaneForProviderProperty",
 		"Add a 'ForProvider' property on every spec",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/crossplane_add_owner_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/crossplane_add_owner_properties.go
@@ -15,8 +15,8 @@ import (
 )
 
 // AddCrossplaneOwnerProperties adds the 3-tuple of (xName, xNameRef, xNameSelector) for each owning resource
-func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func AddCrossplaneOwnerProperties(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		"addCrossplaneOwnerProperties",
 		"Add the 3-tuple of (xName, xNameRef, xNameSelector) for each owning resource",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/delete_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/delete_generated_code.go
@@ -27,8 +27,8 @@ import (
 const DeleteGeneratedCodeStageID = "deleteGenerated"
 
 // DeleteGeneratedCode creates a pipeline stage for cleanup of our output folder prior to generating files
-func DeleteGeneratedCode(outputFolder string) Stage {
-	return MakeLegacyStage(
+func DeleteGeneratedCode(outputFolder string) *Stage {
+	return NewLegacyStage(
 		DeleteGeneratedCodeStageID,
 		"Delete generated code from "+outputFolder,
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/detect_skipping_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/detect_skipping_properties.go
@@ -47,8 +47,8 @@ const DetectSkippingPropertiesStageID = "detectSkippingProperties"
 // - We need to handle type renaming between versions.
 // - When introduced, we will also need to handle property renaming between versions
 //
-func DetectSkippingProperties() Stage {
-	return MakeStage(
+func DetectSkippingProperties() *Stage {
+	return NewStage(
 		DetectSkippingPropertiesStageID,
 		"Detect properties that skip resource or object versions",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
+++ b/v2/tools/generator/internal/codegen/pipeline/determine_resource_ownership.go
@@ -17,8 +17,8 @@ import (
 
 const resourcesPropertyName = astmodel.PropertyName("Resources")
 
-func DetermineResourceOwnership(configuration *config.Configuration) Stage {
-	return MakeLegacyStage(
+func DetermineResourceOwnership(configuration *config.Configuration) *Stage {
+	return NewLegacyStage(
 		"determineResourceOwnership",
 		"Determine ARM resource relationships",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/ensure_type_has_arm_type.go
+++ b/v2/tools/generator/internal/codegen/pipeline/ensure_type_has_arm_type.go
@@ -16,8 +16,8 @@ import (
 
 // TODO: Wondering if we should have an even stronger version of this that asserts it for all types rather than just the top level?
 // EnsureARMTypeExistsForEveryResource performs a check ensuring that every Kubernetes resource spec/status has a corresponding ARM type
-func EnsureARMTypeExistsForEveryResource() Stage {
-	return MakeLegacyStage(
+func EnsureARMTypeExistsForEveryResource() *Stage {
+	return NewLegacyStage(
 		"ensureArmTypeExistsForEveryType",
 		"Check that an ARM type exists for both Spec and Status of each resource",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -18,8 +18,8 @@ import (
 
 // ExportControllerResourceRegistrations creates a Stage to generate type registrations
 // for resources.
-func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory, outputPath string) Stage {
-	return MakeLegacyStage(
+func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory, outputPath string) *Stage {
+	return NewLegacyStage(
 		"exportControllerResourceRegistrations",
 		fmt.Sprintf("Export resource registrations to %q", outputPath),
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -44,7 +44,9 @@ func ExportPackages(outputPath string) *Stage {
 			return definitions, nil
 		})
 
-	return stage.WithRequiredPrerequisites(DeleteGeneratedCodeStageID)
+	stage.RequiresPrerequisiteStages(DeleteGeneratedCodeStageID)
+
+	return stage
 }
 
 // CreatePackagesForDefinitions groups type definitions into packages

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -25,9 +25,9 @@ import (
 const ExportPackagesStageID = "exportPackages"
 
 // ExportPackages creates a Stage to export our generated code as a set of packages
-func ExportPackages(outputPath string) Stage {
+func ExportPackages(outputPath string) *Stage {
 	description := fmt.Sprintf("Export packages to %q", outputPath)
-	stage := MakeLegacyStage(
+	stage := NewLegacyStage(
 		ExportPackagesStageID,
 		description,
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -43,8 +43,8 @@ func ExportPackages(outputPath string) Stage {
 
 			return definitions, nil
 		})
-	stage.RequiresPrerequisiteStages(DeleteGeneratedCodeStageID)
-	return stage
+
+	return stage.WithRequiredPrerequisites(DeleteGeneratedCodeStageID)
 }
 
 // CreatePackagesForDefinitions groups type definitions into packages

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_properties.go
@@ -15,8 +15,8 @@ import (
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
 
-func FlattenProperties() Stage {
-	return MakeLegacyStage("flattenProperties", "Apply flattening to properties marked for flattening", applyPropertyFlattening)
+func FlattenProperties() *Stage {
+	return NewLegacyStage("flattenProperties", "Apply flattening to properties marked for flattening", applyPropertyFlattening)
 }
 
 func applyPropertyFlattening(

--- a/v2/tools/generator/internal/codegen/pipeline/flatten_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/flatten_resources.go
@@ -14,8 +14,8 @@ import (
 )
 
 // FlattenResources flattens any resources directly inside other resources
-func FlattenResources() Stage {
-	return MakeLegacyStage(
+func FlattenResources() *Stage {
+	return NewLegacyStage(
 		"flattenResources",
 		"Flatten nested resource types",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -70,5 +70,6 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage 
 			return state.WithDefinitions(newDefinitions), nil
 		})
 
-	return stage.WithRequiredPrerequisites(InjectPropertyAssignmentFunctionsStageID)
+	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_interface.go
@@ -19,8 +19,8 @@ const ImplementConvertibleInterfaceStageId = "implementConvertibleInterface"
 
 // ImplementConvertibleInterface injects the functions ConvertTo() and ConvertFrom() into each non-hub Resource
 // Type, providing the required implementation of the Convertible interface needed by the controller
-func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		ImplementConvertibleInterfaceStageId,
 		"Implement the Convertible interface on each non-hub Resource type",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -70,6 +70,5 @@ func ImplementConvertibleInterface(idFactory astmodel.IdentifierFactory) Stage {
 			return state.WithDefinitions(newDefinitions), nil
 		})
 
-	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
-	return stage
+	return stage.WithRequiredPrerequisites(InjectPropertyAssignmentFunctionsStageID)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
@@ -41,7 +41,8 @@ func ImplementConvertibleSpecInterface(idFactory astmodel.IdentifierFactory) *St
 			return state.WithDefinitions(defs), nil
 		})
 
-	return stage.WithRequiredPrerequisites(InjectPropertyAssignmentFunctionsStageID)
+	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
+	return stage
 }
 
 // createConvertibleSpecInterfaceImplementation creates both of the funcs required for a given spec to implement the

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_spec_interface.go
@@ -18,8 +18,8 @@ import (
 // ImplementConvertibleSpecInterfaceStageId is the unique identifier for this pipeline stage
 const ImplementConvertibleSpecInterfaceStageId = "implementConvertibleSpecInterface"
 
-func ImplementConvertibleSpecInterface(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func ImplementConvertibleSpecInterface(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		ImplementConvertibleSpecInterfaceStageId,
 		"Inject ConvertSpecTo() and ConvertSpecFrom() to implement genruntime.ConvertibleSpec on each Spec type",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -41,8 +41,7 @@ func ImplementConvertibleSpecInterface(idFactory astmodel.IdentifierFactory) Sta
 			return state.WithDefinitions(defs), nil
 		})
 
-	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
-	return stage
+	return stage.WithRequiredPrerequisites(InjectPropertyAssignmentFunctionsStageID)
 }
 
 // createConvertibleSpecInterfaceImplementation creates both of the funcs required for a given spec to implement the

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
@@ -41,7 +41,8 @@ func ImplementConvertibleStatusInterface(idFactory astmodel.IdentifierFactory) *
 			return state.WithDefinitions(defs), nil
 		})
 
-	return stage.WithRequiredPrerequisites(InjectPropertyAssignmentFunctionsStageID)
+	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
+	return stage
 }
 
 // createConvertibleStatusInterfaceImplementation creates both of the funcs required for a given status to implement the

--- a/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/implement_convertible_status_interface.go
@@ -18,8 +18,8 @@ import (
 // ImplementConvertibleStatusInterfaceStageId is the unique identifier for this pipeline stage
 const ImplementConvertibleStatusInterfaceStageId = "implementConvertibleStatusInterface"
 
-func ImplementConvertibleStatusInterface(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func ImplementConvertibleStatusInterface(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		ImplementConvertibleStatusInterfaceStageId,
 		"Inject ConvertStatusTo() and ConvertStatusFrom() to implement genruntime.ConvertibleStatus on each Status type",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -41,8 +41,7 @@ func ImplementConvertibleStatusInterface(idFactory astmodel.IdentifierFactory) S
 			return state.WithDefinitions(defs), nil
 		})
 
-	stage.RequiresPrerequisiteStages(InjectPropertyAssignmentFunctionsStageID)
-	return stage
+	return stage.WithRequiredPrerequisites(InjectPropertyAssignmentFunctionsStageID)
 }
 
 // createConvertibleStatusInterfaceImplementation creates both of the funcs required for a given status to implement the

--- a/v2/tools/generator/internal/codegen/pipeline/improve_resource_pluralization.go
+++ b/v2/tools/generator/internal/codegen/pipeline/improve_resource_pluralization.go
@@ -12,8 +12,8 @@ import (
 )
 
 // ImproveResourcePluralization improves pluralization for resources
-func ImproveResourcePluralization() Stage {
-	stage := MakeLegacyStage(
+func ImproveResourcePluralization() *Stage {
+	stage := NewLegacyStage(
 		"pluralizeNames",
 		"Improve resource pluralization",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -50,6 +50,5 @@ func ImproveResourcePluralization() Stage {
 			return renamingVisitor.RenameAll(result)
 		})
 
-	stage.RequiresPrerequisiteStages(RemoveTypeAliasesStageID)
-	return stage
+	return stage.WithRequiredPrerequisites(RemoveTypeAliasesStageID)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/improve_resource_pluralization.go
+++ b/v2/tools/generator/internal/codegen/pipeline/improve_resource_pluralization.go
@@ -50,5 +50,6 @@ func ImproveResourcePluralization() *Stage {
 			return renamingVisitor.RenameAll(result)
 		})
 
-	return stage.WithRequiredPrerequisites(RemoveTypeAliasesStageID)
+	stage.RequiresPrerequisiteStages(RemoveTypeAliasesStageID)
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
@@ -48,5 +48,6 @@ func InjectHubFunction(idFactory astmodel.IdentifierFactory) *Stage {
 			return result, nil
 		})
 
-	return stage.WithRequiredPrerequisites(MarkLatestAPIVersionAsStorageVersionId)
+	stage.RequiresPrerequisiteStages(MarkLatestAPIVersionAsStorageVersionId)
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
@@ -19,8 +19,8 @@ const InjectHubFunctionStageID = "injectHubFunction"
 
 // InjectHubFunction modifies the nominates storage version (aka hub version) of each resource by injecting a Hub()
 // function so that it satisfies the required interface.
-func InjectHubFunction(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeLegacyStage(
+func InjectHubFunction(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewLegacyStage(
 		InjectHubFunctionStageID,
 		"Inject the function Hub() into each hub resource",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -48,6 +48,5 @@ func InjectHubFunction(idFactory astmodel.IdentifierFactory) Stage {
 			return result, nil
 		})
 
-	stage.RequiresPrerequisiteStages(MarkLatestAPIVersionAsStorageVersionId)
-	return stage
+	return stage.WithRequiredPrerequisites(MarkLatestAPIVersionAsStorageVersionId)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_hub_function.go
@@ -48,6 +48,6 @@ func InjectHubFunction(idFactory astmodel.IdentifierFactory) *Stage {
 			return result, nil
 		})
 
-	stage.RequiresPrerequisiteStages(MarkLatestAPIVersionAsStorageVersionId)
+	stage.RequiresPrerequisiteStages(MarkLatestStorageVariantAsHubVersionID)
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
@@ -48,5 +48,6 @@ func InjectOriginalGVKFunction(idFactory astmodel.IdentifierFactory) *Stage {
 			return result, nil
 		})
 
-	return stage.WithRequiredPrerequisites(InjectOriginalVersionFunctionStageID)
+	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID)
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_gvk_function.go
@@ -20,8 +20,8 @@ const InjectOriginalGVKFunctionStageID = "injectOriginalGVKFunction"
 // InjectOriginalGVKFunction injects the function OriginalGVK() into each Resource type
 // This function allows us to recover the original version used to create each custom resource, giving the operator the
 // information needed to interact with ARM using the correct API version.
-func InjectOriginalGVKFunction(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeLegacyStage(
+func InjectOriginalGVKFunction(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewLegacyStage(
 		InjectOriginalGVKFunctionStageID,
 		"Inject the function OriginalGVK() into each Resource type",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -48,6 +48,5 @@ func InjectOriginalGVKFunction(idFactory astmodel.IdentifierFactory) Stage {
 			return result, nil
 		})
 
-	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID)
-	return stage
+	return stage.WithRequiredPrerequisites(InjectOriginalVersionFunctionStageID)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
@@ -21,8 +21,8 @@ const InjectOriginalVersionFunctionStageID = "injectOriginalVersionFunction"
 // This function allows us to recover the original version used to create each custom resource, giving the operator the
 // information needed to interact with ARM using the correct API version.
 // We run this stage before we create any storage types, ensuring only API versions get the function.
-func InjectOriginalVersionFunction(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeLegacyStage(
+func InjectOriginalVersionFunction(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewLegacyStage(
 		InjectOriginalVersionFunctionStageID,
 		"Inject the function OriginalVersion() into each Spec type",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -43,6 +43,7 @@ func InjectOriginalVersionFunction(idFactory astmodel.IdentifierFactory) Stage {
 			return result, nil
 		})
 
-	stage.RequiresPostrequisiteStages(CreateStorageTypesStageID, InjectOriginalVersionPropertyStageID)
-	return stage
+	return stage.WithRequiredPostrequisites(
+		CreateStorageTypesStageID,
+		InjectOriginalVersionPropertyStageID)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_function.go
@@ -43,7 +43,9 @@ func InjectOriginalVersionFunction(idFactory astmodel.IdentifierFactory) *Stage 
 			return result, nil
 		})
 
-	return stage.WithRequiredPostrequisites(
+	stage.RequiresPostrequisiteStages(
 		CreateStorageTypesStageID,
 		InjectOriginalVersionPropertyStageID)
+
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
@@ -20,8 +20,8 @@ const InjectOriginalVersionPropertyStageID = "injectOriginalVersionProperty"
 // This property gets populated by reading from the OriginalVersion() function previously injected into the API Spec
 // types, allowing us to recover the original version used to create each custom resource, and giving the operator the
 // information needed to interact with ARM using the correct API version.
-func InjectOriginalVersionProperty() Stage {
-	stage := MakeLegacyStage(
+func InjectOriginalVersionProperty() *Stage {
+	stage := NewLegacyStage(
 		InjectOriginalVersionPropertyStageID,
 		"Inject the property OriginalVersion into each Storage Spec type",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -55,6 +55,5 @@ func InjectOriginalVersionProperty() Stage {
 			return result, nil
 		})
 
-	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID)
-	return stage
+	return stage.WithRequiredPrerequisites(InjectOriginalVersionFunctionStageID)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_original_version_property.go
@@ -55,5 +55,6 @@ func InjectOriginalVersionProperty() *Stage {
 			return result, nil
 		})
 
-	return stage.WithRequiredPrerequisites(InjectOriginalVersionFunctionStageID)
+	stage.RequiresPrerequisiteStages(InjectOriginalVersionFunctionStageID)
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -26,8 +26,8 @@ const InjectPropertyAssignmentFunctionsStageID = "injectPropertyAssignmentFuncti
 // are the building blocks of the main CovertTo*() and ConvertFrom*() methods.
 func InjectPropertyAssignmentFunctions(
 	configuration *config.Configuration,
-	idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+	idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		InjectPropertyAssignmentFunctionsStageID,
 		"Inject property assignment functions AssignFrom() and AssignTo() into resources and objects",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -75,8 +75,7 @@ func InjectPropertyAssignmentFunctions(
 		})
 
 	// Needed to populate the conversion graph
-	stage.RequiresPrerequisiteStages(CreateStorageTypesStageID)
-	return stage
+	return stage.WithRequiredPrerequisites(CreateStorageTypesStageID)
 }
 
 type propertyAssignmentFunctionsFactory struct {

--- a/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/inject_property_assignment_functions.go
@@ -75,7 +75,8 @@ func InjectPropertyAssignmentFunctions(
 		})
 
 	// Needed to populate the conversion graph
-	return stage.WithRequiredPrerequisites(CreateStorageTypesStageID)
+	stage.RequiresPrerequisiteStages(CreateStorageTypesStageID)
+	return stage
 }
 
 type propertyAssignmentFunctionsFactory struct {

--- a/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
@@ -19,8 +19,8 @@ import (
 // InjectJsonSerializationTestsID is the unique identifier for this pipeline stage
 const InjectJsonSerializationTestsID = "injectJSONTestCases"
 
-func InjectJsonSerializationTests(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func InjectJsonSerializationTests(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		InjectJsonSerializationTestsID,
 		"Add test cases to verify JSON serialization",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -45,7 +45,9 @@ func InjectJsonSerializationTests(idFactory astmodel.IdentifierFactory) Stage {
 			return state.WithDefinitions(state.Definitions().OverlayWith(modifiedDefinitions)), nil
 		})
 
-	return stage.RequiresPostrequisiteStages("simplifyDefinitions" /* needs flags */)
+	stage.WithRequiredPostrequisites("simplifyDefinitions" /* needs flags */)
+
+	return stage
 }
 
 type objectSerializationTestCaseFactory struct {

--- a/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
@@ -45,7 +45,7 @@ func InjectJsonSerializationTests(idFactory astmodel.IdentifierFactory) *Stage {
 			return state.WithDefinitions(state.Definitions().OverlayWith(modifiedDefinitions)), nil
 		})
 
-	stage.WithRequiredPostrequisites("simplifyDefinitions" /* needs flags */)
+	stage.RequiresPostrequisiteStages("simplifyDefinitions" /* needs flags */)
 
 	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/load_schema.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_schema.go
@@ -140,10 +140,10 @@ const LoadSchemaIntoTypesStageID = "loadSchema"
 func LoadSchemaIntoTypes(
 	idFactory astmodel.IdentifierFactory,
 	configuration *config.Configuration,
-	schemaLoader schemaLoader) Stage {
+	schemaLoader schemaLoader) *Stage {
 	source := configuration.SchemaURL
 
-	return MakeLegacyStage(
+	return NewLegacyStage(
 		LoadSchemaIntoTypesStageID,
 		"Load and walk schema",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/make_status_properties_optional.go
+++ b/v2/tools/generator/internal/codegen/pipeline/make_status_properties_optional.go
@@ -22,8 +22,8 @@ const MakeStatusPropertiesOptionalStageID = "makeStatusPropertiesOptional"
 // has implications for updating or patching the CRD resource as patching something in the spec or changing an annotation
 // will deserialize the response from apiserver into the object passed in. If there are any spurious empty properties in Status
 // included they will end up getting overwritten (possibly before the client.Status().Update() call can be made).
-func MakeStatusPropertiesOptional() Stage {
-	return MakeStage(
+func MakeStatusPropertiesOptional() *Stage {
+	return NewStage(
 		MakeStatusPropertiesOptionalStageID,
 		"Force all status properties to be optional",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -18,8 +18,8 @@ import (
 const MarkLatestAPIVersionAsStorageVersionId = "markStorageVersion"
 
 // MarkLatestAPIVersionAsStorageVersion creates a Stage to mark a particular version as a storage version
-func MarkLatestAPIVersionAsStorageVersion() Stage {
-	return MakeLegacyStage(
+func MarkLatestAPIVersionAsStorageVersion() *Stage {
+	return NewLegacyStage(
 		MarkLatestAPIVersionAsStorageVersionId,
 		"Mark the latest API version of each resource as the storage version",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -48,5 +48,6 @@ func MarkLatestStorageVariantAsHubVersion() *Stage {
 			return state.WithDefinitions(defs), nil
 		})
 
-	return stage.WithRequiredPrerequisites(CreateConversionGraphStageId)
+	stage.RequiresPrerequisiteStages(CreateConversionGraphStageId)
+	return stage
 }

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_storage_variant_as_hub_version.go
@@ -18,8 +18,8 @@ const MarkLatestStorageVariantAsHubVersionID = "markLatestStorageVariantAsHubVer
 
 // MarkLatestStorageVariantAsHubVersion creates a Stage to mark the latest non-preview storage variant of a resource
 // as the hub version of that resource for persistence
-func MarkLatestStorageVariantAsHubVersion() Stage {
-	stage := MakeStage(
+func MarkLatestStorageVariantAsHubVersion() *Stage {
+	stage := NewStage(
 		MarkLatestStorageVariantAsHubVersionID,
 		"Mark the latest GA storage variant of each resource as the hub version",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -48,7 +48,5 @@ func MarkLatestStorageVariantAsHubVersion() Stage {
 			return state.WithDefinitions(defs), nil
 		})
 
-	stage.RequiresPrerequisiteStages(CreateConversionGraphStageId)
-
-	return stage
+	return stage.WithRequiredPrerequisites(CreateConversionGraphStageId)
 }

--- a/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
+++ b/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
@@ -15,8 +15,8 @@ import (
 )
 
 // NameTypesForCRD - for CRDs all inner enums and objects and validated types must be named, so we do it here
-func NameTypesForCRD(idFactory astmodel.IdentifierFactory) Stage {
-	return MakeLegacyStage(
+func NameTypesForCRD(idFactory astmodel.IdentifierFactory) *Stage {
+	return NewLegacyStage(
 		"nameTypes",
 		"Name inner types for CRD",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
@@ -44,9 +44,11 @@ func InjectPropertyAssignmentTests(idFactory astmodel.IdentifierFactory) *Stage 
 			return state.WithDefinitions(state.Definitions().OverlayWith(modifiedDefs)), nil
 		})
 
-	return stage.WithRequiredPrerequisites(
+	stage.RequiresPrerequisiteStages(
 		InjectPropertyAssignmentFunctionsStageID, // Need PropertyAssignmentFunctions to test
 		InjectJsonSerializationTestsID)           // We reuse the generators from the JSON tests
+
+	return stage
 }
 
 type propertyAssignmentTestCaseFactory struct {

--- a/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
@@ -18,8 +18,8 @@ import (
 // InjectPropertyAssignmentTestsID is the unique identifier for this stage
 const InjectPropertyAssignmentTestsID = "injectPropertyAssignmentTestCases"
 
-func InjectPropertyAssignmentTests(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func InjectPropertyAssignmentTests(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		InjectPropertyAssignmentTestsID,
 		"Add test cases to verify PropertyAssignment functions",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -44,12 +44,9 @@ func InjectPropertyAssignmentTests(idFactory astmodel.IdentifierFactory) Stage {
 			return state.WithDefinitions(state.Definitions().OverlayWith(modifiedDefs)), nil
 		})
 
-	stage.RequiresPrerequisiteStages(
+	return stage.WithRequiredPrerequisites(
 		InjectPropertyAssignmentFunctionsStageID, // Need PropertyAssignmentFunctions to test
-		InjectJsonSerializationTestsID,           // We reuse the generators from the JSON tests
-	)
-
-	return stage
+		InjectJsonSerializationTestsID)           // We reuse the generators from the JSON tests
 }
 
 type propertyAssignmentTestCaseFactory struct {

--- a/v2/tools/generator/internal/codegen/pipeline/remove_apiversion_property.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_apiversion_property.go
@@ -16,8 +16,8 @@ import (
 // RemoveAPIVersionPropertyStageID is the unique identifier for this pipeline stage
 const RemoveAPIVersionPropertyStageID = "removeAPIVersionProperty"
 
-func RemoveAPIVersionProperty() Stage {
-	return MakeStage(
+func RemoveAPIVersionProperty() *Stage {
+	return NewStage(
 		RemoveAPIVersionPropertyStageID,
 		"Remove the ARM API version property and instead augment the ResourceType with it",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_embedded_resources.go
@@ -15,8 +15,8 @@ import (
 // RemoveEmbeddedResourcesStageID is the unique identifier for this pipeline stage
 const RemoveEmbeddedResourcesStageID = "removeEmbeddedResources"
 
-func RemoveEmbeddedResources() Stage {
-	return MakeLegacyStage(
+func RemoveEmbeddedResources() *Stage {
+	return NewLegacyStage(
 		RemoveEmbeddedResourcesStageID,
 		"Remove properties that point to embedded resources. Only removes structural aspects of embedded resources, Id/ARMId references are retained.",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/remove_resource_scope.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_resource_scope.go
@@ -17,8 +17,8 @@ const RemoveResourceScopeStageID = "removeResourceScope"
 
 // RemoveResourceScope removes the "Scope" property from resource Specs, as it only applies in the URL
 // of requests, not in the body.
-func RemoveResourceScope() Stage {
-	return MakeStage(
+func RemoveResourceScope() *Stage {
+	return NewStage(
 		RemoveResourceScopeStageID,
 		"Remove scope from all resources",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/remove_status_property_validations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_status_property_validations.go
@@ -31,8 +31,8 @@ const RemoveStatusPropertyValidationsStageID = "removeStatusPropertyValidation"
 // In the above cases, if we left validation on the Status types, we would be unable to persist the content
 // returned by the service (apiserver will reject it as not matching the OpenAPI schema). This could be a problem
 // in cases where the resource was created via some other means and then imported into
-func RemoveStatusValidations() Stage {
-	return MakeStage(
+func RemoveStatusValidations() *Stage {
+	return NewStage(
 		RemoveStatusPropertyValidationsStageID,
 		"Remove validation from all status properties",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/remove_type_aliases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_type_aliases.go
@@ -21,8 +21,8 @@ import (
 const RemoveTypeAliasesStageID = "removeAliases"
 
 // RemoveTypeAliases creates a pipeline stage removing type aliases
-func RemoveTypeAliases() Stage {
-	return MakeLegacyStage(
+func RemoveTypeAliases() *Stage {
+	return NewLegacyStage(
 		RemoveTypeAliasesStageID,
 		"Remove type aliases",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/remove_type_property.go
+++ b/v2/tools/generator/internal/codegen/pipeline/remove_type_property.go
@@ -16,8 +16,8 @@ import (
 // RemoveTypePropertyStageID is the unique identifier for this pipeline stage
 const RemoveTypePropertyStageID = "removeTypeProperty"
 
-func RemoveTypeProperty() Stage {
-	return MakeStage(
+func RemoveTypeProperty() *Stage {
+	return NewStage(
 		RemoveTypePropertyStageID,
 		"Remove the ARM type property and instead augment the ResourceType with it",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/replace_anytype_with_json.go
+++ b/v2/tools/generator/internal/codegen/pipeline/replace_anytype_with_json.go
@@ -30,8 +30,8 @@ var (
 	mapOfJSON = astmodel.NewMapType(astmodel.StringType, astmodel.JSONType)
 )
 
-func ReplaceAnyTypeWithJSON() Stage {
-	return MakeLegacyStage(
+func ReplaceAnyTypeWithJSON() *Stage {
+	return NewLegacyStage(
 		"replaceAnyTypeWithJSON",
 		"Replace properties using interface{} with arbitrary JSON",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -24,8 +24,8 @@ import (
 const ReportResourceVersionsStageID = "reportResourceVersions"
 
 // ReportResourceVersions creates a pipeline stage that generates a report listing all generated resources.
-func ReportResourceVersions(configuration *config.Configuration) Stage {
-	return MakeStage(
+func ReportResourceVersions(configuration *config.Configuration) *Stage {
+	return NewStage(
 		ReportResourceVersionsStageID,
 		"Generate a report listing all the resources generated",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/report_type_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_type_versions.go
@@ -26,8 +26,8 @@ const ReportOnTypesAndVersionsStageID = "reportTypesAndVersions"
 
 // ReportOnTypesAndVersions creates a pipeline stage that generates a report for each group showing a matrix of all
 // types and versions
-func ReportOnTypesAndVersions(configuration *config.Configuration) Stage {
-	return MakeLegacyStage(
+func ReportOnTypesAndVersions(configuration *config.Configuration) *Stage {
+	return NewLegacyStage(
 		ReportOnTypesAndVersionsStageID,
 		"Generate reports on types and versions in each package",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
@@ -18,8 +18,8 @@ import (
 const InjectResourceConversionTestsID = "injectResourceConversionTestCases"
 
 // InjectResourceConversionTestCases is a pipeline stage to inject test cases
-func InjectResourceConversionTestCases(idFactory astmodel.IdentifierFactory) Stage {
-	stage := MakeStage(
+func InjectResourceConversionTestCases(idFactory astmodel.IdentifierFactory) *Stage {
+	stage := NewStage(
 		InjectResourceConversionTestsID,
 		"Add test cases to verify Resource implementations of conversion.Convertible (funcs ConvertTo & ConvertFrom) behave as expected",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -44,13 +44,10 @@ func InjectResourceConversionTestCases(idFactory astmodel.IdentifierFactory) Sta
 			return state.WithDefinitions(state.Definitions().OverlayWith(modifiedDefs)), nil
 		})
 
-	stage.RequiresPrerequisiteStages(
+	return stage.WithRequiredPrerequisites(
 		InjectPropertyAssignmentFunctionsStageID, // Need PropertyAssignmentFunctions to test
 		ImplementConvertibleInterfaceStageId,     // Need the conversions.Convertible interface to be present
-		InjectJsonSerializationTestsID,           // We reuse the generators from the JSON tests
-	)
-
-	return stage
+		InjectJsonSerializationTestsID) // We reuse the generators from the JSON tests
 }
 
 // resourceConversionTestCaseFactory is a factory for injecting test cases where needed

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
@@ -44,10 +44,12 @@ func InjectResourceConversionTestCases(idFactory astmodel.IdentifierFactory) *St
 			return state.WithDefinitions(state.Definitions().OverlayWith(modifiedDefs)), nil
 		})
 
-	return stage.WithRequiredPrerequisites(
+	stage.RequiresPrerequisiteStages(
 		InjectPropertyAssignmentFunctionsStageID, // Need PropertyAssignmentFunctions to test
 		ImplementConvertibleInterfaceStageId,     // Need the conversions.Convertible interface to be present
-		InjectJsonSerializationTestsID) // We reuse the generators from the JSON tests
+		InjectJsonSerializationTestsID)           // We reuse the generators from the JSON tests
+
+	return stage
 }
 
 // resourceConversionTestCaseFactory is a factory for injecting test cases where needed

--- a/v2/tools/generator/internal/codegen/pipeline/simplify_definitions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/simplify_definitions.go
@@ -15,8 +15,8 @@ import (
 )
 
 // SimplifyDefinitions creates a pipeline stage that removes any wrapper types prior to actual code generation
-func SimplifyDefinitions() Stage {
-	return MakeLegacyStage(
+func SimplifyDefinitions() *Stage {
+	return NewLegacyStage(
 		"simplifyDefinitions",
 		"Flatten definitions by removing wrapper types",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -74,8 +74,8 @@ func (stage *Stage) HasId(id string) bool {
 	return stage.id == id
 }
 
-// WithRequiredPrerequisites declares which stages must have completed before this one is executed
-func (stage *Stage) WithRequiredPrerequisites(prerequisites ...string) *Stage {
+// RequiresPrerequisiteStages declares which stages must have completed before this one is executed
+func (stage *Stage) RequiresPrerequisiteStages(prerequisites ...string) {
 	if len(stage.prerequisites) > 0 {
 		panic(fmt.Sprintf(
 			"Prerequisites of stage '%s' already set to '%s'; cannot modify to '%s'.",
@@ -85,15 +85,13 @@ func (stage *Stage) WithRequiredPrerequisites(prerequisites ...string) *Stage {
 	}
 
 	stage.prerequisites = prerequisites
-
-	return stage
 }
 
-// WithRequiredPostrequisites declares which stages must be executed after this one has completed
-// This is not completely isomorphic with WithRequiredPrerequisites as there may be supporting stages that are
+// RequiresPostrequisiteStages declares which stages must be executed after this one has completed
+// This is not completely isomorphic with RequiresPrerequisiteStages as there may be supporting stages that are
 // sometimes omitted from execution when targeting different outcomes. Having both pre- and post-requisites allows the
 // dependencies to drop out cleanly when different stages are present.
-func (stage *Stage) WithRequiredPostrequisites(postrequisites ...string) *Stage {
+func (stage *Stage) RequiresPostrequisiteStages(postrequisites ...string) {
 	if len(stage.postrequisites) > 0 {
 		panic(fmt.Sprintf(
 			"Postrequisites of stage '%s' already set to '%s'; cannot modify to '%s'.",
@@ -103,8 +101,6 @@ func (stage *Stage) WithRequiredPostrequisites(postrequisites ...string) *Stage 
 	}
 
 	stage.postrequisites = postrequisites
-
-	return stage
 }
 
 // UsedFor specifies that this stage should be used for only the specified targets

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -193,9 +193,9 @@ func (stage *Stage) CheckPrerequisites(priorStages astmodel.StringSet) error {
 	for _, prereq := range stage.prerequisites {
 		satisfied := priorStages.Contains(prereq)
 		if satisfied {
-			klog.V(0).Infof("[✓] Required prerequisite %s satisfied", prereq)
+			klog.V(3).Infof("[✓] Required prerequisite %s satisfied", prereq)
 		} else {
-			klog.V(0).Infof("[✗] Required prerequisite %s NOT satisfied", prereq)
+			klog.V(3).Infof("[✗] Required prerequisite %s NOT satisfied", prereq)
 		}
 
 		if !satisfied {

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -110,9 +110,6 @@ var knownLegacyStages = astmodel.MakeStringSet(
 	"reportTypesAndVersions",
 	"rogueCheck",
 	"simplifyDefinitions",
-	"stripUnreferenced",
-	"stripUnreferenced",
-	"stripUnreferenced",
 	"stripUnreferenced")
 
 // HasId returns true if this stage has the specified id, false otherwise

--- a/v2/tools/generator/internal/codegen/pipeline/stage.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage.go
@@ -54,7 +54,12 @@ func NewLegacyStage(
 	description string,
 	action func(context.Context, astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error)) *Stage {
 
-	klog.Warning(id)
+	if !knownLegacyStages.Contains(id) {
+		msg := fmt.Sprintf(
+			"No new legacy stages (use NewStage instead): %s is not the id of a known legacy stage",
+			id)
+		panic(msg)
+	}
 
 	return NewStage(
 		id,
@@ -68,6 +73,47 @@ func NewLegacyStage(
 			return state.WithDefinitions(types), nil
 		})
 }
+
+var knownLegacyStages = astmodel.MakeStringSet(
+	"addCrossResourceReferences",
+	"addCrossplaneAtProviderProperty",
+	"addCrossplaneEmbeddedResourceSpec",
+	"addCrossplaneEmbeddedResourceStatus",
+	"addCrossplaneForProviderProperty",
+	"addCrossplaneOwnerProperties",
+	"addStatusFromSwagger",
+	"allof-anyof-objects",
+	"applyArmConversionInterface",
+	"assertTypesStructureValid",
+	"augmentSpecWithStatus",
+	"collapseCrossGroupReferences",
+	"createArmTypes",
+	"deleteGenerated",
+	"determineResourceOwnership",
+	"ensureArmTypeExistsForEveryType",
+	"exportControllerResourceRegistrations",
+	"exportPackages",
+	"flattenProperties",
+	"flattenResources",
+	"injectHubFunction",
+	"injectOriginalGVKFunction",
+	"injectOriginalVersionFunction",
+	"injectOriginalVersionProperty",
+	"loadSchema",
+	"markStorageVersion",
+	"nameTypes",
+	"pluralizeNames",
+	"propertyRewrites",
+	"removeAliases",
+	"removeEmbeddedResources",
+	"replaceAnyTypeWithJSON",
+	"reportTypesAndVersions",
+	"rogueCheck",
+	"simplifyDefinitions",
+	"stripUnreferenced",
+	"stripUnreferenced",
+	"stripUnreferenced",
+	"stripUnreferenced")
 
 // HasId returns true if this stage has the specified id, false otherwise
 func (stage *Stage) HasId(id string) bool {

--- a/v2/tools/generator/internal/codegen/pipeline/stage_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/stage_test.go
@@ -13,7 +13,7 @@ import (
 
 // RunTestPipeline is used to run a sequence of stages as a part of a unit test
 // Typically the earlier stages will be used to set up the required preconditions for the final stage under test
-func RunTestPipeline(state *State, stages ...Stage) (*State, error) {
+func RunTestPipeline(state *State, stages ...*Stage) (*State, error) {
 	resultState := state
 	for _, stage := range stages {
 		s, err := stage.Run(context.TODO(), resultState)

--- a/v2/tools/generator/internal/codegen/pipeline/status_augment.go
+++ b/v2/tools/generator/internal/codegen/pipeline/status_augment.go
@@ -44,7 +44,8 @@ func AugmentSpecWithStatus() *Stage {
 			return defs, nil
 		})
 
-	return stage.WithRequiredPrerequisites("allof-anyof-objects", "addStatusFromSwagger")
+	stage.RequiresPrerequisiteStages("allof-anyof-objects", "addStatusFromSwagger")
+	return stage
 }
 
 // an augmenter adds information from the Swagger-derived type to

--- a/v2/tools/generator/internal/codegen/pipeline/status_augment.go
+++ b/v2/tools/generator/internal/codegen/pipeline/status_augment.go
@@ -14,8 +14,8 @@ import (
 
 const AugmentSpecWithStatusStageID = "augmentSpecWithStatus"
 
-func AugmentSpecWithStatus() Stage {
-	return MakeLegacyStage(
+func AugmentSpecWithStatus() *Stage {
+	stage := NewLegacyStage(
 		AugmentSpecWithStatusStageID,
 		"Merge information from Status into Spec",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {
@@ -43,6 +43,8 @@ func AugmentSpecWithStatus() Stage {
 
 			return defs, nil
 		})
+
+	return stage.WithRequiredPrerequisites("allof-anyof-objects", "addStatusFromSwagger")
 }
 
 // an augmenter adds information from the Swagger-derived type to

--- a/v2/tools/generator/internal/codegen/pipeline/status_from_swagger.go
+++ b/v2/tools/generator/internal/codegen/pipeline/status_from_swagger.go
@@ -41,8 +41,8 @@ added to the Status field of the Resource type, after we have renamed all the st
 avoid any conflicts with existing Spec types that have already been defined.
 
 */
-func AddStatusFromSwagger(idFactory astmodel.IdentifierFactory, config *config.Configuration) Stage {
-	return MakeLegacyStage(
+func AddStatusFromSwagger(idFactory astmodel.IdentifierFactory, config *config.Configuration) *Stage {
+	return NewLegacyStage(
 		"addStatusFromSwagger",
 		"Add information from Swagger specs for 'status' fields",
 		func(ctx context.Context, definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/strip_unused_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/strip_unused_types.go
@@ -14,8 +14,8 @@ import (
 // StripUnreferencedTypeDefinitionsStageID is the unique identifier for this pipeline stage
 const StripUnreferencedTypeDefinitionsStageID = "stripUnreferenced"
 
-func StripUnreferencedTypeDefinitions() Stage {
-	return MakeLegacyStage(
+func StripUnreferencedTypeDefinitions() *Stage {
+	return NewLegacyStage(
 		StripUnreferencedTypeDefinitionsStageID,
 		"Strip unreferenced types",
 		func(ctx context.Context, defs astmodel.TypeDefinitionSet) (astmodel.TypeDefinitionSet, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/unroll_recursive_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/unroll_recursive_types.go
@@ -43,8 +43,8 @@ const UnrollRecursiveTypesStageID = "unrollRecursiveTypes"
 // a depth of 1 in practice.
 // If we were to unroll all loops (rather than just types that directly reference themselves like we're doing here) that
 // "in practice" observation may no longer hold, so we avoid doing it here (it's also more complicated to do that).
-func UnrollRecursiveTypes() Stage {
-	return MakeStage(
+func UnrollRecursiveTypes() *Stage {
+	return NewStage(
 		UnrollRecursiveTypesStageID,
 		"Unroll directly recursive types since they are not supported by controller-gen",
 		func(ctx context.Context, state *State) (*State, error) {

--- a/v2/tools/generator/internal/codegen/pipeline/verify_no_errored_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/verify_no_errored_types.go
@@ -18,8 +18,8 @@ import (
 const VerifyNoErroredTypesStageID = "verifyNoErroredTypes"
 
 // VerifyNoErroredTypes creates a Stage that verifies that no types contain an ErroredType with errors
-func VerifyNoErroredTypes() Stage {
-	return MakeStage(
+func VerifyNoErroredTypes() *Stage {
+	stage := NewStage(
 		VerifyNoErroredTypesStageID,
 		"Verify there are no ErroredType's containing errors",
 		func(ctx context.Context, state *State) (*State, error) {
@@ -40,7 +40,9 @@ func VerifyNoErroredTypes() Stage {
 			// This stage doesn't change the generated types at all - if the verification
 			// has passed, just return the same defs we started with
 			return state, nil
-		}).RequiresPrerequisiteStages(ApplyExportFiltersStageID)
+		})
+
+	return stage
 }
 
 type errorCollectingVisitor struct {

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -47,9 +47,9 @@ injectOriginalGVKFunction                 azure      Inject the function Origina
 markLatestStorageVariantAsHubVersion      azure      Mark the latest GA storage variant of each resource as the hub version
 injectHubFunction                         azure      Inject the function Hub() into each hub resource
 implementConvertibleInterface             azure      Implement the Convertible interface on each non-hub Resource type
-injectResourceConversionTestCases         azure      Add test cases to verify Resource implementations of conversion.Convertible (funcs ConvertTo & ConvertFrom) behave as expected
 injectJSONTestCases                       azure      Add test cases to verify JSON serialization
 injectPropertyAssignmentTestCases         azure      Add test cases to verify PropertyAssignment functions
+injectResourceConversionTestCases         azure      Add test cases to verify Resource implementations of conversion.Convertible (funcs ConvertTo & ConvertFrom) behave as expected
 simplifyDefinitions                                  Flatten definitions by removing wrapper types
 createResourceExtensions                  azure      Create Resource Extensions for each resource type
 rogueCheck                                           Check for rogue definitions using AnyTypes

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
@@ -39,9 +39,9 @@ injectOriginalGVKFunction                 azure      Inject the function Origina
 markLatestStorageVariantAsHubVersion      azure      Mark the latest GA storage variant of each resource as the hub version
 injectHubFunction                         azure      Inject the function Hub() into each hub resource
 implementConvertibleInterface             azure      Implement the Convertible interface on each non-hub Resource type
-injectResourceConversionTestCases         azure      Add test cases to verify Resource implementations of conversion.Convertible (funcs ConvertTo & ConvertFrom) behave as expected
 injectJSONTestCases                       azure      Add test cases to verify JSON serialization
 injectPropertyAssignmentTestCases         azure      Add test cases to verify PropertyAssignment functions
+injectResourceConversionTestCases         azure      Add test cases to verify Resource implementations of conversion.Convertible (funcs ConvertTo & ConvertFrom) behave as expected
 simplifyDefinitions                                  Flatten definitions by removing wrapper types
 ensureArmTypeExistsForEveryType           azure      Check that an ARM type exists for both Spec and Status of each resource
 detectSkippingProperties                  azure      Detect properties that skip resource or object versions


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered that many of the pre- and post-requisites declared on our pipeline stages were being dropped and thus not enforced, which is highly likely to result in problems as our pipeline is modified.

* Changes `pipeline.Stage` to be used as a reference type instead of a value type
* Renames factory methods to `NewStage()` and `NewLegacyStage()`
* Fixes pipeline creation to create stages in the correct order
* Adds enforcement so that `NewLegacyStage()` isn't used for new stages
* Added `V(3)` logging of requisite checks

 **How does this PR make you feel**:
![gif](https://media.giphy.com/media/vp122eOzO0Hxm/giphy.gif)

**If applicable**:
- [x] this PR contains tests
