### PR TITLE
Use pointer for registration.StorageType

### DIFF
--- a/v2/internal/controllers/controller_resources.go
+++ b/v2/internal/controllers/controller_resources.go
@@ -31,12 +31,12 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/registration"
 )
 
-func GetKnownStorageTypes() []registration.StorageType {
+func GetKnownStorageTypes() []*registration.StorageType {
 	knownTypes := getKnownStorageTypes()
 
 	knownTypes = append(
 		knownTypes,
-		registration.MakeStorageType(new(resources.ResourceGroup)))
+		registration.NewStorageType(new(resources.ResourceGroup)))
 
 	return knownTypes
 }

--- a/v2/internal/controllers/controller_resources_gen.go
+++ b/v2/internal/controllers/controller_resources_gen.go
@@ -76,59 +76,59 @@ import (
 )
 
 // getKnownStorageTypes returns the list of storage types which can be reconciled.
-func getKnownStorageTypes() []registration.StorageType {
-	var result []registration.StorageType
-	result = append(result, registration.StorageType{
+func getKnownStorageTypes() []*registration.StorageType {
+	var result []*registration.StorageType
+	result = append(result, &registration.StorageType{
 		Obj:     new(authorizationv1alpha1api20200801previewstorage.RoleAssignment),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(batchv1alpha1api20210101storage.BatchAccount),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(cachev1alpha1api20201201storage.Redis),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(cachev1alpha1api20201201storage.RedisFirewallRule),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(cachev1alpha1api20201201storage.RedisLinkedServer),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(cachev1alpha1api20201201storage.RedisPatchSchedule),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(cachev1alpha1api20210301storage.RedisEnterprise),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(cachev1alpha1api20210301storage.RedisEnterpriseDatabase),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(computev1alpha1api20200930storage.Disk),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(computev1alpha1api20200930storage.Snapshot),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj: new(computev1alpha1api20201201storage.VirtualMachine),
 		Indexes: []registration.Index{
 			{
@@ -143,7 +143,7 @@ func getKnownStorageTypes() []registration.StorageType {
 			},
 		},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj: new(computev1alpha1api20201201storage.VirtualMachineScaleSet),
 		Indexes: []registration.Index{
 			{
@@ -158,27 +158,27 @@ func getKnownStorageTypes() []registration.StorageType {
 			},
 		},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(computev1alpha1api20210701storage.Image),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(containerregistryv1alpha1api20210901storage.Registry),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(containerservicev1alpha1api20210501storage.ManagedCluster),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(containerservicev1alpha1api20210501storage.ManagedClustersAgentPool),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj: new(dbformysqlv1alpha1api20210501storage.FlexibleServer),
 		Indexes: []registration.Index{
 			{
@@ -193,17 +193,17 @@ func getKnownStorageTypes() []registration.StorageType {
 			},
 		},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(dbformysqlv1alpha1api20210501storage.FlexibleServersDatabase),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(dbformysqlv1alpha1api20210501storage.FlexibleServersFirewallRule),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj: new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServer),
 		Indexes: []registration.Index{
 			{
@@ -218,237 +218,237 @@ func getKnownStorageTypes() []registration.StorageType {
 			},
 		},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersConfiguration),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersDatabase),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(dbforpostgresqlv1alpha1api20210601storage.FlexibleServersFirewallRule),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.DatabaseAccount),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabase),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabaseCollection),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabaseCollectionThroughputSetting),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.MongodbDatabaseThroughputSetting),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabase),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainer),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerStoredProcedure),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerThroughputSetting),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerTrigger),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseContainerUserDefinedFunction),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(documentdbv1alpha1api20210515storage.SqlDatabaseThroughputSetting),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventgridv1alpha1api20200601storage.Domain),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventgridv1alpha1api20200601storage.DomainsTopic),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventgridv1alpha1api20200601storage.EventSubscription),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventgridv1alpha1api20200601storage.Topic),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventhubv1alpha1api20211101storage.Namespace),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesAuthorizationRule),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesEventhub),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesEventhubsAuthorizationRule),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(eventhubv1alpha1api20211101storage.NamespacesEventhubsConsumerGroup),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(insightsv1alpha1api20180501previewstorage.Webtest),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(insightsv1alpha1api20200202storage.Component),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(managedidentityv1alpha1api20181130storage.UserAssignedIdentity),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.LoadBalancer),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.NetworkInterface),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.NetworkSecurityGroup),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.NetworkSecurityGroupsSecurityRule),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.PublicIPAddress),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.VirtualNetwork),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.VirtualNetworkGateway),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.VirtualNetworksSubnet),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(networkv1alpha1api20201101storage.VirtualNetworksVirtualNetworkPeering),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(operationalinsightsv1alpha1api20210601storage.Workspace),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(servicebusv1alpha1api20210101previewstorage.Namespace),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(servicebusv1alpha1api20210101previewstorage.NamespacesQueue),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(servicebusv1alpha1api20210101previewstorage.NamespacesTopic),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(signalrservicev1alpha1api20211001storage.SignalR),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(storagev1alpha1api20210401storage.StorageAccount),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsBlobService),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsBlobServicesContainer),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsManagementPolicy),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsQueueService),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},
 	})
