### PR TITLE
Improve diagnostics for configuration issues

### DIFF
--- a/v2/tools/generator/go.mod
+++ b/v2/tools/generator/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/go-logr/logr v1.0.0 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/hbollon/go-edlib v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect

--- a/v2/tools/generator/go.sum
+++ b/v2/tools/generator/go.sum
@@ -286,6 +286,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hbollon/go-edlib v1.6.0 h1:ga7AwwVIvP8mHm9GsPueC0d71cfRU/52hmPJ7Tprv4E=
+github.com/hbollon/go-edlib v1.6.0/go.mod h1:wnt6o6EIVEzUfgbUZY7BerzQ2uvzp354qmS2xaLkrhM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/v2/tools/generator/internal/astmodel/string_set.go
+++ b/v2/tools/generator/internal/astmodel/string_set.go
@@ -5,6 +5,10 @@
 
 package astmodel
 
+import (
+	"sort"
+)
+
 // StringSet provides a standard way to have a set of distinct strings with no sort applied
 type StringSet map[string]struct{}
 
@@ -44,5 +48,16 @@ func (set StringSet) Copy() StringSet {
 		result.Add(s)
 	}
 
+	return result
+}
+
+// AsSlice returns a sorted slice of strings from this set
+func (set StringSet) AsSortedSlice() []string {
+	result := make([]string, 0, len(set))
+	for s := range set {
+		result = append(result, s)
+	}
+
+	sort.Strings(result)
 	return result
 }

--- a/v2/tools/generator/internal/config/typo_advisor.go
+++ b/v2/tools/generator/internal/config/typo_advisor.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hbollon/go-edlib"
+	"github.com/pkg/errors"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+)
+
+// TypoAdvisor is a utility that helps augment errors with guidance when mistakes are made in configuration.
+// A zero TypoAdvisor is valid, so there's no factory method
+type TypoAdvisor struct {
+	terms astmodel.StringSet // set of terms we know to exist
+}
+
+// AddTerm records that we saw the specified item
+func (advisor *TypoAdvisor) AddTerm(item string) {
+	if advisor.terms == nil {
+		// Lazy instantiation
+		advisor.terms = make(astmodel.StringSet)
+	}
+
+	advisor.terms.Add(item)
+}
+
+// Wrapf adds any guidance to the provided error, if possible
+func (advisor *TypoAdvisor) Wrapf(originalError error, typo string, format string, args ...interface{}) error {
+
+	if len(advisor.terms) == 0 {
+		// Can't make any suggestions
+		return originalError
+	}
+
+	if advisor.terms.Contains(typo) {
+		// No suggestion needed
+		return originalError
+	}
+
+	msg := fmt.Sprintf(format, args...)
+
+	suggestion, err := edlib.FuzzySearch(
+		strings.ToLower(typo),
+		advisor.terms.AsSortedSlice(),
+		edlib.Levenshtein)
+	if err != nil {
+		// Can't offer a suggestion
+		return errors.Wrapf(
+			originalError,
+			"%s (unable to provide suggestion: %s)",
+			msg,
+			err)
+	}
+
+	return errors.Wrapf(
+		originalError,
+		"%s (did you mean %s?)",
+		msg,
+		suggestion)
+}

--- a/v2/tools/generator/internal/config/typo_advisor_test.go
+++ b/v2/tools/generator/internal/config/typo_advisor_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+func TestTypoAdvisor_Wrapf_WhenNoError_ReturnsNil(t *testing.T) {
+	g := NewGomegaWithT(t)
+	advisor := createTestTypoAdvisor("alpha", "beta", "gamma", "delta")
+	g.Expect(advisor.Wrapf(nil, "beat", "format string")).To(BeNil())
+}
+
+func TestTypoAdvisor_Wrapf_WhenErrorButNoTerms_ReturnsOriginalError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	advisor := createTestTypoAdvisor()
+	err := errors.New("Boom")
+	g.Expect(advisor.Wrapf(err, "beat", "format string")).To(Equal(err))
+
+}
+
+func TestTypoAdvisor_Wrapf_WhenErrorButNoTypo_ReturnsOriginalError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	advisor := createTestTypoAdvisor("alpha", "beta", "gamma", "delta")
+	err := errors.New("Boom")
+	g.Expect(advisor.Wrapf(err, "beta", "format string")).To(Equal(err))
+}
+
+func TestTypoAdvisor_Wrapf_WhenErrorAndTypo_ReturnsExpectedError(t *testing.T) {
+	g := NewGomegaWithT(t)
+	advisor := createTestTypoAdvisor("alpha", "beta", "gamma", "delta")
+	err := errors.New("Boom")
+	actual := advisor.Wrapf(err, "beat", "the typo was %s", "beat")
+
+	g.Expect(actual).NotTo(BeNil())
+	g.Expect(actual.Error()).To(ContainSubstring(err.Error()))
+	g.Expect(actual.Error()).To(ContainSubstring("the typo was beat"))
+}
+
+func createTestTypoAdvisor(terms ...string) TypoAdvisor {
+	var result TypoAdvisor
+	for _, term := range terms {
+		result.AddTerm(term)
+	}
+
+	return result
+}

