### PR TITLE
Include error in panic

### DIFF
--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -198,7 +198,7 @@ func createSharedEnvTest(cfg testConfig, namespaceResources *namespaceResources)
 
 			if time.Now().After(timeoutAt) {
 				err = errors.Wrap(err, "timed out waiting for webhook server to start")
-				panic(err)
+				panic(err.Error())
 			}
 
 			time.Sleep(100 * time.Millisecond)

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -189,7 +189,7 @@ func createSharedEnvTest(cfg testConfig, namespaceResources *namespaceResources)
 		log.Println("Waiting for webhook server to start")
 		// Need to block here until things are actually running
 		chk := mgr.GetWebhookServer().StartedChecker()
-		timeoutAt := time.Now().Add(5 * time.Second)
+		timeoutAt := time.Now().Add(15 * time.Second)
 		for {
 			err = chk(nil)
 			if err == nil {
@@ -197,11 +197,13 @@ func createSharedEnvTest(cfg testConfig, namespaceResources *namespaceResources)
 			}
 
 			if time.Now().After(timeoutAt) {
-				panic("timed out waiting for webhook server to start")
+				err = errors.Wrap(err, "timed out waiting for webhook server to start")
+				panic(err)
 			}
 
 			time.Sleep(100 * time.Millisecond)
 		}
+
 		log.Println("Webhook server started")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Includes the underlying error in the panic when waiting for the webhook server times out.

Also increases the timeout to 15s - given this is failing on a PR that doubles the number of resource versions we have, it's a reasonable hypothesis that it's failing due to workload.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/BoFtqmEwv6yJ26m9dF/giphy.gif)
