### PR TITLE
Update documentation for beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://dev.azure.com/azure/azure-service-operator/_apis/build/status/Azure.azure-service-operator?branchName=main)](https://dev.azure.com/azure/azure-service-operator/_build/latest?definitionId=36&branchName=main)
 ![v2 Status](https://github.com/azure/azure-service-operator/actions/workflows/live-validation.yml/badge.svg?branch=main)
 
-> Note: The API is expected to change (while adhering to semantic versioning). Alpha and Beta resources are generally not recommended for production environments. Alpha, Beta, and Stable mean roughly the same for this project as they do for [all Kubernetes features](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages).
+> Note: The API is expected to change (while adhering to semantic versioning). Alpha, Beta, and Stable mean roughly the same for this project as they do for [all Kubernetes features](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages).
 
 ## What is it?
 **Azure Service Operator** (ASO) helps you provision Azure resources and connect your applications to them from within Kubernetes.
@@ -23,8 +23,8 @@ There are two major versions of Azure Service Operator: v1 and v2. Consult the b
 > Note: ASO v1 and v2 are two totally independent operators. Each has its own unique set of CRDs and controllers. They can be deployed side by side in the same cluster.
 
 | ASO Version | Lifecycle stage | Development status                | Installation options                                                                                                                                                                                      |
-| ----------- | --------------- | --------------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| v2          | Alpha           | Under active development.         | [Helm chart](/v2/charts), [GitHub release 2.x](https://github.com/Azure/azure-service-operator/releases). See [installation](https://azure.github.io/azure-service-operator/#installation) for example.   |
+| ----------- |-----------------| --------------------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| v2          | Beta            | Under active development.         | [Helm chart](/v2/charts), [GitHub release 2.x](https://github.com/Azure/azure-service-operator/releases). See [installation](https://azure.github.io/azure-service-operator/#installation) for example.   |
 | v1          | Beta            | Bug and security fixes primarily. | [Helm chart](/charts), [OperatorHub](https://operatorhub.io/operator/azure-service-operator) or [GitHub release 1.x](https://github.com/Azure/azure-service-operator/releases)                            |
 
 ### ASO v2

--- a/docs/hugo/content/introduction/installing-from-yaml.md
+++ b/docs/hugo/content/introduction/installing-from-yaml.md
@@ -11,7 +11,7 @@ title: "Installation: From YAML"
 
 1. Install [the latest **v2+** release](https://github.com/Azure/azure-service-operator/releases) of Azure Service Operator.
    ```bash
-   kubectl apply --server-side=true -f https://github.com/Azure/azure-service-operator/releases/download/v2.0.0-alpha.6/azureserviceoperator_v2.0.0-alpha.6.yaml
+   kubectl apply --server-side=true -f https://github.com/Azure/azure-service-operator/releases/download/v2.0.0-beta.0/azureserviceoperator_v2.0.0-beta.0.yaml
    ```
 2. Create the Azure Service Operator v2 secret. This secret contains the identity that Azure Service Operator will run as. 
    Make sure that you have the 4 environment variables from the [Helm installation instructions](https://azure.github.io/azure-service-operator/#installation) set.

--- a/docs/hugo/content/introduction/multitenant-deployment.md
+++ b/docs/hugo/content/introduction/multitenant-deployment.md
@@ -31,9 +31,9 @@ To deploy the operator in multi-tenant mode the release YAML has been split into
    * A cluster role binding enabling the per-tenant operator's service account to manage the Azure resources.
 
 ## Example files
-Examples of the deployment YAML files are available on the release page for ASO v2 releases from [v2.0.0-alpha.6](https://github.com/Azure/azure-service-operator/releases/tag/v2.0.0-alpha.6).
-The cluster-wide file `multitenant-cluster_v2.0.0-alpha.6.yaml` can be used as-is (the webhook deployment namespace is fixed as `azureserviceoperator-system`),
-but the namespaces and cluster role binding in the per-tenant file `multitenant-tenant_v2.0.0-alpha.6.yaml` will need to be customised in each tenant's YAML file from `tenant1` to the desired name for that tenant.
+Examples of the deployment YAML files are available on the release page for ASO v2 releases from [v2.0.0-beta.0](https://github.com/Azure/azure-service-operator/releases/tag/v2.0.0-beta.0).
+The cluster-wide file `multitenant-cluster_v2.0.0-beta.0.yaml` can be used as-is (the webhook deployment namespace is fixed as `azureserviceoperator-system`),
+but the namespaces and cluster role binding in the per-tenant file `multitenant-tenant_v2.0.0-beta.0.yaml` will need to be customised in each tenant's YAML file from `tenant1` to the desired name for that tenant.
 
 ## Per-tenant configuration
 Create the `aso-controller-settings` secret as described in the [authentication docs](https://azure.github.io/azure-service-operator/introduction/authentication/),

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,7 +1,7 @@
 # Azure Service Operator v2
 
 ## Project Status
-This project is an alpha. We follow the [Kubernetes definition of alpha](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages).
+This project is a beta. We follow the [Kubernetes definition of beta](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-stages).
 
 ## Why use Azure Service Operator v2?
 - **K8s Native:** we provide CRDs and Golang API structures to deploy and manage Azure resources through Kubernetes.

--- a/v2/config/samples/cache/v1beta20201201_redis.yaml
+++ b/v2/config/samples/cache/v1beta20201201_redis.yaml
@@ -17,3 +17,18 @@ spec:
     maxmemory-delta: "10"
     maxmemory-policy: allkeys-lru
   redisVersion: "6"
+  # Optional: Save the connection details for this Redis into a Kubernetes secret
+  operatorSpec:
+    secrets:
+      primaryKey:
+        name: redis-secret
+        key: primaryKey
+      secondaryKey:
+        name: redis-secret
+        key: secondaryKey
+      hostName:
+        name: redis-secret
+        key: hostName
+      sslPort:
+        name: redis-secret
+        key: port

--- a/v2/config/samples/documentdb/v1beta20210515_databaseaccount.yaml
+++ b/v2/config/samples/documentdb/v1beta20210515_databaseaccount.yaml
@@ -11,3 +11,15 @@ spec:
   databaseAccountOfferType: Standard
   locations:
     - locationName: westcentralus
+  # Optional: Save the connection details for this DatabaseAccount into a Kubernetes secret
+  operatorSpec:
+    secrets:
+      primaryMasterKey:
+        name: db-secret
+        key: primarymasterkey
+      secondaryMasterKey:
+        name: db-secret
+        key: secondarymasterkey
+      documentEndpoint:
+        name: db-secret
+        key: endpoint

--- a/v2/config/samples/storage/v1beta20210401_storageaccount.yaml
+++ b/v2/config/samples/storage/v1beta20210401_storageaccount.yaml
@@ -11,4 +11,16 @@ spec:
   owner:
     name: aso-sample-rg
   accessTier: Hot
+  # Optional: Save the keys for the storage account into a Kubernetes secret
+  operatorSpec:
+    secrets:
+      key1:
+        name: storageaccount-secret
+        key: key1
+      key2:
+        name: storageaccount-secret
+        key: key2
+      blobEndpoint:
+        name: storageaccount-secret
+        key: blobEndpoint
   # supportsHttpsTrafficOnly: true


### PR DESCRIPTION
 - Remove section about "not production ready" for ASOv2.
 - Clarify ASOv2 is in beta now in README table.
 - Add secrets to examples for resources that support them.
 - Change installation instructions to point to beta.0 Helm chart and
   YAML.
