### PR TITLE
Avoid metrics panic if HTTP request returns an error

### DIFF
--- a/v2/internal/genericarmclient/generic_client.go
+++ b/v2/internal/genericarmclient/generic_client.go
@@ -140,16 +140,21 @@ func (client *GenericClient) createOrUpdateByID(
 
 	client.metrics.RecordAzureRequestsTime(resourceType, time.Since(requestStartTime), metrics.HttpPut)
 
+	statusCode := 0
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	client.metrics.RecordAzureRequestsTotal(resourceType, statusCode, metrics.HttpPut)
+
 	if err != nil {
 		client.metrics.RecordAzureFailedRequestsTotal(resourceType, metrics.HttpPut)
 		return nil, err
 	}
 
-	client.metrics.RecordAzureRequestsTotal(resourceType, resp.StatusCode, metrics.HttpPut)
-
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted) {
 		return nil, client.createOrUpdateByIDHandleError(resp)
 	}
+
 	return resp, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We'll currently experience a panic if an HTTP request returns an error as the response will be **nil**. 

Fixed by moving the metrics line after the `err` check, at which point we expect to have a response.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/PupKtxrsQy5Wd3TzW3/giphy.gif)
