### PR TITLE
Generate multitenant deployment yaml files automatically

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,6 +34,11 @@ jobs:
           container_id=${{steps.devcontainer.outputs.id}}
           docker exec "$container_id" task controller:run-kustomize
 
+      - name: Make multitenant files
+        run: |
+          container_id=${{steps.devcontainer.outputs.id}}
+          docker exec "$container_id" task controller:make-multitenant-files
+
       - name: Build & tag Docker image
         run: |
           container_id=${{steps.devcontainer.outputs.id}}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
-          file: v2/bin/azureserviceoperator_*.yaml
+          file: "v2/bin/{azureserviceoperator,multitenant-cluster,multitenant-tenant}_*.yaml"
           file_glob: true
 
       - name: Login to registry

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -543,7 +543,6 @@ tasks:
       - task: controller:docker-push-local
       # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
       - "cmctl check api --wait=2m"
-      - "kubectl get all -n cert-manager"
       # Install cluster yaml - we need to switch the image to the local one.
       - "cat v2/bin/multitenant-cluster_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
       # Install tenant yaml - with same image switch

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -453,11 +453,13 @@ tasks:
 
   controller:kind-delete:
     desc: Deletes a kind cluster
+    run: always
     cmds:
       - "kind delete cluster --name=asov2"
 
   controller:kind-create:
     desc: Creates a kind cluster and local Docker registry. Images in the local registry can be pulled in the kind cluster
+    run: always
     cmds:
       - "export KIND_CLUSTER_NAME=asov2 && {{.SCRIPTS_ROOT}}/kind-with-registry.sh"
     status:
@@ -471,6 +473,7 @@ tasks:
 
   controller:install-cert-manager:
     desc: Installs cert manager
+    run: always
     cmds:
       - "kubectl create namespace cert-manager"
       - "kubectl label namespace cert-manager cert-manager.io/disable-validation=true"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -546,7 +546,6 @@ tasks:
       - "kubectl get all -n cert-manager"
       # Install cluster yaml - we need to switch the image to the local one.
       - "cat v2/bin/multitenant-cluster_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
-      - "sleep 30"
       - "kubectl get -n azureserviceoperator-system certificate azureserviceoperator-serving-cert -o yaml"
       - "kubectl get -n azureserviceoperator-system issuer azureserviceoperator-selfsigned-issuer -o yaml"
       - "kubectl get crd resourcegroups.resources.azure.com -o jsonpath='{.spec.conversion.webhook.clientConfig.caBundle}'"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -543,8 +543,14 @@ tasks:
       - task: controller:docker-push-local
       # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
       - "cmctl check api --wait=2m"
+      - "kubectl get all -n cert-manager"
       # Install cluster yaml - we need to switch the image to the local one.
       - "cat v2/bin/multitenant-cluster_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
+      - "sleep 30"
+      - "kubectl get -n azureserviceoperator-system certificate azureserviceoperator-serving-cert -o yaml"
+      - "kubectl get -n azureserviceoperator-system issuer azureserviceoperator-selfsigned-issuer -o yaml"
+      - "kubectl get crd resourcegroups.resources.azure.com -o jsonpath='{.spec.conversion.webhook.clientConfig.caBundle}'"
+      - "kubectl logs -n cert-manager deploy/cert-manager-cainjector | grep resourcegroups"
       # Install tenant yaml - with same image switch
       - "cat v2/bin/multitenant-tenant_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
       # Make sp secret for tenant watching some target namespaces.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -385,6 +385,14 @@ tasks:
       - mkdir -p bin # in case it doesn't exist
       - kustomize build config/default | sed -e 's@localhost:5000/azureserviceoperator:latest@{{.PUBLIC_REGISTRY}}{{.CONTROLLER_DOCKER_IMAGE}}@g' > bin/azureserviceoperator_{{.VERSION}}.yaml
 