--- a/v2/tools/generator/internal/config/typo_advisor_test.go
+++ b/v2/tools/generator/internal/config/typo_advisor_test.go
@@ -13,12 +13,14 @@ import (
 )
 
 func TestTypoAdvisor_Wrapf_WhenNoError_ReturnsNil(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 	advisor := createTestTypoAdvisor("alpha", "beta", "gamma", "delta")
 	g.Expect(advisor.Wrapf(nil, "beat", "format string")).To(BeNil())
 }
 
 func TestTypoAdvisor_Wrapf_WhenErrorButNoTerms_ReturnsOriginalError(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 	advisor := createTestTypoAdvisor()
 	err := errors.New("Boom")
@@ -27,6 +29,7 @@ func TestTypoAdvisor_Wrapf_WhenErrorButNoTerms_ReturnsOriginalError(t *testing.T
 }
 
 func TestTypoAdvisor_Wrapf_WhenErrorButNoTypo_ReturnsOriginalError(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 	advisor := createTestTypoAdvisor("alpha", "beta", "gamma", "delta")
 	err := errors.New("Boom")
@@ -34,6 +37,7 @@ func TestTypoAdvisor_Wrapf_WhenErrorButNoTypo_ReturnsOriginalError(t *testing.T)
 }
 
 func TestTypoAdvisor_Wrapf_WhenErrorAndTypo_ReturnsExpectedError(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 	advisor := createTestTypoAdvisor("alpha", "beta", "gamma", "delta")
 	err := errors.New("Boom")

--- a/v2/tools/generator/internal/config/typo_advisor_test.go
+++ b/v2/tools/generator/internal/config/typo_advisor_test.go
@@ -42,6 +42,7 @@ func TestTypoAdvisor_Wrapf_WhenErrorAndTypo_ReturnsExpectedError(t *testing.T) {
 	g.Expect(actual).NotTo(BeNil())
 	g.Expect(actual.Error()).To(ContainSubstring(err.Error()))
 	g.Expect(actual.Error()).To(ContainSubstring("the typo was beat"))
+	g.Expect(actual.Error()).To(ContainSubstring("did you mean beta?"))
 }
 
 func createTestTypoAdvisor(terms ...string) TypoAdvisor {


### PR DESCRIPTION
The most common cause for configuration not matching an existing resource is a minor difference between the name used in configuration and the name of the actual resource. This can be caused by singular/plural differences, or by a simple typo, for example. 

We augment the error messages with a hint about a closely named item in the same scope, to aid users in correcting the configuration.

Sample for a misnamed group:

> E0315 13:10:11.348939   12688 gen_kustomize.go:111] Error during code generation:
> failed during pipeline stage 20/60: 
> Apply export filters to reduce the number of generated types: group signalservice not seen **(did you mean signalrservice?)**: 
> group signalservice: version 2021-10-01: type SignalR: $export: true not consumed

Sample for a misnamed version:

> E0315 13:20:47.995079    8840 gen_kustomize.go:111] Error during code generation:
> failed during pipeline stage 20/60: 
> Apply export filters to reduce the number of generated types: group signalrservice: 
> version 2021-10-31 not seen **(did you mean 2021-10-01?)**: version 2021-10-31: type SignalR: $export: true not consumed

Sample for misnamed type:

> E0315 13:22:38.569528   32716 gen_kustomize.go:111] Error during code generation:
> failed during pipeline stage 20/60: Apply export filters to reduce the number of generated types: 
> group signalrservice: version 2021-10-01: type Signal not seen **(did you mean SignalR?)**: 
> type Signal: $export: true not consumed

Sample for misnamed property:

> E0315 13:25:35.792792   21072 gen_kustomize.go:111] Error during code generation:
> failed during pipeline stage 26/60: Replace cross-resource references with genruntime.ResourceReference: 
> Found unused $armReference configurations; these need to be fixed or removed.: 
> group dbforpostgresql: version 2021-06-01: type Network: 
> property PrivateArmy not seen **(did you mean PrivateDnsZoneArmResourceId?)**: 
> property PrivateArmy: $armReference: true not consumed

Partially addresses #2081 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/64a8eboD6s32ZuulTO/giphy.gif)

**If applicable**:
- [x] this PR contains tests
