### PR TITLE
Update golangci-lint install-depedencies.sh to match base image

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -69,7 +69,7 @@ if [ "$1" != "devcontainer" ]; then
     echo "Installing golangci-lint…"
     # golangci-lint is provided by base image if in devcontainer
     # this command copied from there
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$TOOL_DEST" v1.44.2 2>&1
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$TOOL_DEST" v1.45.2 2>&1
 fi
 
 # Install go-task (task runner)


### PR DESCRIPTION
Base image we are using for our devcontainer now includes `golangci-lint` 1.45.2 which (somewhat) supports go 1.18. Update the `install-dependencies.sh` version to match.

This now allows us to use generics. 