+  controller:make-multitenant-files:
+    desc: Splits the deployment yaml into cluster and tenant files for multitenant deployment
+    deps: [controller:run-kustomize]
+    dir: "v2/bin"
+    cmds:
+      - '../../{{.SCRIPTS_ROOT}}/make-multitenant-cluster.sh "{{.VERSION}}" "azureserviceoperator_{{.VERSION}}.yaml"'
+      - '../../{{.SCRIPTS_ROOT}}/make-multitenant-tenant.sh "{{.VERSION}}" "azureserviceoperator_{{.VERSION}}.yaml"'
+
   controller:run-kustomize-for-envtest:
     desc: Generates the CRDs for use in envtest
     deps: [controller:generate-kustomize]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -223,11 +223,14 @@ tasks:
     desc: Builds the {{.CONTROLLER_APP}} Docker image.
     dir: "{{.CONTROLLER_ROOT}}"
     deps: [controller:build]
+    run: always
     sources:
     - Dockerfile
     - ./bin/{{.CONTROLLER_APP}}
     cmds:
     - docker build . -t {{.CONTROLLER_DOCKER_IMAGE}}
+    status:
+    - "docker manifest inspect {{.CONTROLLER_DOCKER_IMAGE}} > /dev/null"
 
   controller:docker-build-and-save:
     desc: Builds the {{.CONTROLLER_APP}} Docker image and saves it using docker save.
@@ -248,9 +251,12 @@ tasks:
     desc: Pushes the controller container image to a local registry
     deps: [controller:docker-build]
     dir: "{{.CONTROLLER_ROOT}}"
+    run: always
     cmds:
     - docker tag {{.CONTROLLER_DOCKER_IMAGE}} {{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}}
     - docker push {{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}}
+    status:
+    - "docker manifest inspect {{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}} > /dev/null"
 
   controller:test-integration-envtest:
     desc: Run integration tests with envtest using record/replay.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -490,6 +490,24 @@ tasks:
       - task: controller:make-aadpodidentity-secret
       - "kubectl wait --for=condition=ready --timeout=2m pod -n azureserviceoperator-system -l control-plane=controller-manager"
 
+  controller:kind-create-multitenant-cluster:
+    desc: Creates a local kind cluster with ASO installed in multitenant configuration.
+    deps: [controller:make-multitenant-files]
+    cmds:
+      - task: controller:kind-create
+      - task: controller:install-cert-manager
+      - task: controller:docker-push-local
+      # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
+      - "cmctl check api --wait=2m"
+      # Install cluster yaml - we need to switch the image to the local one.
+      - "cat v2/bin/multitenant-cluster_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
+      # Install tenant yaml - with same image switch
+      - "cat v2/bin/multitenant-tenant_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
+      # Make sp secret for tenant watching some target namespaces.
+      - "{{.SCRIPTS_ROOT}}/deploy_multitenant_testing_secret.sh"
+      - "kubectl wait --for=condition=ready --timeout=2m pod -n azureserviceoperator-system -l control-plane=controller-manager"
+      - "kubectl wait --for=condition=ready --timeout=2m pod -n tenant1-system -l control-plane=controller-manager"
+
   controller:gen-crd-docs:
     desc: Generates API docs for CRDs
     deps: [controller:generate-crds]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -505,6 +505,9 @@ tasks:
       - "cat v2/bin/multitenant-tenant_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
       # Make sp secret for tenant watching some target namespaces.
       - "{{.SCRIPTS_ROOT}}/deploy_multitenant_testing_secret.sh"
+      # Create the namespaces that the tenant is watching.
+      - "kubectl create namespace t1-items"
+      - "kubectl create namespace t1-more"
       - "kubectl wait --for=condition=ready --timeout=2m pod -n azureserviceoperator-system -l control-plane=controller-manager"
       - "kubectl wait --for=condition=ready --timeout=2m pod -n tenant1-system -l control-plane=controller-manager"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -533,6 +533,9 @@ tasks:
       - task: controller:install-aad-pod-identity-local
       - task: controller:make-aadpodidentity-secret
       - "kubectl wait --for=condition=ready --timeout=2m pod -n azureserviceoperator-system -l control-plane=controller-manager"
