### PR TITLE
Fix bug where Version configuration wasn't used for some packages

### DIFF
--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -13,10 +13,10 @@ import (
 
 // LocalPackageReference specifies a local package name or reference
 type LocalPackageReference struct {
-	localPathPrefix string
-	group           string
-	version         string
-	versionPrefix   string
+	localPathPrefix  string
+	group            string
+	apiVersion       string
+	generatorVersion string
 }
 
 var (
@@ -24,15 +24,15 @@ var (
 	_ fmt.Stringer     = LocalPackageReference{}
 )
 
-const GeneratorVersionPrefix string = "v1alpha1api"
+const GeneratorVersion string = "v1alpha1api"
 
 // MakeLocalPackageReference Creates a new local package reference from a group and version
 func MakeLocalPackageReference(prefix string, group string, versionPrefix string, version string) LocalPackageReference {
 	return LocalPackageReference{
-		localPathPrefix: prefix,
-		group:           group,
-		versionPrefix:   versionPrefix,
-		version:         sanitizePackageName(version),
+		localPathPrefix:  prefix,
+		group:            group,
+		generatorVersion: versionPrefix,
+		apiVersion:       sanitizePackageName(version),
 	}
 }
 
@@ -48,7 +48,7 @@ func (pr LocalPackageReference) Group() string {
 
 // Version returns the version of this local reference
 func (pr LocalPackageReference) Version() string {
-	return pr.versionPrefix + pr.version
+	return pr.generatorVersion + pr.apiVersion
 }
 
 // PackageName returns the package name of this reference
@@ -70,8 +70,8 @@ func (pr LocalPackageReference) Equals(ref PackageReference) bool {
 
 	if other, ok := ref.(LocalPackageReference); ok {
 		return pr.localPathPrefix == other.localPathPrefix &&
-			pr.versionPrefix == other.versionPrefix &&
-			pr.version == other.version &&
+			pr.generatorVersion == other.generatorVersion &&
+			pr.apiVersion == other.apiVersion &&
 			pr.group == other.group
 	}
 
@@ -87,18 +87,26 @@ func (pr LocalPackageReference) String() string {
 // We don't check the version prefix (which contains the version of the generator) as that may contain alpha or beta
 // even if the ARM version is not preview.
 func (pr LocalPackageReference) IsPreview() bool {
-	return containsPreviewVersionLabel(strings.ToLower(pr.version))
+	return containsPreviewVersionLabel(strings.ToLower(pr.apiVersion))
 }
 
 // WithVersionPrefix returns a new LocalPackageReference with a different version prefix
 func (pr LocalPackageReference) WithVersionPrefix(prefix string) LocalPackageReference {
-	pr.versionPrefix = prefix
+	pr.generatorVersion = prefix
 	return pr
 }
 
 // HasVersionPrefix returns true if we have the specified version prefix, false otherwise.
 func (pr LocalPackageReference) HasVersionPrefix(prefix string) bool {
-	return pr.versionPrefix == prefix
+	return pr.generatorVersion == prefix
+}
+
+func (pr LocalPackageReference) GeneratorVersion() string {
+	return pr.generatorVersion
+}
+
+func (pr LocalPackageReference) ApiVersion() string {
+	return pr.apiVersion
 }
 
 // IsLocalPackageReference returns true if the supplied reference is a local one

--- a/v2/tools/generator/internal/astmodel/local_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference_test.go
@@ -150,8 +150,8 @@ func TestLocalPackageReferenceIsPreview(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			// Using GeneratorVersionPrefix here to make sure IsPreview isn't fooled
-			ref := MakeLocalPackageReference("prefix", "microsoft.storage", GeneratorVersionPrefix, c.version)
+			// Using GeneratorVersion here to make sure IsPreview isn't fooled
+			ref := MakeLocalPackageReference("prefix", "microsoft.storage", GeneratorVersion, c.version)
 
 			g.Expect(ref.IsPreview()).To(Equal(c.isPreview))
 		})

--- a/v2/tools/generator/internal/astmodel/storage_package_reference_test.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference_test.go
@@ -90,8 +90,8 @@ func TestStoragePackageReferenceIsPreview(t *testing.T) {
 			t.Parallel()
 			g := NewGomegaWithT(t)
 
-			// Using GeneratorVersionPrefix here to make sure IsPreview isn't fooled
-			local := MakeLocalPackageReference("prefix", "microsoft.storage", GeneratorVersionPrefix, c.version)
+			// Using GeneratorVersion here to make sure IsPreview isn't fooled
+			local := MakeLocalPackageReference("prefix", "microsoft.storage", GeneratorVersion, c.version)
 			ref := MakeStoragePackageReference(local)
 
 			g.Expect(ref.IsPreview()).To(Equal(c.isPreview))

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -182,7 +182,7 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		// TODO: For now only used for ARM
 		pipeline.InjectOriginalVersionFunction(idFactory).UsedFor(pipeline.ARMTarget),
 		pipeline.CreateStorageTypes().UsedFor(pipeline.ARMTarget),
-		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersionPrefix).UsedFor(pipeline.ARMTarget),
+		pipeline.CreateConversionGraph(configuration, astmodel.GeneratorVersion).UsedFor(pipeline.ARMTarget),
 		pipeline.InjectOriginalVersionProperty().UsedFor(pipeline.ARMTarget),
 		pipeline.InjectPropertyAssignmentFunctions(configuration, idFactory).UsedFor(pipeline.ARMTarget),
 		pipeline.ImplementConvertibleSpecInterface(idFactory).UsedFor(pipeline.ARMTarget),

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
 )
 
-var goldenTestPackageReference = astmodel.MakeLocalPackageReference(test.GoModulePrefix, "test", astmodel.GeneratorVersionPrefix, "20200101")
+var goldenTestPackageReference = astmodel.MakeLocalPackageReference(test.GoModulePrefix, "test", astmodel.GeneratorVersion, "20200101")
 
 type GoldenTestConfig struct {
 	HasARMResources      bool                        `yaml:"hasArmResources"`

--- a/v2/tools/generator/internal/codegen/pipeline/status_from_swagger.go
+++ b/v2/tools/generator/internal/codegen/pipeline/status_from_swagger.go
@@ -509,7 +509,7 @@ func loadAllSchemas(
 			pkg := astmodel.MakeLocalPackageReference(
 				localPathPrefix,
 				idFactory.CreateGroupName(group),
-				astmodel.GeneratorVersionPrefix,
+				astmodel.GeneratorVersion,
 				version)
 
 			// all files are loaded in parallel to speed this up

--- a/v2/tools/generator/internal/config/configuration.go
+++ b/v2/tools/generator/internal/config/configuration.go
@@ -376,7 +376,7 @@ func (config *Configuration) TransformTypeProperties(name astmodel.TypeName, obj
 
 // MakeLocalPackageReference creates a local package reference based on the configured destination location
 func (config *Configuration) MakeLocalPackageReference(group string, version string) astmodel.LocalPackageReference {
-	return astmodel.MakeLocalPackageReference(config.LocalPathPrefix(), group, astmodel.GeneratorVersionPrefix, version)
+	return astmodel.MakeLocalPackageReference(config.LocalPathPrefix(), group, astmodel.GeneratorVersion, version)
 }
 
 func getModulePathFromModFile(modFilePath string) (string, error) {

--- a/v2/tools/generator/internal/config/group_configuration.go
+++ b/v2/tools/generator/internal/config/group_configuration.go
@@ -108,9 +108,17 @@ func (gc *GroupConfiguration) findVersion(ref astmodel.PackageReference) (*Versi
 // findVersion uses the provided LocalPackageReference to work out which nested VersionConfiguration should be used
 func (gc *GroupConfiguration) findVersionForLocalPackageReference(ref astmodel.LocalPackageReference) (*VersionConfiguration, error) {
 	gc.advisor.AddTerm(ref.ApiVersion())
+	gc.advisor.AddTerm(ref.PackageName())
 
-	v := strings.ToLower(ref.ApiVersion())
-	if version, ok := gc.versions[v]; ok {
+	// Check based on the ApiVersion alone
+	apiKey := strings.ToLower(ref.ApiVersion())
+	if version, ok := gc.versions[apiKey]; ok {
+		return version, nil
+	}
+
+	// Also check the entire package name (allows config to specify just a particular generator version if needed)
+	pkgKey := strings.ToLower(ref.PackageName())
+	if version, ok := gc.versions[pkgKey]; ok {
 		return version, nil
 	}
 

--- a/v2/tools/generator/internal/config/group_configuration.go
+++ b/v2/tools/generator/internal/config/group_configuration.go
@@ -48,25 +48,10 @@ func (gc *GroupConfiguration) add(version *VersionConfiguration) {
 	// Convert version.name into a package version
 	// We do this by constructing a local package reference because this avoids replicating the logic here and risking
 	// inconsistency if things are changed in the future.
-	local := astmodel.MakeLocalPackageReference("prefix", "group", astmodel.GeneratorVersionPrefix, version.name)
-	_, lv, ok := local.GroupVersion()
-	if !ok {
-		msg := fmt.Sprintf("local package reference %s unexpectedly failed to return GroupVersion()", local)
-		panic(msg)
-	}
-
-	// Convert version.name into a storage package version
-	// We do this by constructing a storage package reference for reasons similar to above.
-	storage := astmodel.MakeStoragePackageReference(local)
-	_, sv, ok := storage.GroupVersion()
-	if !ok {
-		msg := fmt.Sprintf("storage package reference %s unexpectedly failed to return GroupVersion()", storage)
-		panic(msg)
-	}
+	local := astmodel.MakeLocalPackageReference("prefix", "group", astmodel.GeneratorVersion, version.name)
 
 	gc.versions[strings.ToLower(version.name)] = version
-	gc.versions[strings.ToLower(lv)] = version
-	gc.versions[strings.ToLower(sv)] = version
+	gc.versions[strings.ToLower(local.ApiVersion())] = version
 }
 
 // visitVersion invokes the provided visitor on the specified version if present.
@@ -75,7 +60,7 @@ func (gc *GroupConfiguration) visitVersion(
 	name astmodel.TypeName,
 	visitor *configurationVisitor,
 ) error {
-	vc, err := gc.findVersion(name)
+	vc, err := gc.findVersion(name.PackageReference)
 	if err != nil {
 		return err
 	}
@@ -108,17 +93,23 @@ func (gc *GroupConfiguration) visitVersions(visitor *configurationVisitor) error
 		gc.name)
 }
 
-// findVersion uses the provided TypeName to work out which nested VersionConfiguration should be used
-func (gc *GroupConfiguration) findVersion(name astmodel.TypeName) (*VersionConfiguration, error) {
-	ref := name.PackageReference
-	if s, ok := ref.(astmodel.StoragePackageReference); ok {
-		// If we have a storage package reference, need to unwrap the actual local package reference
-		// as all our configuration is based on API versions, not storage versions
-		ref = s.Local()
+// findVersion uses the provided PackageReference to work out which nested VersionConfiguration should be used
+func (gc *GroupConfiguration) findVersion(ref astmodel.PackageReference) (*VersionConfiguration, error) {
+	switch r := ref.(type) {
+	case astmodel.StoragePackageReference:
+		return gc.findVersion(r.Local())
+	case astmodel.LocalPackageReference:
+		return gc.findVersionForLocalPackageReference(r)
 	}
 
-	gc.advisor.AddTerm(ref.PackageName())
-	v := strings.ToLower(ref.PackageName())
+	panic(fmt.Sprintf("didn't expect PackageReference of type %T", ref))
+}
+
+// findVersion uses the provided LocalPackageReference to work out which nested VersionConfiguration should be used
+func (gc *GroupConfiguration) findVersionForLocalPackageReference(ref astmodel.LocalPackageReference) (*VersionConfiguration, error) {
+	gc.advisor.AddTerm(ref.ApiVersion())
+
+	v := strings.ToLower(ref.ApiVersion())
 	if version, ok := gc.versions[v]; ok {
 		return version, nil
 	}

--- a/v2/tools/generator/internal/config/group_configuration_test.go
+++ b/v2/tools/generator/internal/config/group_configuration_test.go
@@ -13,6 +13,9 @@ import (
 
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/test"
 )
 
 func TestGroupConfiguration_WhenYAMLWellFormed_ReturnsExpectedResult(t *testing.T) {
@@ -28,8 +31,8 @@ func TestGroupConfiguration_WhenYAMLWellFormed_ReturnsExpectedResult(t *testing.
 	g.Expect(group.versions).To(HaveKey("2021-01-01"))
 	g.Expect(group.versions).To(HaveKey("2021-05-15"))
 	// Check for local package name equivalents
-	g.Expect(group.versions).To(HaveKey("v1alpha1api20210101"))
-	g.Expect(group.versions).To(HaveKey("v1alpha1api20210515"))
+	g.Expect(group.versions).To(HaveKey("20210101"))
+	g.Expect(group.versions).To(HaveKey("20210515"))
 }
 
 func TestGroupConfiguration_WhenYAMLBadlyFormed_ReturnsError(t *testing.T) {
@@ -42,11 +45,53 @@ func TestGroupConfiguration_WhenYAMLBadlyFormed_ReturnsError(t *testing.T) {
 	g.Expect(err).NotTo(Succeed())
 }
 
+func TestGroupConfiguration_FindVersion_GivenTypeName_ReturnsExpectedVersion(t *testing.T) {
+	t.Parallel()
+
+	ver := "2021-01-01"
+	refTest := test.MakeLocalPackageReference("demo", ver)
+	refOther := test.MakeLocalPackageReference("demo", "2022-12-31")
+	refAlpha := astmodel.MakeLocalPackageReference("prefix", "demo", "v1alpha1api", ver)
+	refBeta := astmodel.MakeLocalPackageReference("prefix", "demo", "v1beta", ver)
+
+	groupConfiguration := NewGroupConfiguration("demo")
+	versionConfig := NewVersionConfiguration("2021-01-01")
+	groupConfiguration.add(versionConfig)
+
+	cases := []struct {
+		name          string
+		ref           astmodel.PackageReference
+		expectedFound bool
+	}{
+		{"Lookup by version", refTest, true},
+		{"Lookup by alpha version", refAlpha, true},
+		{"Lookup by beta version", refBeta, true},
+		{"Lookup by other version", refOther, false},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			v, err := groupConfiguration.findVersion(c.ref)
+			if c.expectedFound {
+				g.Expect(err).To(BeNil())
+				g.Expect(v).To(Equal(versionConfig))
+			} else {
+				g.Expect(err).NotTo(BeNil())
+			}
+		})
+	}
+
+}
+
 func loadTestData(t *testing.T) []byte {
 	testName := t.Name()
 	index := strings.Index(testName, "_")
 
-	folder := string(testName[0:index])
+	folder := testName[0:index]
 	file := string(testName[index+1:]) + ".yaml"
 	yamlPath := filepath.Join("testdata", folder, file)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered during work to move our generator prefix to `v1beta`, our configuration wasn't being picked up by some packages, resulting in needed modifications not being made to the object model.

This PR changes the way we look up version-configuration within the object-model-configuration hierarchy so that it's independent of the generator version.

We also enable configuration based on the generator version as well (which is needed by some tests), ensuring some forward compatibility.

**How does this PR make you feel**:
![image](https://user-images.githubusercontent.com/1272094/160038376-ca62ceb0-9b79-4332-a3b7-cc6b526c538e.png)

**If applicable**:
- [x] this PR contains tests