### PR TITLE
Make indexers work for envtests non-cached client

### DIFF
--- a/v2/cmd/controller/main.go
+++ b/v2/cmd/controller/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	armreconciler "github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm"
+	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"github.com/Azure/azure-service-operator/v2/internal/version"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
@@ -95,8 +96,12 @@ func main() {
 			os.Exit(1)
 		}
 
+		kubeClient := kubeclient.NewClient(mgr.GetClient())
+
 		err = controllers.RegisterAll(
 			mgr,
+			mgr.GetFieldIndexer(),
+			kubeClient,
 			clientFactory,
 			controllers.GetKnownStorageTypes(),
 			extensions,

--- a/v2/internal/reflecthelpers/reflect_helpers_test.go
+++ b/v2/internal/reflecthelpers/reflect_helpers_test.go
@@ -185,3 +185,30 @@ func Test_GetObjectListItems(t *testing.T) {
 	g.Expect(items).To(HaveLen(1))
 	g.Expect(items[0].GetName()).To(Equal("test-group"))
 }
+
+func Test_SetObjectListItems(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	res := &ResourceWithReferences{
+		Spec: ResourceWithReferencesSpec{
+			AzureName: "azureName",
+			Location:  "westus",
+			Owner: genruntime.KnownResourceReference{
+				Name: "myrg",
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-group",
+			Namespace: "test-namespace",
+		},
+	}
+
+	list := &ResourceWithReferencesList{}
+
+	itemList := []client.Object{res}
+	err := reflecthelpers.SetObjectListItems(list, itemList)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(list.Items).To(HaveLen(1))
+	g.Expect(list.Items[0].GetName()).To(Equal("test-group"))
+}

--- a/v2/internal/testcommon/kube_client_no_cache.go
+++ b/v2/internal/testcommon/kube_client_no_cache.go
@@ -1,0 +1,205 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package testcommon
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"github.com/Azure/azure-service-operator/v2/internal/reflecthelpers"
+)
+
+type noCacheClient struct {
+	client  client.Client
+	indexer *Indexer
+}
+
+var _ client.Client = &noCacheClient{}
+
+func NewClient(client client.Client, indexer *Indexer) client.Client {
+	return &noCacheClient{
+		client:  client,
+		indexer: indexer,
+	}
+}
+
+func (c *noCacheClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	return c.client.Get(ctx, key, obj)
+}
+
+func (c *noCacheClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return c.indexer.noCachingList(ctx, c.client, list, opts...)
+}
+
+func (c *noCacheClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c *noCacheClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c *noCacheClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c *noCacheClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *noCacheClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *noCacheClient) Status() client.StatusWriter {
+	return c.client.Status()
+}
+
+func (c *noCacheClient) Scheme() *runtime.Scheme {
+	return c.client.Scheme()
+}
+
+func (c *noCacheClient) RESTMapper() meta.RESTMapper {
+	return c.client.RESTMapper()
+}
+
+type index map[string]client.IndexerFunc
+
+type Indexer struct {
+	scheme *runtime.Scheme
+
+	indexes map[schema.GroupVersionKind]index
+}
+
+func NewIndexer(scheme *runtime.Scheme) *Indexer {
+	return &Indexer{
+		scheme:  scheme,
+		indexes: make(map[schema.GroupVersionKind]index),
+	}
+}
+
+var _ client.FieldIndexer = &Indexer{}
+
+func (i *Indexer) IndexField(_ context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	gvk, err := apiutil.GVKForObject(obj, i.scheme)
+	if err != nil {
+		return err
+	}
+
+	idx, ok := i.indexes[gvk]
+	if !ok {
+		idx = make(index)
+		i.indexes[gvk] = idx
+	}
+
+	// TODO: This isn't doing the namespace-aware thing the client does. I don't think it matters for our case though
+	idx[field] = extractValue
+	return nil
+}
+
+func (i *Indexer) doSelectorsMatch(obj client.Object, selectors []fields.Selector) (bool, error) {
+	gvk, err := apiutil.GVKForObject(obj, i.scheme)
+	if err != nil {
+		return false, err
+	}
+
+	match := true
+	for _, sel := range selectors {
+		// See https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/cache/internal/cache_reader.go#L119
+		field, val, required := requiresExactMatch(sel)
+		if !required {
+			return false, errors.Errorf("non-exact matches are not supported")
+		}
+
+		idx, ok := i.indexes[gvk]
+		if !ok {
+			return false, errors.Errorf("no index defined for gvk %s", gvk)
+		}
+
+		extractValue, ok := idx[field]
+		if !ok {
+			return false, errors.Errorf("no index defined for field %s", field)
+		}
+
+		values := extractValue(obj)
+		selectorMatches := false
+		for _, extractedVal := range values {
+			if val == extractedVal {
+				selectorMatches = true
+				break
+			}
+		}
+
+		if !selectorMatches {
+			match = false
+			break
+		}
+	}
+
+	return match, nil
+}
+
+// Note: This should only be used in test
+func (i *Indexer) noCachingList(ctx context.Context, c client.Client, list client.ObjectList, opts ...client.ListOption) error {
+	var filteredOpts []client.ListOption
+	var selectors []fields.Selector
+
+	for _, opt := range opts {
+		if matchingFields, ok := opt.(client.MatchingFields); ok {
+			sel := fields.Set(matchingFields).AsSelector()
+			selectors = append(selectors, sel)
+		} else {
+			filteredOpts = append(filteredOpts, opt)
+		}
+	}
+
+	err := c.List(ctx, list, filteredOpts...)
+	if err != nil {
+		return err
+	}
+
+	// Apply selectors manually
+	items, err := reflecthelpers.GetObjectListItems(list)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve items from ObjectList")
+	}
+
+	var result []client.Object
+
+	for _, obj := range items {
+		var match bool
+		match, err = i.doSelectorsMatch(obj, selectors)
+		if err != nil {
+			return err
+		}
+
+		if match {
+			result = append(result, obj)
+		}
+	}
+
+	return reflecthelpers.SetObjectListItems(list, result)
+}
+
+func requiresExactMatch(sel fields.Selector) (field, val string, required bool) {
+	reqs := sel.Requirements()
+	if len(reqs) != 1 {
+		return "", "", false
+	}
+	req := reqs[0]
+	if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
+		return "", "", false
+	}
+	return req.Field, req.Value, true
+}

--- a/v2/internal/util/kubeclient/and_indexer.go
+++ b/v2/internal/util/kubeclient/and_indexer.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package kubeclient
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type andIndexer struct {
+	indexers []client.FieldIndexer
+}
+
+func NewAndIndexer(indexers ...client.FieldIndexer) client.FieldIndexer {
+	return &andIndexer{
+		indexers: indexers,
+	}
+}
+
+var _ client.FieldIndexer = &andIndexer{}
+
+func (a *andIndexer) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	for _, indexer := range a.indexers {
+		err := indexer.IndexField(ctx, obj, field, extractValue)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Our envtests use a non-cached kubeclient for consistency. One problem
with this is that indexing for CRDs is entirely client-side in the
cached-client layer. Since our envtests don't use that, any queries that
attempt to make use of indicies fail.

This adds a custom kubeclient that simulates indicies for our test
client so that we can at least not *break* if an indexed query is made.
Actual end-to-end tests should probably still be written for cases where
use of an index is required... The focus of our tests is on ASO though,
so as long as the clients index feature works we may even be able to
avoid that.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/916t1VsCg2qoo/giphy.gif)