+      # Wait for the webhook client config caBundles to be set on the
+      # ASO CRDs.
+      - "{{.SCRIPTS_ROOT}}/wait-for-ca-bundles.sh"
 
   controller:kind-create-multitenant-cluster:
     desc: Creates a local kind cluster with ASO installed in multitenant configuration.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,6 +159,7 @@ tasks:
     cmds:
       - task: cleanup-old-live-azure-resources
       - task: controller:test-integration-kind-ci
+      - task: controller:test-multitenant-integration-kind-ci
 
   controller:ci-live:
     cmds:
@@ -306,6 +307,37 @@ tasks:
       # to keep CI fast
       - go test -timeout 15m -v -run '{{default ".*" .TEST_FILTER}}' ./test
 
+  controller:test-multitenant-integration-kind-ci:
+    desc: Run live multitenant integration tests in kind.
+    dir: "{{.CONTROLLER_ROOT}}"
+    deps: [controller:kind-create-multitenant-cluster]
+    cmds:
+      # This timeout is purposefully low - if we find that this job is
+      # taking a long time we may need to think of other ways to keep
+      # CI fast
+      # TODO: Below pattern was taken from
+      # https://github.com/go-task/task/pull/474 to ensure cleanup
+      # runs after the test.
+      - |
+        (go test -timeout 15m -v -run '{{default ".*" .TEST_FILTER}}' ./test/multitenant); # Run the tests in a subshell.
+        TEST_EXIT=$?;
+        kind delete cluster --name=asov2
+        exit $TEST_EXIT
+
+  # Note that this target isn't used in CI and is intended for use
+  # when running locally on a kind cluster that you don't want to
+  # delete (in contrast to test-multitenant-integration-kind which
+  # will delete the kind cluster when it is done.
+  controller:test-multitenant-integration-kind:
+    desc: Run live multitenant integration tests in kind.
+    dir: "{{.CONTROLLER_ROOT}}"
+    deps: [controller:kind-create-multitenant-cluster]
+    cmds:
+      # This timeout is purposefully low - if we find that this job is
+      # taking a long time we may need to think of other ways to keep
+      # CI fast
+      - go test -timeout 15m -v -run '{{default ".*" .TEST_FILTER}}' ./test/multitenant
+
   controller:test-integration-ci:
     desc: Run integration tests for CI
     dir: "{{.CONTROLLER_ROOT}}"
@@ -314,7 +346,10 @@ tasks:
   controller:test-integration-ci-live:
     desc: Run integration tests for CI in live mode
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:test-integration-envtest-live, controller:test-integration-kind-ci, cleanup-old-live-azure-resources]
+    deps:
+      - controller:test-integration-envtest-live
+      - controller:test-integration-kind-ci
+      - cleanup-old-live-azure-resources
 
   controller:generate-types:
     desc: Run {{.GENERATOR_APP}} to generate input files for controller-gen for {{.CONTROLLER_APP}}.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -546,10 +546,6 @@ tasks:
       - "kubectl get all -n cert-manager"
       # Install cluster yaml - we need to switch the image to the local one.
       - "cat v2/bin/multitenant-cluster_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
-      - "kubectl get -n azureserviceoperator-system certificate azureserviceoperator-serving-cert -o yaml"
-      - "kubectl get -n azureserviceoperator-system issuer azureserviceoperator-selfsigned-issuer -o yaml"
-      - "kubectl get crd resourcegroups.resources.azure.com -o jsonpath='{.spec.conversion.webhook.clientConfig.caBundle}'"
-      - "kubectl logs -n cert-manager deploy/cert-manager-cainjector | grep resourcegroups"
       # Install tenant yaml - with same image switch
       - "cat v2/bin/multitenant-tenant_{{.VERSION}}.yaml | sed -e 's|image: mcr.microsoft.com/k8s/azureserviceoperator:.*|image: localhost:5000/azureserviceoperator:latest|' | kubectl apply --server-side=true -f -"
       # Make sp secret for tenant watching some target namespaces.
