### PR TITLE
Exclude tools directory from structure diagram

### DIFF
--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Update ASO v2 diagram
         uses: githubocto/repo-visualizer@main
         with:
+          # Paths are relative to root_path
           excluded_paths: "ignore,.github,tools"
           output_file: "docs/hugo/content/contributing/contributing/aso-v2-structure.svg"
           root_path: "v2"

--- a/.github/workflows/visualize-repo.yml
+++ b/.github/workflows/visualize-repo.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Update ASO v2 diagram
         uses: githubocto/repo-visualizer@main
         with:
-          excluded_paths: "ignore,.github,v2/tools"
+          excluded_paths: "ignore,.github,tools"
           output_file: "docs/hugo/content/contributing/contributing/aso-v2-structure.svg"
           root_path: "v2"
           commit_message: "Updating visualization for ASO v2"


### PR DESCRIPTION
**What this PR does / why we need it**:

The structure diagram for ASO v2 included all the details of our code-generator, which is covered by another diagram.

There was already an exclusion for this folder, but it wasn't working.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/nnRG5giXc4coZ7xWCw/giphy.gif)
