### PR TITLE
Make base types appropriate for non-ARM resources

### DIFF
--- a/v2/api/cache/customizations/redis_extensions.go
+++ b/v2/api/cache/customizations/redis_extensions.go
@@ -28,7 +28,7 @@ var _ extensions.SecretsRetriever = &RedisExtension{}
 
 func (ext *RedisExtension) RetrieveSecrets(
 	ctx context.Context,
-	obj genruntime.MetaObject,
+	obj genruntime.ARMMetaObject,
 	armClient *genericarmclient.GenericClient,
 	log logr.Logger) ([]*v1.Secret, error) {
 

--- a/v2/api/documentdb/customizations/database_account_extensions.go
+++ b/v2/api/documentdb/customizations/database_account_extensions.go
@@ -27,7 +27,7 @@ var _ extensions.SecretsRetriever = &DatabaseAccountExtension{}
 
 func (ext *DatabaseAccountExtension) RetrieveSecrets(
 	ctx context.Context,
-	obj genruntime.MetaObject,
+	obj genruntime.ARMMetaObject,
 	armClient *genericarmclient.GenericClient,
 	log logr.Logger) ([]*v1.Secret, error) {
 

--- a/v2/api/network/customizations/virtual_network_extensions.go
+++ b/v2/api/network/customizations/virtual_network_extensions.go
@@ -27,7 +27,7 @@ var _ extensions.ARMResourceModifier = &VirtualNetworkExtension{}
 func (extension *VirtualNetworkExtension) ModifyARMResource(
 	ctx context.Context,
 	armObj genruntime.ARMResource,
-	obj genruntime.MetaObject,
+	obj genruntime.ARMMetaObject,
 	kubeClient kubeclient.Client,
 	resolver *resolver.Resolver,
 	log logr.Logger) (genruntime.ARMResource, error) {
@@ -81,7 +81,7 @@ func getSubnetNames(subnets []genruntime.ARMResourceSpec) []string {
 	return result
 }
 
-func getSubnetGVK(vnet genruntime.MetaObject) schema.GroupVersionKind {
+func getSubnetGVK(vnet genruntime.ARMMetaObject) schema.GroupVersionKind {
 	gvk := genruntime.GetOriginalGVK(vnet)
 	gvk.Kind = reflect.TypeOf(network.VirtualNetworksSubnet{}).Name() // "VirtualNetworksSubnet"
 
@@ -90,7 +90,7 @@ func getSubnetGVK(vnet genruntime.MetaObject) schema.GroupVersionKind {
 
 func transformToARM(
 	ctx context.Context,
-	obj genruntime.MetaObject,
+	obj genruntime.ARMMetaObject,
 	gvk schema.GroupVersionKind,
 	kubeClient kubeclient.Client,
 	resolver *resolver.Resolver) (genruntime.ARMResourceSpec, error) {

--- a/v2/api/storage/customizations/storage_account_extensions.go
+++ b/v2/api/storage/customizations/storage_account_extensions.go
@@ -27,7 +27,7 @@ var _ extensions.SecretsRetriever = &StorageAccountExtension{}
 
 func (ext *StorageAccountExtension) RetrieveSecrets(
 	ctx context.Context,
-	obj genruntime.MetaObject,
+	obj genruntime.ARMMetaObject,
 	armClient *genericarmclient.GenericClient,
 	log logr.Logger) ([]*v1.Secret, error) {
 

--- a/v2/cmd/controller/main.go
+++ b/v2/cmd/controller/main.go
@@ -92,7 +92,7 @@ func main() {
 
 	armClient := genericarmclient.NewGenericClient(arm.AzurePublicCloud, creds, cfg.SubscriptionID, armMetrics)
 
-	var clientFactory armreconciler.ARMClientFactory = func(_ genruntime.MetaObject) *genericarmclient.GenericClient {
+	var clientFactory armreconciler.ARMClientFactory = func(_ genruntime.ARMMetaObject) *genericarmclient.GenericClient {
 		// always use the configured ARM client
 		return armClient
 	}

--- a/v2/internal/reconcilers/arm/arm_client_factory.go
+++ b/v2/internal/reconcilers/arm/arm_client_factory.go
@@ -10,4 +10,4 @@ import (
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
-type ARMClientFactory func(genruntime.MetaObject) *genericarmclient.GenericClient
+type ARMClientFactory func(genruntime.ARMMetaObject) *genericarmclient.GenericClient

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -32,13 +32,13 @@ import (
 
 type azureDeploymentReconcilerInstance struct {
 	AzureDeploymentReconciler
-	Obj       genruntime.MetaObject
+	Obj       genruntime.ARMMetaObject
 	Log       logr.Logger
 	ARMClient *genericarmclient.GenericClient
 }
 
 func newAzureDeploymentReconcilerInstance(
-	metaObj genruntime.MetaObject,
+	metaObj genruntime.ARMMetaObject,
 	log logr.Logger,
 	armClient *genericarmclient.GenericClient,
 	reconciler AzureDeploymentReconciler) *azureDeploymentReconcilerInstance {
@@ -567,7 +567,7 @@ func (r *azureDeploymentReconcilerInstance) updateStatus(ctx context.Context) er
 }
 
 func (r *azureDeploymentReconcilerInstance) CommitUpdate(ctx context.Context) error {
-	err := CommitObject(ctx, r.KubeClient, r.Obj)
+	err := r.KubeClient.CommitObject(ctx, r.Obj)
 	if err != nil {
 		return err
 	}
@@ -664,7 +664,7 @@ func (r *azureDeploymentReconcilerInstance) saveAzureSecrets(ctx context.Context
 	return nil
 }
 
-// ConvertResourceToARMResource converts a genruntime.MetaObject (a Kubernetes representation of a resource) into
+// ConvertResourceToARMResource converts a genruntime.ARMMetaObject (a Kubernetes representation of a resource) into
 // a genruntime.ARMResourceSpec - a specification which can be submitted to Azure for deployment
 func (r *azureDeploymentReconcilerInstance) ConvertResourceToARMResource(ctx context.Context) (genruntime.ARMResource, error) {
 	metaObject := r.Obj
@@ -683,7 +683,7 @@ func (r *azureDeploymentReconcilerInstance) ConvertResourceToARMResource(ctx con
 // ConvertToARMResourceImpl factored out of AzureDeploymentReconciler.ConvertResourceToARMResource to allow for testing
 func ConvertToARMResourceImpl(
 	ctx context.Context,
-	metaObject genruntime.MetaObject,
+	metaObject genruntime.ARMMetaObject,
 	scheme *runtime.Scheme,
 	resolver *resolver.Resolver,
 	subscriptionID string) (genruntime.ARMResource, error) {

--- a/v2/internal/reconcilers/arm/client_helpers.go
+++ b/v2/internal/reconcilers/arm/client_helpers.go
@@ -6,49 +6,9 @@
 package arm
 
 import (
-	"context"
-
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
-
-// CommitObject persists the contents of obj to etcd by using the Kubernetes client.
-// Note that after this method has been called, obj contains the result of the update
-// from APIServer (including an updated resourceVersion).
-func CommitObject(ctx context.Context, kubeClient kubeclient.Client, obj genruntime.MetaObject) error {
-	// Order of updates (spec first or status first) matters here.
-	// If the status is updated first: clients that are waiting on status
-	// Condition Ready == true might see that quickly enough, and make a spec
-	// update fast enough, to conflict with the second write (that of the spec).
-	// This will trigger extra requests to Azure and fail our recording tests but is
-	// otherwise harmless in an actual deployment.
-	// We update the spec first to avoid the above problem.
-
-	// We must clone here because the result of this update could contain
-	// fields such as status.location that may not be set but are not omitempty.
-	// This will cause the contents we have in Status.Location to be overwritten.
-	clone := obj.DeepCopyObject().(client.Object)
-
-	err := kubeClient.Update(ctx, clone)
-	if err != nil {
-		return errors.Wrapf(err, "updating %s/%s resource", obj.GetNamespace(), obj.GetName())
-	}
-
-	obj.SetResourceVersion(clone.GetResourceVersion())
-
-	// Note that subsequent calls to GET can (if using a cached client) can miss the updates we've just done.
-	// See: https://github.com/kubernetes-sigs/controller-runtime/issues/1464.
-	err = kubeClient.Status().Update(ctx, obj)
-	if err != nil {
-		return errors.Wrapf(err, "updating %s/%s resource status", obj.GetNamespace(), obj.GetName())
-	}
-
-	return nil
-}
 
 func IgnoreNotFoundAndConflict(err error) error {
 	if apierrors.IsConflict(err) {

--- a/v2/internal/resolver/resolver.go
+++ b/v2/internal/resolver/resolver.go
@@ -74,8 +74,8 @@ func (r *Resolver) ResolveReferencesToARMIDs(ctx context.Context, refs map[genru
 	return genruntime.MakeResolvedReferences(result), nil
 }
 
-// ResolveResourceReferences resolves every reference found on the specified genruntime.MetaObject to its corresponding ARM ID.
-func (r *Resolver) ResolveResourceReferences(ctx context.Context, metaObject genruntime.MetaObject) (genruntime.ResolvedReferences, error) {
+// ResolveResourceReferences resolves every reference found on the specified genruntime.ARMMetaObject to its corresponding ARM ID.
+func (r *Resolver) ResolveResourceReferences(ctx context.Context, metaObject genruntime.ARMMetaObject) (genruntime.ResolvedReferences, error) {
 	refs, err := reflecthelpers.FindResourceReferences(metaObject)
 	if err != nil {
 		return genruntime.ResolvedReferences{}, errors.Wrapf(err, "finding references on %q", metaObject.GetName())
@@ -98,7 +98,7 @@ func (r *Resolver) ResolveResourceReferences(ctx context.Context, metaObject gen
 
 // ResolveResourceHierarchy gets the resource hierarchy for a given resource. The result is a slice of
 // resources, with the uppermost parent at position 0 and the resource itself at position len(slice)-1
-func (r *Resolver) ResolveResourceHierarchy(ctx context.Context, obj genruntime.MetaObject) (ResourceHierarchy, error) {
+func (r *Resolver) ResolveResourceHierarchy(ctx context.Context, obj genruntime.ARMMetaObject) (ResourceHierarchy, error) {
 	owner := obj.Owner()
 	if owner == nil {
 		return ResourceHierarchy{obj}, nil
@@ -118,7 +118,7 @@ func (r *Resolver) ResolveResourceHierarchy(ctx context.Context, obj genruntime.
 }
 
 // ResolveReference resolves a reference, or returns an error if the reference is not pointing to a KubernetesResource
-func (r *Resolver) ResolveReference(ctx context.Context, ref genruntime.NamespacedResourceReference) (genruntime.MetaObject, error) {
+func (r *Resolver) ResolveReference(ctx context.Context, ref genruntime.NamespacedResourceReference) (genruntime.ARMMetaObject, error) {
 	refGVK, err := r.findGVK(ref)
 	if err != nil {
 		return nil, err
@@ -139,9 +139,9 @@ func (r *Resolver) ResolveReference(ctx context.Context, ref genruntime.Namespac
 		return nil, errors.Wrapf(err, "couldn't resolve reference %s", ref.String())
 	}
 
-	metaObj, ok := refObj.(genruntime.MetaObject)
+	metaObj, ok := refObj.(genruntime.ARMMetaObject)
 	if !ok {
-		return nil, errors.Errorf("reference %s (%s) was not of type genruntime.MetaObject", refNamespacedName, refGVK)
+		return nil, errors.Errorf("reference %s (%s) was not of type genruntime.ARMMetaObject", refNamespacedName, refGVK)
 	}
 
 	return metaObj, nil
@@ -150,7 +150,7 @@ func (r *Resolver) ResolveReference(ctx context.Context, ref genruntime.Namespac
 // ResolveOwner returns the MetaObject for the given resources owner. If the resource is supposed to have
 // an owner but doesn't, this returns an ReferenceNotFound error. If the resource is not supposed
 // to have an owner (for example, ResourceGroup), returns nil.
-func (r *Resolver) ResolveOwner(ctx context.Context, obj genruntime.MetaObject) (genruntime.MetaObject, error) {
+func (r *Resolver) ResolveOwner(ctx context.Context, obj genruntime.ARMMetaObject) (genruntime.ARMMetaObject, error) {
 	owner := obj.Owner()
 
 	if owner == nil {
@@ -198,8 +198,8 @@ func (r *Resolver) ResolveSecretReferences(
 	return r.kubeSecretResolver.ResolveSecretReferences(ctx, refs)
 }
 
-// ResolveResourceSecretReferences resolves all of the specified genruntime.MetaObject's secret references.
-func (r *Resolver) ResolveResourceSecretReferences(ctx context.Context, metaObject genruntime.MetaObject) (genruntime.ResolvedSecrets, error) {
+// ResolveResourceSecretReferences resolves all of the specified genruntime.ARMMetaObject's secret references.
+func (r *Resolver) ResolveResourceSecretReferences(ctx context.Context, metaObject genruntime.ARMMetaObject) (genruntime.ResolvedSecrets, error) {
 	refs, err := reflecthelpers.FindSecretReferences(metaObject)
 	if err != nil {
 		return genruntime.ResolvedSecrets{}, errors.Wrapf(err, "finding secrets on %q", metaObject.GetName())
@@ -220,9 +220,9 @@ func (r *Resolver) ResolveResourceSecretReferences(ctx context.Context, metaObje
 	return resolvedSecrets, nil
 }
 
-// ResolveAll resolves every reference on the provided genruntime.MetaObject.
+// ResolveAll resolves every reference on the provided genruntime.ARMMetaObject.
 // This includes: owner, all resource references, and all secrets.
-func (r *Resolver) ResolveAll(ctx context.Context, metaObject genruntime.MetaObject) (ResourceHierarchy, genruntime.ConvertToARMResolvedDetails, error) {
+func (r *Resolver) ResolveAll(ctx context.Context, metaObject genruntime.ARMMetaObject) (ResourceHierarchy, genruntime.ConvertToARMResolvedDetails, error) {
 	// Resolve the resource hierarchy (owner)
 	resourceHierarchy, err := r.ResolveResourceHierarchy(ctx, metaObject)
 	if err != nil {

--- a/v2/internal/resolver/resolver_test.go
+++ b/v2/internal/resolver/resolver_test.go
@@ -109,7 +109,7 @@ func createResourceGroup(name string) *resources.ResourceGroup {
 	}
 }
 
-func createResourceGroupRootedResource(rgName string, name string) (genruntime.MetaObject, genruntime.MetaObject) {
+func createResourceGroupRootedResource(rgName string, name string) (genruntime.ARMMetaObject, genruntime.ARMMetaObject) {
 	a := createResourceGroup(rgName)
 
 	b := &batch.BatchAccount{
@@ -171,7 +171,7 @@ func createDeeplyNestedResource(rgName string, parentName string, name string) r
 	return resolver.ResourceHierarchy{a, b, c}
 }
 
-func createSimpleExtensionResource(name string, ownerName string, ownerGVK schema.GroupVersionKind) genruntime.MetaObject {
+func createSimpleExtensionResource(name string, ownerName string, ownerGVK schema.GroupVersionKind) genruntime.ARMMetaObject {
 	return &testcommon.SimpleExtensionResource{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SimpleExtensionResource",
@@ -192,7 +192,7 @@ func createSimpleExtensionResource(name string, ownerName string, ownerGVK schem
 	}
 }
 
-func createExtensionResourceOnResourceGroup(rgName string, name string) (genruntime.MetaObject, genruntime.MetaObject) {
+func createExtensionResourceOnResourceGroup(rgName string, name string) (genruntime.ARMMetaObject, genruntime.ARMMetaObject) {
 	a := createResourceGroup(rgName)
 	gvk := a.GetObjectKind().GroupVersionKind()
 	b := createSimpleExtensionResource(name, a.GetName(), gvk)

--- a/v2/internal/resolver/resource_hierarchy.go
+++ b/v2/internal/resolver/resource_hierarchy.go
@@ -26,7 +26,7 @@ const (
 const ResourceGroupKind = "ResourceGroup"
 const ResourceGroupGroup = "resources.azure.com"
 
-type ResourceHierarchy []genruntime.MetaObject
+type ResourceHierarchy []genruntime.ARMMetaObject
 
 // ResourceGroup returns the resource group that the hierarchy is in, or an error if the hierarchy is not rooted
 // in a resource group.
@@ -158,7 +158,7 @@ func (h ResourceHierarchy) getAzureNames() []string {
 	return azureNames
 }
 
-func getResourceTypeAndProvider(res genruntime.MetaObject) (string, []string, error) {
+func getResourceTypeAndProvider(res genruntime.ARMMetaObject) (string, []string, error) {
 	rawType := res.GetType()
 
 	split := strings.Split(rawType, "/")

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -100,7 +100,7 @@ func createSharedEnvTest(cfg testConfig, namespaceResources *namespaceResources)
 		return nil, errors.Wrapf(err, "creating controller-runtime manager")
 	}
 
-	var clientFactory arm.ARMClientFactory = func(mo genruntime.MetaObject) *genericarmclient.GenericClient {
+	var clientFactory arm.ARMClientFactory = func(mo genruntime.ARMMetaObject) *genericarmclient.GenericClient {
 		result := namespaceResources.Lookup(mo.GetNamespace())
 		if result == nil {
 			panic(fmt.Sprintf("unable to locate ARM client for namespace %s; tests should only create resources in the namespace they are assigned or have declared via TargetNamespaces",

--- a/v2/pkg/genruntime/admissions.go
+++ b/v2/pkg/genruntime/admissions.go
@@ -30,7 +30,7 @@ type Defaulter interface {
 }
 
 // ValidateWriteOnceProperties function validates the update on WriteOnce properties.
-func ValidateWriteOnceProperties(oldObj MetaObject, newObj MetaObject) error {
+func ValidateWriteOnceProperties(oldObj ARMMetaObject, newObj ARMMetaObject) error {
 	var errs []error
 
 	if !IsResourceCreatedSuccessfully(newObj) {
@@ -49,6 +49,6 @@ func ValidateWriteOnceProperties(oldObj MetaObject, newObj MetaObject) error {
 	return kerrors.NewAggregate(errs)
 }
 
-func IsResourceCreatedSuccessfully(obj MetaObject) bool {
+func IsResourceCreatedSuccessfully(obj ARMMetaObject) bool {
 	return GetResourceIDOrDefault(obj) != ""
 }

--- a/v2/pkg/genruntime/arm_id.go
+++ b/v2/pkg/genruntime/arm_id.go
@@ -11,11 +11,25 @@ import (
 )
 
 // GetAndParseResourceID gets the ARM ID from the given MetaObject and parses it into its constituent parts
-func GetAndParseResourceID(obj MetaObject) (*arm.ResourceID, error) {
+func GetAndParseResourceID(obj ARMMetaObject) (*arm.ResourceID, error) {
 	resourceID, hasResourceID := GetResourceID(obj)
 	if !hasResourceID {
 		return nil, errors.Errorf("cannot find resource id for obj %s/%s", obj.GetNamespace(), obj.GetName())
 	}
 
 	return arm.ParseResourceID(resourceID)
+}
+
+// TODO: We really want these methods to be on ARMMetaObject itself -- should update code generator to make them at some point
+func GetResourceID(obj ARMMetaObject) (string, bool) {
+	result, ok := obj.GetAnnotations()[ResourceIDAnnotation]
+	return result, ok
+}
+
+func GetResourceIDOrDefault(obj ARMMetaObject) string {
+	return obj.GetAnnotations()[ResourceIDAnnotation]
+}
+
+func SetResourceID(obj ARMMetaObject, id string) {
+	AddAnnotation(obj, ResourceIDAnnotation, id)
 }

--- a/v2/pkg/genruntime/convertible_spec.go
+++ b/v2/pkg/genruntime/convertible_spec.go
@@ -47,13 +47,13 @@ type ConvertibleSpec interface {
 
 // GetVersionedSpec returns a versioned spec for the provided resource; the original API version used when the
 // resource was first created is used to identify the version to return
-func GetVersionedSpec(metaObject MetaObject, scheme *runtime.Scheme) (ConvertibleSpec, error) {
+func GetVersionedSpec(metaObject ARMMetaObject, scheme *runtime.Scheme) (ConvertibleSpec, error) {
 	return GetVersionedSpecFromGVK(metaObject, scheme, GetOriginalGVK(metaObject))
 }
 
 // GetVersionedSpecFromGVK returns a versioned spec for the provided resource; the original API version used when the
 // resource was first created is used to identify the version to return
-func GetVersionedSpecFromGVK(metaObject MetaObject, scheme *runtime.Scheme, gvk schema.GroupVersionKind) (ConvertibleSpec, error) {
+func GetVersionedSpecFromGVK(metaObject ARMMetaObject, scheme *runtime.Scheme, gvk schema.GroupVersionKind) (ConvertibleSpec, error) {
 	rsrc, err := NewEmptyVersionedResourceFromGVK(scheme, gvk)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting versioned spec")

--- a/v2/pkg/genruntime/convertible_status.go
+++ b/v2/pkg/genruntime/convertible_status.go
@@ -25,7 +25,7 @@ type ConvertibleStatus interface {
 
 // GetVersionedStatus returns a versioned status for the provided resource; the original API version used when the
 // resource was first created is used to identify the version to return
-func GetVersionedStatus(metaObject MetaObject, scheme *runtime.Scheme) (ConvertibleStatus, error) {
+func GetVersionedStatus(metaObject ARMMetaObject, scheme *runtime.Scheme) (ConvertibleStatus, error) {
 	rsrc, err := NewEmptyVersionedResource(metaObject, scheme)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting versioned status")
@@ -48,12 +48,12 @@ func GetVersionedStatus(metaObject MetaObject, scheme *runtime.Scheme) (Converti
 
 // NewEmptyVersionedStatus returns a blank versioned status for the provided resource; the original API version used
 // when the resource was first created is used to identify the version to return
-func NewEmptyVersionedStatus(metaObject MetaObject, scheme *runtime.Scheme) (ConvertibleStatus, error) {
+func NewEmptyVersionedStatus(metaObject ARMMetaObject, scheme *runtime.Scheme) (ConvertibleStatus, error) {
 	return NewEmptyVersionedStatusFromGVK(metaObject, scheme, GetOriginalGVK(metaObject))
 }
 
 // NewEmptyVersionedStatusFromGVK returns a blank versioned status for the provided resource and GVK
-func NewEmptyVersionedStatusFromGVK(metaObject MetaObject, scheme *runtime.Scheme, gvk schema.GroupVersionKind) (ConvertibleStatus, error) {
+func NewEmptyVersionedStatusFromGVK(metaObject ARMMetaObject, scheme *runtime.Scheme, gvk schema.GroupVersionKind) (ConvertibleStatus, error) {
 	rsrc, err := NewEmptyVersionedResourceFromGVK(scheme, gvk)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating new empty versioned status")
@@ -70,7 +70,7 @@ func NewEmptyVersionedStatusFromGVK(metaObject MetaObject, scheme *runtime.Schem
 
 // NewEmptyARMStatus returns an empty ARM status object ready for deserialization from ARM; the original API version
 // used when the resource was first created is used to create the appropriate version
-func NewEmptyARMStatus(metaObject MetaObject, scheme *runtime.Scheme) (ARMResourceStatus, error) {
+func NewEmptyARMStatus(metaObject ARMMetaObject, scheme *runtime.Scheme) (ARMResourceStatus, error) {
 	status, err := GetVersionedStatus(metaObject, scheme)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating ARM status")

--- a/v2/pkg/genruntime/extensions/arm_resource_modifier.go
+++ b/v2/pkg/genruntime/extensions/arm_resource_modifier.go
@@ -24,13 +24,13 @@ type ARMResourceModifier interface {
 	ModifyARMResource(
 		ctx context.Context,
 		armObj genruntime.ARMResource,
-		obj genruntime.MetaObject,
+		obj genruntime.ARMMetaObject,
 		kubeClient kubeclient.Client,
 		resolver *resolver.Resolver,
 		log logr.Logger) (genruntime.ARMResource, error)
 }
 
-type ARMResourceModifierFunc = func(ctx context.Context, obj genruntime.MetaObject, armObj genruntime.ARMResource) (genruntime.ARMResource, error)
+type ARMResourceModifierFunc = func(ctx context.Context, obj genruntime.ARMMetaObject, armObj genruntime.ARMResource) (genruntime.ARMResource, error)
 
 // CreateARMResourceModifier returns a function that performs per-resource modifications. If the ARMResourceModifier extension has
 // not been implemented for the resource in question, the default behavior is to return the provided genruntime.ARMResource unmodified.
@@ -42,12 +42,12 @@ func CreateARMResourceModifier(
 
 	impl, ok := host.(ARMResourceModifier)
 	if !ok {
-		return func(ctx context.Context, obj genruntime.MetaObject, armObj genruntime.ARMResource) (genruntime.ARMResource, error) {
+		return func(ctx context.Context, obj genruntime.ARMMetaObject, armObj genruntime.ARMResource) (genruntime.ARMResource, error) {
 			return armObj, nil
 		}
 	}
 
-	return func(ctx context.Context, obj genruntime.MetaObject, armObj genruntime.ARMResource) (genruntime.ARMResource, error) {
+	return func(ctx context.Context, obj genruntime.ARMMetaObject, armObj genruntime.ARMResource) (genruntime.ARMResource, error) {
 		log.V(Info).Info("Modifying ARM payload")
 
 		armResource, err := impl.ModifyARMResource(ctx, armObj, obj, kubeClient, resolver, log)

--- a/v2/pkg/genruntime/extensions/secrets_retriever.go
+++ b/v2/pkg/genruntime/extensions/secrets_retriever.go
@@ -24,12 +24,12 @@ type SecretsRetriever interface {
 	// will write the secrets to their destination.
 	RetrieveSecrets(
 		ctx context.Context,
-		obj genruntime.MetaObject,
+		obj genruntime.ARMMetaObject,
 		armClient *genericarmclient.GenericClient,
 		log logr.Logger) ([]*corev1.Secret, error)
 }
 
-type SecretRetrievalFunc = func(obj genruntime.MetaObject) ([]*corev1.Secret, error)
+type SecretRetrievalFunc = func(obj genruntime.ARMMetaObject) ([]*corev1.Secret, error)
 
 // CreateSecretRetriever creates a function to retrieve secrets from Azure. If the resource
 // in question has not been configured with the SecretsRetriever extension, the returned function
@@ -42,12 +42,12 @@ func CreateSecretRetriever(
 
 	impl, ok := host.(SecretsRetriever)
 	if !ok {
-		return func(obj genruntime.MetaObject) ([]*corev1.Secret, error) {
+		return func(obj genruntime.ARMMetaObject) ([]*corev1.Secret, error) {
 			return nil, nil
 		}
 	}
 
-	return func(obj genruntime.MetaObject) ([]*corev1.Secret, error) {
+	return func(obj genruntime.ARMMetaObject) ([]*corev1.Secret, error) {
 		log.V(Info).Info("Retrieving secrets from Azure")
 		secrets, err := impl.RetrieveSecrets(ctx, obj, armClient, log)
 		if err != nil {

--- a/v2/pkg/genruntime/group_version_kind_aware.go
+++ b/v2/pkg/genruntime/group_version_kind_aware.go
@@ -17,7 +17,7 @@ type GroupVersionKindAware interface {
 }
 
 // GetOriginalGVK gets the GVK the original GVK the object was created with.
-func GetOriginalGVK(obj MetaObject) schema.GroupVersionKind {
+func GetOriginalGVK(obj ARMMetaObject) schema.GroupVersionKind {
 	// If our current resource is aware of its original GVK, use that for our result
 	aware, ok := obj.(GroupVersionKindAware)
 	if ok {

--- a/v2/pkg/genruntime/kubernetes_resource.go
+++ b/v2/pkg/genruntime/kubernetes_resource.go
@@ -9,14 +9,11 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
 )
 
 // KubernetesResource is an Azure resource. This interface contains the common set of
-// methods that apply to all ASO resources.
+// methods that apply to all ASO ARM resources.
 type KubernetesResource interface {
-	conditions.Conditioner
 
 	// Owner returns the ResourceReference of the owner, or nil if there is no owner
 	Owner() *ResourceReference
@@ -57,12 +54,12 @@ type KubernetesResource interface {
 // NewEmptyVersionedResource returns a new blank resource based on the passed metaObject; the original API version used
 // (if available) from when the resource was first created is used to identify the version to return.
 // Returns an empty resource.
-func NewEmptyVersionedResource(metaObject MetaObject, scheme *runtime.Scheme) (MetaObject, error) {
+func NewEmptyVersionedResource(metaObject ARMMetaObject, scheme *runtime.Scheme) (ARMMetaObject, error) {
 	return NewEmptyVersionedResourceFromGVK(scheme, GetOriginalGVK(metaObject))
 }
 
 // NewEmptyVersionedResourceFromGVK creates a new empty versioned resource from the specified GVK
-func NewEmptyVersionedResourceFromGVK(scheme *runtime.Scheme, gvk schema.GroupVersionKind) (MetaObject, error) {
+func NewEmptyVersionedResourceFromGVK(scheme *runtime.Scheme, gvk schema.GroupVersionKind) (ARMMetaObject, error) {
 	// Create an empty resource at the desired version
 	rsrc, err := scheme.New(gvk)
 	if err != nil {
@@ -70,9 +67,9 @@ func NewEmptyVersionedResourceFromGVK(scheme *runtime.Scheme, gvk schema.GroupVe
 	}
 
 	// Convert it to our interface
-	mo, ok := rsrc.(MetaObject)
+	mo, ok := rsrc.(ARMMetaObject)
 	if !ok {
-		return nil, errors.Errorf("expected resource %s to implement genruntime.MetaObject", gvk)
+		return nil, errors.Errorf("expected resource %s to implement genruntime.ARMMetaObject", gvk)
 	}
 
 	// Ensure GVK is populated


### PR DESCRIPTION
Change type hierarchy so that MetaObject doesn't assume a resource exists in ARM.

In the future, the GenericController must function on types that aren't ARM resources, such as MySQL Users.