@@ -557,8 +553,12 @@ tasks:
       # Create the namespaces that the tenant is watching.
       - "kubectl create namespace t1-items"
       - "kubectl create namespace t1-more"
+      # Wait for all the operator pods to be ready.
       - "kubectl wait --for=condition=ready --timeout=2m pod -n azureserviceoperator-system -l control-plane=controller-manager"
       - "kubectl wait --for=condition=ready --timeout=2m pod -n tenant1-system -l control-plane=controller-manager"
+      # Wait for the webhook client config caBundles to be set on the
+      # ASO CRDs.
+      - "{{.SCRIPTS_ROOT}}/wait-for-ca-bundles.sh"
 
   controller:gen-crd-docs:
     desc: Generates API docs for CRDs

--- a/scripts/deploy_multitenant_testing_secret.sh
+++ b/scripts/deploy_multitenant_testing_secret.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aso-controller-settings
+  namespace: tenant1-system
+stringData:
+  AZURE_SUBSCRIPTION_ID: "$AZURE_SUBSCRIPTION_ID"
+  AZURE_TENANT_ID: "$AZURE_TENANT_ID"
+  AZURE_CLIENT_ID: "$AZURE_CLIENT_ID"
+  AZURE_CLIENT_SECRET: "$AZURE_CLIENT_SECRET"
+  AZURE_TARGET_NAMESPACES: "t1-items,t1-more"
+EOF

--- a/scripts/make-multitenant-cluster.sh
+++ b/scripts/make-multitenant-cluster.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+version="$1"
+target="multitenant-cluster_${version}.yaml"
+source="$2"
+
+# Collect all of the documents we want in the cluster deployment yaml.
 crd='.kind == "CustomResourceDefinition"'
 namespace='.kind == "Namespace"'
 cluster_role='.kind == "ClusterRole"'
@@ -8,14 +13,36 @@ leader_election_role='(.kind == "Role" and .metadata.name == "azureserviceoperat
 leader_election_binding='(.kind == "RoleBinding" and .metadata.name == "azureserviceoperator-leader-election-rolebinding")'
 proxy_binding='(.kind == "ClusterRoleBinding" and .metadata.name == "azureserviceoperator-proxy-rolebinding")'
 service='.kind == "Service"'
-deployment='.kind == "Deployment"'
+deployment='(.kind == "Deployment" and .metadata.name == "azureserviceoperator-controller-manager")'
 certificate='.kind == "Certificate"'
 issuer='.kind == "Issuer"'
 webhooks='(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration")'
 query="select($crd or $namespace or $cluster_role or $leader_election_role or $leader_election_binding or $service or $deployment or $certificate or $issuer or $webhooks or $proxy_binding)"
 
-version="$1"
-target="multitenant-cluster_${version}.yaml"
-source="$2"
-
 yq eval "$query" "$source" > "$target"
+
+
+# Edit the deployment to run the ASO binary in webhooks-only mode.
+# Remove the aadpodidbinding label - this is only needed for communicating to ARM
+yq eval -i "del(select($deployment) | .spec.template.metadata.labels.aadpodidbinding)" "$target"
+
+# Change the manager container env vars - the webhook server only
+# needs pod namespace, operator mode and subscription id (which isn't
+# used).
+
+# This is awkward but I can't see a better way to express it in yq -
+# it corresponds to this yaml:
+# - name: POD_NAMESPACE
+#   valueFrom:
+#     fieldRef:
+#       fieldPath: metadata.namespace
+# - name: AZURE_OPERATOR_MODE
+#   value: webhooks
+#   # This is unfortunately required although we won't use it.
+# - name: AZURE_SUBSCRIPTION_ID
+#   value: none
+pod_namespace='{"name": "POD_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}}'
+operator_mode='{"name": "AZURE_OPERATOR_MODE", "value": "webhooks"}'
+subscription_id='{"name": "AZURE_SUBSCRIPTION_ID", "value": "none"}'
+new_env_vars="[$pod_namespace, $operator_mode, $subscription_id]"
+yq eval -i "(select($deployment) | .spec.template.spec.containers[] | select(.name == \"manager\").env) = $new_env_vars" "$target"