-	result = append(result, registration.StorageType{
+	result = append(result, &registration.StorageType{
 		Obj:     new(storagev1alpha1api20210401storage.StorageAccountsQueueServicesQueue),
 		Indexes: []registration.Index{},
 		Watches: []registration.Watch{},

--- a/v2/internal/controllers/generic_controller.go
+++ b/v2/internal/controllers/generic_controller.go
@@ -99,7 +99,7 @@ func registerWebhook(mgr ctrl.Manager, obj client.Object) error {
 func RegisterAll(
 	mgr ctrl.Manager,
 	clientFactory arm.ARMClientFactory,
-	objs []registration.StorageType,
+	objs []*registration.StorageType,
 	extensions map[schema.GroupVersionKind]genruntime.ResourceExtension,
 	options Options) error {
 
@@ -137,7 +137,7 @@ func register(
 	mgr ctrl.Manager,
 	reconciledResourceLookup map[schema.GroupKind]schema.GroupVersionKind,
 	clientFactory arm.ARMClientFactory,
-	info registration.StorageType,
+	info *registration.StorageType,
 	extensions map[schema.GroupVersionKind]genruntime.ResourceExtension,
 	options Options) error {
 
@@ -223,7 +223,7 @@ func register(
 
 // MakeResourceGVKLookup creates a map of schema.GroupKind to schema.GroupVersionKind. This can be used to look up
 // the version of a GroupKind that is being reconciled.
-func MakeResourceGVKLookup(mgr ctrl.Manager, objs []registration.StorageType) (map[schema.GroupKind]schema.GroupVersionKind, error) {
+func MakeResourceGVKLookup(mgr ctrl.Manager, objs []*registration.StorageType) (map[schema.GroupKind]schema.GroupVersionKind, error) {
 	result := make(map[schema.GroupKind]schema.GroupVersionKind)
 
 	for _, obj := range objs {

--- a/v2/pkg/genruntime/registration/registration.go
+++ b/v2/pkg/genruntime/registration/registration.go
@@ -37,9 +37,9 @@ type StorageType struct {
 	Watches []Watch
 }
 
-// MakeStorageType makes a new storage type for the specified object
-func MakeStorageType(obj client.Object) StorageType {
-	return StorageType{
+// NewStorageType makes a new storage type for the specified object
+func NewStorageType(obj client.Object) *StorageType {
+	return &StorageType{
 		Obj: obj,
 	}
 }

--- a/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_registration_file.go
@@ -247,8 +247,8 @@ func createGetKnownTypesFunc(codeGenerationContext *astmodel.CodeGenerationConte
 
 // createGetKnownStorageTypesFunc creates a getKnownStorageTypes function that returns all storage types:
 //		func getKnownStorageTypes() []registration.StorageType {
-//			var result []registration.StorageType
-//			result = append(result, registration.StorageType{
+//			var result []*registration.StorageType
+//			result = append(result, &registration.StorageType{
 //				Obj: new(<package>.<resource>),
 //				Indexes: []registration.Index{
 //					{
@@ -279,9 +279,7 @@ func createGetKnownStorageTypesFunc(
 	resultIdent := dst.NewIdent("result")
 	resultVar := astbuilder.LocalVariableDeclaration(
 		resultIdent.String(),
-		&dst.ArrayType{
-			Elt: astmodel.StorageTypeRegistrationType.AsType(codeGenerationContext),
-		},
+		astmodel.NewArrayType(astmodel.NewOptionalType(astmodel.StorageTypeRegistrationType)).AsType(codeGenerationContext),
 		"")
 
 	sort.Slice(resources, orderByImportedTypeName(codeGenerationContext, resources))
@@ -360,7 +358,7 @@ func createGetKnownStorageTypesFunc(
 
 		appendStmt := astbuilder.AppendSlice(
 			resultIdent,
-			newStorageTypeBuilder.Build())
+			astbuilder.AddrOf(newStorageTypeBuilder.Build()))
 		resourceAppendStatements = append(resourceAppendStatements, appendStmt)
 	}
 
@@ -381,9 +379,8 @@ func createGetKnownStorageTypesFunc(
 		Params: []*dst.Field{},
 		Returns: []*dst.Field{
 			{
-				Type: &dst.ArrayType{
-					Elt: astmodel.StorageTypeRegistrationType.AsType(codeGenerationContext),
-				},
+				Type: astmodel.NewArrayType(
+					astmodel.NewOptionalType(astmodel.StorageTypeRegistrationType)).AsType(codeGenerationContext),
 			},
 		},
 	}


### PR DESCRIPTION
This enables it to be more easily changed by the handcrafted code, for
example to add extra indices that may be needed for extensions.