### PR TITLE
Simply access to Group and Version

### DIFF
--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -54,12 +54,12 @@ func (pr ExternalPackageReference) String() string {
 	return pr.packagePath
 }
 
-// GroupVersion returns the group and version of this local reference.
+// TryGroupVersion returns the group and version of this external reference.
 func (pr ExternalPackageReference) TryGroupVersion() (string, string, bool) {
 	return "", "", false
 }
 
-// MustGroupVersion triggers a panic because external references don't have a group or version
+// GroupVersion triggers a panic because external references don't have a group or version
 func (pr ExternalPackageReference) GroupVersion() (string, string) {
 	panic(fmt.Sprintf("external package reference %s doesn't have a group or version", pr))
 }

--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -55,6 +55,6 @@ func (pr ExternalPackageReference) String() string {
 }
 
 // GroupVersion returns the group and version of this local reference.
-func (pr ExternalPackageReference) GroupVersion() (string, string, bool) {
+func (pr ExternalPackageReference) TryGroupVersion() (string, string, bool) {
 	return "", "", false
 }

--- a/v2/tools/generator/internal/astmodel/external_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/external_package_reference.go
@@ -58,3 +58,8 @@ func (pr ExternalPackageReference) String() string {
 func (pr ExternalPackageReference) TryGroupVersion() (string, string, bool) {
 	return "", "", false
 }
+
+// MustGroupVersion triggers a panic because external references don't have a group or version
+func (pr ExternalPackageReference) GroupVersion() (string, string) {
+	panic(fmt.Sprintf("external package reference %s doesn't have a group or version", pr))
+}

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -116,7 +116,7 @@ func IsLocalPackageReference(ref PackageReference) bool {
 }
 
 // GroupVersion returns the group and version of this local reference.
-func (pr LocalPackageReference) GroupVersion() (string, string, bool) {
+func (pr LocalPackageReference) TryGroupVersion() (string, string, bool) {
 	return pr.group, pr.Version(), true
 }
 

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -115,12 +115,12 @@ func IsLocalPackageReference(ref PackageReference) bool {
 	return ok
 }
 
-// GroupVersion returns the group and version of this local reference.
+// TryGroupVersion returns the group and version of this local reference.
 func (pr LocalPackageReference) TryGroupVersion() (string, string, bool) {
 	return pr.group, pr.Version(), true
 }
 
-// MustGroupVersion returns the group and version of this local reference.
+// GroupVersion returns the group and version of this local reference.
 func (pr LocalPackageReference) GroupVersion() (string, string) {
 	return pr.group, pr.Version()
 }

--- a/v2/tools/generator/internal/astmodel/local_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/local_package_reference.go
@@ -120,6 +120,11 @@ func (pr LocalPackageReference) TryGroupVersion() (string, string, bool) {
 	return pr.group, pr.Version(), true
 }
 
+// MustGroupVersion returns the group and version of this local reference.
+func (pr LocalPackageReference) GroupVersion() (string, string) {
+	return pr.group, pr.Version()
+}
+
 // sanitizePackageName removes all non-alphanumeric characters and converts to lower case
 func sanitizePackageName(input string) string {
 	var builder = make([]rune, 0, len(input))

--- a/v2/tools/generator/internal/astmodel/package_import_set.go
+++ b/v2/tools/generator/internal/astmodel/package_import_set.go
@@ -186,7 +186,7 @@ func (set *PackageImportSet) orderImports(i PackageImport, j PackageImport) bool
 func (set *PackageImportSet) createMapByGroup() map[string][]PackageImport {
 	result := make(map[string][]PackageImport)
 	for _, imp := range set.imports {
-		group, _, ok := imp.packageReference.GroupVersion()
+		group, _, ok := imp.packageReference.TryGroupVersion()
 		if !ok {
 			continue
 		}

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -31,6 +31,8 @@ type PackageReference interface {
 	// GroupVersion returns the group and version of this reference.
 	// Returns true if the reference has a group and version, false otherwise.
 	TryGroupVersion() (string, string, bool)
+	// MustGroupVersion returns the group and version of this reference, triggering a panic if they aren't available
+	GroupVersion() (string, string)
 }
 
 // IsExternalPackageReference returns true if the provided reference is external

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -28,10 +28,10 @@ type PackageReference interface {
 	// IsPreview returns true if this package reference has a suffix indicating it's a preview
 	// release, false otherwise
 	IsPreview() bool
-	// GroupVersion returns the group and version of this reference.
+	// TryGroupVersion returns the group and version of this reference.
 	// Returns true if the reference has a group and version, false otherwise.
 	TryGroupVersion() (string, string, bool)
-	// MustGroupVersion returns the group and version of this reference, triggering a panic if they aren't available
+	// GroupVersion returns the group and version of this reference, triggering a panic if they aren't available
 	GroupVersion() (string, string)
 }
 

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -246,7 +246,7 @@ func (v *versionComparer) IsZero(r rune) bool {
 
 // previewVersionLabels is a sequence of specially treated identifiers
 // These come before all others and are compared in the order listed here
-var previewVersionLabels []string = []string{
+var previewVersionLabels = []string{
 	"alpha",
 	"beta",
 	"preview",

--- a/v2/tools/generator/internal/astmodel/package_reference.go
+++ b/v2/tools/generator/internal/astmodel/package_reference.go
@@ -30,7 +30,7 @@ type PackageReference interface {
 	IsPreview() bool
 	// GroupVersion returns the group and version of this reference.
 	// Returns true if the reference has a group and version, false otherwise.
-	GroupVersion() (string, string, bool)
+	TryGroupVersion() (string, string, bool)
 }
 
 // IsExternalPackageReference returns true if the provided reference is external

--- a/v2/tools/generator/internal/astmodel/property_reference.go
+++ b/v2/tools/generator/internal/astmodel/property_reference.go
@@ -43,6 +43,6 @@ func (ref PropertyReference) IsEmpty() bool {
 
 // String returns a string representation of this property reference
 func (ref PropertyReference) String() string {
-	g, v, _ := ref.declaringType.PackageReference.GroupVersion()
+	g, v := ref.declaringType.PackageReference.GroupVersion()
 	return fmt.Sprintf("%s/%s/%s.%s", g, v, ref.declaringType.Name(), ref.property)
 }

--- a/v2/tools/generator/internal/astmodel/resource_type.go
+++ b/v2/tools/generator/internal/astmodel/resource_type.go
@@ -548,10 +548,7 @@ func (resource *ResourceType) AsDeclarations(codeGenerationContext *CodeGenerati
 
 	// Add required RBAC annotations, only on storage version
 	if resource.isStorageVersion {
-		group, _, ok := declContext.Name.PackageReference.GroupVersion()
-		if !ok {
-			panic(fmt.Sprintf("expected resource package reference to be local: %q", declContext.Name))
-		}
+		group, _ := declContext.Name.PackageReference.GroupVersion()
 		group = strings.ToLower(group + GroupSuffix)
 		resourceName := strings.ToLower(declContext.Name.Plural().Name())
 

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -73,6 +73,12 @@ func (s StoragePackageReference) TryGroupVersion() (string, string, bool) {
 	return g, v + StoragePackageSuffix, true
 }
 
+// MustGroupVersion returns the group and version of this storage reference.
+func (s StoragePackageReference) GroupVersion() (string, string) {
+	g, v := s.inner.GroupVersion()
+	return g, v + StoragePackageSuffix
+}
+
 // Local returns the local package reference wrapped by this reference
 func (s StoragePackageReference) Local() LocalPackageReference {
 	return s.inner

--- a/v2/tools/generator/internal/astmodel/storage_package_reference.go
+++ b/v2/tools/generator/internal/astmodel/storage_package_reference.go
@@ -67,9 +67,9 @@ func IsStoragePackageReference(reference PackageReference) bool {
 	return ok
 }
 
-// GroupVersion returns the group and version of this local reference.
-func (s StoragePackageReference) GroupVersion() (string, string, bool) {
-	g, v, _ := s.inner.GroupVersion()
+// TryGroupVersion returns the group and version of this storage reference.
+func (s StoragePackageReference) TryGroupVersion() (string, string, bool) {
+	g, v, _ := s.inner.TryGroupVersion()
 	return g, v + StoragePackageSuffix, true
 }
 

--- a/v2/tools/generator/internal/astmodel/type_definition_test.go
+++ b/v2/tools/generator/internal/astmodel/type_definition_test.go
@@ -33,7 +33,7 @@ func Test_MakeTypeDefinition_GivenValues_InitializesProperties(t *testing.T) {
 	g.Expect(objectDefinition.Name().name).To(Equal(name))
 	g.Expect(objectDefinition.Type()).To(Equal(objectType))
 
-	actualGroup, actualVersion, ok := objectDefinition.Name().PackageReference.GroupVersion()
+	actualGroup, actualVersion, ok := objectDefinition.Name().PackageReference.TryGroupVersion()
 	g.Expect(ok).To(BeTrue())
 	g.Expect(actualGroup).To(Equal(group))
 	g.Expect(actualVersion).To(Equal(pkg))

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -269,12 +269,7 @@ func exportPackagesTestPipelineStage(t *testing.T, testName string) *pipeline.St
 				ref := def.Name().PackageReference
 				pkg, ok := pkgs[ref]
 				if !ok {
-					// expected to always be ok because we don't use external package references for type definitions
-					g, v, ok := ref.GroupVersion()
-					if !ok {
-						t.Fatalf("didn't expect package reference %s", ref)
-					}
-
+					g, v := ref.GroupVersion()
 					pkg = astmodel.NewPackageDefinition(g, v)
 					pkgs[ref] = pkg
 

--- a/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_arm_conversion_interface.go
@@ -249,15 +249,9 @@ func (c *armConversionApplier) addARMConversionInterface(
 }
 
 func (c *armConversionApplier) createOwnerProperty(ownerTypeName *astmodel.TypeName) (*astmodel.PropertyDefinition, error) {
-	ref := ownerTypeName.PackageReference
-	var group string
-	var kind string
-	if grp, _, ok := ref.GroupVersion(); ok {
-		group = grp + astmodel.GroupSuffix
-		kind = ownerTypeName.Name()
-	} else {
-		return nil, errors.Errorf("owners from external package %s not currently supported", ref)
-	}
+	grp, _ := ownerTypeName.PackageReference.GroupVersion()
+	group := grp + astmodel.GroupSuffix
+	kind := ownerTypeName.Name()
 
 	prop := astmodel.NewPropertyDefinition(
 		c.idFactory.CreatePropertyName(astmodel.OwnerProperty, astmodel.Exported),

--- a/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
+++ b/v2/tools/generator/internal/codegen/pipeline/check_for_anytype.go
@@ -97,7 +97,7 @@ func containsAnyType(theType astmodel.Type) bool {
 }
 
 func packageName(name astmodel.TypeName) string {
-	if group, version, ok := name.PackageReference.GroupVersion(); ok {
+	if group, version, ok := name.PackageReference.TryGroupVersion(); ok {
 		return group + "/" + version
 	}
 

--- a/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_resource_extension_types.go
@@ -30,7 +30,7 @@ func CreateResourceExtensions(localPath string, idFactory astmodel.IdentifierFac
 
 			// Iterate through resource types and aggregate the resource types that share the same extension type in a map.
 			for _, typeDef := range resourceDefs {
-				group, _, _ := typeDef.Name().PackageReference.GroupVersion()
+				group, _ := typeDef.Name().PackageReference.GroupVersion()
 				packageRef := astmodel.MakeLocalPackageReference(
 					localPath,
 					group,

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -164,10 +164,7 @@ func makeUniqueIndexMethodName(
 
 	lastProp := propertyChain[len(propertyChain)-1]
 
-	group, _, ok := resourceTypeName.PackageReference.GroupVersion()
-	if !ok {
-		panic(fmt.Sprintf("cannot generate index method for type %s", resourceTypeName.String()))
-	}
+	group, _ := resourceTypeName.PackageReference.GroupVersion()
 	return fmt.Sprintf("index%s%s%s",
 		idFactory.CreateIdentifier(group, astmodel.Exported),
 		resourceTypeName.Name(),

--- a/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_generated_code.go
@@ -55,12 +55,7 @@ func CreatePackagesForDefinitions(definitions astmodel.TypeDefinitionSet) (map[a
 	for _, def := range definitions {
 		name := def.Name()
 		ref := name.PackageReference
-		group, version, ok := ref.GroupVersion()
-		if !ok {
-			klog.Errorf("Definition %s from external package %s skipped", name.Name(), ref)
-			continue
-		}
-
+		group, version := ref.GroupVersion()
 		if pkg, ok := packages[ref]; ok {
 			pkg.AddDefinition(def)
 		} else {

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -105,11 +105,7 @@ func groupResourcesByVersion(definitions astmodel.TypeDefinitionSet) (map[unvers
 
 func getUnversionedName(name astmodel.TypeName) (unversionedName, error) {
 	ref := name.PackageReference
-	group, _, ok := ref.GroupVersion()
-	if !ok {
-		return unversionedName{}, errors.Errorf("cannot get unversioned name for external reference %s", ref)
-	}
-
+	group, _ := ref.GroupVersion()
 	return unversionedName{group, name.Name()}, nil
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
+++ b/v2/tools/generator/internal/codegen/pipeline/mark_latest_api_version_as_storage_version.go
@@ -74,7 +74,7 @@ func groupResourcesByVersion(definitions astmodel.TypeDefinitionSet) (map[unvers
 
 	for _, def := range definitions {
 
-		// We want to explicitly avoid storage definitions, as as this approach for flagging the hub version is
+		// We want to explicitly avoid storage definitions, as this approach for flagging the hub version is
 		// used when we aren't leveraging the conversions between storage versions.
 		if astmodel.IsStoragePackageReference(def.Name().PackageReference) {
 			continue

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -14,10 +14,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
-
 	"github.com/Azure/azure-service-operator/v2/internal/set"
+	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -68,13 +66,7 @@ func (report *ResourceVersionsReport) summarize(definitions astmodel.TypeDefinit
 			continue
 		}
 
-		grp, _, ok := pkg.GroupVersion()
-		if !ok {
-			// Any external packages we encounter here  are odd, but not worth aborting our run over
-			klog.V(3).Infof("Skipping external package %s while generating resource version report", pkg.String())
-			continue
-		}
-
+		grp, _ := pkg.GroupVersion()
 		report.groups.Add(grp)
 		report.lists[pkg] = append(report.lists[pkg], rsrc)
 

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph.go
@@ -6,8 +6,6 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -25,11 +23,7 @@ type ConversionGraph struct {
 // Returns the end and true if it's found, or nil and false if not.
 func (graph *ConversionGraph) LookupTransition(ref astmodel.PackageReference) (astmodel.PackageReference, bool) {
 	// Expect to get either a local or a storage reference, not an external one
-	group, _, ok := ref.GroupVersion()
-	if !ok {
-		panic(fmt.Sprintf("cannot use external package reference %s with a conversion graph", ref))
-	}
-
+	group, _ := ref.GroupVersion()
 	subgraph, ok := graph.subGraphs[group]
 	if !ok {
 		return nil, false
@@ -178,11 +172,7 @@ func (graph *ConversionGraph) searchForRenamedType(
 	// Validity check on the type-rename to verify that it specifies a type that exists.
 	// If we didn't find the type, the configured rename is invalid
 	if result.IsEmpty() {
-		group, version, ok := name.PackageReference.GroupVersion()
-		if !ok {
-			panic(fmt.Sprintf("never expected external reference %s", name.PackageReference))
-		}
-
+		group, version := name.PackageReference.GroupVersion()
 		return astmodel.EmptyTypeName, -1, errors.Errorf(
 			"rename of %s/%s/%s invalid because no type with name %s was found in any later version",
 			group,

--- a/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
+++ b/v2/tools/generator/internal/codegen/storage/conversion_graph_builder.go
@@ -6,8 +6,6 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
@@ -71,11 +69,7 @@ func (b *ConversionGraphBuilder) Build() (*ConversionGraph, error) {
 // getSubBuilder finds the relevant builder for the group of the provided reference, creating one if necessary
 func (b *ConversionGraphBuilder) getSubBuilder(ref astmodel.PackageReference) *GroupConversionGraphBuilder {
 	// Expect to get either a local or a storage reference, not an external one
-	group, _, ok := ref.GroupVersion()
-	if !ok {
-		panic(fmt.Sprintf("cannot use external package reference %s with a conversion graph", ref))
-	}
-
+	group, _ := ref.GroupVersion()
 	subBuilder, ok := b.subBuilders[group]
 	if !ok {
 		subBuilder = NewGroupConversionGraphBuilder(group, b.versionPrefix)

--- a/v2/tools/generator/internal/config/object_model_configuration.go
+++ b/v2/tools/generator/internal/config/object_model_configuration.go
@@ -302,12 +302,7 @@ func (omc *ObjectModelConfiguration) visitGroups(visitor *configurationVisitor) 
 
 // findGroup uses the provided TypeName to work out which nested GroupConfiguration should be used
 func (omc *ObjectModelConfiguration) findGroup(ref astmodel.PackageReference) (*GroupConfiguration, error) {
-	group, _, ok := ref.GroupVersion()
-	if !ok {
-		return nil, errors.Errorf(
-			"external package reference %s not supported",
-			ref)
-	}
+	group, _ := ref.GroupVersion()
 
 	if omc == nil || omc.groups == nil {
 		msg := fmt.Sprintf("no configuration for group %s", group)
@@ -376,13 +371,7 @@ func (omc *ObjectModelConfiguration) configuredGroups() []string {
 func (omc *ObjectModelConfiguration) ModifyGroup(
 	ref astmodel.PackageReference,
 	action func(configuration *GroupConfiguration) error) error {
-	groupName, _, ok := ref.GroupVersion()
-	if !ok {
-		return errors.Errorf(
-			"external package reference %s not supported",
-			ref)
-	}
-
+	groupName, _ := ref.GroupVersion()
 	grp, err := omc.findGroup(ref)
 	if err != nil && !IsNotConfiguredError(err) {
 		return errors.Wrapf(err, "configuring groupName %s", groupName)
@@ -402,13 +391,7 @@ func (omc *ObjectModelConfiguration) ModifyGroup(
 func (omc *ObjectModelConfiguration) ModifyVersion(
 	ref astmodel.PackageReference,
 	action func(configuration *VersionConfiguration) error) error {
-	_, version, ok := ref.GroupVersion()
-	if !ok {
-		return errors.Errorf(
-			"external package reference %s not supported",
-			ref)
-	}
-
+	_, version := ref.GroupVersion()
 	return omc.ModifyGroup(
 		ref,
 		func(configuration *GroupConfiguration) error {

--- a/v2/tools/generator/internal/config/type_matcher.go
+++ b/v2/tools/generator/internal/config/type_matcher.go
@@ -78,26 +78,25 @@ func (t *TypeMatcher) matches(glob string, regex **regexp.Regexp, name string) b
 
 // AppliesToType indicates whether this filter should be applied to the supplied type definition
 func (t *TypeMatcher) AppliesToType(typeName astmodel.TypeName) bool {
-	if group, version, ok := typeName.PackageReference.GroupVersion(); ok {
-
-		result := t.groupMatches(group) &&
-			t.versionMatches(version) &&
-			t.nameMatches(typeName.Name())
-
-		// Track this match, so we can later report if we didn't match anything
-		if result {
-			if t.matchedTypes == nil {
-				t.matchedTypes = astmodel.NewTypeNameSet(typeName)
-			} else {
-				t.matchedTypes.Add(typeName)
-			}
-		}
-
-		return result
+	group, version, ok := typeName.PackageReference.TryGroupVersion()
+	if !ok {
+		// Never match external references
 	}
 
-	// Never match external references
-	return false
+	result := t.groupMatches(group) &&
+		t.versionMatches(version) &&
+		t.nameMatches(typeName.Name())
+
+	// Track this match, so we can later report if we didn't match anything
+	if result {
+		if t.matchedTypes == nil {
+			t.matchedTypes = astmodel.NewTypeNameSet(typeName)
+		} else {
+			t.matchedTypes.Add(typeName)
+		}
+	}
+
+	return result
 }
 
 func (t *TypeMatcher) MatchedRequiredTypes() bool {

--- a/v2/tools/generator/internal/config/type_matcher.go
+++ b/v2/tools/generator/internal/config/type_matcher.go
@@ -81,6 +81,7 @@ func (t *TypeMatcher) AppliesToType(typeName astmodel.TypeName) bool {
 	group, version, ok := typeName.PackageReference.TryGroupVersion()
 	if !ok {
 		// Never match external references
+		return false
 	}
 
 	result := t.groupMatches(group) &&

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_defaulter.go
@@ -46,10 +46,7 @@ func (d *DefaulterBuilder) AddDefault(f *ResourceFunction) {
 // as well as helper functions that allow additional handcrafted defaults to be injected by
 // implementing the genruntime.Defaulter interface.
 func (d *DefaulterBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplementation {
-	group, version, ok := d.resourceName.PackageReference.GroupVersion()
-	if !ok {
-		panic(fmt.Sprintf("unexpected external package reference for resource name %s", d.resourceName))
-	}
+	group, version := d.resourceName.PackageReference.GroupVersion()
 
 	// e.g. group = "microsoft.network.azure.com"
 	// e.g. resource = "backendaddresspools"

--- a/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
+++ b/v2/tools/generator/internal/functions/kubernetes_admissions_validator.go
@@ -61,10 +61,7 @@ func (v *ValidatorBuilder) AddValidation(kind ValidationKind, f *ResourceFunctio
 // as well as helper functions that allow additional handcrafted validations to be injected by
 // implementing the genruntime.Validator interface.
 func (v *ValidatorBuilder) ToInterfaceImplementation() *astmodel.InterfaceImplementation {
-	group, version, ok := v.resourceName.PackageReference.GroupVersion()
-	if !ok {
-		panic(fmt.Sprintf("unexpected external package reference for resource name %s", v.resourceName))
-	}
+	group, version := v.resourceName.PackageReference.GroupVersion()
 
 	// e.g. group = "microsoft.network.azure.com"
 	// e.g. resource = "backendaddresspools"

--- a/v2/tools/generator/internal/functions/resource_conversion_function.go
+++ b/v2/tools/generator/internal/functions/resource_conversion_function.go
@@ -151,13 +151,7 @@ func (fn *ResourceConversionFunction) directConversion(
 	receiverName string, generationContext *astmodel.CodeGenerationContext) []dst.Stmt {
 	fmtPackage := generationContext.MustGetImportedPackageName(astmodel.FmtReference)
 
-	// Expect this to always work; our hub type will never be an external reference
-	hubGroup, hubVersion, ok := fn.hub.PackageReference.GroupVersion()
-	if !ok {
-		msg := fmt.Sprintf("hub type with external package reference %s is unexpected", fn.hub.PackageReference)
-		panic(msg)
-	}
-
+	hubGroup, hubVersion := fn.hub.PackageReference.GroupVersion()
 	localId := fn.localVariableId()
 	localIdent := dst.NewIdent(localId)
 	hubIdent := dst.NewIdent("hub")

--- a/v2/tools/generator/internal/test/asserts.go
+++ b/v2/tools/generator/internal/test/asserts.go
@@ -28,12 +28,7 @@ func AssertPackagesGenerateExpectedCode(t *testing.T, definitions astmodel.TypeD
 	// Write a file for each package
 	for _, defs := range groups {
 		ref := defs[0].Name().PackageReference
-		group, version, ok := ref.GroupVersion()
-		if !ok {
-			msg := fmt.Sprintf("May not have definitions from external package %s - fix your test", ref)
-			panic(msg)
-		}
-
+		group, version := ref.GroupVersion()
 		fileName := fmt.Sprintf("%s-%s", group, version)
 		AssertTypeDefinitionsGenerateExpectedCode(t, fileName, defs, options...)
 	}

--- a/v2/tools/generator/internal/test/file_definition.go
+++ b/v2/tools/generator/internal/test/file_definition.go
@@ -6,8 +6,6 @@
 package test
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 )
 
@@ -15,11 +13,7 @@ func CreateFileDefinition(definitions ...astmodel.TypeDefinition) *astmodel.File
 	packages := make(map[astmodel.PackageReference]*astmodel.PackageDefinition)
 
 	ref := definitions[0].Name().PackageReference
-	group, version, ok := ref.GroupVersion()
-	if !ok {
-		panic(errors.Errorf("Expected first definition not to have external package reference %s - fix your test!", ref))
-	}
-
+	group, version := ref.GroupVersion()
 	pkgDefinition := astmodel.NewPackageDefinition(group, version)
 	for _, def := range definitions {
 		pkgDefinition.AddDefinition(def)
@@ -39,11 +33,7 @@ func CreateTestFileDefinition(definitions ...astmodel.TypeDefinition) *astmodel.
 	// Use the package reference of the first definition for the whole file
 	ref := definitions[0].Name().PackageReference
 
-	group, version, ok := ref.GroupVersion()
-	if !ok {
-		panic(errors.Errorf("Expected first definition not to have external package reference %s - fix your test!", ref))
-	}
-
+	group, version := ref.GroupVersion()
 	pkgDefinition := astmodel.NewPackageDefinition(group, version)
 	for _, def := range definitions {
 		pkgDefinition.AddDefinition(def)


### PR DESCRIPTION
**What this PR does / why we need it**:

Most of the time when accessing the `Group` and `Version` from a `PackageReference` we either know that we won't have an `ExternalPackageReference` or want to panic if we do have one. We had boilerplate doing this over and over, so I've added a helper to simplify consumption.

We now have
* `TryGroupVersion()` as it may not succeed (returning a **false**)
* `GroupVersion()` which either succeeds or panics

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3gYWWyWuvJFydDtTuU/giphy.gif)