--- a/scripts/make-multitenant-cluster.sh
+++ b/scripts/make-multitenant-cluster.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+crd='.kind == "CustomResourceDefinition"'
+namespace='.kind == "Namespace"'
+cluster_role='.kind == "ClusterRole"'
+leader_election_role='(.kind == "Role" and .metadata.name == "azureserviceoperator-leader-election-role")'
+leader_election_binding='(.kind == "RoleBinding" and .metadata.name == "azureserviceoperator-leader-election-rolebinding")'
+proxy_binding='(.kind == "ClusterRoleBinding" and .metadata.name == "azureserviceoperator-proxy-rolebinding")'
+service='.kind == "Service"'
+deployment='.kind == "Deployment"'
+certificate='.kind == "Certificate"'
+issuer='.kind == "Issuer"'
+webhooks='(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration")'
+query="select($crd or $namespace or $cluster_role or $leader_election_role or $leader_election_binding or $service or $deployment or $certificate or $issuer or $webhooks or $proxy_binding)"
+
+version="$1"
+target="multitenant-cluster_${version}.yaml"
+source="$2"
+
+yq eval "$query" "$source" > "$target"

--- a/scripts/make-multitenant-tenant.sh
+++ b/scripts/make-multitenant-tenant.sh
@@ -1,4 +1,58 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-echo TODO
+version="$1"
+target="multitenant-tenant_${version}.yaml"
+source="$2"
+
+tenant="tenant1"
+tenant_namespace="$tenant-system"
+
+
+# Collect the few documents we want in the per-tenant yaml.
+namespace='.kind == "Namespace"'
+leader_election_role='(.kind == "Role" and .metadata.name == "azureserviceoperator-leader-election-role")'
+leader_election_binding='(.kind == "RoleBinding" and .metadata.name == "azureserviceoperator-leader-election-rolebinding")'
+manager_role_binding='(.kind == "ClusterRoleBinding" and .metadata.name == "azureserviceoperator-manager-rolebinding")'
+deployment='(.kind == "Deployment" and .metadata.name == "azureserviceoperator-controller-manager")'
+query="select($namespace or $leader_election_role or $leader_election_binding or $manager_role_binding or $deployment)"
+
+yq eval "$query" "$source" > "$target"
+
+function inplace_edit() {
+    command=$1
+    yq eval -i "$command" "$target"
+}
+
+# Create the tenant namespace.
+inplace_edit "(select($namespace).metadata.name) = \"$tenant_namespace\""
+
+# Put the other resources into that namespace (except for the cluster
+# role binding since that's not namespaced).
+inplace_edit "(select($leader_election_role or $leader_election_binding or $deployment).metadata.namespace) = \"$tenant_namespace\""
+
+# Update the subject namespaces for the bindings so they refer to the
+# service account in the tenant namespace
+inplace_edit "(select($leader_election_binding or $manager_role_binding).subjects[0].namespace) = \"$tenant_namespace\""
+
+# Rename the cluster role binding so bindings for different tenants
+# can coexist.
+inplace_edit "(select($manager_role_binding).metadata.name) = \"azureserviceoperator-manager-rolebinding-$tenant\""
+
+# Changes to the deployment:
+# * Remove the webserver cert volume and mount.
+inplace_edit "del(select($deployment) | .spec.template.spec.volumes)"
+
+manager_container="select($deployment) | .spec.template.spec.containers[] | select(.name == \"manager\")"
+
+inplace_edit "del(${manager_container}.volumeMounts)"
+
+# * Remove the rbac-proxy container.
+inplace_edit "del(select($deployment) | .spec.template.spec.containers[] | select(.name == \"kube-rbac-proxy\"))"
+
+# * Remove the webhook port.
+inplace_edit "del(${manager_container} | .ports[] | select(.name == \"webhook-server\"))"
+
+# * Set the operator-mode env var to "watchers".
+new_env_val='{"name": "AZURE_OPERATOR_MODE", "value": "watchers"}'
+inplace_edit "(${manager_container} | .env[] | select(.name == \"AZURE_OPERATOR_MODE\")) = $new_env_val"

