### PR TITLE
Always add known terms to the typo advisor

### DIFF
--- a/v2/tools/generator/internal/config/group_configuration.go
+++ b/v2/tools/generator/internal/config/group_configuration.go
@@ -117,9 +117,9 @@ func (gc *GroupConfiguration) findVersion(name astmodel.TypeName) (*VersionConfi
 		ref = s.Local()
 	}
 
+	gc.advisor.AddTerm(ref.PackageName())
 	v := strings.ToLower(ref.PackageName())
 	if version, ok := gc.versions[v]; ok {
-		gc.advisor.AddTerm(version.name)
 		return version, nil
 	}
 

--- a/v2/tools/generator/internal/config/type_configuration.go
+++ b/v2/tools/generator/internal/config/type_configuration.go
@@ -179,9 +179,9 @@ func (tc *TypeConfiguration) visitProperties(visitor *configurationVisitor) erro
 func (tc *TypeConfiguration) findProperty(property astmodel.PropertyName) (*PropertyConfiguration, error) {
 	// Store the property id using lowercase,
 	// so we can do case-insensitive lookups later
+	tc.advisor.AddTerm(string(property))
 	p := strings.ToLower(string(property))
 	if pc, ok := tc.properties[p]; ok {
-		tc.advisor.AddTerm(pc.name)
 		return pc, nil
 	}
 

--- a/v2/tools/generator/internal/config/version_configuration.go
+++ b/v2/tools/generator/internal/config/version_configuration.go
@@ -78,9 +78,9 @@ func (vc *VersionConfiguration) visitTypes(visitor *configurationVisitor) error 
 
 // findType uses the provided name to work out which nested TypeConfiguration should be used
 func (vc *VersionConfiguration) findType(name string) (*TypeConfiguration, error) {
+	vc.advisor.AddTerm(name)
 	n := strings.ToLower(name)
 	if t, ok := vc.types[n]; ok {
-		vc.advisor.AddTerm(t.name)
 		return t, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Spotted a minor bug where the typo advisor would only ever suggest something already configured as a potential fix for the item that's wrong. 

The set of possible suggestions should include all terms that exist, not just the subset we've already set up.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/dANyyVJRU0VB7Ui5dG/giphy.gif)
