### PR TITLE
Make theme wider

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,6 +70,7 @@ tasks:
   build-docs-site:
     dir: docs/hugo
     cmds:
+    - cp themes/_variables.scss themes/book/assets/
     - hugo 
     # - htmltest 
     # disabled pending: https://github.com/wjdp/htmltest/issues/45

--- a/docs/hugo/themes/_variables.scss
+++ b/docs/hugo/themes/_variables.scss
@@ -1,0 +1,7 @@
+/*
+ * SASS Variable overrides for injection into our theme
+ *
+ * Gets copied into place by our Taskfile
+ */
+
+ $container-max-width: 120rem


### PR DESCRIPTION
**What this PR does / why we need it**:

Our current docs site theme ([book](https://github.com/alex-shpak/hugo-book)) is a bit narrow for our purposes, with many of our tables ending up awkwardly cropped or squashed:

![image](https://user-images.githubusercontent.com/1272094/164567039-830d9e33-e731-418c-b469-f2e246e5885e.png)
![image](https://user-images.githubusercontent.com/1272094/164567072-02c849b7-4d5d-4030-a632-c12572ab10b1.png)

By making the central column wider, we can avoid most issues:

![image](https://user-images.githubusercontent.com/1272094/164567135-5dcc94d9-de26-4c30-82df-cb6715ce386b.png)
![image](https://user-images.githubusercontent.com/1272094/164567459-01978d23-e1fb-4c96-a70a-9e48447702ea.png)

**Special notes for your reviewer**:

Our theme comes from a submodule, so we can't tweak it directly; I ended up creating the required change as a separate file and copying it into place via the Taskfile.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/VFB3cJJne7b5m/giphy.gif)