--- a/scripts/make-multitenant-tenant.sh
+++ b/scripts/make-multitenant-tenant.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+echo TODO

--- a/scripts/wait-for-ca-bundles.sh
+++ b/scripts/wait-for-ca-bundles.sh
@@ -30,3 +30,6 @@ until all_crds_have_cabundle; do
     echo "Waiting 5s"
     sleep 5
 done
+
+echo "All CRDs have CA bundles"
+exit 0

--- a/scripts/wait-for-ca-bundles.sh
+++ b/scripts/wait-for-ca-bundles.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function all_crds_have_cabundle() {
+    for crd in $(kubectl api-resources -o name | grep '\.azure\.com'); do
+        cabundle=$(kubectl get crd "$crd" -o jsonpath='{.spec.conversion.webhook.clientConfig.caBundle}')
+        if [ -z "$cabundle" ]; then
+            echo "$crd has no CA bundle"
+            return 1
+        fi
+    done
+    return 0
+}
+
+# Wait for all CRDs to have CA bundles set, or 30s.
+SECONDS=0
+
+until all_crds_have_cabundle; do
+    if (( SECONDS > 30 )); then
+        echo "Timed out waiting for all CRDs to have CA bundles"
+    fi
+
+    echo "Waiting 5s"
+    sleep 5
+done

--- a/scripts/wait-for-ca-bundles.sh
+++ b/scripts/wait-for-ca-bundles.sh
@@ -22,8 +22,9 @@ function all_crds_have_cabundle() {
 SECONDS=0
 
 until all_crds_have_cabundle; do
-    if (( SECONDS > 30 )); then
+    if (( SECONDS > 60 )); then
         echo "Timed out waiting for all CRDs to have CA bundles"
+        exit 1
     fi
 
     echo "Waiting 5s"

--- a/v2/test/multitenant/suite_test.go
+++ b/v2/test/multitenant/suite_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package multitenant_test
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"k8s.io/klog/v2/klogr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
+)
+
+const (
+	DefaultResourceTimeout = 10 * time.Minute
+)
+
+var globalTestContext testcommon.KubeGlobalContext
+
+func setup() error {
+	log.Println("Running test setup")
+
+	// Note: These are set just so we have somewhat reasonable defaults. Almost all
+	// usage of Eventually is done through the testContext wrapper which manages its
+	// own timeouts.
+	gomega.SetDefaultEventuallyTimeout(DefaultResourceTimeout)
+	gomega.SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	// setup global logger for controller-runtime:
+	ctrl.SetLogger(klogr.New())
+
+	nameConfig := testcommon.NewResourceNameConfig(
+		testcommon.LiveResourcePrefix,
+		"-",
+		6,
+		testcommon.ResourceNamerModeRandom)
+
+	// set global context var
+	newGlobalTestContext, err := testcommon.NewKubeContext(
+		false,
+		false,
+		testcommon.DefaultTestRegion,
+		nameConfig)
+	if err != nil {
+		return err
+	}
+
+	log.Print("Done with test setup")
+	globalTestContext = newGlobalTestContext
+	return nil
+}
+
+func teardown() error {
+	return globalTestContext.Cleanup()
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(testcommon.SetupTeardownTestMain(m, setup, teardown))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The multitenant deployment files can be generated by running the `controller:make-multitenant-files` task. They'll be generated and attached to new releases.

Also adds an integration test to validate that we can create resources in a multitenant-deployed cluster that is run in the PR validation CI.

**How does this PR make you feel**:
![gif](https://c.tenor.com/0q0Dc2Tt2OYAAAAd/the-setup-is-complete-yeti.gif)

**If applicable**:
- [x] this PR contains tests
