### PR TITLE
Change ConvertToARM to return a ptr

### DIFF
--- a/v2/api/authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1alpha1api20200801preview/role_assignment_types_gen.go
@@ -715,7 +715,7 @@ func (assignments *RoleAssignments_Spec) ConvertToARM(resolved genruntime.Conver
 	if assignments == nil {
 		return nil, nil
 	}
-	var result RoleAssignments_SpecARM
+	result := &RoleAssignments_SpecARM{}
 
 	// Set property ‘Location’:
 	if assignments.Location != nil {

--- a/v2/api/authorization/v1alpha1api20200801preview/role_assignments__spec_arm_types_gen.go
+++ b/v2/api/authorization/v1alpha1api20200801preview/role_assignments__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (assignments RoleAssignments_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (assignments RoleAssignments_SpecARM) GetName() string {
+func (assignments *RoleAssignments_SpecARM) GetName() string {
 	return assignments.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Authorization/roleAssignments"
-func (assignments RoleAssignments_SpecARM) GetType() string {
+func (assignments *RoleAssignments_SpecARM) GetType() string {
 	return "Microsoft.Authorization/roleAssignments"
 }
 

--- a/v2/api/authorization/v1beta20200801preview/role_assignment_types_gen.go
+++ b/v2/api/authorization/v1beta20200801preview/role_assignment_types_gen.go
@@ -748,7 +748,7 @@ func (assignments *RoleAssignments_Spec) ConvertToARM(resolved genruntime.Conver
 	if assignments == nil {
 		return nil, nil
 	}
-	var result RoleAssignments_SpecARM
+	result := &RoleAssignments_SpecARM{}
 
 	// Set property ‘Location’:
 	if assignments.Location != nil {

--- a/v2/api/authorization/v1beta20200801preview/role_assignments__spec_arm_types_gen.go
+++ b/v2/api/authorization/v1beta20200801preview/role_assignments__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (assignments RoleAssignments_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (assignments RoleAssignments_SpecARM) GetName() string {
+func (assignments *RoleAssignments_SpecARM) GetName() string {
 	return assignments.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Authorization/roleAssignments"
-func (assignments RoleAssignments_SpecARM) GetType() string {
+func (assignments *RoleAssignments_SpecARM) GetType() string {
 	return "Microsoft.Authorization/roleAssignments"
 }
 

--- a/v2/api/batch/v1alpha1api20210101/batch_account_types_gen.go
+++ b/v2/api/batch/v1alpha1api20210101/batch_account_types_gen.go
@@ -978,7 +978,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	if accounts == nil {
 		return nil, nil
 	}
-	var result BatchAccounts_SpecARM
+	result := &BatchAccounts_SpecARM{}
 
 	// Set property ‘Identity’:
 	if accounts.Identity != nil {
@@ -986,7 +986,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(BatchAccountIdentityARM)
+		identity := *identityARM.(*BatchAccountIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1012,7 +1012,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		autoStorage := autoStorageARM.(AutoStorageBasePropertiesARM)
+		autoStorage := *autoStorageARM.(*AutoStorageBasePropertiesARM)
 		result.Properties.AutoStorage = &autoStorage
 	}
 	if accounts.Encryption != nil {
@@ -1020,7 +1020,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionPropertiesARM)
+		encryption := *encryptionARM.(*EncryptionPropertiesARM)
 		result.Properties.Encryption = &encryption
 	}
 	if accounts.KeyVaultReference != nil {
@@ -1028,7 +1028,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		keyVaultReference := keyVaultReferenceARM.(KeyVaultReferenceARM)
+		keyVaultReference := *keyVaultReferenceARM.(*KeyVaultReferenceARM)
 		result.Properties.KeyVaultReference = &keyVaultReference
 	}
 	if accounts.PoolAllocationMode != nil {
@@ -1418,7 +1418,7 @@ func (properties *AutoStorageBaseProperties) ConvertToARM(resolved genruntime.Co
 	if properties == nil {
 		return nil, nil
 	}
-	var result AutoStorageBasePropertiesARM
+	result := &AutoStorageBasePropertiesARM{}
 
 	// Set property ‘StorageAccountId’:
 	if properties.StorageAccountReference != nil {
@@ -1593,7 +1593,7 @@ func (identity *BatchAccountIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	if identity == nil {
 		return nil, nil
 	}
-	var result BatchAccountIdentityARM
+	result := &BatchAccountIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -1834,7 +1834,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	if properties == nil {
 		return nil, nil
 	}
-	var result EncryptionPropertiesARM
+	result := &EncryptionPropertiesARM{}
 
 	// Set property ‘KeySource’:
 	if properties.KeySource != nil {
@@ -1848,7 +1848,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		keyVaultProperties := keyVaultPropertiesARM.(KeyVaultPropertiesARM)
+		keyVaultProperties := *keyVaultPropertiesARM.(*KeyVaultPropertiesARM)
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 	return result, nil
@@ -2070,7 +2070,7 @@ func (reference *KeyVaultReference) ConvertToARM(resolved genruntime.ConvertToAR
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultReferenceARM
+	result := &KeyVaultReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -2618,7 +2618,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘KeyIdentifier’:
 	if properties.KeyIdentifier != nil {

--- a/v2/api/batch/v1alpha1api20210101/batch_accounts__spec_arm_types_gen.go
+++ b/v2/api/batch/v1alpha1api20210101/batch_accounts__spec_arm_types_gen.go
@@ -22,12 +22,12 @@ func (accounts BatchAccounts_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (accounts BatchAccounts_SpecARM) GetName() string {
+func (accounts *BatchAccounts_SpecARM) GetName() string {
 	return accounts.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Batch/batchAccounts"
-func (accounts BatchAccounts_SpecARM) GetType() string {
+func (accounts *BatchAccounts_SpecARM) GetType() string {
 	return "Microsoft.Batch/batchAccounts"
 }
 

--- a/v2/api/batch/v1beta20210101/batch_account_types_gen.go
+++ b/v2/api/batch/v1beta20210101/batch_account_types_gen.go
@@ -1019,7 +1019,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 	if accounts == nil {
 		return nil, nil
 	}
-	var result BatchAccounts_SpecARM
+	result := &BatchAccounts_SpecARM{}
 
 	// Set property ‘Identity’:
 	if accounts.Identity != nil {
@@ -1027,7 +1027,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(BatchAccountIdentityARM)
+		identity := *identityARM.(*BatchAccountIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1053,7 +1053,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		autoStorage := autoStorageARM.(AutoStorageBasePropertiesARM)
+		autoStorage := *autoStorageARM.(*AutoStorageBasePropertiesARM)
 		result.Properties.AutoStorage = &autoStorage
 	}
 	if accounts.Encryption != nil {
@@ -1061,7 +1061,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionPropertiesARM)
+		encryption := *encryptionARM.(*EncryptionPropertiesARM)
 		result.Properties.Encryption = &encryption
 	}
 	if accounts.KeyVaultReference != nil {
@@ -1069,7 +1069,7 @@ func (accounts *BatchAccounts_Spec) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		keyVaultReference := keyVaultReferenceARM.(KeyVaultReferenceARM)
+		keyVaultReference := *keyVaultReferenceARM.(*KeyVaultReferenceARM)
 		result.Properties.KeyVaultReference = &keyVaultReference
 	}
 	if accounts.PoolAllocationMode != nil {
@@ -1460,7 +1460,7 @@ func (properties *AutoStorageBaseProperties) ConvertToARM(resolved genruntime.Co
 	if properties == nil {
 		return nil, nil
 	}
-	var result AutoStorageBasePropertiesARM
+	result := &AutoStorageBasePropertiesARM{}
 
 	// Set property ‘StorageAccountId’:
 	if properties.StorageAccountReference != nil {
@@ -1634,7 +1634,7 @@ func (identity *BatchAccountIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	if identity == nil {
 		return nil, nil
 	}
-	var result BatchAccountIdentityARM
+	result := &BatchAccountIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -1885,7 +1885,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 	if properties == nil {
 		return nil, nil
 	}
-	var result EncryptionPropertiesARM
+	result := &EncryptionPropertiesARM{}
 
 	// Set property ‘KeySource’:
 	if properties.KeySource != nil {
@@ -1899,7 +1899,7 @@ func (properties *EncryptionProperties) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		keyVaultProperties := keyVaultPropertiesARM.(KeyVaultPropertiesARM)
+		keyVaultProperties := *keyVaultPropertiesARM.(*KeyVaultPropertiesARM)
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 	return result, nil
@@ -2125,7 +2125,7 @@ func (reference *KeyVaultReference) ConvertToARM(resolved genruntime.ConvertToAR
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultReferenceARM
+	result := &KeyVaultReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -2687,7 +2687,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘KeyIdentifier’:
 	if properties.KeyIdentifier != nil {

--- a/v2/api/batch/v1beta20210101/batch_accounts__spec_arm_types_gen.go
+++ b/v2/api/batch/v1beta20210101/batch_accounts__spec_arm_types_gen.go
@@ -34,12 +34,12 @@ func (accounts BatchAccounts_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (accounts BatchAccounts_SpecARM) GetName() string {
+func (accounts *BatchAccounts_SpecARM) GetName() string {
 	return accounts.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Batch/batchAccounts"
-func (accounts BatchAccounts_SpecARM) GetType() string {
+func (accounts *BatchAccounts_SpecARM) GetType() string {
 	return "Microsoft.Batch/batchAccounts"
 }
 

--- a/v2/api/cache/v1alpha1api20201201/redis__spec_arm_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis__spec_arm_types_gen.go
@@ -22,12 +22,12 @@ func (redis Redis_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (redis Redis_SpecARM) GetName() string {
+func (redis *Redis_SpecARM) GetName() string {
 	return redis.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis"
-func (redis Redis_SpecARM) GetType() string {
+func (redis *Redis_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis"
 }
 

--- a/v2/api/cache/v1alpha1api20201201/redis_firewall_rule_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_firewall_rule_types_gen.go
@@ -534,7 +534,7 @@ func (rules *RedisFirewallRules_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if rules == nil {
 		return nil, nil
 	}
-	var result RedisFirewallRules_SpecARM
+	result := &RedisFirewallRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/cache/v1alpha1api20201201/redis_firewall_rules__spec_arm_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_firewall_rules__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (rules RedisFirewallRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules RedisFirewallRules_SpecARM) GetName() string {
+func (rules *RedisFirewallRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis/firewallRules"
-func (rules RedisFirewallRules_SpecARM) GetType() string {
+func (rules *RedisFirewallRules_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis/firewallRules"
 }
 

--- a/v2/api/cache/v1alpha1api20201201/redis_linked_server_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_linked_server_types_gen.go
@@ -579,7 +579,7 @@ func (servers *RedisLinkedServers_Spec) ConvertToARM(resolved genruntime.Convert
 	if servers == nil {
 		return nil, nil
 	}
-	var result RedisLinkedServers_SpecARM
+	result := &RedisLinkedServers_SpecARM{}
 
 	// Set property ‘Location’:
 	if servers.Location != nil {

--- a/v2/api/cache/v1alpha1api20201201/redis_linked_servers__spec_arm_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_linked_servers__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (servers RedisLinkedServers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (servers RedisLinkedServers_SpecARM) GetName() string {
+func (servers *RedisLinkedServers_SpecARM) GetName() string {
 	return servers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis/linkedServers"
-func (servers RedisLinkedServers_SpecARM) GetType() string {
+func (servers *RedisLinkedServers_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis/linkedServers"
 }
 

--- a/v2/api/cache/v1alpha1api20201201/redis_patch_schedule_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_patch_schedule_types_gen.go
@@ -552,7 +552,7 @@ func (schedules *RedisPatchSchedules_Spec) ConvertToARM(resolved genruntime.Conv
 	if schedules == nil {
 		return nil, nil
 	}
-	var result RedisPatchSchedules_SpecARM
+	result := &RedisPatchSchedules_SpecARM{}
 
 	// Set property ‘Location’:
 	if schedules.Location != nil {
@@ -572,7 +572,7 @@ func (schedules *RedisPatchSchedules_Spec) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ScheduleEntries = append(result.Properties.ScheduleEntries, itemARM.(ScheduleEntryARM))
+		result.Properties.ScheduleEntries = append(result.Properties.ScheduleEntries, *itemARM.(*ScheduleEntryARM))
 	}
 
 	// Set property ‘Tags’:
@@ -795,7 +795,7 @@ func (entry *ScheduleEntry) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if entry == nil {
 		return nil, nil
 	}
-	var result ScheduleEntryARM
+	result := &ScheduleEntryARM{}
 
 	// Set property ‘DayOfWeek’:
 	if entry.DayOfWeek != nil {

--- a/v2/api/cache/v1alpha1api20201201/redis_patch_schedules__spec_arm_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_patch_schedules__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (schedules RedisPatchSchedules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (schedules RedisPatchSchedules_SpecARM) GetName() string {
+func (schedules *RedisPatchSchedules_SpecARM) GetName() string {
 	return schedules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis/patchSchedules"
-func (schedules RedisPatchSchedules_SpecARM) GetType() string {
+func (schedules *RedisPatchSchedules_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis/patchSchedules"
 }
 

--- a/v2/api/cache/v1alpha1api20201201/redis_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_types_gen.go
@@ -1058,7 +1058,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if redis == nil {
 		return nil, nil
 	}
-	var result Redis_SpecARM
+	result := &Redis_SpecARM{}
 
 	// Set property ‘Location’:
 	if redis.Location != nil {
@@ -1123,7 +1123,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Properties.Sku = &sku
 	}
 	if redis.StaticIP != nil {
@@ -1993,7 +1993,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise__spec_arm_types_gen.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise__spec_arm_types_gen.go
@@ -23,12 +23,12 @@ func (enterprise RedisEnterprise_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (enterprise RedisEnterprise_SpecARM) GetName() string {
+func (enterprise *RedisEnterprise_SpecARM) GetName() string {
 	return enterprise.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redisEnterprise"
-func (enterprise RedisEnterprise_SpecARM) GetType() string {
+func (enterprise *RedisEnterprise_SpecARM) GetType() string {
 	return "Microsoft.Cache/redisEnterprise"
 }
 

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise_database_types_gen.go
@@ -738,7 +738,7 @@ func (databases *RedisEnterpriseDatabases_Spec) ConvertToARM(resolved genruntime
 	if databases == nil {
 		return nil, nil
 	}
-	var result RedisEnterpriseDatabases_SpecARM
+	result := &RedisEnterpriseDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {
@@ -775,14 +775,14 @@ func (databases *RedisEnterpriseDatabases_Spec) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Modules = append(result.Properties.Modules, itemARM.(ModuleARM))
+		result.Properties.Modules = append(result.Properties.Modules, *itemARM.(*ModuleARM))
 	}
 	if databases.Persistence != nil {
 		persistenceARM, err := (*databases.Persistence).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		persistence := persistenceARM.(PersistenceARM)
+		persistence := *persistenceARM.(*PersistenceARM)
 		result.Properties.Persistence = &persistence
 	}
 	if databases.Port != nil {
@@ -1183,7 +1183,7 @@ func (module *Module) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if module == nil {
 		return nil, nil
 	}
-	var result ModuleARM
+	result := &ModuleARM{}
 
 	// Set property ‘Args’:
 	if module.Args != nil {
@@ -1361,7 +1361,7 @@ func (persistence *Persistence) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if persistence == nil {
 		return nil, nil
 	}
-	var result PersistenceARM
+	result := &PersistenceARM{}
 
 	// Set property ‘AofEnabled’:
 	if persistence.AofEnabled != nil {

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise_databases__spec_arm_types_gen.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise_databases__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (databases RedisEnterpriseDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases RedisEnterpriseDatabases_SpecARM) GetName() string {
+func (databases *RedisEnterpriseDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redisEnterprise/databases"
-func (databases RedisEnterpriseDatabases_SpecARM) GetType() string {
+func (databases *RedisEnterpriseDatabases_SpecARM) GetType() string {
 	return "Microsoft.Cache/redisEnterprise/databases"
 }
 

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise_types_gen.go
@@ -743,7 +743,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 	if enterprise == nil {
 		return nil, nil
 	}
-	var result RedisEnterprise_SpecARM
+	result := &RedisEnterprise_SpecARM{}
 
 	// Set property ‘Location’:
 	if enterprise.Location != nil {
@@ -769,7 +769,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1100,7 +1100,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {

--- a/v2/api/cache/v1beta20201201/redis__spec_arm_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis__spec_arm_types_gen.go
@@ -30,12 +30,12 @@ func (redis Redis_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (redis Redis_SpecARM) GetName() string {
+func (redis *Redis_SpecARM) GetName() string {
 	return redis.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis"
-func (redis Redis_SpecARM) GetType() string {
+func (redis *Redis_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis"
 }
 

--- a/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen.go
@@ -536,7 +536,7 @@ func (rules *RedisFirewallRules_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if rules == nil {
 		return nil, nil
 	}
-	var result RedisFirewallRules_SpecARM
+	result := &RedisFirewallRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/cache/v1beta20201201/redis_firewall_rules__spec_arm_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_firewall_rules__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (rules RedisFirewallRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules RedisFirewallRules_SpecARM) GetName() string {
+func (rules *RedisFirewallRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis/firewallRules"
-func (rules RedisFirewallRules_SpecARM) GetType() string {
+func (rules *RedisFirewallRules_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis/firewallRules"
 }
 

--- a/v2/api/cache/v1beta20201201/redis_linked_server_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_linked_server_types_gen.go
@@ -586,7 +586,7 @@ func (servers *RedisLinkedServers_Spec) ConvertToARM(resolved genruntime.Convert
 	if servers == nil {
 		return nil, nil
 	}
-	var result RedisLinkedServers_SpecARM
+	result := &RedisLinkedServers_SpecARM{}
 
 	// Set property ‘Location’:
 	if servers.Location != nil {

--- a/v2/api/cache/v1beta20201201/redis_linked_servers__spec_arm_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_linked_servers__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (servers RedisLinkedServers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (servers RedisLinkedServers_SpecARM) GetName() string {
+func (servers *RedisLinkedServers_SpecARM) GetName() string {
 	return servers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis/linkedServers"
-func (servers RedisLinkedServers_SpecARM) GetType() string {
+func (servers *RedisLinkedServers_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis/linkedServers"
 }
 

--- a/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen.go
@@ -552,7 +552,7 @@ func (schedules *RedisPatchSchedules_Spec) ConvertToARM(resolved genruntime.Conv
 	if schedules == nil {
 		return nil, nil
 	}
-	var result RedisPatchSchedules_SpecARM
+	result := &RedisPatchSchedules_SpecARM{}
 
 	// Set property ‘Location’:
 	if schedules.Location != nil {
@@ -572,7 +572,7 @@ func (schedules *RedisPatchSchedules_Spec) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ScheduleEntries = append(result.Properties.ScheduleEntries, itemARM.(ScheduleEntryARM))
+		result.Properties.ScheduleEntries = append(result.Properties.ScheduleEntries, *itemARM.(*ScheduleEntryARM))
 	}
 
 	// Set property ‘Tags’:
@@ -799,7 +799,7 @@ func (entry *ScheduleEntry) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if entry == nil {
 		return nil, nil
 	}
-	var result ScheduleEntryARM
+	result := &ScheduleEntryARM{}
 
 	// Set property ‘DayOfWeek’:
 	if entry.DayOfWeek != nil {

--- a/v2/api/cache/v1beta20201201/redis_patch_schedules__spec_arm_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_patch_schedules__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (schedules RedisPatchSchedules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (schedules RedisPatchSchedules_SpecARM) GetName() string {
+func (schedules *RedisPatchSchedules_SpecARM) GetName() string {
 	return schedules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redis/patchSchedules"
-func (schedules RedisPatchSchedules_SpecARM) GetType() string {
+func (schedules *RedisPatchSchedules_SpecARM) GetType() string {
 	return "Microsoft.Cache/redis/patchSchedules"
 }
 

--- a/v2/api/cache/v1beta20201201/redis_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_types_gen.go
@@ -1135,7 +1135,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if redis == nil {
 		return nil, nil
 	}
-	var result Redis_SpecARM
+	result := &Redis_SpecARM{}
 
 	// Set property ‘Location’:
 	if redis.Location != nil {
@@ -1200,7 +1200,7 @@ func (redis *Redis_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Properties.Sku = &sku
 	}
 	if redis.StaticIP != nil {
@@ -2075,7 +2075,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {

--- a/v2/api/cache/v1beta20210301/redis_enterprise__spec_arm_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise__spec_arm_types_gen.go
@@ -33,12 +33,12 @@ func (enterprise RedisEnterprise_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (enterprise RedisEnterprise_SpecARM) GetName() string {
+func (enterprise *RedisEnterprise_SpecARM) GetName() string {
 	return enterprise.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redisEnterprise"
-func (enterprise RedisEnterprise_SpecARM) GetType() string {
+func (enterprise *RedisEnterprise_SpecARM) GetType() string {
 	return "Microsoft.Cache/redisEnterprise"
 }
 

--- a/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen.go
@@ -763,7 +763,7 @@ func (databases *RedisEnterpriseDatabases_Spec) ConvertToARM(resolved genruntime
 	if databases == nil {
 		return nil, nil
 	}
-	var result RedisEnterpriseDatabases_SpecARM
+	result := &RedisEnterpriseDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {
@@ -800,14 +800,14 @@ func (databases *RedisEnterpriseDatabases_Spec) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Modules = append(result.Properties.Modules, itemARM.(ModuleARM))
+		result.Properties.Modules = append(result.Properties.Modules, *itemARM.(*ModuleARM))
 	}
 	if databases.Persistence != nil {
 		persistenceARM, err := (*databases.Persistence).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		persistence := persistenceARM.(PersistenceARM)
+		persistence := *persistenceARM.(*PersistenceARM)
 		result.Properties.Persistence = &persistence
 	}
 	if databases.Port != nil {
@@ -1207,7 +1207,7 @@ func (module *Module) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if module == nil {
 		return nil, nil
 	}
-	var result ModuleARM
+	result := &ModuleARM{}
 
 	// Set property ‘Args’:
 	if module.Args != nil {
@@ -1396,7 +1396,7 @@ func (persistence *Persistence) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if persistence == nil {
 		return nil, nil
 	}
-	var result PersistenceARM
+	result := &PersistenceARM{}
 
 	// Set property ‘AofEnabled’:
 	if persistence.AofEnabled != nil {

--- a/v2/api/cache/v1beta20210301/redis_enterprise_databases__spec_arm_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_databases__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (databases RedisEnterpriseDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases RedisEnterpriseDatabases_SpecARM) GetName() string {
+func (databases *RedisEnterpriseDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cache/redisEnterprise/databases"
-func (databases RedisEnterpriseDatabases_SpecARM) GetType() string {
+func (databases *RedisEnterpriseDatabases_SpecARM) GetType() string {
 	return "Microsoft.Cache/redisEnterprise/databases"
 }
 

--- a/v2/api/cache/v1beta20210301/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_types_gen.go
@@ -763,7 +763,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 	if enterprise == nil {
 		return nil, nil
 	}
-	var result RedisEnterprise_SpecARM
+	result := &RedisEnterprise_SpecARM{}
 
 	// Set property ‘Location’:
 	if enterprise.Location != nil {
@@ -789,7 +789,7 @@ func (enterprise *RedisEnterprise_Spec) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1123,7 +1123,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {

--- a/v2/api/cdn/v1beta20210601/profile_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profile_types_gen.go
@@ -741,7 +741,7 @@ func (profiles *Profiles_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if profiles == nil {
 		return nil, nil
 	}
-	var result Profiles_SpecARM
+	result := &Profiles_SpecARM{}
 
 	// Set property ‘Location’:
 	if profiles.Location != nil {
@@ -761,7 +761,7 @@ func (profiles *Profiles_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(ManagedServiceIdentityARM)
+		identity := *identityARM.(*ManagedServiceIdentityARM)
 		result.Properties.Identity = &identity
 	}
 	if profiles.OriginResponseTimeoutSeconds != nil {
@@ -775,7 +775,7 @@ func (profiles *Profiles_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1061,7 +1061,7 @@ func (identity *ManagedServiceIdentity) ConvertToARM(resolved genruntime.Convert
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedServiceIdentityARM
+	result := &ManagedServiceIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -1206,7 +1206,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {

--- a/v2/api/cdn/v1beta20210601/profiles__spec_arm_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profiles__spec_arm_types_gen.go
@@ -51,12 +51,12 @@ func (profiles Profiles_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (profiles Profiles_SpecARM) GetName() string {
+func (profiles *Profiles_SpecARM) GetName() string {
 	return profiles.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cdn/profiles"
-func (profiles Profiles_SpecARM) GetType() string {
+func (profiles *Profiles_SpecARM) GetType() string {
 	return "Microsoft.Cdn/profiles"
 }
 

--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
@@ -1304,7 +1304,7 @@ func (endpoints *ProfilesEndpoints_Spec) ConvertToARM(resolved genruntime.Conver
 	if endpoints == nil {
 		return nil, nil
 	}
-	var result ProfilesEndpoints_SpecARM
+	result := &ProfilesEndpoints_SpecARM{}
 
 	// Set property ‘Location’:
 	if endpoints.Location != nil {
@@ -1342,7 +1342,7 @@ func (endpoints *ProfilesEndpoints_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		defaultOriginGroup := defaultOriginGroupARM.(ResourceReferenceARM)
+		defaultOriginGroup := *defaultOriginGroupARM.(*ResourceReferenceARM)
 		result.Properties.DefaultOriginGroup = &defaultOriginGroup
 	}
 	if endpoints.DeliveryPolicy != nil {
@@ -1350,7 +1350,7 @@ func (endpoints *ProfilesEndpoints_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		deliveryPolicy := deliveryPolicyARM.(EndpointPropertiesUpdateParametersDeliveryPolicyARM)
+		deliveryPolicy := *deliveryPolicyARM.(*EndpointPropertiesUpdateParametersDeliveryPolicyARM)
 		result.Properties.DeliveryPolicy = &deliveryPolicy
 	}
 	for _, item := range endpoints.GeoFilters {
@@ -1358,7 +1358,7 @@ func (endpoints *ProfilesEndpoints_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.GeoFilters = append(result.Properties.GeoFilters, itemARM.(GeoFilterARM))
+		result.Properties.GeoFilters = append(result.Properties.GeoFilters, *itemARM.(*GeoFilterARM))
 	}
 	if endpoints.IsCompressionEnabled != nil {
 		isCompressionEnabled := *endpoints.IsCompressionEnabled
@@ -1381,7 +1381,7 @@ func (endpoints *ProfilesEndpoints_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.OriginGroups = append(result.Properties.OriginGroups, itemARM.(ProfilesEndpoints_Spec_Properties_OriginGroupsARM))
+		result.Properties.OriginGroups = append(result.Properties.OriginGroups, *itemARM.(*ProfilesEndpoints_Spec_Properties_OriginGroupsARM))
 	}
 	if endpoints.OriginHostHeader != nil {
 		originHostHeader := *endpoints.OriginHostHeader
@@ -1396,7 +1396,7 @@ func (endpoints *ProfilesEndpoints_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Origins = append(result.Properties.Origins, itemARM.(ProfilesEndpoints_Spec_Properties_OriginsARM))
+		result.Properties.Origins = append(result.Properties.Origins, *itemARM.(*ProfilesEndpoints_Spec_Properties_OriginsARM))
 	}
 	if endpoints.ProbePath != nil {
 		probePath := *endpoints.ProbePath
@@ -1411,14 +1411,14 @@ func (endpoints *ProfilesEndpoints_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.UrlSigningKeys = append(result.Properties.UrlSigningKeys, itemARM.(UrlSigningKeyARM))
+		result.Properties.UrlSigningKeys = append(result.Properties.UrlSigningKeys, *itemARM.(*UrlSigningKeyARM))
 	}
 	if endpoints.WebApplicationFirewallPolicyLink != nil {
 		webApplicationFirewallPolicyLinkARM, err := (*endpoints.WebApplicationFirewallPolicyLink).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		webApplicationFirewallPolicyLink := webApplicationFirewallPolicyLinkARM.(EndpointPropertiesUpdateParametersWebApplicationFirewallPolicyLinkARM)
+		webApplicationFirewallPolicyLink := *webApplicationFirewallPolicyLinkARM.(*EndpointPropertiesUpdateParametersWebApplicationFirewallPolicyLinkARM)
 		result.Properties.WebApplicationFirewallPolicyLink = &webApplicationFirewallPolicyLink
 	}
 
@@ -2708,7 +2708,7 @@ func (policy *EndpointPropertiesUpdateParametersDeliveryPolicy) ConvertToARM(res
 	if policy == nil {
 		return nil, nil
 	}
-	var result EndpointPropertiesUpdateParametersDeliveryPolicyARM
+	result := &EndpointPropertiesUpdateParametersDeliveryPolicyARM{}
 
 	// Set property ‘Description’:
 	if policy.Description != nil {
@@ -2722,7 +2722,7 @@ func (policy *EndpointPropertiesUpdateParametersDeliveryPolicy) ConvertToARM(res
 		if err != nil {
 			return nil, err
 		}
-		result.Rules = append(result.Rules, itemARM.(DeliveryRuleARM))
+		result.Rules = append(result.Rules, *itemARM.(*DeliveryRuleARM))
 	}
 	return result, nil
 }
@@ -2837,7 +2837,7 @@ func (link *EndpointPropertiesUpdateParametersWebApplicationFirewallPolicyLink) 
 	if link == nil {
 		return nil, nil
 	}
-	var result EndpointPropertiesUpdateParametersWebApplicationFirewallPolicyLinkARM
+	result := &EndpointPropertiesUpdateParametersWebApplicationFirewallPolicyLinkARM{}
 
 	// Set property ‘Id’:
 	if link.Reference != nil {
@@ -3095,7 +3095,7 @@ func (filter *GeoFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if filter == nil {
 		return nil, nil
 	}
-	var result GeoFilterARM
+	result := &GeoFilterARM{}
 
 	// Set property ‘Action’:
 	if filter.Action != nil {
@@ -3349,7 +3349,7 @@ func (groups *ProfilesEndpoints_Spec_Properties_OriginGroups) ConvertToARM(resol
 	if groups == nil {
 		return nil, nil
 	}
-	var result ProfilesEndpoints_Spec_Properties_OriginGroupsARM
+	result := &ProfilesEndpoints_Spec_Properties_OriginGroupsARM{}
 
 	// Set property ‘Name’:
 	if groups.Name != nil {
@@ -3369,7 +3369,7 @@ func (groups *ProfilesEndpoints_Spec_Properties_OriginGroups) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		healthProbeSettings := healthProbeSettingsARM.(HealthProbeParametersARM)
+		healthProbeSettings := *healthProbeSettingsARM.(*HealthProbeParametersARM)
 		result.Properties.HealthProbeSettings = &healthProbeSettings
 	}
 	for _, item := range groups.Origins {
@@ -3377,14 +3377,14 @@ func (groups *ProfilesEndpoints_Spec_Properties_OriginGroups) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Origins = append(result.Properties.Origins, itemARM.(ResourceReferenceARM))
+		result.Properties.Origins = append(result.Properties.Origins, *itemARM.(*ResourceReferenceARM))
 	}
 	if groups.ResponseBasedOriginErrorDetectionSettings != nil {
 		responseBasedOriginErrorDetectionSettingsARM, err := (*groups.ResponseBasedOriginErrorDetectionSettings).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		responseBasedOriginErrorDetectionSettings := responseBasedOriginErrorDetectionSettingsARM.(ResponseBasedOriginErrorDetectionParametersARM)
+		responseBasedOriginErrorDetectionSettings := *responseBasedOriginErrorDetectionSettingsARM.(*ResponseBasedOriginErrorDetectionParametersARM)
 		result.Properties.ResponseBasedOriginErrorDetectionSettings = &responseBasedOriginErrorDetectionSettings
 	}
 	if groups.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes != nil {
@@ -3657,7 +3657,7 @@ func (origins *ProfilesEndpoints_Spec_Properties_Origins) ConvertToARM(resolved 
 	if origins == nil {
 		return nil, nil
 	}
-	var result ProfilesEndpoints_Spec_Properties_OriginsARM
+	result := &ProfilesEndpoints_Spec_Properties_OriginsARM{}
 
 	// Set property ‘Name’:
 	if origins.Name != nil {
@@ -4019,7 +4019,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	if reference == nil {
 		return nil, nil
 	}
-	var result ResourceReferenceARM
+	result := &ResourceReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -4167,7 +4167,7 @@ func (signingKey *UrlSigningKey) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if signingKey == nil {
 		return nil, nil
 	}
-	var result UrlSigningKeyARM
+	result := &UrlSigningKeyARM{}
 
 	// Set property ‘KeyId’:
 	if signingKey.KeyId != nil {
@@ -4181,7 +4181,7 @@ func (signingKey *UrlSigningKey) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		keySourceParameters := keySourceParametersARM.(KeyVaultSigningKeyParametersARM)
+		keySourceParameters := *keySourceParametersARM.(*KeyVaultSigningKeyParametersARM)
 		result.KeySourceParameters = &keySourceParameters
 	}
 	return result, nil
@@ -4396,7 +4396,7 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if rule == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleARM
+	result := &DeliveryRuleARM{}
 
 	// Set property ‘Actions’:
 	for _, item := range rule.Actions {
@@ -4404,7 +4404,7 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		result.Actions = append(result.Actions, itemARM.(DeliveryRuleAction1ARM))
+		result.Actions = append(result.Actions, *itemARM.(*DeliveryRuleAction1ARM))
 	}
 
 	// Set property ‘Conditions’:
@@ -4413,7 +4413,7 @@ func (rule *DeliveryRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		result.Conditions = append(result.Conditions, itemARM.(DeliveryRuleConditionARM))
+		result.Conditions = append(result.Conditions, *itemARM.(*DeliveryRuleConditionARM))
 	}
 
 	// Set property ‘Name’:
@@ -4782,7 +4782,7 @@ func (parameters *HealthProbeParameters) ConvertToARM(resolved genruntime.Conver
 	if parameters == nil {
 		return nil, nil
 	}
-	var result HealthProbeParametersARM
+	result := &HealthProbeParametersARM{}
 
 	// Set property ‘ProbeIntervalInSeconds’:
 	if parameters.ProbeIntervalInSeconds != nil {
@@ -5083,7 +5083,7 @@ func (parameters *KeyVaultSigningKeyParameters) ConvertToARM(resolved genruntime
 	if parameters == nil {
 		return nil, nil
 	}
-	var result KeyVaultSigningKeyParametersARM
+	result := &KeyVaultSigningKeyParametersARM{}
 
 	// Set property ‘ResourceGroupName’:
 	if parameters.ResourceGroupName != nil {
@@ -5418,7 +5418,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) ConvertToARM(reso
 	if parameters == nil {
 		return nil, nil
 	}
-	var result ResponseBasedOriginErrorDetectionParametersARM
+	result := &ResponseBasedOriginErrorDetectionParametersARM{}
 
 	// Set property ‘HttpErrorRanges’:
 	for _, item := range parameters.HttpErrorRanges {
@@ -5426,7 +5426,7 @@ func (parameters *ResponseBasedOriginErrorDetectionParameters) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		result.HttpErrorRanges = append(result.HttpErrorRanges, itemARM.(HttpErrorRangeParametersARM))
+		result.HttpErrorRanges = append(result.HttpErrorRanges, *itemARM.(*HttpErrorRangeParametersARM))
 	}
 
 	// Set property ‘ResponseBasedDetectedErrorTypes’:
@@ -5742,7 +5742,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 	if action1 == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleAction1ARM
+	result := &DeliveryRuleAction1ARM{}
 
 	// Set property ‘DeliveryRuleCacheExpiration’:
 	if action1.DeliveryRuleCacheExpiration != nil {
@@ -5750,7 +5750,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleCacheExpiration := deliveryRuleCacheExpirationARM.(DeliveryRuleCacheExpirationActionARM)
+		deliveryRuleCacheExpiration := *deliveryRuleCacheExpirationARM.(*DeliveryRuleCacheExpirationActionARM)
 		result.DeliveryRuleCacheExpiration = &deliveryRuleCacheExpiration
 	}
 
@@ -5760,7 +5760,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleCacheKeyQueryString := deliveryRuleCacheKeyQueryStringARM.(DeliveryRuleCacheKeyQueryStringActionARM)
+		deliveryRuleCacheKeyQueryString := *deliveryRuleCacheKeyQueryStringARM.(*DeliveryRuleCacheKeyQueryStringActionARM)
 		result.DeliveryRuleCacheKeyQueryString = &deliveryRuleCacheKeyQueryString
 	}
 
@@ -5770,7 +5770,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRequestHeader := deliveryRuleRequestHeaderARM.(DeliveryRuleRequestHeaderActionARM)
+		deliveryRuleRequestHeader := *deliveryRuleRequestHeaderARM.(*DeliveryRuleRequestHeaderActionARM)
 		result.DeliveryRuleRequestHeader = &deliveryRuleRequestHeader
 	}
 
@@ -5780,7 +5780,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleResponseHeader := deliveryRuleResponseHeaderARM.(DeliveryRuleResponseHeaderActionARM)
+		deliveryRuleResponseHeader := *deliveryRuleResponseHeaderARM.(*DeliveryRuleResponseHeaderActionARM)
 		result.DeliveryRuleResponseHeader = &deliveryRuleResponseHeader
 	}
 
@@ -5790,7 +5790,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRouteConfigurationOverride := deliveryRuleRouteConfigurationOverrideARM.(DeliveryRuleRouteConfigurationOverrideActionARM)
+		deliveryRuleRouteConfigurationOverride := *deliveryRuleRouteConfigurationOverrideARM.(*DeliveryRuleRouteConfigurationOverrideActionARM)
 		result.DeliveryRuleRouteConfigurationOverride = &deliveryRuleRouteConfigurationOverride
 	}
 
@@ -5800,7 +5800,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		originGroupOverride := originGroupOverrideARM.(OriginGroupOverrideActionARM)
+		originGroupOverride := *originGroupOverrideARM.(*OriginGroupOverrideActionARM)
 		result.OriginGroupOverride = &originGroupOverride
 	}
 
@@ -5810,7 +5810,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		urlRedirect := urlRedirectARM.(UrlRedirectActionARM)
+		urlRedirect := *urlRedirectARM.(*UrlRedirectActionARM)
 		result.UrlRedirect = &urlRedirect
 	}
 
@@ -5820,7 +5820,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		urlRewrite := urlRewriteARM.(UrlRewriteActionARM)
+		urlRewrite := *urlRewriteARM.(*UrlRewriteActionARM)
 		result.UrlRewrite = &urlRewrite
 	}
 
@@ -5830,7 +5830,7 @@ func (action1 *DeliveryRuleAction1) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		urlSigning := urlSigningARM.(UrlSigningActionARM)
+		urlSigning := *urlSigningARM.(*UrlSigningActionARM)
 		result.UrlSigning = &urlSigning
 	}
 	return result, nil
@@ -6325,7 +6325,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleConditionARM
+	result := &DeliveryRuleConditionARM{}
 
 	// Set property ‘DeliveryRuleClientPort’:
 	if condition.DeliveryRuleClientPort != nil {
@@ -6333,7 +6333,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleClientPort := deliveryRuleClientPortARM.(DeliveryRuleClientPortConditionARM)
+		deliveryRuleClientPort := *deliveryRuleClientPortARM.(*DeliveryRuleClientPortConditionARM)
 		result.DeliveryRuleClientPort = &deliveryRuleClientPort
 	}
 
@@ -6343,7 +6343,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleCookies := deliveryRuleCookiesARM.(DeliveryRuleCookiesConditionARM)
+		deliveryRuleCookies := *deliveryRuleCookiesARM.(*DeliveryRuleCookiesConditionARM)
 		result.DeliveryRuleCookies = &deliveryRuleCookies
 	}
 
@@ -6353,7 +6353,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleHostName := deliveryRuleHostNameARM.(DeliveryRuleHostNameConditionARM)
+		deliveryRuleHostName := *deliveryRuleHostNameARM.(*DeliveryRuleHostNameConditionARM)
 		result.DeliveryRuleHostName = &deliveryRuleHostName
 	}
 
@@ -6363,7 +6363,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleHttpVersion := deliveryRuleHttpVersionARM.(DeliveryRuleHttpVersionConditionARM)
+		deliveryRuleHttpVersion := *deliveryRuleHttpVersionARM.(*DeliveryRuleHttpVersionConditionARM)
 		result.DeliveryRuleHttpVersion = &deliveryRuleHttpVersion
 	}
 
@@ -6373,7 +6373,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleIsDevice := deliveryRuleIsDeviceARM.(DeliveryRuleIsDeviceConditionARM)
+		deliveryRuleIsDevice := *deliveryRuleIsDeviceARM.(*DeliveryRuleIsDeviceConditionARM)
 		result.DeliveryRuleIsDevice = &deliveryRuleIsDevice
 	}
 
@@ -6383,7 +6383,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRulePostArgs := deliveryRulePostArgsARM.(DeliveryRulePostArgsConditionARM)
+		deliveryRulePostArgs := *deliveryRulePostArgsARM.(*DeliveryRulePostArgsConditionARM)
 		result.DeliveryRulePostArgs = &deliveryRulePostArgs
 	}
 
@@ -6393,7 +6393,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleQueryString := deliveryRuleQueryStringARM.(DeliveryRuleQueryStringConditionARM)
+		deliveryRuleQueryString := *deliveryRuleQueryStringARM.(*DeliveryRuleQueryStringConditionARM)
 		result.DeliveryRuleQueryString = &deliveryRuleQueryString
 	}
 
@@ -6403,7 +6403,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRemoteAddress := deliveryRuleRemoteAddressARM.(DeliveryRuleRemoteAddressConditionARM)
+		deliveryRuleRemoteAddress := *deliveryRuleRemoteAddressARM.(*DeliveryRuleRemoteAddressConditionARM)
 		result.DeliveryRuleRemoteAddress = &deliveryRuleRemoteAddress
 	}
 
@@ -6413,7 +6413,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRequestBody := deliveryRuleRequestBodyARM.(DeliveryRuleRequestBodyConditionARM)
+		deliveryRuleRequestBody := *deliveryRuleRequestBodyARM.(*DeliveryRuleRequestBodyConditionARM)
 		result.DeliveryRuleRequestBody = &deliveryRuleRequestBody
 	}
 
@@ -6423,7 +6423,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRequestHeader := deliveryRuleRequestHeaderARM.(DeliveryRuleRequestHeaderConditionARM)
+		deliveryRuleRequestHeader := *deliveryRuleRequestHeaderARM.(*DeliveryRuleRequestHeaderConditionARM)
 		result.DeliveryRuleRequestHeader = &deliveryRuleRequestHeader
 	}
 
@@ -6433,7 +6433,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRequestMethod := deliveryRuleRequestMethodARM.(DeliveryRuleRequestMethodConditionARM)
+		deliveryRuleRequestMethod := *deliveryRuleRequestMethodARM.(*DeliveryRuleRequestMethodConditionARM)
 		result.DeliveryRuleRequestMethod = &deliveryRuleRequestMethod
 	}
 
@@ -6443,7 +6443,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRequestScheme := deliveryRuleRequestSchemeARM.(DeliveryRuleRequestSchemeConditionARM)
+		deliveryRuleRequestScheme := *deliveryRuleRequestSchemeARM.(*DeliveryRuleRequestSchemeConditionARM)
 		result.DeliveryRuleRequestScheme = &deliveryRuleRequestScheme
 	}
 
@@ -6453,7 +6453,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleRequestUri := deliveryRuleRequestUriARM.(DeliveryRuleRequestUriConditionARM)
+		deliveryRuleRequestUri := *deliveryRuleRequestUriARM.(*DeliveryRuleRequestUriConditionARM)
 		result.DeliveryRuleRequestUri = &deliveryRuleRequestUri
 	}
 
@@ -6463,7 +6463,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleServerPort := deliveryRuleServerPortARM.(DeliveryRuleServerPortConditionARM)
+		deliveryRuleServerPort := *deliveryRuleServerPortARM.(*DeliveryRuleServerPortConditionARM)
 		result.DeliveryRuleServerPort = &deliveryRuleServerPort
 	}
 
@@ -6473,7 +6473,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleSocketAddr := deliveryRuleSocketAddrARM.(DeliveryRuleSocketAddrConditionARM)
+		deliveryRuleSocketAddr := *deliveryRuleSocketAddrARM.(*DeliveryRuleSocketAddrConditionARM)
 		result.DeliveryRuleSocketAddr = &deliveryRuleSocketAddr
 	}
 
@@ -6483,7 +6483,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleSslProtocol := deliveryRuleSslProtocolARM.(DeliveryRuleSslProtocolConditionARM)
+		deliveryRuleSslProtocol := *deliveryRuleSslProtocolARM.(*DeliveryRuleSslProtocolConditionARM)
 		result.DeliveryRuleSslProtocol = &deliveryRuleSslProtocol
 	}
 
@@ -6493,7 +6493,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleUrlFileExtension := deliveryRuleUrlFileExtensionARM.(DeliveryRuleUrlFileExtensionConditionARM)
+		deliveryRuleUrlFileExtension := *deliveryRuleUrlFileExtensionARM.(*DeliveryRuleUrlFileExtensionConditionARM)
 		result.DeliveryRuleUrlFileExtension = &deliveryRuleUrlFileExtension
 	}
 
@@ -6503,7 +6503,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleUrlFileName := deliveryRuleUrlFileNameARM.(DeliveryRuleUrlFileNameConditionARM)
+		deliveryRuleUrlFileName := *deliveryRuleUrlFileNameARM.(*DeliveryRuleUrlFileNameConditionARM)
 		result.DeliveryRuleUrlFileName = &deliveryRuleUrlFileName
 	}
 
@@ -6513,7 +6513,7 @@ func (condition *DeliveryRuleCondition) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		deliveryRuleUrlPath := deliveryRuleUrlPathARM.(DeliveryRuleUrlPathConditionARM)
+		deliveryRuleUrlPath := *deliveryRuleUrlPathARM.(*DeliveryRuleUrlPathConditionARM)
 		result.DeliveryRuleUrlPath = &deliveryRuleUrlPath
 	}
 	return result, nil
@@ -7345,7 +7345,7 @@ func (parameters *HttpErrorRangeParameters) ConvertToARM(resolved genruntime.Con
 	if parameters == nil {
 		return nil, nil
 	}
-	var result HttpErrorRangeParametersARM
+	result := &HttpErrorRangeParametersARM{}
 
 	// Set property ‘Begin’:
 	if parameters.Begin != nil {
@@ -7556,7 +7556,7 @@ func (action *DeliveryRuleCacheExpirationAction) ConvertToARM(resolved genruntim
 	if action == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleCacheExpirationActionARM
+	result := &DeliveryRuleCacheExpirationActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -7569,7 +7569,7 @@ func (action *DeliveryRuleCacheExpirationAction) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(CacheExpirationActionParametersARM)
+		parameters := *parametersARM.(*CacheExpirationActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -7685,7 +7685,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) ConvertToARM(resolved genru
 	if action == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleCacheKeyQueryStringActionARM
+	result := &DeliveryRuleCacheKeyQueryStringActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -7698,7 +7698,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(CacheKeyQueryStringActionParametersARM)
+		parameters := *parametersARM.(*CacheKeyQueryStringActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -7814,7 +7814,7 @@ func (condition *DeliveryRuleClientPortCondition) ConvertToARM(resolved genrunti
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleClientPortConditionARM
+	result := &DeliveryRuleClientPortConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -7827,7 +7827,7 @@ func (condition *DeliveryRuleClientPortCondition) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(ClientPortMatchConditionParametersARM)
+		parameters := *parametersARM.(*ClientPortMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -7943,7 +7943,7 @@ func (condition *DeliveryRuleCookiesCondition) ConvertToARM(resolved genruntime.
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleCookiesConditionARM
+	result := &DeliveryRuleCookiesConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -7956,7 +7956,7 @@ func (condition *DeliveryRuleCookiesCondition) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(CookiesMatchConditionParametersARM)
+		parameters := *parametersARM.(*CookiesMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8072,7 +8072,7 @@ func (condition *DeliveryRuleHostNameCondition) ConvertToARM(resolved genruntime
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleHostNameConditionARM
+	result := &DeliveryRuleHostNameConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -8085,7 +8085,7 @@ func (condition *DeliveryRuleHostNameCondition) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(HostNameMatchConditionParametersARM)
+		parameters := *parametersARM.(*HostNameMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8201,7 +8201,7 @@ func (condition *DeliveryRuleHttpVersionCondition) ConvertToARM(resolved genrunt
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleHttpVersionConditionARM
+	result := &DeliveryRuleHttpVersionConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -8214,7 +8214,7 @@ func (condition *DeliveryRuleHttpVersionCondition) ConvertToARM(resolved genrunt
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(HttpVersionMatchConditionParametersARM)
+		parameters := *parametersARM.(*HttpVersionMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8330,7 +8330,7 @@ func (condition *DeliveryRuleIsDeviceCondition) ConvertToARM(resolved genruntime
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleIsDeviceConditionARM
+	result := &DeliveryRuleIsDeviceConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -8343,7 +8343,7 @@ func (condition *DeliveryRuleIsDeviceCondition) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(IsDeviceMatchConditionParametersARM)
+		parameters := *parametersARM.(*IsDeviceMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8459,7 +8459,7 @@ func (condition *DeliveryRulePostArgsCondition) ConvertToARM(resolved genruntime
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRulePostArgsConditionARM
+	result := &DeliveryRulePostArgsConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -8472,7 +8472,7 @@ func (condition *DeliveryRulePostArgsCondition) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(PostArgsMatchConditionParametersARM)
+		parameters := *parametersARM.(*PostArgsMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8588,7 +8588,7 @@ func (condition *DeliveryRuleQueryStringCondition) ConvertToARM(resolved genrunt
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleQueryStringConditionARM
+	result := &DeliveryRuleQueryStringConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -8601,7 +8601,7 @@ func (condition *DeliveryRuleQueryStringCondition) ConvertToARM(resolved genrunt
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(QueryStringMatchConditionParametersARM)
+		parameters := *parametersARM.(*QueryStringMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8717,7 +8717,7 @@ func (condition *DeliveryRuleRemoteAddressCondition) ConvertToARM(resolved genru
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRemoteAddressConditionARM
+	result := &DeliveryRuleRemoteAddressConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -8730,7 +8730,7 @@ func (condition *DeliveryRuleRemoteAddressCondition) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(RemoteAddressMatchConditionParametersARM)
+		parameters := *parametersARM.(*RemoteAddressMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8846,7 +8846,7 @@ func (condition *DeliveryRuleRequestBodyCondition) ConvertToARM(resolved genrunt
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRequestBodyConditionARM
+	result := &DeliveryRuleRequestBodyConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -8859,7 +8859,7 @@ func (condition *DeliveryRuleRequestBodyCondition) ConvertToARM(resolved genrunt
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(RequestBodyMatchConditionParametersARM)
+		parameters := *parametersARM.(*RequestBodyMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -8975,7 +8975,7 @@ func (action *DeliveryRuleRequestHeaderAction) ConvertToARM(resolved genruntime.
 	if action == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRequestHeaderActionARM
+	result := &DeliveryRuleRequestHeaderActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -8988,7 +8988,7 @@ func (action *DeliveryRuleRequestHeaderAction) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(HeaderActionParametersARM)
+		parameters := *parametersARM.(*HeaderActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -9104,7 +9104,7 @@ func (condition *DeliveryRuleRequestHeaderCondition) ConvertToARM(resolved genru
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRequestHeaderConditionARM
+	result := &DeliveryRuleRequestHeaderConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -9117,7 +9117,7 @@ func (condition *DeliveryRuleRequestHeaderCondition) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(RequestHeaderMatchConditionParametersARM)
+		parameters := *parametersARM.(*RequestHeaderMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -9233,7 +9233,7 @@ func (condition *DeliveryRuleRequestMethodCondition) ConvertToARM(resolved genru
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRequestMethodConditionARM
+	result := &DeliveryRuleRequestMethodConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -9246,7 +9246,7 @@ func (condition *DeliveryRuleRequestMethodCondition) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(RequestMethodMatchConditionParametersARM)
+		parameters := *parametersARM.(*RequestMethodMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -9362,7 +9362,7 @@ func (condition *DeliveryRuleRequestSchemeCondition) ConvertToARM(resolved genru
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRequestSchemeConditionARM
+	result := &DeliveryRuleRequestSchemeConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -9375,7 +9375,7 @@ func (condition *DeliveryRuleRequestSchemeCondition) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(RequestSchemeMatchConditionParametersARM)
+		parameters := *parametersARM.(*RequestSchemeMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -9491,7 +9491,7 @@ func (condition *DeliveryRuleRequestUriCondition) ConvertToARM(resolved genrunti
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRequestUriConditionARM
+	result := &DeliveryRuleRequestUriConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -9504,7 +9504,7 @@ func (condition *DeliveryRuleRequestUriCondition) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(RequestUriMatchConditionParametersARM)
+		parameters := *parametersARM.(*RequestUriMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -9620,7 +9620,7 @@ func (action *DeliveryRuleResponseHeaderAction) ConvertToARM(resolved genruntime
 	if action == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleResponseHeaderActionARM
+	result := &DeliveryRuleResponseHeaderActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -9633,7 +9633,7 @@ func (action *DeliveryRuleResponseHeaderAction) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(HeaderActionParametersARM)
+		parameters := *parametersARM.(*HeaderActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -9749,7 +9749,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) ConvertToARM(resolve
 	if action == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleRouteConfigurationOverrideActionARM
+	result := &DeliveryRuleRouteConfigurationOverrideActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -9762,7 +9762,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(RouteConfigurationOverrideActionParametersARM)
+		parameters := *parametersARM.(*RouteConfigurationOverrideActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -9878,7 +9878,7 @@ func (condition *DeliveryRuleServerPortCondition) ConvertToARM(resolved genrunti
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleServerPortConditionARM
+	result := &DeliveryRuleServerPortConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -9891,7 +9891,7 @@ func (condition *DeliveryRuleServerPortCondition) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(ServerPortMatchConditionParametersARM)
+		parameters := *parametersARM.(*ServerPortMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10007,7 +10007,7 @@ func (condition *DeliveryRuleSocketAddrCondition) ConvertToARM(resolved genrunti
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleSocketAddrConditionARM
+	result := &DeliveryRuleSocketAddrConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -10020,7 +10020,7 @@ func (condition *DeliveryRuleSocketAddrCondition) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(SocketAddrMatchConditionParametersARM)
+		parameters := *parametersARM.(*SocketAddrMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10136,7 +10136,7 @@ func (condition *DeliveryRuleSslProtocolCondition) ConvertToARM(resolved genrunt
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleSslProtocolConditionARM
+	result := &DeliveryRuleSslProtocolConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -10149,7 +10149,7 @@ func (condition *DeliveryRuleSslProtocolCondition) ConvertToARM(resolved genrunt
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(SslProtocolMatchConditionParametersARM)
+		parameters := *parametersARM.(*SslProtocolMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10265,7 +10265,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) ConvertToARM(resolved ge
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleUrlFileExtensionConditionARM
+	result := &DeliveryRuleUrlFileExtensionConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -10278,7 +10278,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(UrlFileExtensionMatchConditionParametersARM)
+		parameters := *parametersARM.(*UrlFileExtensionMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10394,7 +10394,7 @@ func (condition *DeliveryRuleUrlFileNameCondition) ConvertToARM(resolved genrunt
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleUrlFileNameConditionARM
+	result := &DeliveryRuleUrlFileNameConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -10407,7 +10407,7 @@ func (condition *DeliveryRuleUrlFileNameCondition) ConvertToARM(resolved genrunt
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(UrlFileNameMatchConditionParametersARM)
+		parameters := *parametersARM.(*UrlFileNameMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10523,7 +10523,7 @@ func (condition *DeliveryRuleUrlPathCondition) ConvertToARM(resolved genruntime.
 	if condition == nil {
 		return nil, nil
 	}
-	var result DeliveryRuleUrlPathConditionARM
+	result := &DeliveryRuleUrlPathConditionARM{}
 
 	// Set property ‘Name’:
 	if condition.Name != nil {
@@ -10536,7 +10536,7 @@ func (condition *DeliveryRuleUrlPathCondition) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(UrlPathMatchConditionParametersARM)
+		parameters := *parametersARM.(*UrlPathMatchConditionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10652,7 +10652,7 @@ func (action *OriginGroupOverrideAction) ConvertToARM(resolved genruntime.Conver
 	if action == nil {
 		return nil, nil
 	}
-	var result OriginGroupOverrideActionARM
+	result := &OriginGroupOverrideActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -10665,7 +10665,7 @@ func (action *OriginGroupOverrideAction) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(OriginGroupOverrideActionParametersARM)
+		parameters := *parametersARM.(*OriginGroupOverrideActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10781,7 +10781,7 @@ func (action *UrlRedirectAction) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if action == nil {
 		return nil, nil
 	}
-	var result UrlRedirectActionARM
+	result := &UrlRedirectActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -10794,7 +10794,7 @@ func (action *UrlRedirectAction) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(UrlRedirectActionParametersARM)
+		parameters := *parametersARM.(*UrlRedirectActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -10910,7 +10910,7 @@ func (action *UrlRewriteAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if action == nil {
 		return nil, nil
 	}
-	var result UrlRewriteActionARM
+	result := &UrlRewriteActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -10923,7 +10923,7 @@ func (action *UrlRewriteAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(UrlRewriteActionParametersARM)
+		parameters := *parametersARM.(*UrlRewriteActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -11039,7 +11039,7 @@ func (action *UrlSigningAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if action == nil {
 		return nil, nil
 	}
-	var result UrlSigningActionARM
+	result := &UrlSigningActionARM{}
 
 	// Set property ‘Name’:
 	if action.Name != nil {
@@ -11052,7 +11052,7 @@ func (action *UrlSigningAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		parameters := parametersARM.(UrlSigningActionParametersARM)
+		parameters := *parametersARM.(*UrlSigningActionParametersARM)
 		result.Parameters = &parameters
 	}
 	return result, nil
@@ -11175,7 +11175,7 @@ func (parameters *CacheExpirationActionParameters) ConvertToARM(resolved genrunt
 	if parameters == nil {
 		return nil, nil
 	}
-	var result CacheExpirationActionParametersARM
+	result := &CacheExpirationActionParametersARM{}
 
 	// Set property ‘CacheBehavior’:
 	if parameters.CacheBehavior != nil {
@@ -11340,7 +11340,7 @@ func (parameters *CacheKeyQueryStringActionParameters) ConvertToARM(resolved gen
 	if parameters == nil {
 		return nil, nil
 	}
-	var result CacheKeyQueryStringActionParametersARM
+	result := &CacheKeyQueryStringActionParametersARM{}
 
 	// Set property ‘QueryParameters’:
 	if parameters.QueryParameters != nil {
@@ -11483,7 +11483,7 @@ func (parameters *ClientPortMatchConditionParameters) ConvertToARM(resolved genr
 	if parameters == nil {
 		return nil, nil
 	}
-	var result ClientPortMatchConditionParametersARM
+	result := &ClientPortMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -11691,7 +11691,7 @@ func (parameters *CookiesMatchConditionParameters) ConvertToARM(resolved genrunt
 	if parameters == nil {
 		return nil, nil
 	}
-	var result CookiesMatchConditionParametersARM
+	result := &CookiesMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -12032,7 +12032,7 @@ func (parameters *HeaderActionParameters) ConvertToARM(resolved genruntime.Conve
 	if parameters == nil {
 		return nil, nil
 	}
-	var result HeaderActionParametersARM
+	result := &HeaderActionParametersARM{}
 
 	// Set property ‘HeaderAction’:
 	if parameters.HeaderAction != nil {
@@ -12193,7 +12193,7 @@ func (parameters *HostNameMatchConditionParameters) ConvertToARM(resolved genrun
 	if parameters == nil {
 		return nil, nil
 	}
-	var result HostNameMatchConditionParametersARM
+	result := &HostNameMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -12398,7 +12398,7 @@ func (parameters *HttpVersionMatchConditionParameters) ConvertToARM(resolved gen
 	if parameters == nil {
 		return nil, nil
 	}
-	var result HttpVersionMatchConditionParametersARM
+	result := &HttpVersionMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -12603,7 +12603,7 @@ func (parameters *IsDeviceMatchConditionParameters) ConvertToARM(resolved genrun
 	if parameters == nil {
 		return nil, nil
 	}
-	var result IsDeviceMatchConditionParametersARM
+	result := &IsDeviceMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -12824,7 +12824,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 	if parameters == nil {
 		return nil, nil
 	}
-	var result OriginGroupOverrideActionParametersARM
+	result := &OriginGroupOverrideActionParametersARM{}
 
 	// Set property ‘OriginGroup’:
 	if parameters.OriginGroup != nil {
@@ -12832,7 +12832,7 @@ func (parameters *OriginGroupOverrideActionParameters) ConvertToARM(resolved gen
 		if err != nil {
 			return nil, err
 		}
-		originGroup := originGroupARM.(ResourceReferenceARM)
+		originGroup := *originGroupARM.(*ResourceReferenceARM)
 		result.OriginGroup = &originGroup
 	}
 
@@ -12969,7 +12969,7 @@ func (parameters *PostArgsMatchConditionParameters) ConvertToARM(resolved genrun
 	if parameters == nil {
 		return nil, nil
 	}
-	var result PostArgsMatchConditionParametersARM
+	result := &PostArgsMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -13192,7 +13192,7 @@ func (parameters *QueryStringMatchConditionParameters) ConvertToARM(resolved gen
 	if parameters == nil {
 		return nil, nil
 	}
-	var result QueryStringMatchConditionParametersARM
+	result := &QueryStringMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -13398,7 +13398,7 @@ func (parameters *RemoteAddressMatchConditionParameters) ConvertToARM(resolved g
 	if parameters == nil {
 		return nil, nil
 	}
-	var result RemoteAddressMatchConditionParametersARM
+	result := &RemoteAddressMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -13603,7 +13603,7 @@ func (parameters *RequestBodyMatchConditionParameters) ConvertToARM(resolved gen
 	if parameters == nil {
 		return nil, nil
 	}
-	var result RequestBodyMatchConditionParametersARM
+	result := &RequestBodyMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -13811,7 +13811,7 @@ func (parameters *RequestHeaderMatchConditionParameters) ConvertToARM(resolved g
 	if parameters == nil {
 		return nil, nil
 	}
-	var result RequestHeaderMatchConditionParametersARM
+	result := &RequestHeaderMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -14034,7 +14034,7 @@ func (parameters *RequestMethodMatchConditionParameters) ConvertToARM(resolved g
 	if parameters == nil {
 		return nil, nil
 	}
-	var result RequestMethodMatchConditionParametersARM
+	result := &RequestMethodMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -14259,7 +14259,7 @@ func (parameters *RequestSchemeMatchConditionParameters) ConvertToARM(resolved g
 	if parameters == nil {
 		return nil, nil
 	}
-	var result RequestSchemeMatchConditionParametersARM
+	result := &RequestSchemeMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -14484,7 +14484,7 @@ func (parameters *RequestUriMatchConditionParameters) ConvertToARM(resolved genr
 	if parameters == nil {
 		return nil, nil
 	}
-	var result RequestUriMatchConditionParametersARM
+	result := &RequestUriMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -14683,7 +14683,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 	if parameters == nil {
 		return nil, nil
 	}
-	var result RouteConfigurationOverrideActionParametersARM
+	result := &RouteConfigurationOverrideActionParametersARM{}
 
 	// Set property ‘CacheConfiguration’:
 	if parameters.CacheConfiguration != nil {
@@ -14691,7 +14691,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		cacheConfiguration := cacheConfigurationARM.(CacheConfigurationARM)
+		cacheConfiguration := *cacheConfigurationARM.(*CacheConfigurationARM)
 		result.CacheConfiguration = &cacheConfiguration
 	}
 
@@ -14701,7 +14701,7 @@ func (parameters *RouteConfigurationOverrideActionParameters) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		originGroupOverride := originGroupOverrideARM.(OriginGroupOverrideARM)
+		originGroupOverride := *originGroupOverrideARM.(*OriginGroupOverrideARM)
 		result.OriginGroupOverride = &originGroupOverride
 	}
 
@@ -14870,7 +14870,7 @@ func (parameters *ServerPortMatchConditionParameters) ConvertToARM(resolved genr
 	if parameters == nil {
 		return nil, nil
 	}
-	var result ServerPortMatchConditionParametersARM
+	result := &ServerPortMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -15075,7 +15075,7 @@ func (parameters *SocketAddrMatchConditionParameters) ConvertToARM(resolved genr
 	if parameters == nil {
 		return nil, nil
 	}
-	var result SocketAddrMatchConditionParametersARM
+	result := &SocketAddrMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -15280,7 +15280,7 @@ func (parameters *SslProtocolMatchConditionParameters) ConvertToARM(resolved gen
 	if parameters == nil {
 		return nil, nil
 	}
-	var result SslProtocolMatchConditionParametersARM
+	result := &SslProtocolMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -15505,7 +15505,7 @@ func (parameters *UrlFileExtensionMatchConditionParameters) ConvertToARM(resolve
 	if parameters == nil {
 		return nil, nil
 	}
-	var result UrlFileExtensionMatchConditionParametersARM
+	result := &UrlFileExtensionMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -15710,7 +15710,7 @@ func (parameters *UrlFileNameMatchConditionParameters) ConvertToARM(resolved gen
 	if parameters == nil {
 		return nil, nil
 	}
-	var result UrlFileNameMatchConditionParametersARM
+	result := &UrlFileNameMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -15915,7 +15915,7 @@ func (parameters *UrlPathMatchConditionParameters) ConvertToARM(resolved genrunt
 	if parameters == nil {
 		return nil, nil
 	}
-	var result UrlPathMatchConditionParametersARM
+	result := &UrlPathMatchConditionParametersARM{}
 
 	// Set property ‘MatchValues’:
 	for _, item := range parameters.MatchValues {
@@ -16135,7 +16135,7 @@ func (parameters *UrlRedirectActionParameters) ConvertToARM(resolved genruntime.
 	if parameters == nil {
 		return nil, nil
 	}
-	var result UrlRedirectActionParametersARM
+	result := &UrlRedirectActionParametersARM{}
 
 	// Set property ‘CustomFragment’:
 	if parameters.CustomFragment != nil {
@@ -16364,7 +16364,7 @@ func (parameters *UrlRewriteActionParameters) ConvertToARM(resolved genruntime.C
 	if parameters == nil {
 		return nil, nil
 	}
-	var result UrlRewriteActionParametersARM
+	result := &UrlRewriteActionParametersARM{}
 
 	// Set property ‘Destination’:
 	if parameters.Destination != nil {
@@ -16523,7 +16523,7 @@ func (parameters *UrlSigningActionParameters) ConvertToARM(resolved genruntime.C
 	if parameters == nil {
 		return nil, nil
 	}
-	var result UrlSigningActionParametersARM
+	result := &UrlSigningActionParametersARM{}
 
 	// Set property ‘Algorithm’:
 	if parameters.Algorithm != nil {
@@ -16537,7 +16537,7 @@ func (parameters *UrlSigningActionParameters) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		result.ParameterNameOverride = append(result.ParameterNameOverride, itemARM.(UrlSigningParamIdentifierARM))
+		result.ParameterNameOverride = append(result.ParameterNameOverride, *itemARM.(*UrlSigningParamIdentifierARM))
 	}
 
 	// Set property ‘TypeName’:
@@ -16706,7 +16706,7 @@ func (configuration *CacheConfiguration) ConvertToARM(resolved genruntime.Conver
 	if configuration == nil {
 		return nil, nil
 	}
-	var result CacheConfigurationARM
+	result := &CacheConfigurationARM{}
 
 	// Set property ‘CacheBehavior’:
 	if configuration.CacheBehavior != nil {
@@ -17084,7 +17084,7 @@ func (override *OriginGroupOverride) ConvertToARM(resolved genruntime.ConvertToA
 	if override == nil {
 		return nil, nil
 	}
-	var result OriginGroupOverrideARM
+	result := &OriginGroupOverrideARM{}
 
 	// Set property ‘ForwardingProtocol’:
 	if override.ForwardingProtocol != nil {
@@ -17098,7 +17098,7 @@ func (override *OriginGroupOverride) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		originGroup := originGroupARM.(ResourceReferenceARM)
+		originGroup := *originGroupARM.(*ResourceReferenceARM)
 		result.OriginGroup = &originGroup
 	}
 	return result, nil
@@ -17712,7 +17712,7 @@ func (identifier *UrlSigningParamIdentifier) ConvertToARM(resolved genruntime.Co
 	if identifier == nil {
 		return nil, nil
 	}
-	var result UrlSigningParamIdentifierARM
+	result := &UrlSigningParamIdentifierARM{}
 
 	// Set property ‘ParamIndicator’:
 	if identifier.ParamIndicator != nil {

--- a/v2/api/cdn/v1beta20210601/profiles_endpoints__spec_arm_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoints__spec_arm_types_gen.go
@@ -30,12 +30,12 @@ func (endpoints ProfilesEndpoints_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (endpoints ProfilesEndpoints_SpecARM) GetName() string {
+func (endpoints *ProfilesEndpoints_SpecARM) GetName() string {
 	return endpoints.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Cdn/profiles/endpoints"
-func (endpoints ProfilesEndpoints_SpecARM) GetType() string {
+func (endpoints *ProfilesEndpoints_SpecARM) GetType() string {
 	return "Microsoft.Cdn/profiles/endpoints"
 }
 

--- a/v2/api/compute/v1alpha1api20200930/disk_types_gen.go
+++ b/v2/api/compute/v1alpha1api20200930/disk_types_gen.go
@@ -1189,7 +1189,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if disks == nil {
 		return nil, nil
 	}
-	var result Disks_SpecARM
+	result := &Disks_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if disks.ExtendedLocation != nil {
@@ -1197,7 +1197,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1238,7 +1238,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		creationData := creationDataARM.(CreationDataARM)
+		creationData := *creationDataARM.(*CreationDataARM)
 		result.Properties.CreationData = &creationData
 	}
 	if disks.DiskAccessReference != nil {
@@ -1274,7 +1274,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if disks.EncryptionSettingsCollection != nil {
@@ -1282,7 +1282,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		encryptionSettingsCollection := encryptionSettingsCollectionARM.(EncryptionSettingsCollectionARM)
+		encryptionSettingsCollection := *encryptionSettingsCollectionARM.(*EncryptionSettingsCollectionARM)
 		result.Properties.EncryptionSettingsCollection = &encryptionSettingsCollection
 	}
 	if disks.HyperVGeneration != nil {
@@ -1306,7 +1306,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		purchasePlan := purchasePlanARM.(PurchasePlanARM)
+		purchasePlan := *purchasePlanARM.(*PurchasePlanARM)
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 	if disks.Tier != nil {
@@ -1320,7 +1320,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(DiskSkuARM)
+		sku := *skuARM.(*DiskSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1971,7 +1971,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if data == nil {
 		return nil, nil
 	}
-	var result CreationDataARM
+	result := &CreationDataARM{}
 
 	// Set property ‘CreateOption’:
 	if data.CreateOption != nil {
@@ -1985,7 +1985,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		galleryImageReference := galleryImageReferenceARM.(ImageDiskReferenceARM)
+		galleryImageReference := *galleryImageReferenceARM.(*ImageDiskReferenceARM)
 		result.GalleryImageReference = &galleryImageReference
 	}
 
@@ -1995,7 +1995,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		imageReference := imageReferenceARM.(ImageDiskReferenceARM)
+		imageReference := *imageReferenceARM.(*ImageDiskReferenceARM)
 		result.ImageReference = &imageReference
 	}
 
@@ -2507,7 +2507,7 @@ func (diskSku *DiskSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if diskSku == nil {
 		return nil, nil
 	}
-	var result DiskSkuARM
+	result := &DiskSkuARM{}
 
 	// Set property ‘Name’:
 	if diskSku.Name != nil {
@@ -2684,7 +2684,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘DiskEncryptionSetId’:
 	if encryption.DiskEncryptionSetReference != nil {
@@ -2798,7 +2798,7 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 	if collection == nil {
 		return nil, nil
 	}
-	var result EncryptionSettingsCollectionARM
+	result := &EncryptionSettingsCollectionARM{}
 
 	// Set property ‘Enabled’:
 	if collection.Enabled != nil {
@@ -2812,7 +2812,7 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		result.EncryptionSettings = append(result.EncryptionSettings, itemARM.(EncryptionSettingsElementARM))
+		result.EncryptionSettings = append(result.EncryptionSettings, *itemARM.(*EncryptionSettingsElementARM))
 	}
 
 	// Set property ‘EncryptionSettingsVersion’:
@@ -3164,7 +3164,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -3363,7 +3363,7 @@ func (plan *PurchasePlan) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if plan == nil {
 		return nil, nil
 	}
-	var result PurchasePlanARM
+	result := &PurchasePlanARM{}
 
 	// Set property ‘Name’:
 	if plan.Name != nil {
@@ -3673,7 +3673,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 	if element == nil {
 		return nil, nil
 	}
-	var result EncryptionSettingsElementARM
+	result := &EncryptionSettingsElementARM{}
 
 	// Set property ‘DiskEncryptionKey’:
 	if element.DiskEncryptionKey != nil {
@@ -3681,7 +3681,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionKey := diskEncryptionKeyARM.(KeyVaultAndSecretReferenceARM)
+		diskEncryptionKey := *diskEncryptionKeyARM.(*KeyVaultAndSecretReferenceARM)
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
@@ -3691,7 +3691,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		keyEncryptionKey := keyEncryptionKeyARM.(KeyVaultAndKeyReferenceARM)
+		keyEncryptionKey := *keyEncryptionKeyARM.(*KeyVaultAndKeyReferenceARM)
 		result.KeyEncryptionKey = &keyEncryptionKey
 	}
 	return result, nil
@@ -3957,7 +3957,7 @@ func (reference *ImageDiskReference) ConvertToARM(resolved genruntime.ConvertToA
 	if reference == nil {
 		return nil, nil
 	}
-	var result ImageDiskReferenceARM
+	result := &ImageDiskReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -4133,7 +4133,7 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultAndKeyReferenceARM
+	result := &KeyVaultAndKeyReferenceARM{}
 
 	// Set property ‘KeyUrl’:
 	if reference.KeyUrl != nil {
@@ -4147,7 +4147,7 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SourceVaultARM)
+		sourceVault := *sourceVaultARM.(*SourceVaultARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -4349,7 +4349,7 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultAndSecretReferenceARM
+	result := &KeyVaultAndSecretReferenceARM{}
 
 	// Set property ‘SecretUrl’:
 	if reference.SecretUrl != nil {
@@ -4363,7 +4363,7 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SourceVaultARM)
+		sourceVault := *sourceVaultARM.(*SourceVaultARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -4561,7 +4561,7 @@ func (vault *SourceVault) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if vault == nil {
 		return nil, nil
 	}
-	var result SourceVaultARM
+	result := &SourceVaultARM{}
 
 	// Set property ‘Id’:
 	if vault.Reference != nil {

--- a/v2/api/compute/v1alpha1api20200930/disks__spec_arm_types_gen.go
+++ b/v2/api/compute/v1alpha1api20200930/disks__spec_arm_types_gen.go
@@ -24,12 +24,12 @@ func (disks Disks_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (disks Disks_SpecARM) GetName() string {
+func (disks *Disks_SpecARM) GetName() string {
 	return disks.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/disks"
-func (disks Disks_SpecARM) GetType() string {
+func (disks *Disks_SpecARM) GetType() string {
 	return "Microsoft.Compute/disks"
 }
 

--- a/v2/api/compute/v1alpha1api20200930/snapshot_types_gen.go
+++ b/v2/api/compute/v1alpha1api20200930/snapshot_types_gen.go
@@ -1006,7 +1006,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if snapshots == nil {
 		return nil, nil
 	}
-	var result Snapshots_SpecARM
+	result := &Snapshots_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if snapshots.ExtendedLocation != nil {
@@ -1014,7 +1014,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1046,7 +1046,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		creationData := creationDataARM.(CreationDataARM)
+		creationData := *creationDataARM.(*CreationDataARM)
 		result.Properties.CreationData = &creationData
 	}
 	if snapshots.DiskAccessReference != nil {
@@ -1070,7 +1070,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if snapshots.EncryptionSettingsCollection != nil {
@@ -1078,7 +1078,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		encryptionSettingsCollection := encryptionSettingsCollectionARM.(EncryptionSettingsCollectionARM)
+		encryptionSettingsCollection := *encryptionSettingsCollectionARM.(*EncryptionSettingsCollectionARM)
 		result.Properties.EncryptionSettingsCollection = &encryptionSettingsCollection
 	}
 	if snapshots.HyperVGeneration != nil {
@@ -1102,7 +1102,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		purchasePlan := purchasePlanARM.(PurchasePlanARM)
+		purchasePlan := *purchasePlanARM.(*PurchasePlanARM)
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 
@@ -1112,7 +1112,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SnapshotSkuARM)
+		sku := *skuARM.(*SnapshotSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1733,7 +1733,7 @@ func (snapshotSku *SnapshotSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if snapshotSku == nil {
 		return nil, nil
 	}
-	var result SnapshotSkuARM
+	result := &SnapshotSkuARM{}
 
 	// Set property ‘Name’:
 	if snapshotSku.Name != nil {

--- a/v2/api/compute/v1alpha1api20200930/snapshots__spec_arm_types_gen.go
+++ b/v2/api/compute/v1alpha1api20200930/snapshots__spec_arm_types_gen.go
@@ -23,12 +23,12 @@ func (snapshots Snapshots_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (snapshots Snapshots_SpecARM) GetName() string {
+func (snapshots *Snapshots_SpecARM) GetName() string {
 	return snapshots.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/snapshots"
-func (snapshots Snapshots_SpecARM) GetType() string {
+func (snapshots *Snapshots_SpecARM) GetType() string {
 	return "Microsoft.Compute/snapshots"
 }
 

--- a/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
@@ -1152,7 +1152,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 	if sets == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_SpecARM
+	result := &VirtualMachineScaleSets_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if sets.ExtendedLocation != nil {
@@ -1160,7 +1160,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1170,7 +1170,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(VirtualMachineScaleSetIdentityARM)
+		identity := *identityARM.(*VirtualMachineScaleSetIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1189,7 +1189,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		plan := planARM.(PlanARM)
+		plan := *planARM.(*PlanARM)
 		result.Plan = &plan
 	}
 
@@ -1214,7 +1214,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		additionalCapabilities := additionalCapabilitiesARM.(AdditionalCapabilitiesARM)
+		additionalCapabilities := *additionalCapabilitiesARM.(*AdditionalCapabilitiesARM)
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if sets.AutomaticRepairsPolicy != nil {
@@ -1222,7 +1222,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		automaticRepairsPolicy := automaticRepairsPolicyARM.(AutomaticRepairsPolicyARM)
+		automaticRepairsPolicy := *automaticRepairsPolicyARM.(*AutomaticRepairsPolicyARM)
 		result.Properties.AutomaticRepairsPolicy = &automaticRepairsPolicy
 	}
 	if sets.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -1234,7 +1234,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		hostGroup := hostGroupARM.(SubResourceARM)
+		hostGroup := *hostGroupARM.(*SubResourceARM)
 		result.Properties.HostGroup = &hostGroup
 	}
 	if sets.OrchestrationMode != nil {
@@ -1254,7 +1254,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		proximityPlacementGroup := proximityPlacementGroupARM.(SubResourceARM)
+		proximityPlacementGroup := *proximityPlacementGroupARM.(*SubResourceARM)
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if sets.ScaleInPolicy != nil {
@@ -1262,7 +1262,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		scaleInPolicy := scaleInPolicyARM.(ScaleInPolicyARM)
+		scaleInPolicy := *scaleInPolicyARM.(*ScaleInPolicyARM)
 		result.Properties.ScaleInPolicy = &scaleInPolicy
 	}
 	if sets.SinglePlacementGroup != nil {
@@ -1274,7 +1274,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		upgradePolicy := upgradePolicyARM.(UpgradePolicyARM)
+		upgradePolicy := *upgradePolicyARM.(*UpgradePolicyARM)
 		result.Properties.UpgradePolicy = &upgradePolicy
 	}
 	if sets.VirtualMachineProfile != nil {
@@ -1282,7 +1282,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		virtualMachineProfile := virtualMachineProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM)
+		virtualMachineProfile := *virtualMachineProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM)
 		result.Properties.VirtualMachineProfile = &virtualMachineProfile
 	}
 	if sets.ZoneBalance != nil {
@@ -1296,7 +1296,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -2041,7 +2041,7 @@ func (policy *AutomaticRepairsPolicy) ConvertToARM(resolved genruntime.ConvertTo
 	if policy == nil {
 		return nil, nil
 	}
-	var result AutomaticRepairsPolicyARM
+	result := &AutomaticRepairsPolicyARM{}
 
 	// Set property ‘Enabled’:
 	if policy.Enabled != nil {
@@ -2231,7 +2231,7 @@ func (policy *ScaleInPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if policy == nil {
 		return nil, nil
 	}
-	var result ScaleInPolicyARM
+	result := &ScaleInPolicyARM{}
 
 	// Set property ‘Rules’:
 	for _, item := range policy.Rules {
@@ -2401,7 +2401,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {
@@ -2596,7 +2596,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if policy == nil {
 		return nil, nil
 	}
-	var result UpgradePolicyARM
+	result := &UpgradePolicyARM{}
 
 	// Set property ‘AutomaticOSUpgradePolicy’:
 	if policy.AutomaticOSUpgradePolicy != nil {
@@ -2604,7 +2604,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		automaticOSUpgradePolicy := automaticOSUpgradePolicyARM.(AutomaticOSUpgradePolicyARM)
+		automaticOSUpgradePolicy := *automaticOSUpgradePolicyARM.(*AutomaticOSUpgradePolicyARM)
 		result.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
@@ -2620,7 +2620,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		rollingUpgradePolicy := rollingUpgradePolicyARM.(RollingUpgradePolicyARM)
+		rollingUpgradePolicy := *rollingUpgradePolicyARM.(*RollingUpgradePolicyARM)
 		result.RollingUpgradePolicy = &rollingUpgradePolicy
 	}
 	return result, nil
@@ -2909,7 +2909,7 @@ func (identity *VirtualMachineScaleSetIdentity) ConvertToARM(resolved genruntime
 	if identity == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetIdentityARM
+	result := &VirtualMachineScaleSetIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -3548,7 +3548,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM{}
 
 	// Set property ‘BillingProfile’:
 	if profile.BillingProfile != nil {
@@ -3556,7 +3556,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		billingProfile := billingProfileARM.(BillingProfileARM)
+		billingProfile := *billingProfileARM.(*BillingProfileARM)
 		result.BillingProfile = &billingProfile
 	}
 
@@ -3566,7 +3566,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		diagnosticsProfile := diagnosticsProfileARM.(DiagnosticsProfileARM)
+		diagnosticsProfile := *diagnosticsProfileARM.(*DiagnosticsProfileARM)
 		result.DiagnosticsProfile = &diagnosticsProfile
 	}
 
@@ -3582,7 +3582,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		extensionProfile := extensionProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM)
+		extensionProfile := *extensionProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM)
 		result.ExtensionProfile = &extensionProfile
 	}
 
@@ -3598,7 +3598,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		networkProfile := networkProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM)
+		networkProfile := *networkProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM)
 		result.NetworkProfile = &networkProfile
 	}
 
@@ -3608,7 +3608,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		osProfile := osProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM)
+		osProfile := *osProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM)
 		result.OsProfile = &osProfile
 	}
 
@@ -3624,7 +3624,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		scheduledEventsProfile := scheduledEventsProfileARM.(ScheduledEventsProfileARM)
+		scheduledEventsProfile := *scheduledEventsProfileARM.(*ScheduledEventsProfileARM)
 		result.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
@@ -3634,7 +3634,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		securityProfile := securityProfileARM.(SecurityProfileARM)
+		securityProfile := *securityProfileARM.(*SecurityProfileARM)
 		result.SecurityProfile = &securityProfile
 	}
 
@@ -3644,7 +3644,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		storageProfile := storageProfileARM.(VirtualMachineScaleSetStorageProfileARM)
+		storageProfile := *storageProfileARM.(*VirtualMachineScaleSetStorageProfileARM)
 		result.StorageProfile = &storageProfile
 	}
 	return result, nil
@@ -4038,7 +4038,7 @@ func (policy *AutomaticOSUpgradePolicy) ConvertToARM(resolved genruntime.Convert
 	if policy == nil {
 		return nil, nil
 	}
-	var result AutomaticOSUpgradePolicyARM
+	result := &AutomaticOSUpgradePolicyARM{}
 
 	// Set property ‘DisableAutomaticRollback’:
 	if policy.DisableAutomaticRollback != nil {
@@ -4254,7 +4254,7 @@ func (policy *RollingUpgradePolicy) ConvertToARM(resolved genruntime.ConvertToAR
 	if policy == nil {
 		return nil, nil
 	}
-	var result RollingUpgradePolicyARM
+	result := &RollingUpgradePolicyARM{}
 
 	// Set property ‘EnableCrossZoneUpgrade’:
 	if policy.EnableCrossZoneUpgrade != nil {
@@ -4629,7 +4629,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 	if profile == nil {
 		return nil, nil
 	}
-	var result ScheduledEventsProfileARM
+	result := &ScheduledEventsProfileARM{}
 
 	// Set property ‘TerminateNotificationProfile’:
 	if profile.TerminateNotificationProfile != nil {
@@ -4637,7 +4637,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		terminateNotificationProfile := terminateNotificationProfileARM.(TerminateNotificationProfileARM)
+		terminateNotificationProfile := *terminateNotificationProfileARM.(*TerminateNotificationProfileARM)
 		result.TerminateNotificationProfile = &terminateNotificationProfile
 	}
 	return result, nil
@@ -5338,7 +5338,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetStorageProfileARM
+	result := &VirtualMachineScaleSetStorageProfileARM{}
 
 	// Set property ‘DataDisks’:
 	for _, item := range profile.DataDisks {
@@ -5346,7 +5346,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		result.DataDisks = append(result.DataDisks, itemARM.(VirtualMachineScaleSetDataDiskARM))
+		result.DataDisks = append(result.DataDisks, *itemARM.(*VirtualMachineScaleSetDataDiskARM))
 	}
 
 	// Set property ‘ImageReference’:
@@ -5355,7 +5355,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		imageReference := imageReferenceARM.(ImageReferenceARM)
+		imageReference := *imageReferenceARM.(*ImageReferenceARM)
 		result.ImageReference = &imageReference
 	}
 
@@ -5365,7 +5365,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		osDisk := osDiskARM.(VirtualMachineScaleSetOSDiskARM)
+		osDisk := *osDiskARM.(*VirtualMachineScaleSetOSDiskARM)
 		result.OsDisk = &osDisk
 	}
 	return result, nil
@@ -5724,7 +5724,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Ext
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM{}
 
 	// Set property ‘Extensions’:
 	for _, item := range profile.Extensions {
@@ -5732,7 +5732,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Ext
 		if err != nil {
 			return nil, err
 		}
-		result.Extensions = append(result.Extensions, itemARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM))
+		result.Extensions = append(result.Extensions, *itemARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM))
 	}
 
 	// Set property ‘ExtensionsTimeBudget’:
@@ -5853,7 +5853,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Net
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM{}
 
 	// Set property ‘HealthProbe’:
 	if profile.HealthProbe != nil {
@@ -5861,7 +5861,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Net
 		if err != nil {
 			return nil, err
 		}
-		healthProbe := healthProbeARM.(ApiEntityReferenceARM)
+		healthProbe := *healthProbeARM.(*ApiEntityReferenceARM)
 		result.HealthProbe = &healthProbe
 	}
 
@@ -5871,7 +5871,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Net
 		if err != nil {
 			return nil, err
 		}
-		result.NetworkInterfaceConfigurations = append(result.NetworkInterfaceConfigurations, itemARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM))
+		result.NetworkInterfaceConfigurations = append(result.NetworkInterfaceConfigurations, *itemARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM))
 	}
 	return result, nil
 }
@@ -6014,7 +6014,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM{}
 
 	// Set property ‘AdminPassword’:
 	if profile.AdminPassword != nil {
@@ -6050,7 +6050,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 		if err != nil {
 			return nil, err
 		}
-		linuxConfiguration := linuxConfigurationARM.(LinuxConfigurationARM)
+		linuxConfiguration := *linuxConfigurationARM.(*LinuxConfigurationARM)
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
@@ -6060,7 +6060,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 		if err != nil {
 			return nil, err
 		}
-		result.Secrets = append(result.Secrets, itemARM.(VaultSecretGroupARM))
+		result.Secrets = append(result.Secrets, *itemARM.(*VaultSecretGroupARM))
 	}
 
 	// Set property ‘WindowsConfiguration’:
@@ -6069,7 +6069,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 		if err != nil {
 			return nil, err
 		}
-		windowsConfiguration := windowsConfigurationARM.(WindowsConfigurationARM)
+		windowsConfiguration := *windowsConfigurationARM.(*WindowsConfigurationARM)
 		result.WindowsConfiguration = &windowsConfiguration
 	}
 	return result, nil
@@ -6296,7 +6296,7 @@ func (reference *ApiEntityReference) ConvertToARM(resolved genruntime.ConvertToA
 	if reference == nil {
 		return nil, nil
 	}
-	var result ApiEntityReferenceARM
+	result := &ApiEntityReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -6438,7 +6438,7 @@ func (profile *TerminateNotificationProfile) ConvertToARM(resolved genruntime.Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result TerminateNotificationProfileARM
+	result := &TerminateNotificationProfileARM{}
 
 	// Set property ‘Enable’:
 	if profile.Enable != nil {
@@ -6632,7 +6632,7 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 	if disk == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetDataDiskARM
+	result := &VirtualMachineScaleSetDataDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -6676,7 +6676,7 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(VirtualMachineScaleSetManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*VirtualMachineScaleSetManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -7742,7 +7742,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 	if disk == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetOSDiskARM
+	result := &VirtualMachineScaleSetOSDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -7762,7 +7762,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		diffDiskSettings := diffDiskSettingsARM.(DiffDiskSettingsARM)
+		diffDiskSettings := *diffDiskSettingsARM.(*DiffDiskSettingsARM)
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
@@ -7778,7 +7778,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		image := imageARM.(VirtualHardDiskARM)
+		image := *imageARM.(*VirtualHardDiskARM)
 		result.Image = &image
 	}
 
@@ -7788,7 +7788,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(VirtualMachineScaleSetManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*VirtualMachineScaleSetManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -8394,7 +8394,7 @@ func (extensions *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_
 	if extensions == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM{}
 
 	// Set property ‘Name’:
 	if extensions.Name != nil {
@@ -8617,7 +8617,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 	if configurations == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM{}
 
 	// Set property ‘Id’:
 	if configurations.Id != nil {
@@ -8646,7 +8646,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if configurations.EnableAcceleratedNetworking != nil {
@@ -8666,14 +8666,14 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, itemARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM))
+		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *itemARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM))
 	}
 	if configurations.NetworkSecurityGroup != nil {
 		networkSecurityGroupARM, err := (*configurations.NetworkSecurityGroup).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		networkSecurityGroup := networkSecurityGroupARM.(SubResourceARM)
+		networkSecurityGroup := *networkSecurityGroupARM.(*SubResourceARM)
 		result.Properties.NetworkSecurityGroup = &networkSecurityGroup
 	}
 	if configurations.Primary != nil {
@@ -9407,7 +9407,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 	if parameters == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetManagedDiskParametersARM
+	result := &VirtualMachineScaleSetManagedDiskParametersARM{}
 
 	// Set property ‘DiskEncryptionSet’:
 	if parameters.DiskEncryptionSet != nil {
@@ -9415,7 +9415,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -9639,7 +9639,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) ConvertTo
 	if settings == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM
+	result := &VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM{}
 
 	// Set property ‘DnsServers’:
 	for _, item := range settings.DnsServers {
@@ -9817,7 +9817,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 	if configurations == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM{}
 
 	// Set property ‘Id’:
 	if configurations.Id != nil {
@@ -9847,28 +9847,28 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.ApplicationSecurityGroups {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerBackendAddressPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerInboundNatPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerInboundNatPools = append(result.Properties.LoadBalancerInboundNatPools, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerInboundNatPools = append(result.Properties.LoadBalancerInboundNatPools, *itemARM.(*SubResourceARM))
 	}
 	if configurations.Primary != nil {
 		primary := *configurations.Primary
@@ -9883,7 +9883,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddressConfiguration := publicIPAddressConfigurationARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM)
+		publicIPAddressConfiguration := *publicIPAddressConfigurationARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM)
 		result.Properties.PublicIPAddressConfiguration = &publicIPAddressConfiguration
 	}
 	if configurations.Subnet != nil {
@@ -9891,7 +9891,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(ApiEntityReferenceARM)
+		subnet := *subnetARM.(*ApiEntityReferenceARM)
 		result.Properties.Subnet = &subnet
 	}
 	return result, nil
@@ -10565,7 +10565,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 	if configuration == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM{}
 
 	// Set property ‘Name’:
 	if configuration.Name != nil {
@@ -10586,7 +10586,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if configuration.IdleTimeoutInMinutes != nil {
@@ -10598,7 +10598,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpTags = append(result.Properties.IpTags, itemARM.(VirtualMachineScaleSetIpTagARM))
+		result.Properties.IpTags = append(result.Properties.IpTags, *itemARM.(*VirtualMachineScaleSetIpTagARM))
 	}
 	if configuration.PublicIPAddressVersion != nil {
 		publicIPAddressVersion := *configuration.PublicIPAddressVersion
@@ -10609,7 +10609,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 		if err != nil {
 			return nil, err
 		}
-		publicIPPrefix := publicIPPrefixARM.(SubResourceARM)
+		publicIPPrefix := *publicIPPrefixARM.(*SubResourceARM)
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	return result, nil
@@ -10844,7 +10844,7 @@ func (ipTag *VirtualMachineScaleSetIpTag) ConvertToARM(resolved genruntime.Conve
 	if ipTag == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetIpTagARM
+	result := &VirtualMachineScaleSetIpTagARM{}
 
 	// Set property ‘IpTagType’:
 	if ipTag.IpTagType != nil {
@@ -11007,7 +11007,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) C
 	if settings == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM
+	result := &VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM{}
 
 	// Set property ‘DomainNameLabel’:
 	if settings.DomainNameLabel != nil {

--- a/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_sets__spec_arm_types_gen.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_sets__spec_arm_types_gen.go
@@ -29,12 +29,12 @@ func (sets VirtualMachineScaleSets_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (sets VirtualMachineScaleSets_SpecARM) GetName() string {
+func (sets *VirtualMachineScaleSets_SpecARM) GetName() string {
 	return sets.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/virtualMachineScaleSets"
-func (sets VirtualMachineScaleSets_SpecARM) GetType() string {
+func (sets *VirtualMachineScaleSets_SpecARM) GetType() string {
 	return "Microsoft.Compute/virtualMachineScaleSets"
 }
 

--- a/v2/api/compute/v1alpha1api20201201/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machine_types_gen.go
@@ -1400,7 +1400,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if machines == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_SpecARM
+	result := &VirtualMachines_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if machines.ExtendedLocation != nil {
@@ -1408,7 +1408,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1418,7 +1418,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(VirtualMachineIdentityARM)
+		identity := *identityARM.(*VirtualMachineIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1437,7 +1437,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		plan := planARM.(PlanARM)
+		plan := *planARM.(*PlanARM)
 		result.Plan = &plan
 	}
 
@@ -1467,7 +1467,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		additionalCapabilities := additionalCapabilitiesARM.(AdditionalCapabilitiesARM)
+		additionalCapabilities := *additionalCapabilitiesARM.(*AdditionalCapabilitiesARM)
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if machines.AvailabilitySet != nil {
@@ -1475,7 +1475,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		availabilitySet := availabilitySetARM.(SubResourceARM)
+		availabilitySet := *availabilitySetARM.(*SubResourceARM)
 		result.Properties.AvailabilitySet = &availabilitySet
 	}
 	if machines.BillingProfile != nil {
@@ -1483,7 +1483,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		billingProfile := billingProfileARM.(BillingProfileARM)
+		billingProfile := *billingProfileARM.(*BillingProfileARM)
 		result.Properties.BillingProfile = &billingProfile
 	}
 	if machines.DiagnosticsProfile != nil {
@@ -1491,7 +1491,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		diagnosticsProfile := diagnosticsProfileARM.(DiagnosticsProfileARM)
+		diagnosticsProfile := *diagnosticsProfileARM.(*DiagnosticsProfileARM)
 		result.Properties.DiagnosticsProfile = &diagnosticsProfile
 	}
 	if machines.EvictionPolicy != nil {
@@ -1507,7 +1507,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		hardwareProfile := hardwareProfileARM.(HardwareProfileARM)
+		hardwareProfile := *hardwareProfileARM.(*HardwareProfileARM)
 		result.Properties.HardwareProfile = &hardwareProfile
 	}
 	if machines.Host != nil {
@@ -1515,7 +1515,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		host := hostARM.(SubResourceARM)
+		host := *hostARM.(*SubResourceARM)
 		result.Properties.Host = &host
 	}
 	if machines.HostGroup != nil {
@@ -1523,7 +1523,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		hostGroup := hostGroupARM.(SubResourceARM)
+		hostGroup := *hostGroupARM.(*SubResourceARM)
 		result.Properties.HostGroup = &hostGroup
 	}
 	if machines.LicenseType != nil {
@@ -1535,7 +1535,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		networkProfile := networkProfileARM.(VirtualMachines_Spec_Properties_NetworkProfileARM)
+		networkProfile := *networkProfileARM.(*VirtualMachines_Spec_Properties_NetworkProfileARM)
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if machines.OsProfile != nil {
@@ -1543,7 +1543,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		osProfile := osProfileARM.(VirtualMachines_Spec_Properties_OsProfileARM)
+		osProfile := *osProfileARM.(*VirtualMachines_Spec_Properties_OsProfileARM)
 		result.Properties.OsProfile = &osProfile
 	}
 	if machines.PlatformFaultDomain != nil {
@@ -1559,7 +1559,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		proximityPlacementGroup := proximityPlacementGroupARM.(SubResourceARM)
+		proximityPlacementGroup := *proximityPlacementGroupARM.(*SubResourceARM)
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if machines.SecurityProfile != nil {
@@ -1567,7 +1567,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		securityProfile := securityProfileARM.(SecurityProfileARM)
+		securityProfile := *securityProfileARM.(*SecurityProfileARM)
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if machines.StorageProfile != nil {
@@ -1575,7 +1575,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		storageProfile := storageProfileARM.(StorageProfileARM)
+		storageProfile := *storageProfileARM.(*StorageProfileARM)
 		result.Properties.StorageProfile = &storageProfile
 	}
 	if machines.VirtualMachineScaleSet != nil {
@@ -1583,7 +1583,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		virtualMachineScaleSet := virtualMachineScaleSetARM.(SubResourceARM)
+		virtualMachineScaleSet := *virtualMachineScaleSetARM.(*SubResourceARM)
 		result.Properties.VirtualMachineScaleSet = &virtualMachineScaleSet
 	}
 
@@ -2475,7 +2475,7 @@ func (capabilities *AdditionalCapabilities) ConvertToARM(resolved genruntime.Con
 	if capabilities == nil {
 		return nil, nil
 	}
-	var result AdditionalCapabilitiesARM
+	result := &AdditionalCapabilitiesARM{}
 
 	// Set property ‘UltraSSDEnabled’:
 	if capabilities.UltraSSDEnabled != nil {
@@ -2626,7 +2626,7 @@ func (profile *BillingProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if profile == nil {
 		return nil, nil
 	}
-	var result BillingProfileARM
+	result := &BillingProfileARM{}
 
 	// Set property ‘MaxPrice’:
 	if profile.MaxPrice != nil {
@@ -2777,7 +2777,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	if profile == nil {
 		return nil, nil
 	}
-	var result DiagnosticsProfileARM
+	result := &DiagnosticsProfileARM{}
 
 	// Set property ‘BootDiagnostics’:
 	if profile.BootDiagnostics != nil {
@@ -2785,7 +2785,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		bootDiagnostics := bootDiagnosticsARM.(BootDiagnosticsARM)
+		bootDiagnostics := *bootDiagnosticsARM.(*BootDiagnosticsARM)
 		result.BootDiagnostics = &bootDiagnostics
 	}
 	return result, nil
@@ -2967,7 +2967,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -3149,7 +3149,7 @@ func (profile *HardwareProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if profile == nil {
 		return nil, nil
 	}
-	var result HardwareProfileARM
+	result := &HardwareProfileARM{}
 
 	// Set property ‘VmSize’:
 	if profile.VmSize != nil {
@@ -3644,7 +3644,7 @@ func (plan *Plan) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	if plan == nil {
 		return nil, nil
 	}
-	var result PlanARM
+	result := &PlanARM{}
 
 	// Set property ‘Name’:
 	if plan.Name != nil {
@@ -3879,7 +3879,7 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if profile == nil {
 		return nil, nil
 	}
-	var result SecurityProfileARM
+	result := &SecurityProfileARM{}
 
 	// Set property ‘EncryptionAtHost’:
 	if profile.EncryptionAtHost != nil {
@@ -3899,7 +3899,7 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		uefiSettings := uefiSettingsARM.(UefiSettingsARM)
+		uefiSettings := *uefiSettingsARM.(*UefiSettingsARM)
 		result.UefiSettings = &uefiSettings
 	}
 	return result, nil
@@ -4164,7 +4164,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if profile == nil {
 		return nil, nil
 	}
-	var result StorageProfileARM
+	result := &StorageProfileARM{}
 
 	// Set property ‘DataDisks’:
 	for _, item := range profile.DataDisks {
@@ -4172,7 +4172,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.DataDisks = append(result.DataDisks, itemARM.(DataDiskARM))
+		result.DataDisks = append(result.DataDisks, *itemARM.(*DataDiskARM))
 	}
 
 	// Set property ‘ImageReference’:
@@ -4181,7 +4181,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		imageReference := imageReferenceARM.(ImageReferenceARM)
+		imageReference := *imageReferenceARM.(*ImageReferenceARM)
 		result.ImageReference = &imageReference
 	}
 
@@ -4191,7 +4191,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		osDisk := osDiskARM.(OSDiskARM)
+		osDisk := *osDiskARM.(*OSDiskARM)
 		result.OsDisk = &osDisk
 	}
 	return result, nil
@@ -4528,7 +4528,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if resource == nil {
 		return nil, nil
 	}
-	var result SubResourceARM
+	result := &SubResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {
@@ -5029,7 +5029,7 @@ func (identity *VirtualMachineIdentity) ConvertToARM(resolved genruntime.Convert
 	if identity == nil {
 		return nil, nil
 	}
-	var result VirtualMachineIdentityARM
+	result := &VirtualMachineIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -5799,7 +5799,7 @@ func (profile *VirtualMachines_Spec_Properties_NetworkProfile) ConvertToARM(reso
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_Spec_Properties_NetworkProfileARM
+	result := &VirtualMachines_Spec_Properties_NetworkProfileARM{}
 
 	// Set property ‘NetworkInterfaces’:
 	for _, item := range profile.NetworkInterfaces {
@@ -5807,7 +5807,7 @@ func (profile *VirtualMachines_Spec_Properties_NetworkProfile) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		result.NetworkInterfaces = append(result.NetworkInterfaces, itemARM.(VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM))
+		result.NetworkInterfaces = append(result.NetworkInterfaces, *itemARM.(*VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM))
 	}
 	return result, nil
 }
@@ -5917,7 +5917,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_Spec_Properties_OsProfileARM
+	result := &VirtualMachines_Spec_Properties_OsProfileARM{}
 
 	// Set property ‘AdminPassword’:
 	if profile.AdminPassword != nil {
@@ -5959,7 +5959,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		linuxConfiguration := linuxConfigurationARM.(LinuxConfigurationARM)
+		linuxConfiguration := *linuxConfigurationARM.(*LinuxConfigurationARM)
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
@@ -5975,7 +5975,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		result.Secrets = append(result.Secrets, itemARM.(VaultSecretGroupARM))
+		result.Secrets = append(result.Secrets, *itemARM.(*VaultSecretGroupARM))
 	}
 
 	// Set property ‘WindowsConfiguration’:
@@ -5984,7 +5984,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		windowsConfiguration := windowsConfigurationARM.(WindowsConfigurationARM)
+		windowsConfiguration := *windowsConfigurationARM.(*WindowsConfigurationARM)
 		result.WindowsConfiguration = &windowsConfiguration
 	}
 	return result, nil
@@ -6256,7 +6256,7 @@ func (diagnostics *BootDiagnostics) ConvertToARM(resolved genruntime.ConvertToAR
 	if diagnostics == nil {
 		return nil, nil
 	}
-	var result BootDiagnosticsARM
+	result := &BootDiagnosticsARM{}
 
 	// Set property ‘Enabled’:
 	if diagnostics.Enabled != nil {
@@ -6559,7 +6559,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if disk == nil {
 		return nil, nil
 	}
-	var result DataDiskARM
+	result := &DataDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -6591,7 +6591,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		if err != nil {
 			return nil, err
 		}
-		image := imageARM.(VirtualHardDiskARM)
+		image := *imageARM.(*VirtualHardDiskARM)
 		result.Image = &image
 	}
 
@@ -6607,7 +6607,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(ManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*ManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -6629,7 +6629,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		if err != nil {
 			return nil, err
 		}
-		vhd := vhdARM.(VirtualHardDiskARM)
+		vhd := *vhdARM.(*VirtualHardDiskARM)
 		result.Vhd = &vhd
 	}
 
@@ -7777,7 +7777,7 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if reference == nil {
 		return nil, nil
 	}
-	var result ImageReferenceARM
+	result := &ImageReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -8178,7 +8178,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 	if configuration == nil {
 		return nil, nil
 	}
-	var result LinuxConfigurationARM
+	result := &LinuxConfigurationARM{}
 
 	// Set property ‘DisablePasswordAuthentication’:
 	if configuration.DisablePasswordAuthentication != nil {
@@ -8192,7 +8192,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		patchSettings := patchSettingsARM.(LinuxPatchSettingsARM)
+		patchSettings := *patchSettingsARM.(*LinuxPatchSettingsARM)
 		result.PatchSettings = &patchSettings
 	}
 
@@ -8208,7 +8208,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		ssh := sshARM.(SshConfigurationARM)
+		ssh := *sshARM.(*SshConfigurationARM)
 		result.Ssh = &ssh
 	}
 	return result, nil
@@ -8794,7 +8794,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if disk == nil {
 		return nil, nil
 	}
-	var result OSDiskARM
+	result := &OSDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -8814,7 +8814,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		diffDiskSettings := diffDiskSettingsARM.(DiffDiskSettingsARM)
+		diffDiskSettings := *diffDiskSettingsARM.(*DiffDiskSettingsARM)
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
@@ -8830,7 +8830,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		encryptionSettings := encryptionSettingsARM.(DiskEncryptionSettingsARM)
+		encryptionSettings := *encryptionSettingsARM.(*DiskEncryptionSettingsARM)
 		result.EncryptionSettings = &encryptionSettings
 	}
 
@@ -8840,7 +8840,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		image := imageARM.(VirtualHardDiskARM)
+		image := *imageARM.(*VirtualHardDiskARM)
 		result.Image = &image
 	}
 
@@ -8850,7 +8850,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(ManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*ManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -8872,7 +8872,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		vhd := vhdARM.(VirtualHardDiskARM)
+		vhd := *vhdARM.(*VirtualHardDiskARM)
 		result.Vhd = &vhd
 	}
 
@@ -9577,7 +9577,7 @@ func (settings *UefiSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if settings == nil {
 		return nil, nil
 	}
-	var result UefiSettingsARM
+	result := &UefiSettingsARM{}
 
 	// Set property ‘SecureBootEnabled’:
 	if settings.SecureBootEnabled != nil {
@@ -9780,7 +9780,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if group == nil {
 		return nil, nil
 	}
-	var result VaultSecretGroupARM
+	result := &VaultSecretGroupARM{}
 
 	// Set property ‘SourceVault’:
 	if group.SourceVault != nil {
@@ -9788,7 +9788,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SubResourceARM)
+		sourceVault := *sourceVaultARM.(*SubResourceARM)
 		result.SourceVault = &sourceVault
 	}
 
@@ -9798,7 +9798,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.VaultCertificates = append(result.VaultCertificates, itemARM.(VaultCertificateARM))
+		result.VaultCertificates = append(result.VaultCertificates, *itemARM.(*VaultCertificateARM))
 	}
 	return result, nil
 }
@@ -10719,7 +10719,7 @@ func (interfaces *VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfac
 	if interfaces == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM
+	result := &VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM{}
 
 	// Set property ‘Id’:
 	if interfaces.Reference != nil {
@@ -10841,7 +10841,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 	if configuration == nil {
 		return nil, nil
 	}
-	var result WindowsConfigurationARM
+	result := &WindowsConfigurationARM{}
 
 	// Set property ‘AdditionalUnattendContent’:
 	for _, item := range configuration.AdditionalUnattendContent {
@@ -10849,7 +10849,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, itemARM.(AdditionalUnattendContentARM))
+		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, *itemARM.(*AdditionalUnattendContentARM))
 	}
 
 	// Set property ‘EnableAutomaticUpdates’:
@@ -10864,7 +10864,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		patchSettings := patchSettingsARM.(PatchSettingsARM)
+		patchSettings := *patchSettingsARM.(*PatchSettingsARM)
 		result.PatchSettings = &patchSettings
 	}
 
@@ -10886,7 +10886,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		winRM := winRMARM.(WinRMConfigurationARM)
+		winRM := *winRMARM.(*WinRMConfigurationARM)
 		result.WinRM = &winRM
 	}
 	return result, nil
@@ -11341,7 +11341,7 @@ func (content *AdditionalUnattendContent) ConvertToARM(resolved genruntime.Conve
 	if content == nil {
 		return nil, nil
 	}
-	var result AdditionalUnattendContentARM
+	result := &AdditionalUnattendContentARM{}
 
 	// Set property ‘ComponentName’:
 	if content.ComponentName != nil {
@@ -11867,7 +11867,7 @@ func (settings *DiffDiskSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	if settings == nil {
 		return nil, nil
 	}
-	var result DiffDiskSettingsARM
+	result := &DiffDiskSettingsARM{}
 
 	// Set property ‘Option’:
 	if settings.Option != nil {
@@ -12071,7 +12071,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 	if settings == nil {
 		return nil, nil
 	}
-	var result DiskEncryptionSettingsARM
+	result := &DiskEncryptionSettingsARM{}
 
 	// Set property ‘DiskEncryptionKey’:
 	if settings.DiskEncryptionKey != nil {
@@ -12079,7 +12079,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionKey := diskEncryptionKeyARM.(KeyVaultSecretReferenceARM)
+		diskEncryptionKey := *diskEncryptionKeyARM.(*KeyVaultSecretReferenceARM)
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
@@ -12095,7 +12095,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		keyEncryptionKey := keyEncryptionKeyARM.(KeyVaultKeyReferenceARM)
+		keyEncryptionKey := *keyEncryptionKeyARM.(*KeyVaultKeyReferenceARM)
 		result.KeyEncryptionKey = &keyEncryptionKey
 	}
 	return result, nil
@@ -12624,7 +12624,7 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	if settings == nil {
 		return nil, nil
 	}
-	var result LinuxPatchSettingsARM
+	result := &LinuxPatchSettingsARM{}
 
 	// Set property ‘PatchMode’:
 	if settings.PatchMode != nil {
@@ -12788,7 +12788,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 	if parameters == nil {
 		return nil, nil
 	}
-	var result ManagedDiskParametersARM
+	result := &ManagedDiskParametersARM{}
 
 	// Set property ‘DiskEncryptionSet’:
 	if parameters.DiskEncryptionSet != nil {
@@ -12796,7 +12796,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -13099,7 +13099,7 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if settings == nil {
 		return nil, nil
 	}
-	var result PatchSettingsARM
+	result := &PatchSettingsARM{}
 
 	// Set property ‘EnableHotpatching’:
 	if settings.EnableHotpatching != nil {
@@ -13301,7 +13301,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	if configuration == nil {
 		return nil, nil
 	}
-	var result SshConfigurationARM
+	result := &SshConfigurationARM{}
 
 	// Set property ‘PublicKeys’:
 	for _, item := range configuration.PublicKeys {
@@ -13309,7 +13309,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.PublicKeys = append(result.PublicKeys, itemARM.(SshPublicKeyARM))
+		result.PublicKeys = append(result.PublicKeys, *itemARM.(*SshPublicKeyARM))
 	}
 	return result, nil
 }
@@ -13504,7 +13504,7 @@ func (certificate *VaultCertificate) ConvertToARM(resolved genruntime.ConvertToA
 	if certificate == nil {
 		return nil, nil
 	}
-	var result VaultCertificateARM
+	result := &VaultCertificateARM{}
 
 	// Set property ‘CertificateStore’:
 	if certificate.CertificateStore != nil {
@@ -13666,7 +13666,7 @@ func (disk *VirtualHardDisk) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if disk == nil {
 		return nil, nil
 	}
-	var result VirtualHardDiskARM
+	result := &VirtualHardDiskARM{}
 
 	// Set property ‘Uri’:
 	if disk.Uri != nil {
@@ -13904,7 +13904,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 	if configuration == nil {
 		return nil, nil
 	}
-	var result WinRMConfigurationARM
+	result := &WinRMConfigurationARM{}
 
 	// Set property ‘Listeners’:
 	for _, item := range configuration.Listeners {
@@ -13912,7 +13912,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Listeners = append(result.Listeners, itemARM.(WinRMListenerARM))
+		result.Listeners = append(result.Listeners, *itemARM.(*WinRMListenerARM))
 	}
 	return result, nil
 }
@@ -14356,7 +14356,7 @@ func (parameters *DiskEncryptionSetParameters) ConvertToARM(resolved genruntime.
 	if parameters == nil {
 		return nil, nil
 	}
-	var result DiskEncryptionSetParametersARM
+	result := &DiskEncryptionSetParametersARM{}
 
 	// Set property ‘Id’:
 	if parameters.Reference != nil {
@@ -14443,7 +14443,7 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultKeyReferenceARM
+	result := &KeyVaultKeyReferenceARM{}
 
 	// Set property ‘KeyUrl’:
 	if reference.KeyUrl != nil {
@@ -14457,7 +14457,7 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SubResourceARM)
+		sourceVault := *sourceVaultARM.(*SubResourceARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -14659,7 +14659,7 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultSecretReferenceARM
+	result := &KeyVaultSecretReferenceARM{}
 
 	// Set property ‘SecretUrl’:
 	if reference.SecretUrl != nil {
@@ -14673,7 +14673,7 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SubResourceARM)
+		sourceVault := *sourceVaultARM.(*SubResourceARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -14934,7 +14934,7 @@ func (publicKey *SshPublicKey) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if publicKey == nil {
 		return nil, nil
 	}
-	var result SshPublicKeyARM
+	result := &SshPublicKeyARM{}
 
 	// Set property ‘KeyData’:
 	if publicKey.KeyData != nil {
@@ -15109,7 +15109,7 @@ func (listener *WinRMListener) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if listener == nil {
 		return nil, nil
 	}
-	var result WinRMListenerARM
+	result := &WinRMListenerARM{}
 
 	// Set property ‘CertificateUrl’:
 	if listener.CertificateUrl != nil {

--- a/v2/api/compute/v1alpha1api20201201/virtual_machines__spec_arm_types_gen.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machines__spec_arm_types_gen.go
@@ -28,12 +28,12 @@ func (machines VirtualMachines_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (machines VirtualMachines_SpecARM) GetName() string {
+func (machines *VirtualMachines_SpecARM) GetName() string {
 	return machines.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/virtualMachines"
-func (machines VirtualMachines_SpecARM) GetType() string {
+func (machines *VirtualMachines_SpecARM) GetType() string {
 	return "Microsoft.Compute/virtualMachines"
 }
 

--- a/v2/api/compute/v1alpha1api20210701/image_types_gen.go
+++ b/v2/api/compute/v1alpha1api20210701/image_types_gen.go
@@ -690,7 +690,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if images == nil {
 		return nil, nil
 	}
-	var result Images_SpecARM
+	result := &Images_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if images.ExtendedLocation != nil {
@@ -698,7 +698,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -726,7 +726,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		sourceVirtualMachine := sourceVirtualMachineARM.(SubResourceARM)
+		sourceVirtualMachine := *sourceVirtualMachineARM.(*SubResourceARM)
 		result.Properties.SourceVirtualMachine = &sourceVirtualMachine
 	}
 	if images.StorageProfile != nil {
@@ -734,7 +734,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		storageProfile := storageProfileARM.(ImageStorageProfileARM)
+		storageProfile := *storageProfileARM.(*ImageStorageProfileARM)
 		result.Properties.StorageProfile = &storageProfile
 	}
 
@@ -1053,7 +1053,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -1254,7 +1254,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 	if profile == nil {
 		return nil, nil
 	}
-	var result ImageStorageProfileARM
+	result := &ImageStorageProfileARM{}
 
 	// Set property ‘DataDisks’:
 	for _, item := range profile.DataDisks {
@@ -1262,7 +1262,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		result.DataDisks = append(result.DataDisks, itemARM.(ImageDataDiskARM))
+		result.DataDisks = append(result.DataDisks, *itemARM.(*ImageDataDiskARM))
 	}
 
 	// Set property ‘OsDisk’:
@@ -1271,7 +1271,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		osDisk := osDiskARM.(ImageOSDiskARM)
+		osDisk := *osDiskARM.(*ImageOSDiskARM)
 		result.OsDisk = &osDisk
 	}
 
@@ -1588,7 +1588,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if resource == nil {
 		return nil, nil
 	}
-	var result SubResourceARM
+	result := &SubResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {
@@ -1738,7 +1738,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if disk == nil {
 		return nil, nil
 	}
-	var result ImageDataDiskARM
+	result := &ImageDataDiskARM{}
 
 	// Set property ‘BlobUri’:
 	if disk.BlobUri != nil {
@@ -1758,7 +1758,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -1780,7 +1780,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(SubResourceARM)
+		managedDisk := *managedDiskARM.(*SubResourceARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -1790,7 +1790,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		snapshot := snapshotARM.(SubResourceARM)
+		snapshot := *snapshotARM.(*SubResourceARM)
 		result.Snapshot = &snapshot
 	}
 
@@ -2288,7 +2288,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if disk == nil {
 		return nil, nil
 	}
-	var result ImageOSDiskARM
+	result := &ImageOSDiskARM{}
 
 	// Set property ‘BlobUri’:
 	if disk.BlobUri != nil {
@@ -2308,7 +2308,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -2324,7 +2324,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(SubResourceARM)
+		managedDisk := *managedDiskARM.(*SubResourceARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -2346,7 +2346,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		snapshot := snapshotARM.(SubResourceARM)
+		snapshot := *snapshotARM.(*SubResourceARM)
 		result.Snapshot = &snapshot
 	}
 
@@ -2897,7 +2897,7 @@ func (parameters *DiskEncryptionSetParameters) ConvertToARM(resolved genruntime.
 	if parameters == nil {
 		return nil, nil
 	}
-	var result DiskEncryptionSetParametersARM
+	result := &DiskEncryptionSetParametersARM{}
 
 	// Set property ‘Id’:
 	if parameters.Reference != nil {

--- a/v2/api/compute/v1alpha1api20210701/images__spec_arm_types_gen.go
+++ b/v2/api/compute/v1alpha1api20210701/images__spec_arm_types_gen.go
@@ -22,12 +22,12 @@ func (images Images_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (images Images_SpecARM) GetName() string {
+func (images *Images_SpecARM) GetName() string {
 	return images.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/images"
-func (images Images_SpecARM) GetType() string {
+func (images *Images_SpecARM) GetType() string {
 	return "Microsoft.Compute/images"
 }
 

--- a/v2/api/compute/v1beta20200930/disk_types_gen.go
+++ b/v2/api/compute/v1beta20200930/disk_types_gen.go
@@ -1293,7 +1293,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if disks == nil {
 		return nil, nil
 	}
-	var result Disks_SpecARM
+	result := &Disks_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if disks.ExtendedLocation != nil {
@@ -1301,7 +1301,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1342,7 +1342,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		creationData := creationDataARM.(CreationDataARM)
+		creationData := *creationDataARM.(*CreationDataARM)
 		result.Properties.CreationData = &creationData
 	}
 	if disks.DiskAccessReference != nil {
@@ -1378,7 +1378,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if disks.EncryptionSettingsCollection != nil {
@@ -1386,7 +1386,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		encryptionSettingsCollection := encryptionSettingsCollectionARM.(EncryptionSettingsCollectionARM)
+		encryptionSettingsCollection := *encryptionSettingsCollectionARM.(*EncryptionSettingsCollectionARM)
 		result.Properties.EncryptionSettingsCollection = &encryptionSettingsCollection
 	}
 	if disks.HyperVGeneration != nil {
@@ -1410,7 +1410,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		purchasePlan := purchasePlanARM.(PurchasePlanARM)
+		purchasePlan := *purchasePlanARM.(*PurchasePlanARM)
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 	if disks.Tier != nil {
@@ -1424,7 +1424,7 @@ func (disks *Disks_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(DiskSkuARM)
+		sku := *skuARM.(*DiskSkuARM)
 		result.Sku = &sku
 	}
 
@@ -2093,7 +2093,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if data == nil {
 		return nil, nil
 	}
-	var result CreationDataARM
+	result := &CreationDataARM{}
 
 	// Set property ‘CreateOption’:
 	if data.CreateOption != nil {
@@ -2107,7 +2107,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		galleryImageReference := galleryImageReferenceARM.(ImageDiskReferenceARM)
+		galleryImageReference := *galleryImageReferenceARM.(*ImageDiskReferenceARM)
 		result.GalleryImageReference = &galleryImageReference
 	}
 
@@ -2117,7 +2117,7 @@ func (data *CreationData) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		imageReference := imageReferenceARM.(ImageDiskReferenceARM)
+		imageReference := *imageReferenceARM.(*ImageDiskReferenceARM)
 		result.ImageReference = &imageReference
 	}
 
@@ -2644,7 +2644,7 @@ func (diskSku *DiskSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if diskSku == nil {
 		return nil, nil
 	}
-	var result DiskSkuARM
+	result := &DiskSkuARM{}
 
 	// Set property ‘Name’:
 	if diskSku.Name != nil {
@@ -2823,7 +2823,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘DiskEncryptionSetId’:
 	if encryption.DiskEncryptionSetReference != nil {
@@ -2945,7 +2945,7 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 	if collection == nil {
 		return nil, nil
 	}
-	var result EncryptionSettingsCollectionARM
+	result := &EncryptionSettingsCollectionARM{}
 
 	// Set property ‘Enabled’:
 	if collection.Enabled != nil {
@@ -2959,7 +2959,7 @@ func (collection *EncryptionSettingsCollection) ConvertToARM(resolved genruntime
 		if err != nil {
 			return nil, err
 		}
-		result.EncryptionSettings = append(result.EncryptionSettings, itemARM.(EncryptionSettingsElementARM))
+		result.EncryptionSettings = append(result.EncryptionSettings, *itemARM.(*EncryptionSettingsElementARM))
 	}
 
 	// Set property ‘EncryptionSettingsVersion’:
@@ -3321,7 +3321,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -3527,7 +3527,7 @@ func (plan *PurchasePlan) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if plan == nil {
 		return nil, nil
 	}
-	var result PurchasePlanARM
+	result := &PurchasePlanARM{}
 
 	// Set property ‘Name’:
 	if plan.Name != nil {
@@ -3846,7 +3846,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 	if element == nil {
 		return nil, nil
 	}
-	var result EncryptionSettingsElementARM
+	result := &EncryptionSettingsElementARM{}
 
 	// Set property ‘DiskEncryptionKey’:
 	if element.DiskEncryptionKey != nil {
@@ -3854,7 +3854,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionKey := diskEncryptionKeyARM.(KeyVaultAndSecretReferenceARM)
+		diskEncryptionKey := *diskEncryptionKeyARM.(*KeyVaultAndSecretReferenceARM)
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
@@ -3864,7 +3864,7 @@ func (element *EncryptionSettingsElement) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		keyEncryptionKey := keyEncryptionKeyARM.(KeyVaultAndKeyReferenceARM)
+		keyEncryptionKey := *keyEncryptionKeyARM.(*KeyVaultAndKeyReferenceARM)
 		result.KeyEncryptionKey = &keyEncryptionKey
 	}
 	return result, nil
@@ -4134,7 +4134,7 @@ func (reference *ImageDiskReference) ConvertToARM(resolved genruntime.ConvertToA
 	if reference == nil {
 		return nil, nil
 	}
-	var result ImageDiskReferenceARM
+	result := &ImageDiskReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -4316,7 +4316,7 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultAndKeyReferenceARM
+	result := &KeyVaultAndKeyReferenceARM{}
 
 	// Set property ‘KeyUrl’:
 	if reference.KeyUrl != nil {
@@ -4330,7 +4330,7 @@ func (reference *KeyVaultAndKeyReference) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SourceVaultARM)
+		sourceVault := *sourceVaultARM.(*SourceVaultARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -4537,7 +4537,7 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultAndSecretReferenceARM
+	result := &KeyVaultAndSecretReferenceARM{}
 
 	// Set property ‘SecretUrl’:
 	if reference.SecretUrl != nil {
@@ -4551,7 +4551,7 @@ func (reference *KeyVaultAndSecretReference) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SourceVaultARM)
+		sourceVault := *sourceVaultARM.(*SourceVaultARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -4752,7 +4752,7 @@ func (vault *SourceVault) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if vault == nil {
 		return nil, nil
 	}
-	var result SourceVaultARM
+	result := &SourceVaultARM{}
 
 	// Set property ‘Id’:
 	if vault.Reference != nil {

--- a/v2/api/compute/v1beta20200930/disks__spec_arm_types_gen.go
+++ b/v2/api/compute/v1beta20200930/disks__spec_arm_types_gen.go
@@ -37,12 +37,12 @@ func (disks Disks_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (disks Disks_SpecARM) GetName() string {
+func (disks *Disks_SpecARM) GetName() string {
 	return disks.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/disks"
-func (disks Disks_SpecARM) GetType() string {
+func (disks *Disks_SpecARM) GetType() string {
 	return "Microsoft.Compute/disks"
 }
 

--- a/v2/api/compute/v1beta20200930/snapshot_types_gen.go
+++ b/v2/api/compute/v1beta20200930/snapshot_types_gen.go
@@ -1068,7 +1068,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if snapshots == nil {
 		return nil, nil
 	}
-	var result Snapshots_SpecARM
+	result := &Snapshots_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if snapshots.ExtendedLocation != nil {
@@ -1076,7 +1076,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1108,7 +1108,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		creationData := creationDataARM.(CreationDataARM)
+		creationData := *creationDataARM.(*CreationDataARM)
 		result.Properties.CreationData = &creationData
 	}
 	if snapshots.DiskAccessReference != nil {
@@ -1132,7 +1132,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if snapshots.EncryptionSettingsCollection != nil {
@@ -1140,7 +1140,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		encryptionSettingsCollection := encryptionSettingsCollectionARM.(EncryptionSettingsCollectionARM)
+		encryptionSettingsCollection := *encryptionSettingsCollectionARM.(*EncryptionSettingsCollectionARM)
 		result.Properties.EncryptionSettingsCollection = &encryptionSettingsCollection
 	}
 	if snapshots.HyperVGeneration != nil {
@@ -1164,7 +1164,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		purchasePlan := purchasePlanARM.(PurchasePlanARM)
+		purchasePlan := *purchasePlanARM.(*PurchasePlanARM)
 		result.Properties.PurchasePlan = &purchasePlan
 	}
 
@@ -1174,7 +1174,7 @@ func (snapshots *Snapshots_Spec) ConvertToARM(resolved genruntime.ConvertToARMRe
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SnapshotSkuARM)
+		sku := *skuARM.(*SnapshotSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1788,7 +1788,7 @@ func (snapshotSku *SnapshotSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if snapshotSku == nil {
 		return nil, nil
 	}
-	var result SnapshotSkuARM
+	result := &SnapshotSkuARM{}
 
 	// Set property ‘Name’:
 	if snapshotSku.Name != nil {

--- a/v2/api/compute/v1beta20200930/snapshots__spec_arm_types_gen.go
+++ b/v2/api/compute/v1beta20200930/snapshots__spec_arm_types_gen.go
@@ -35,12 +35,12 @@ func (snapshots Snapshots_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (snapshots Snapshots_SpecARM) GetName() string {
+func (snapshots *Snapshots_SpecARM) GetName() string {
 	return snapshots.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/snapshots"
-func (snapshots Snapshots_SpecARM) GetType() string {
+func (snapshots *Snapshots_SpecARM) GetType() string {
 	return "Microsoft.Compute/snapshots"
 }
 

--- a/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen.go
@@ -1242,7 +1242,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 	if sets == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_SpecARM
+	result := &VirtualMachineScaleSets_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if sets.ExtendedLocation != nil {
@@ -1250,7 +1250,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1260,7 +1260,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(VirtualMachineScaleSetIdentityARM)
+		identity := *identityARM.(*VirtualMachineScaleSetIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1279,7 +1279,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		plan := planARM.(PlanARM)
+		plan := *planARM.(*PlanARM)
 		result.Plan = &plan
 	}
 
@@ -1304,7 +1304,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		additionalCapabilities := additionalCapabilitiesARM.(AdditionalCapabilitiesARM)
+		additionalCapabilities := *additionalCapabilitiesARM.(*AdditionalCapabilitiesARM)
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if sets.AutomaticRepairsPolicy != nil {
@@ -1312,7 +1312,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		automaticRepairsPolicy := automaticRepairsPolicyARM.(AutomaticRepairsPolicyARM)
+		automaticRepairsPolicy := *automaticRepairsPolicyARM.(*AutomaticRepairsPolicyARM)
 		result.Properties.AutomaticRepairsPolicy = &automaticRepairsPolicy
 	}
 	if sets.DoNotRunExtensionsOnOverprovisionedVMs != nil {
@@ -1324,7 +1324,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		hostGroup := hostGroupARM.(SubResourceARM)
+		hostGroup := *hostGroupARM.(*SubResourceARM)
 		result.Properties.HostGroup = &hostGroup
 	}
 	if sets.OrchestrationMode != nil {
@@ -1344,7 +1344,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		proximityPlacementGroup := proximityPlacementGroupARM.(SubResourceARM)
+		proximityPlacementGroup := *proximityPlacementGroupARM.(*SubResourceARM)
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if sets.ScaleInPolicy != nil {
@@ -1352,7 +1352,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		scaleInPolicy := scaleInPolicyARM.(ScaleInPolicyARM)
+		scaleInPolicy := *scaleInPolicyARM.(*ScaleInPolicyARM)
 		result.Properties.ScaleInPolicy = &scaleInPolicy
 	}
 	if sets.SinglePlacementGroup != nil {
@@ -1364,7 +1364,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		upgradePolicy := upgradePolicyARM.(UpgradePolicyARM)
+		upgradePolicy := *upgradePolicyARM.(*UpgradePolicyARM)
 		result.Properties.UpgradePolicy = &upgradePolicy
 	}
 	if sets.VirtualMachineProfile != nil {
@@ -1372,7 +1372,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		virtualMachineProfile := virtualMachineProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM)
+		virtualMachineProfile := *virtualMachineProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM)
 		result.Properties.VirtualMachineProfile = &virtualMachineProfile
 	}
 	if sets.ZoneBalance != nil {
@@ -1386,7 +1386,7 @@ func (sets *VirtualMachineScaleSets_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -2138,7 +2138,7 @@ func (policy *AutomaticRepairsPolicy) ConvertToARM(resolved genruntime.ConvertTo
 	if policy == nil {
 		return nil, nil
 	}
-	var result AutomaticRepairsPolicyARM
+	result := &AutomaticRepairsPolicyARM{}
 
 	// Set property ‘Enabled’:
 	if policy.Enabled != nil {
@@ -2344,7 +2344,7 @@ func (policy *ScaleInPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if policy == nil {
 		return nil, nil
 	}
-	var result ScaleInPolicyARM
+	result := &ScaleInPolicyARM{}
 
 	// Set property ‘Rules’:
 	for _, item := range policy.Rules {
@@ -2532,7 +2532,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {
@@ -2743,7 +2743,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if policy == nil {
 		return nil, nil
 	}
-	var result UpgradePolicyARM
+	result := &UpgradePolicyARM{}
 
 	// Set property ‘AutomaticOSUpgradePolicy’:
 	if policy.AutomaticOSUpgradePolicy != nil {
@@ -2751,7 +2751,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		automaticOSUpgradePolicy := automaticOSUpgradePolicyARM.(AutomaticOSUpgradePolicyARM)
+		automaticOSUpgradePolicy := *automaticOSUpgradePolicyARM.(*AutomaticOSUpgradePolicyARM)
 		result.AutomaticOSUpgradePolicy = &automaticOSUpgradePolicy
 	}
 
@@ -2767,7 +2767,7 @@ func (policy *UpgradePolicy) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		rollingUpgradePolicy := rollingUpgradePolicyARM.(RollingUpgradePolicyARM)
+		rollingUpgradePolicy := *rollingUpgradePolicyARM.(*RollingUpgradePolicyARM)
 		result.RollingUpgradePolicy = &rollingUpgradePolicy
 	}
 	return result, nil
@@ -3067,7 +3067,7 @@ func (identity *VirtualMachineScaleSetIdentity) ConvertToARM(resolved genruntime
 	if identity == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetIdentityARM
+	result := &VirtualMachineScaleSetIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -3788,7 +3788,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfileARM{}
 
 	// Set property ‘BillingProfile’:
 	if profile.BillingProfile != nil {
@@ -3796,7 +3796,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		billingProfile := billingProfileARM.(BillingProfileARM)
+		billingProfile := *billingProfileARM.(*BillingProfileARM)
 		result.BillingProfile = &billingProfile
 	}
 
@@ -3806,7 +3806,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		diagnosticsProfile := diagnosticsProfileARM.(DiagnosticsProfileARM)
+		diagnosticsProfile := *diagnosticsProfileARM.(*DiagnosticsProfileARM)
 		result.DiagnosticsProfile = &diagnosticsProfile
 	}
 
@@ -3822,7 +3822,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		extensionProfile := extensionProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM)
+		extensionProfile := *extensionProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM)
 		result.ExtensionProfile = &extensionProfile
 	}
 
@@ -3838,7 +3838,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		networkProfile := networkProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM)
+		networkProfile := *networkProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM)
 		result.NetworkProfile = &networkProfile
 	}
 
@@ -3848,7 +3848,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		osProfile := osProfileARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM)
+		osProfile := *osProfileARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM)
 		result.OsProfile = &osProfile
 	}
 
@@ -3864,7 +3864,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		scheduledEventsProfile := scheduledEventsProfileARM.(ScheduledEventsProfileARM)
+		scheduledEventsProfile := *scheduledEventsProfileARM.(*ScheduledEventsProfileARM)
 		result.ScheduledEventsProfile = &scheduledEventsProfile
 	}
 
@@ -3874,7 +3874,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		securityProfile := securityProfileARM.(SecurityProfileARM)
+		securityProfile := *securityProfileARM.(*SecurityProfileARM)
 		result.SecurityProfile = &securityProfile
 	}
 
@@ -3884,7 +3884,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile) Co
 		if err != nil {
 			return nil, err
 		}
-		storageProfile := storageProfileARM.(VirtualMachineScaleSetStorageProfileARM)
+		storageProfile := *storageProfileARM.(*VirtualMachineScaleSetStorageProfileARM)
 		result.StorageProfile = &storageProfile
 	}
 	return result, nil
@@ -4285,7 +4285,7 @@ func (policy *AutomaticOSUpgradePolicy) ConvertToARM(resolved genruntime.Convert
 	if policy == nil {
 		return nil, nil
 	}
-	var result AutomaticOSUpgradePolicyARM
+	result := &AutomaticOSUpgradePolicyARM{}
 
 	// Set property ‘DisableAutomaticRollback’:
 	if policy.DisableAutomaticRollback != nil {
@@ -4524,7 +4524,7 @@ func (policy *RollingUpgradePolicy) ConvertToARM(resolved genruntime.ConvertToAR
 	if policy == nil {
 		return nil, nil
 	}
-	var result RollingUpgradePolicyARM
+	result := &RollingUpgradePolicyARM{}
 
 	// Set property ‘EnableCrossZoneUpgrade’:
 	if policy.EnableCrossZoneUpgrade != nil {
@@ -4916,7 +4916,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 	if profile == nil {
 		return nil, nil
 	}
-	var result ScheduledEventsProfileARM
+	result := &ScheduledEventsProfileARM{}
 
 	// Set property ‘TerminateNotificationProfile’:
 	if profile.TerminateNotificationProfile != nil {
@@ -4924,7 +4924,7 @@ func (profile *ScheduledEventsProfile) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		terminateNotificationProfile := terminateNotificationProfileARM.(TerminateNotificationProfileARM)
+		terminateNotificationProfile := *terminateNotificationProfileARM.(*TerminateNotificationProfileARM)
 		result.TerminateNotificationProfile = &terminateNotificationProfile
 	}
 	return result, nil
@@ -5674,7 +5674,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetStorageProfileARM
+	result := &VirtualMachineScaleSetStorageProfileARM{}
 
 	// Set property ‘DataDisks’:
 	for _, item := range profile.DataDisks {
@@ -5682,7 +5682,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		result.DataDisks = append(result.DataDisks, itemARM.(VirtualMachineScaleSetDataDiskARM))
+		result.DataDisks = append(result.DataDisks, *itemARM.(*VirtualMachineScaleSetDataDiskARM))
 	}
 
 	// Set property ‘ImageReference’:
@@ -5691,7 +5691,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		imageReference := imageReferenceARM.(ImageReferenceARM)
+		imageReference := *imageReferenceARM.(*ImageReferenceARM)
 		result.ImageReference = &imageReference
 	}
 
@@ -5701,7 +5701,7 @@ func (profile *VirtualMachineScaleSetStorageProfile) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		osDisk := osDiskARM.(VirtualMachineScaleSetOSDiskARM)
+		osDisk := *osDiskARM.(*VirtualMachineScaleSetOSDiskARM)
 		result.OsDisk = &osDisk
 	}
 	return result, nil
@@ -6071,7 +6071,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Ext
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfileARM{}
 
 	// Set property ‘Extensions’:
 	for _, item := range profile.Extensions {
@@ -6079,7 +6079,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Ext
 		if err != nil {
 			return nil, err
 		}
-		result.Extensions = append(result.Extensions, itemARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM))
+		result.Extensions = append(result.Extensions, *itemARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM))
 	}
 
 	// Set property ‘ExtensionsTimeBudget’:
@@ -6202,7 +6202,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Net
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfileARM{}
 
 	// Set property ‘HealthProbe’:
 	if profile.HealthProbe != nil {
@@ -6210,7 +6210,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Net
 		if err != nil {
 			return nil, err
 		}
-		healthProbe := healthProbeARM.(ApiEntityReferenceARM)
+		healthProbe := *healthProbeARM.(*ApiEntityReferenceARM)
 		result.HealthProbe = &healthProbe
 	}
 
@@ -6220,7 +6220,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_Net
 		if err != nil {
 			return nil, err
 		}
-		result.NetworkInterfaceConfigurations = append(result.NetworkInterfaceConfigurations, itemARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM))
+		result.NetworkInterfaceConfigurations = append(result.NetworkInterfaceConfigurations, *itemARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM))
 	}
 	return result, nil
 }
@@ -6410,7 +6410,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsProfileARM{}
 
 	// Set property ‘AdminPassword’:
 	if profile.AdminPassword != nil {
@@ -6446,7 +6446,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 		if err != nil {
 			return nil, err
 		}
-		linuxConfiguration := linuxConfigurationARM.(LinuxConfigurationARM)
+		linuxConfiguration := *linuxConfigurationARM.(*LinuxConfigurationARM)
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
@@ -6456,7 +6456,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 		if err != nil {
 			return nil, err
 		}
-		result.Secrets = append(result.Secrets, itemARM.(VaultSecretGroupARM))
+		result.Secrets = append(result.Secrets, *itemARM.(*VaultSecretGroupARM))
 	}
 
 	// Set property ‘WindowsConfiguration’:
@@ -6465,7 +6465,7 @@ func (profile *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_OsP
 		if err != nil {
 			return nil, err
 		}
-		windowsConfiguration := windowsConfigurationARM.(WindowsConfigurationARM)
+		windowsConfiguration := *windowsConfigurationARM.(*WindowsConfigurationARM)
 		result.WindowsConfiguration = &windowsConfiguration
 	}
 	return result, nil
@@ -6693,7 +6693,7 @@ func (reference *ApiEntityReference) ConvertToARM(resolved genruntime.ConvertToA
 	if reference == nil {
 		return nil, nil
 	}
-	var result ApiEntityReferenceARM
+	result := &ApiEntityReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -6840,7 +6840,7 @@ func (profile *TerminateNotificationProfile) ConvertToARM(resolved genruntime.Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result TerminateNotificationProfileARM
+	result := &TerminateNotificationProfileARM{}
 
 	// Set property ‘Enable’:
 	if profile.Enable != nil {
@@ -7063,7 +7063,7 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 	if disk == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetDataDiskARM
+	result := &VirtualMachineScaleSetDataDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -7107,7 +7107,7 @@ func (disk *VirtualMachineScaleSetDataDisk) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(VirtualMachineScaleSetManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*VirtualMachineScaleSetManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -8277,7 +8277,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 	if disk == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetOSDiskARM
+	result := &VirtualMachineScaleSetOSDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -8297,7 +8297,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		diffDiskSettings := diffDiskSettingsARM.(DiffDiskSettingsARM)
+		diffDiskSettings := *diffDiskSettingsARM.(*DiffDiskSettingsARM)
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
@@ -8313,7 +8313,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		image := imageARM.(VirtualHardDiskARM)
+		image := *imageARM.(*VirtualHardDiskARM)
 		result.Image = &image
 	}
 
@@ -8323,7 +8323,7 @@ func (disk *VirtualMachineScaleSetOSDisk) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(VirtualMachineScaleSetManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*VirtualMachineScaleSetManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -8966,7 +8966,7 @@ func (extensions *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_
 	if extensions == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_ExtensionProfile_ExtensionsARM{}
 
 	// Set property ‘Name’:
 	if extensions.Name != nil {
@@ -9201,7 +9201,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 	if configurations == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurationsARM{}
 
 	// Set property ‘Id’:
 	if configurations.Id != nil {
@@ -9230,7 +9230,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if configurations.EnableAcceleratedNetworking != nil {
@@ -9250,14 +9250,14 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, itemARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM))
+		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *itemARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM))
 	}
 	if configurations.NetworkSecurityGroup != nil {
 		networkSecurityGroupARM, err := (*configurations.NetworkSecurityGroup).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		networkSecurityGroup := networkSecurityGroupARM.(SubResourceARM)
+		networkSecurityGroup := *networkSecurityGroupARM.(*SubResourceARM)
 		result.Properties.NetworkSecurityGroup = &networkSecurityGroup
 	}
 	if configurations.Primary != nil {
@@ -10019,7 +10019,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 	if parameters == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetManagedDiskParametersARM
+	result := &VirtualMachineScaleSetManagedDiskParametersARM{}
 
 	// Set property ‘DiskEncryptionSet’:
 	if parameters.DiskEncryptionSet != nil {
@@ -10027,7 +10027,7 @@ func (parameters *VirtualMachineScaleSetManagedDiskParameters) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -10255,7 +10255,7 @@ func (settings *VirtualMachineScaleSetNetworkConfigurationDnsSettings) ConvertTo
 	if settings == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM
+	result := &VirtualMachineScaleSetNetworkConfigurationDnsSettingsARM{}
 
 	// Set property ‘DnsServers’:
 	for _, item := range settings.DnsServers {
@@ -10451,7 +10451,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 	if configurations == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurationsARM{}
 
 	// Set property ‘Id’:
 	if configurations.Id != nil {
@@ -10481,28 +10481,28 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.ApplicationSecurityGroups {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerBackendAddressPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerInboundNatPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerInboundNatPools = append(result.Properties.LoadBalancerInboundNatPools, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerInboundNatPools = append(result.Properties.LoadBalancerInboundNatPools, *itemARM.(*SubResourceARM))
 	}
 	if configurations.Primary != nil {
 		primary := *configurations.Primary
@@ -10517,7 +10517,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddressConfiguration := publicIPAddressConfigurationARM.(VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM)
+		publicIPAddressConfiguration := *publicIPAddressConfigurationARM.(*VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM)
 		result.Properties.PublicIPAddressConfiguration = &publicIPAddressConfiguration
 	}
 	if configurations.Subnet != nil {
@@ -10525,7 +10525,7 @@ func (configurations *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProf
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(ApiEntityReferenceARM)
+		subnet := *subnetARM.(*ApiEntityReferenceARM)
 		result.Properties.Subnet = &subnet
 	}
 	return result, nil
@@ -11209,7 +11209,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 	if configuration == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM
+	result := &VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfile_NetworkProfile_NetworkInterfaceConfigurations_Properties_IpConfigurations_Properties_PublicIPAddressConfigurationARM{}
 
 	// Set property ‘Name’:
 	if configuration.Name != nil {
@@ -11230,7 +11230,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if configuration.IdleTimeoutInMinutes != nil {
@@ -11242,7 +11242,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpTags = append(result.Properties.IpTags, itemARM.(VirtualMachineScaleSetIpTagARM))
+		result.Properties.IpTags = append(result.Properties.IpTags, *itemARM.(*VirtualMachineScaleSetIpTagARM))
 	}
 	if configuration.PublicIPAddressVersion != nil {
 		publicIPAddressVersion := *configuration.PublicIPAddressVersion
@@ -11253,7 +11253,7 @@ func (configuration *VirtualMachineScaleSets_Spec_Properties_VirtualMachineProfi
 		if err != nil {
 			return nil, err
 		}
-		publicIPPrefix := publicIPPrefixARM.(SubResourceARM)
+		publicIPPrefix := *publicIPPrefixARM.(*SubResourceARM)
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	return result, nil
@@ -11491,7 +11491,7 @@ func (ipTag *VirtualMachineScaleSetIpTag) ConvertToARM(resolved genruntime.Conve
 	if ipTag == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetIpTagARM
+	result := &VirtualMachineScaleSetIpTagARM{}
 
 	// Set property ‘IpTagType’:
 	if ipTag.IpTagType != nil {
@@ -11658,7 +11658,7 @@ func (settings *VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings) C
 	if settings == nil {
 		return nil, nil
 	}
-	var result VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM
+	result := &VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettingsARM{}
 
 	// Set property ‘DomainNameLabel’:
 	if settings.DomainNameLabel != nil {

--- a/v2/api/compute/v1beta20201201/virtual_machine_scale_sets__spec_arm_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_scale_sets__spec_arm_types_gen.go
@@ -49,12 +49,12 @@ func (sets VirtualMachineScaleSets_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (sets VirtualMachineScaleSets_SpecARM) GetName() string {
+func (sets *VirtualMachineScaleSets_SpecARM) GetName() string {
 	return sets.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/virtualMachineScaleSets"
-func (sets VirtualMachineScaleSets_SpecARM) GetType() string {
+func (sets *VirtualMachineScaleSets_SpecARM) GetType() string {
 	return "Microsoft.Compute/virtualMachineScaleSets"
 }
 

--- a/v2/api/compute/v1beta20201201/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_types_gen.go
@@ -1562,7 +1562,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if machines == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_SpecARM
+	result := &VirtualMachines_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if machines.ExtendedLocation != nil {
@@ -1570,7 +1570,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1580,7 +1580,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(VirtualMachineIdentityARM)
+		identity := *identityARM.(*VirtualMachineIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1599,7 +1599,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		plan := planARM.(PlanARM)
+		plan := *planARM.(*PlanARM)
 		result.Plan = &plan
 	}
 
@@ -1629,7 +1629,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		additionalCapabilities := additionalCapabilitiesARM.(AdditionalCapabilitiesARM)
+		additionalCapabilities := *additionalCapabilitiesARM.(*AdditionalCapabilitiesARM)
 		result.Properties.AdditionalCapabilities = &additionalCapabilities
 	}
 	if machines.AvailabilitySet != nil {
@@ -1637,7 +1637,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		availabilitySet := availabilitySetARM.(SubResourceARM)
+		availabilitySet := *availabilitySetARM.(*SubResourceARM)
 		result.Properties.AvailabilitySet = &availabilitySet
 	}
 	if machines.BillingProfile != nil {
@@ -1645,7 +1645,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		billingProfile := billingProfileARM.(BillingProfileARM)
+		billingProfile := *billingProfileARM.(*BillingProfileARM)
 		result.Properties.BillingProfile = &billingProfile
 	}
 	if machines.DiagnosticsProfile != nil {
@@ -1653,7 +1653,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		diagnosticsProfile := diagnosticsProfileARM.(DiagnosticsProfileARM)
+		diagnosticsProfile := *diagnosticsProfileARM.(*DiagnosticsProfileARM)
 		result.Properties.DiagnosticsProfile = &diagnosticsProfile
 	}
 	if machines.EvictionPolicy != nil {
@@ -1669,7 +1669,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		hardwareProfile := hardwareProfileARM.(HardwareProfileARM)
+		hardwareProfile := *hardwareProfileARM.(*HardwareProfileARM)
 		result.Properties.HardwareProfile = &hardwareProfile
 	}
 	if machines.Host != nil {
@@ -1677,7 +1677,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		host := hostARM.(SubResourceARM)
+		host := *hostARM.(*SubResourceARM)
 		result.Properties.Host = &host
 	}
 	if machines.HostGroup != nil {
@@ -1685,7 +1685,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		hostGroup := hostGroupARM.(SubResourceARM)
+		hostGroup := *hostGroupARM.(*SubResourceARM)
 		result.Properties.HostGroup = &hostGroup
 	}
 	if machines.LicenseType != nil {
@@ -1697,7 +1697,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		networkProfile := networkProfileARM.(VirtualMachines_Spec_Properties_NetworkProfileARM)
+		networkProfile := *networkProfileARM.(*VirtualMachines_Spec_Properties_NetworkProfileARM)
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if machines.OsProfile != nil {
@@ -1705,7 +1705,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		osProfile := osProfileARM.(VirtualMachines_Spec_Properties_OsProfileARM)
+		osProfile := *osProfileARM.(*VirtualMachines_Spec_Properties_OsProfileARM)
 		result.Properties.OsProfile = &osProfile
 	}
 	if machines.PlatformFaultDomain != nil {
@@ -1721,7 +1721,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		proximityPlacementGroup := proximityPlacementGroupARM.(SubResourceARM)
+		proximityPlacementGroup := *proximityPlacementGroupARM.(*SubResourceARM)
 		result.Properties.ProximityPlacementGroup = &proximityPlacementGroup
 	}
 	if machines.SecurityProfile != nil {
@@ -1729,7 +1729,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		securityProfile := securityProfileARM.(SecurityProfileARM)
+		securityProfile := *securityProfileARM.(*SecurityProfileARM)
 		result.Properties.SecurityProfile = &securityProfile
 	}
 	if machines.StorageProfile != nil {
@@ -1737,7 +1737,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		storageProfile := storageProfileARM.(StorageProfileARM)
+		storageProfile := *storageProfileARM.(*StorageProfileARM)
 		result.Properties.StorageProfile = &storageProfile
 	}
 	if machines.VirtualMachineScaleSet != nil {
@@ -1745,7 +1745,7 @@ func (machines *VirtualMachines_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		virtualMachineScaleSet := virtualMachineScaleSetARM.(SubResourceARM)
+		virtualMachineScaleSet := *virtualMachineScaleSetARM.(*SubResourceARM)
 		result.Properties.VirtualMachineScaleSet = &virtualMachineScaleSet
 	}
 
@@ -2640,7 +2640,7 @@ func (capabilities *AdditionalCapabilities) ConvertToARM(resolved genruntime.Con
 	if capabilities == nil {
 		return nil, nil
 	}
-	var result AdditionalCapabilitiesARM
+	result := &AdditionalCapabilitiesARM{}
 
 	// Set property ‘UltraSSDEnabled’:
 	if capabilities.UltraSSDEnabled != nil {
@@ -2805,7 +2805,7 @@ func (profile *BillingProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if profile == nil {
 		return nil, nil
 	}
-	var result BillingProfileARM
+	result := &BillingProfileARM{}
 
 	// Set property ‘MaxPrice’:
 	if profile.MaxPrice != nil {
@@ -2971,7 +2971,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 	if profile == nil {
 		return nil, nil
 	}
-	var result DiagnosticsProfileARM
+	result := &DiagnosticsProfileARM{}
 
 	// Set property ‘BootDiagnostics’:
 	if profile.BootDiagnostics != nil {
@@ -2979,7 +2979,7 @@ func (profile *DiagnosticsProfile) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		bootDiagnostics := bootDiagnosticsARM.(BootDiagnosticsARM)
+		bootDiagnostics := *bootDiagnosticsARM.(*BootDiagnosticsARM)
 		result.BootDiagnostics = &bootDiagnostics
 	}
 	return result, nil
@@ -3166,7 +3166,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -3361,7 +3361,7 @@ func (profile *HardwareProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if profile == nil {
 		return nil, nil
 	}
-	var result HardwareProfileARM
+	result := &HardwareProfileARM{}
 
 	// Set property ‘VmSize’:
 	if profile.VmSize != nil {
@@ -3919,7 +3919,7 @@ func (plan *Plan) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) 
 	if plan == nil {
 		return nil, nil
 	}
-	var result PlanARM
+	result := &PlanARM{}
 
 	// Set property ‘Name’:
 	if plan.Name != nil {
@@ -4170,7 +4170,7 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if profile == nil {
 		return nil, nil
 	}
-	var result SecurityProfileARM
+	result := &SecurityProfileARM{}
 
 	// Set property ‘EncryptionAtHost’:
 	if profile.EncryptionAtHost != nil {
@@ -4190,7 +4190,7 @@ func (profile *SecurityProfile) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		uefiSettings := uefiSettingsARM.(UefiSettingsARM)
+		uefiSettings := *uefiSettingsARM.(*UefiSettingsARM)
 		result.UefiSettings = &uefiSettings
 	}
 	return result, nil
@@ -4476,7 +4476,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if profile == nil {
 		return nil, nil
 	}
-	var result StorageProfileARM
+	result := &StorageProfileARM{}
 
 	// Set property ‘DataDisks’:
 	for _, item := range profile.DataDisks {
@@ -4484,7 +4484,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.DataDisks = append(result.DataDisks, itemARM.(DataDiskARM))
+		result.DataDisks = append(result.DataDisks, *itemARM.(*DataDiskARM))
 	}
 
 	// Set property ‘ImageReference’:
@@ -4493,7 +4493,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		imageReference := imageReferenceARM.(ImageReferenceARM)
+		imageReference := *imageReferenceARM.(*ImageReferenceARM)
 		result.ImageReference = &imageReference
 	}
 
@@ -4503,7 +4503,7 @@ func (profile *StorageProfile) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		osDisk := osDiskARM.(OSDiskARM)
+		osDisk := *osDiskARM.(*OSDiskARM)
 		result.OsDisk = &osDisk
 	}
 	return result, nil
@@ -4851,7 +4851,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if resource == nil {
 		return nil, nil
 	}
-	var result SubResourceARM
+	result := &SubResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {
@@ -5391,7 +5391,7 @@ func (identity *VirtualMachineIdentity) ConvertToARM(resolved genruntime.Convert
 	if identity == nil {
 		return nil, nil
 	}
-	var result VirtualMachineIdentityARM
+	result := &VirtualMachineIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -6204,7 +6204,7 @@ func (profile *VirtualMachines_Spec_Properties_NetworkProfile) ConvertToARM(reso
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_Spec_Properties_NetworkProfileARM
+	result := &VirtualMachines_Spec_Properties_NetworkProfileARM{}
 
 	// Set property ‘NetworkInterfaces’:
 	for _, item := range profile.NetworkInterfaces {
@@ -6212,7 +6212,7 @@ func (profile *VirtualMachines_Spec_Properties_NetworkProfile) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		result.NetworkInterfaces = append(result.NetworkInterfaces, itemARM.(VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM))
+		result.NetworkInterfaces = append(result.NetworkInterfaces, *itemARM.(*VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM))
 	}
 	return result, nil
 }
@@ -6384,7 +6384,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 	if profile == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_Spec_Properties_OsProfileARM
+	result := &VirtualMachines_Spec_Properties_OsProfileARM{}
 
 	// Set property ‘AdminPassword’:
 	if profile.AdminPassword != nil {
@@ -6426,7 +6426,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		linuxConfiguration := linuxConfigurationARM.(LinuxConfigurationARM)
+		linuxConfiguration := *linuxConfigurationARM.(*LinuxConfigurationARM)
 		result.LinuxConfiguration = &linuxConfiguration
 	}
 
@@ -6442,7 +6442,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		result.Secrets = append(result.Secrets, itemARM.(VaultSecretGroupARM))
+		result.Secrets = append(result.Secrets, *itemARM.(*VaultSecretGroupARM))
 	}
 
 	// Set property ‘WindowsConfiguration’:
@@ -6451,7 +6451,7 @@ func (profile *VirtualMachines_Spec_Properties_OsProfile) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		windowsConfiguration := windowsConfigurationARM.(WindowsConfigurationARM)
+		windowsConfiguration := *windowsConfigurationARM.(*WindowsConfigurationARM)
 		result.WindowsConfiguration = &windowsConfiguration
 	}
 	return result, nil
@@ -6727,7 +6727,7 @@ func (diagnostics *BootDiagnostics) ConvertToARM(resolved genruntime.ConvertToAR
 	if diagnostics == nil {
 		return nil, nil
 	}
-	var result BootDiagnosticsARM
+	result := &BootDiagnosticsARM{}
 
 	// Set property ‘Enabled’:
 	if diagnostics.Enabled != nil {
@@ -7079,7 +7079,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if disk == nil {
 		return nil, nil
 	}
-	var result DataDiskARM
+	result := &DataDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -7111,7 +7111,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		if err != nil {
 			return nil, err
 		}
-		image := imageARM.(VirtualHardDiskARM)
+		image := *imageARM.(*VirtualHardDiskARM)
 		result.Image = &image
 	}
 
@@ -7127,7 +7127,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(ManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*ManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -7149,7 +7149,7 @@ func (disk *DataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 		if err != nil {
 			return nil, err
 		}
-		vhd := vhdARM.(VirtualHardDiskARM)
+		vhd := *vhdARM.(*VirtualHardDiskARM)
 		result.Vhd = &vhd
 	}
 
@@ -8360,7 +8360,7 @@ func (reference *ImageReference) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if reference == nil {
 		return nil, nil
 	}
-	var result ImageReferenceARM
+	result := &ImageReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -8792,7 +8792,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 	if configuration == nil {
 		return nil, nil
 	}
-	var result LinuxConfigurationARM
+	result := &LinuxConfigurationARM{}
 
 	// Set property ‘DisablePasswordAuthentication’:
 	if configuration.DisablePasswordAuthentication != nil {
@@ -8806,7 +8806,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		patchSettings := patchSettingsARM.(LinuxPatchSettingsARM)
+		patchSettings := *patchSettingsARM.(*LinuxPatchSettingsARM)
 		result.PatchSettings = &patchSettings
 	}
 
@@ -8822,7 +8822,7 @@ func (configuration *LinuxConfiguration) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		ssh := sshARM.(SshConfigurationARM)
+		ssh := *sshARM.(*SshConfigurationARM)
 		result.Ssh = &ssh
 	}
 	return result, nil
@@ -9467,7 +9467,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if disk == nil {
 		return nil, nil
 	}
-	var result OSDiskARM
+	result := &OSDiskARM{}
 
 	// Set property ‘Caching’:
 	if disk.Caching != nil {
@@ -9487,7 +9487,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		diffDiskSettings := diffDiskSettingsARM.(DiffDiskSettingsARM)
+		diffDiskSettings := *diffDiskSettingsARM.(*DiffDiskSettingsARM)
 		result.DiffDiskSettings = &diffDiskSettings
 	}
 
@@ -9503,7 +9503,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		encryptionSettings := encryptionSettingsARM.(DiskEncryptionSettingsARM)
+		encryptionSettings := *encryptionSettingsARM.(*DiskEncryptionSettingsARM)
 		result.EncryptionSettings = &encryptionSettings
 	}
 
@@ -9513,7 +9513,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		image := imageARM.(VirtualHardDiskARM)
+		image := *imageARM.(*VirtualHardDiskARM)
 		result.Image = &image
 	}
 
@@ -9523,7 +9523,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(ManagedDiskParametersARM)
+		managedDisk := *managedDiskARM.(*ManagedDiskParametersARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -9545,7 +9545,7 @@ func (disk *OSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 		if err != nil {
 			return nil, err
 		}
-		vhd := vhdARM.(VirtualHardDiskARM)
+		vhd := *vhdARM.(*VirtualHardDiskARM)
 		result.Vhd = &vhd
 	}
 
@@ -10291,7 +10291,7 @@ func (settings *UefiSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if settings == nil {
 		return nil, nil
 	}
-	var result UefiSettingsARM
+	result := &UefiSettingsARM{}
 
 	// Set property ‘SecureBootEnabled’:
 	if settings.SecureBootEnabled != nil {
@@ -10500,7 +10500,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if group == nil {
 		return nil, nil
 	}
-	var result VaultSecretGroupARM
+	result := &VaultSecretGroupARM{}
 
 	// Set property ‘SourceVault’:
 	if group.SourceVault != nil {
@@ -10508,7 +10508,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SubResourceARM)
+		sourceVault := *sourceVaultARM.(*SubResourceARM)
 		result.SourceVault = &sourceVault
 	}
 
@@ -10518,7 +10518,7 @@ func (group *VaultSecretGroup) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.VaultCertificates = append(result.VaultCertificates, itemARM.(VaultCertificateARM))
+		result.VaultCertificates = append(result.VaultCertificates, *itemARM.(*VaultCertificateARM))
 	}
 	return result, nil
 }
@@ -11459,7 +11459,7 @@ func (interfaces *VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfac
 	if interfaces == nil {
 		return nil, nil
 	}
-	var result VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM
+	result := &VirtualMachines_Spec_Properties_NetworkProfile_NetworkInterfacesARM{}
 
 	// Set property ‘Id’:
 	if interfaces.Reference != nil {
@@ -11601,7 +11601,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 	if configuration == nil {
 		return nil, nil
 	}
-	var result WindowsConfigurationARM
+	result := &WindowsConfigurationARM{}
 
 	// Set property ‘AdditionalUnattendContent’:
 	for _, item := range configuration.AdditionalUnattendContent {
@@ -11609,7 +11609,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, itemARM.(AdditionalUnattendContentARM))
+		result.AdditionalUnattendContent = append(result.AdditionalUnattendContent, *itemARM.(*AdditionalUnattendContentARM))
 	}
 
 	// Set property ‘EnableAutomaticUpdates’:
@@ -11624,7 +11624,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		patchSettings := patchSettingsARM.(PatchSettingsARM)
+		patchSettings := *patchSettingsARM.(*PatchSettingsARM)
 		result.PatchSettings = &patchSettings
 	}
 
@@ -11646,7 +11646,7 @@ func (configuration *WindowsConfiguration) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		winRM := winRMARM.(WinRMConfigurationARM)
+		winRM := *winRMARM.(*WinRMConfigurationARM)
 		result.WinRM = &winRM
 	}
 	return result, nil
@@ -12130,7 +12130,7 @@ func (content *AdditionalUnattendContent) ConvertToARM(resolved genruntime.Conve
 	if content == nil {
 		return nil, nil
 	}
-	var result AdditionalUnattendContentARM
+	result := &AdditionalUnattendContentARM{}
 
 	// Set property ‘ComponentName’:
 	if content.ComponentName != nil {
@@ -12687,7 +12687,7 @@ func (settings *DiffDiskSettings) ConvertToARM(resolved genruntime.ConvertToARMR
 	if settings == nil {
 		return nil, nil
 	}
-	var result DiffDiskSettingsARM
+	result := &DiffDiskSettingsARM{}
 
 	// Set property ‘Option’:
 	if settings.Option != nil {
@@ -12905,7 +12905,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 	if settings == nil {
 		return nil, nil
 	}
-	var result DiskEncryptionSettingsARM
+	result := &DiskEncryptionSettingsARM{}
 
 	// Set property ‘DiskEncryptionKey’:
 	if settings.DiskEncryptionKey != nil {
@@ -12913,7 +12913,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionKey := diskEncryptionKeyARM.(KeyVaultSecretReferenceARM)
+		diskEncryptionKey := *diskEncryptionKeyARM.(*KeyVaultSecretReferenceARM)
 		result.DiskEncryptionKey = &diskEncryptionKey
 	}
 
@@ -12929,7 +12929,7 @@ func (settings *DiskEncryptionSettings) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		keyEncryptionKey := keyEncryptionKeyARM.(KeyVaultKeyReferenceARM)
+		keyEncryptionKey := *keyEncryptionKeyARM.(*KeyVaultKeyReferenceARM)
 		result.KeyEncryptionKey = &keyEncryptionKey
 	}
 	return result, nil
@@ -13491,7 +13491,7 @@ func (settings *LinuxPatchSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	if settings == nil {
 		return nil, nil
 	}
-	var result LinuxPatchSettingsARM
+	result := &LinuxPatchSettingsARM{}
 
 	// Set property ‘PatchMode’:
 	if settings.PatchMode != nil {
@@ -13667,7 +13667,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 	if parameters == nil {
 		return nil, nil
 	}
-	var result ManagedDiskParametersARM
+	result := &ManagedDiskParametersARM{}
 
 	// Set property ‘DiskEncryptionSet’:
 	if parameters.DiskEncryptionSet != nil {
@@ -13675,7 +13675,7 @@ func (parameters *ManagedDiskParameters) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -13992,7 +13992,7 @@ func (settings *PatchSettings) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if settings == nil {
 		return nil, nil
 	}
-	var result PatchSettingsARM
+	result := &PatchSettingsARM{}
 
 	// Set property ‘EnableHotpatching’:
 	if settings.EnableHotpatching != nil {
@@ -14206,7 +14206,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 	if configuration == nil {
 		return nil, nil
 	}
-	var result SshConfigurationARM
+	result := &SshConfigurationARM{}
 
 	// Set property ‘PublicKeys’:
 	for _, item := range configuration.PublicKeys {
@@ -14214,7 +14214,7 @@ func (configuration *SshConfiguration) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.PublicKeys = append(result.PublicKeys, itemARM.(SshPublicKeyARM))
+		result.PublicKeys = append(result.PublicKeys, *itemARM.(*SshPublicKeyARM))
 	}
 	return result, nil
 }
@@ -14424,7 +14424,7 @@ func (certificate *VaultCertificate) ConvertToARM(resolved genruntime.ConvertToA
 	if certificate == nil {
 		return nil, nil
 	}
-	var result VaultCertificateARM
+	result := &VaultCertificateARM{}
 
 	// Set property ‘CertificateStore’:
 	if certificate.CertificateStore != nil {
@@ -14601,7 +14601,7 @@ func (disk *VirtualHardDisk) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if disk == nil {
 		return nil, nil
 	}
-	var result VirtualHardDiskARM
+	result := &VirtualHardDiskARM{}
 
 	// Set property ‘Uri’:
 	if disk.Uri != nil {
@@ -14844,7 +14844,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 	if configuration == nil {
 		return nil, nil
 	}
-	var result WinRMConfigurationARM
+	result := &WinRMConfigurationARM{}
 
 	// Set property ‘Listeners’:
 	for _, item := range configuration.Listeners {
@@ -14852,7 +14852,7 @@ func (configuration *WinRMConfiguration) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Listeners = append(result.Listeners, itemARM.(WinRMListenerARM))
+		result.Listeners = append(result.Listeners, *itemARM.(*WinRMListenerARM))
 	}
 	return result, nil
 }
@@ -15289,7 +15289,7 @@ func (parameters *DiskEncryptionSetParameters) ConvertToARM(resolved genruntime.
 	if parameters == nil {
 		return nil, nil
 	}
-	var result DiskEncryptionSetParametersARM
+	result := &DiskEncryptionSetParametersARM{}
 
 	// Set property ‘Id’:
 	if parameters.Reference != nil {
@@ -15377,7 +15377,7 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultKeyReferenceARM
+	result := &KeyVaultKeyReferenceARM{}
 
 	// Set property ‘KeyUrl’:
 	if reference.KeyUrl != nil {
@@ -15391,7 +15391,7 @@ func (reference *KeyVaultKeyReference) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SubResourceARM)
+		sourceVault := *sourceVaultARM.(*SubResourceARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -15596,7 +15596,7 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 	if reference == nil {
 		return nil, nil
 	}
-	var result KeyVaultSecretReferenceARM
+	result := &KeyVaultSecretReferenceARM{}
 
 	// Set property ‘SecretUrl’:
 	if reference.SecretUrl != nil {
@@ -15610,7 +15610,7 @@ func (reference *KeyVaultSecretReference) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		sourceVault := sourceVaultARM.(SubResourceARM)
+		sourceVault := *sourceVaultARM.(*SubResourceARM)
 		result.SourceVault = &sourceVault
 	}
 	return result, nil
@@ -15872,7 +15872,7 @@ func (publicKey *SshPublicKey) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if publicKey == nil {
 		return nil, nil
 	}
-	var result SshPublicKeyARM
+	result := &SshPublicKeyARM{}
 
 	// Set property ‘KeyData’:
 	if publicKey.KeyData != nil {
@@ -16066,7 +16066,7 @@ func (listener *WinRMListener) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if listener == nil {
 		return nil, nil
 	}
-	var result WinRMListenerARM
+	result := &WinRMListenerARM{}
 
 	// Set property ‘CertificateUrl’:
 	if listener.CertificateUrl != nil {

--- a/v2/api/compute/v1beta20201201/virtual_machines__spec_arm_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machines__spec_arm_types_gen.go
@@ -45,12 +45,12 @@ func (machines VirtualMachines_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (machines VirtualMachines_SpecARM) GetName() string {
+func (machines *VirtualMachines_SpecARM) GetName() string {
 	return machines.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/virtualMachines"
-func (machines VirtualMachines_SpecARM) GetType() string {
+func (machines *VirtualMachines_SpecARM) GetType() string {
 	return "Microsoft.Compute/virtualMachines"
 }
 

--- a/v2/api/compute/v1beta20210701/image_types_gen.go
+++ b/v2/api/compute/v1beta20210701/image_types_gen.go
@@ -710,7 +710,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if images == nil {
 		return nil, nil
 	}
-	var result Images_SpecARM
+	result := &Images_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if images.ExtendedLocation != nil {
@@ -718,7 +718,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -746,7 +746,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		sourceVirtualMachine := sourceVirtualMachineARM.(SubResourceARM)
+		sourceVirtualMachine := *sourceVirtualMachineARM.(*SubResourceARM)
 		result.Properties.SourceVirtualMachine = &sourceVirtualMachine
 	}
 	if images.StorageProfile != nil {
@@ -754,7 +754,7 @@ func (images *Images_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		storageProfile := storageProfileARM.(ImageStorageProfileARM)
+		storageProfile := *storageProfileARM.(*ImageStorageProfileARM)
 		result.Properties.StorageProfile = &storageProfile
 	}
 
@@ -1076,7 +1076,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -1285,7 +1285,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 	if profile == nil {
 		return nil, nil
 	}
-	var result ImageStorageProfileARM
+	result := &ImageStorageProfileARM{}
 
 	// Set property ‘DataDisks’:
 	for _, item := range profile.DataDisks {
@@ -1293,7 +1293,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		result.DataDisks = append(result.DataDisks, itemARM.(ImageDataDiskARM))
+		result.DataDisks = append(result.DataDisks, *itemARM.(*ImageDataDiskARM))
 	}
 
 	// Set property ‘OsDisk’:
@@ -1302,7 +1302,7 @@ func (profile *ImageStorageProfile) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		osDisk := osDiskARM.(ImageOSDiskARM)
+		osDisk := *osDiskARM.(*ImageOSDiskARM)
 		result.OsDisk = &osDisk
 	}
 
@@ -1629,7 +1629,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if resource == nil {
 		return nil, nil
 	}
-	var result SubResourceARM
+	result := &SubResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {
@@ -1801,7 +1801,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if disk == nil {
 		return nil, nil
 	}
-	var result ImageDataDiskARM
+	result := &ImageDataDiskARM{}
 
 	// Set property ‘BlobUri’:
 	if disk.BlobUri != nil {
@@ -1821,7 +1821,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -1843,7 +1843,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(SubResourceARM)
+		managedDisk := *managedDiskARM.(*SubResourceARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -1853,7 +1853,7 @@ func (disk *ImageDataDisk) ConvertToARM(resolved genruntime.ConvertToARMResolved
 		if err != nil {
 			return nil, err
 		}
-		snapshot := snapshotARM.(SubResourceARM)
+		snapshot := *snapshotARM.(*SubResourceARM)
 		result.Snapshot = &snapshot
 	}
 
@@ -2400,7 +2400,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if disk == nil {
 		return nil, nil
 	}
-	var result ImageOSDiskARM
+	result := &ImageOSDiskARM{}
 
 	// Set property ‘BlobUri’:
 	if disk.BlobUri != nil {
@@ -2420,7 +2420,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		diskEncryptionSet := diskEncryptionSetARM.(DiskEncryptionSetParametersARM)
+		diskEncryptionSet := *diskEncryptionSetARM.(*DiskEncryptionSetParametersARM)
 		result.DiskEncryptionSet = &diskEncryptionSet
 	}
 
@@ -2436,7 +2436,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		managedDisk := managedDiskARM.(SubResourceARM)
+		managedDisk := *managedDiskARM.(*SubResourceARM)
 		result.ManagedDisk = &managedDisk
 	}
 
@@ -2458,7 +2458,7 @@ func (disk *ImageOSDisk) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		snapshot := snapshotARM.(SubResourceARM)
+		snapshot := *snapshotARM.(*SubResourceARM)
 		result.Snapshot = &snapshot
 	}
 
@@ -3038,7 +3038,7 @@ func (parameters *DiskEncryptionSetParameters) ConvertToARM(resolved genruntime.
 	if parameters == nil {
 		return nil, nil
 	}
-	var result DiskEncryptionSetParametersARM
+	result := &DiskEncryptionSetParametersARM{}
 
 	// Set property ‘Id’:
 	if parameters.Reference != nil {

--- a/v2/api/compute/v1beta20210701/images__spec_arm_types_gen.go
+++ b/v2/api/compute/v1beta20210701/images__spec_arm_types_gen.go
@@ -30,12 +30,12 @@ func (images Images_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (images Images_SpecARM) GetName() string {
+func (images *Images_SpecARM) GetName() string {
 	return images.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Compute/images"
-func (images Images_SpecARM) GetType() string {
+func (images *Images_SpecARM) GetType() string {
 	return "Microsoft.Compute/images"
 }
 

--- a/v2/api/containerregistry/v1alpha1api20210901/registries__spec_arm_types_gen.go
+++ b/v2/api/containerregistry/v1alpha1api20210901/registries__spec_arm_types_gen.go
@@ -23,12 +23,12 @@ func (registries Registries_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (registries Registries_SpecARM) GetName() string {
+func (registries *Registries_SpecARM) GetName() string {
 	return registries.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ContainerRegistry/registries"
-func (registries Registries_SpecARM) GetType() string {
+func (registries *Registries_SpecARM) GetType() string {
 	return "Microsoft.ContainerRegistry/registries"
 }
 

--- a/v2/api/containerregistry/v1alpha1api20210901/registry_types_gen.go
+++ b/v2/api/containerregistry/v1alpha1api20210901/registry_types_gen.go
@@ -374,7 +374,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if registries == nil {
 		return nil, nil
 	}
-	var result Registries_SpecARM
+	result := &Registries_SpecARM{}
 
 	// Set property ‘Identity’:
 	if registries.Identity != nil {
@@ -382,7 +382,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityPropertiesARM)
+		identity := *identityARM.(*IdentityPropertiesARM)
 		result.Identity = &identity
 	}
 
@@ -419,7 +419,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionPropertyARM)
+		encryption := *encryptionARM.(*EncryptionPropertyARM)
 		result.Properties.Encryption = &encryption
 	}
 	if registries.NetworkRuleBypassOptions != nil {
@@ -431,7 +431,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		networkRuleSet := networkRuleSetARM.(NetworkRuleSetARM)
+		networkRuleSet := *networkRuleSetARM.(*NetworkRuleSetARM)
 		result.Properties.NetworkRuleSet = &networkRuleSet
 	}
 	if registries.Policies != nil {
@@ -439,7 +439,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		policies := policiesARM.(PoliciesARM)
+		policies := *policiesARM.(*PoliciesARM)
 		result.Properties.Policies = &policies
 	}
 	if registries.PublicNetworkAccess != nil {
@@ -457,7 +457,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1639,7 +1639,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 	if property == nil {
 		return nil, nil
 	}
-	var result EncryptionPropertyARM
+	result := &EncryptionPropertyARM{}
 
 	// Set property ‘KeyVaultProperties’:
 	if property.KeyVaultProperties != nil {
@@ -1647,7 +1647,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		keyVaultProperties := keyVaultPropertiesARM.(KeyVaultPropertiesARM)
+		keyVaultProperties := *keyVaultPropertiesARM.(*KeyVaultPropertiesARM)
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 
@@ -1874,7 +1874,7 @@ func (properties *IdentityProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result IdentityPropertiesARM
+	result := &IdentityPropertiesARM{}
 
 	// Set property ‘PrincipalId’:
 	if properties.PrincipalId != nil {
@@ -1902,7 +1902,7 @@ func (properties *IdentityProperties) ConvertToARM(resolved genruntime.ConvertTo
 			if err != nil {
 				return nil, err
 			}
-			result.UserAssignedIdentities[key] = valueARM.(UserIdentityPropertiesARM)
+			result.UserAssignedIdentities[key] = *valueARM.(*UserIdentityPropertiesARM)
 		}
 	}
 	return result, nil
@@ -2200,7 +2200,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if ruleSet == nil {
 		return nil, nil
 	}
-	var result NetworkRuleSetARM
+	result := &NetworkRuleSetARM{}
 
 	// Set property ‘DefaultAction’:
 	if ruleSet.DefaultAction != nil {
@@ -2214,7 +2214,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.IpRules = append(result.IpRules, itemARM.(IPRuleARM))
+		result.IpRules = append(result.IpRules, *itemARM.(*IPRuleARM))
 	}
 	return result, nil
 }
@@ -2456,7 +2456,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if policies == nil {
 		return nil, nil
 	}
-	var result PoliciesARM
+	result := &PoliciesARM{}
 
 	// Set property ‘ExportPolicy’:
 	if policies.ExportPolicy != nil {
@@ -2464,7 +2464,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		exportPolicy := exportPolicyARM.(ExportPolicyARM)
+		exportPolicy := *exportPolicyARM.(*ExportPolicyARM)
 		result.ExportPolicy = &exportPolicy
 	}
 
@@ -2474,7 +2474,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		quarantinePolicy := quarantinePolicyARM.(QuarantinePolicyARM)
+		quarantinePolicy := *quarantinePolicyARM.(*QuarantinePolicyARM)
 		result.QuarantinePolicy = &quarantinePolicy
 	}
 
@@ -2484,7 +2484,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		retentionPolicy := retentionPolicyARM.(RetentionPolicyARM)
+		retentionPolicy := *retentionPolicyARM.(*RetentionPolicyARM)
 		result.RetentionPolicy = &retentionPolicy
 	}
 
@@ -2494,7 +2494,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		trustPolicy := trustPolicyARM.(TrustPolicyARM)
+		trustPolicy := *trustPolicyARM.(*TrustPolicyARM)
 		result.TrustPolicy = &trustPolicy
 	}
 	return result, nil
@@ -3015,7 +3015,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -3424,7 +3424,7 @@ func (policy *ExportPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if policy == nil {
 		return nil, nil
 	}
-	var result ExportPolicyARM
+	result := &ExportPolicyARM{}
 
 	// Set property ‘Status’:
 	if policy.Status != nil {
@@ -3578,7 +3578,7 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if rule == nil {
 		return nil, nil
 	}
-	var result IPRuleARM
+	result := &IPRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -3761,7 +3761,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Identity’:
 	if properties.Identity != nil {
@@ -3980,7 +3980,7 @@ func (policy *QuarantinePolicy) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if policy == nil {
 		return nil, nil
 	}
-	var result QuarantinePolicyARM
+	result := &QuarantinePolicyARM{}
 
 	// Set property ‘Status’:
 	if policy.Status != nil {
@@ -4132,7 +4132,7 @@ func (policy *RetentionPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if policy == nil {
 		return nil, nil
 	}
-	var result RetentionPolicyARM
+	result := &RetentionPolicyARM{}
 
 	// Set property ‘Days’:
 	if policy.Days != nil {
@@ -4328,7 +4328,7 @@ func (policy *TrustPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if policy == nil {
 		return nil, nil
 	}
-	var result TrustPolicyARM
+	result := &TrustPolicyARM{}
 
 	// Set property ‘Status’:
 	if policy.Status != nil {
@@ -4531,7 +4531,7 @@ func (properties *UserIdentityProperties) ConvertToARM(resolved genruntime.Conve
 	if properties == nil {
 		return nil, nil
 	}
-	var result UserIdentityPropertiesARM
+	result := &UserIdentityPropertiesARM{}
 
 	// Set property ‘ClientId’:
 	if properties.ClientId != nil {

--- a/v2/api/containerregistry/v1beta20210901/registries__spec_arm_types_gen.go
+++ b/v2/api/containerregistry/v1beta20210901/registries__spec_arm_types_gen.go
@@ -33,12 +33,12 @@ func (registries Registries_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (registries Registries_SpecARM) GetName() string {
+func (registries *Registries_SpecARM) GetName() string {
 	return registries.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ContainerRegistry/registries"
-func (registries Registries_SpecARM) GetType() string {
+func (registries *Registries_SpecARM) GetType() string {
 	return "Microsoft.ContainerRegistry/registries"
 }
 

--- a/v2/api/containerregistry/v1beta20210901/registry_types_gen.go
+++ b/v2/api/containerregistry/v1beta20210901/registry_types_gen.go
@@ -379,7 +379,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if registries == nil {
 		return nil, nil
 	}
-	var result Registries_SpecARM
+	result := &Registries_SpecARM{}
 
 	// Set property ‘Identity’:
 	if registries.Identity != nil {
@@ -387,7 +387,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityPropertiesARM)
+		identity := *identityARM.(*IdentityPropertiesARM)
 		result.Identity = &identity
 	}
 
@@ -424,7 +424,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionPropertyARM)
+		encryption := *encryptionARM.(*EncryptionPropertyARM)
 		result.Properties.Encryption = &encryption
 	}
 	if registries.NetworkRuleBypassOptions != nil {
@@ -436,7 +436,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		networkRuleSet := networkRuleSetARM.(NetworkRuleSetARM)
+		networkRuleSet := *networkRuleSetARM.(*NetworkRuleSetARM)
 		result.Properties.NetworkRuleSet = &networkRuleSet
 	}
 	if registries.Policies != nil {
@@ -444,7 +444,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		policies := policiesARM.(PoliciesARM)
+		policies := *policiesARM.(*PoliciesARM)
 		result.Properties.Policies = &policies
 	}
 	if registries.PublicNetworkAccess != nil {
@@ -462,7 +462,7 @@ func (registries *Registries_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1688,7 +1688,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 	if property == nil {
 		return nil, nil
 	}
-	var result EncryptionPropertyARM
+	result := &EncryptionPropertyARM{}
 
 	// Set property ‘KeyVaultProperties’:
 	if property.KeyVaultProperties != nil {
@@ -1696,7 +1696,7 @@ func (property *EncryptionProperty) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		keyVaultProperties := keyVaultPropertiesARM.(KeyVaultPropertiesARM)
+		keyVaultProperties := *keyVaultPropertiesARM.(*KeyVaultPropertiesARM)
 		result.KeyVaultProperties = &keyVaultProperties
 	}
 
@@ -1935,7 +1935,7 @@ func (properties *IdentityProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result IdentityPropertiesARM
+	result := &IdentityPropertiesARM{}
 
 	// Set property ‘PrincipalId’:
 	if properties.PrincipalId != nil {
@@ -1963,7 +1963,7 @@ func (properties *IdentityProperties) ConvertToARM(resolved genruntime.ConvertTo
 			if err != nil {
 				return nil, err
 			}
-			result.UserAssignedIdentities[key] = valueARM.(UserIdentityPropertiesARM)
+			result.UserAssignedIdentities[key] = *valueARM.(*UserIdentityPropertiesARM)
 		}
 	}
 	return result, nil
@@ -2273,7 +2273,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if ruleSet == nil {
 		return nil, nil
 	}
-	var result NetworkRuleSetARM
+	result := &NetworkRuleSetARM{}
 
 	// Set property ‘DefaultAction’:
 	if ruleSet.DefaultAction != nil {
@@ -2287,7 +2287,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.IpRules = append(result.IpRules, itemARM.(IPRuleARM))
+		result.IpRules = append(result.IpRules, *itemARM.(*IPRuleARM))
 	}
 	return result, nil
 }
@@ -2538,7 +2538,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if policies == nil {
 		return nil, nil
 	}
-	var result PoliciesARM
+	result := &PoliciesARM{}
 
 	// Set property ‘ExportPolicy’:
 	if policies.ExportPolicy != nil {
@@ -2546,7 +2546,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		exportPolicy := exportPolicyARM.(ExportPolicyARM)
+		exportPolicy := *exportPolicyARM.(*ExportPolicyARM)
 		result.ExportPolicy = &exportPolicy
 	}
 
@@ -2556,7 +2556,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		quarantinePolicy := quarantinePolicyARM.(QuarantinePolicyARM)
+		quarantinePolicy := *quarantinePolicyARM.(*QuarantinePolicyARM)
 		result.QuarantinePolicy = &quarantinePolicy
 	}
 
@@ -2566,7 +2566,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		retentionPolicy := retentionPolicyARM.(RetentionPolicyARM)
+		retentionPolicy := *retentionPolicyARM.(*RetentionPolicyARM)
 		result.RetentionPolicy = &retentionPolicy
 	}
 
@@ -2576,7 +2576,7 @@ func (policies *Policies) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		trustPolicy := trustPolicyARM.(TrustPolicyARM)
+		trustPolicy := *trustPolicyARM.(*TrustPolicyARM)
 		result.TrustPolicy = &trustPolicy
 	}
 	return result, nil
@@ -3098,7 +3098,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -3523,7 +3523,7 @@ func (policy *ExportPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if policy == nil {
 		return nil, nil
 	}
-	var result ExportPolicyARM
+	result := &ExportPolicyARM{}
 
 	// Set property ‘Status’:
 	if policy.Status != nil {
@@ -3679,7 +3679,7 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if rule == nil {
 		return nil, nil
 	}
-	var result IPRuleARM
+	result := &IPRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -3867,7 +3867,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Identity’:
 	if properties.Identity != nil {
@@ -4095,7 +4095,7 @@ func (policy *QuarantinePolicy) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if policy == nil {
 		return nil, nil
 	}
-	var result QuarantinePolicyARM
+	result := &QuarantinePolicyARM{}
 
 	// Set property ‘Status’:
 	if policy.Status != nil {
@@ -4250,7 +4250,7 @@ func (policy *RetentionPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if policy == nil {
 		return nil, nil
 	}
-	var result RetentionPolicyARM
+	result := &RetentionPolicyARM{}
 
 	// Set property ‘Days’:
 	if policy.Days != nil {
@@ -4453,7 +4453,7 @@ func (policy *TrustPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if policy == nil {
 		return nil, nil
 	}
-	var result TrustPolicyARM
+	result := &TrustPolicyARM{}
 
 	// Set property ‘Status’:
 	if policy.Status != nil {
@@ -4661,7 +4661,7 @@ func (properties *UserIdentityProperties) ConvertToARM(resolved genruntime.Conve
 	if properties == nil {
 		return nil, nil
 	}
-	var result UserIdentityPropertiesARM
+	result := &UserIdentityPropertiesARM{}
 
 	// Set property ‘ClientId’:
 	if properties.ClientId != nil {

--- a/v2/api/containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
@@ -1488,7 +1488,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if clusters == nil {
 		return nil, nil
 	}
-	var result ManagedClusters_SpecARM
+	result := &ManagedClusters_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if clusters.ExtendedLocation != nil {
@@ -1496,7 +1496,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1506,7 +1506,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(ManagedClusterIdentityARM)
+		identity := *identityARM.(*ManagedClusterIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1549,7 +1549,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		aadProfile := aadProfileARM.(ManagedClusterAADProfileARM)
+		aadProfile := *aadProfileARM.(*ManagedClusterAADProfileARM)
 		result.Properties.AadProfile = &aadProfile
 	}
 	if clusters.AddonProfiles != nil {
@@ -1559,7 +1559,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 			if err != nil {
 				return nil, err
 			}
-			result.Properties.AddonProfiles[key] = valueARM.(ManagedClusterAddonProfileARM)
+			result.Properties.AddonProfiles[key] = *valueARM.(*ManagedClusterAddonProfileARM)
 		}
 	}
 	for _, item := range clusters.AgentPoolProfiles {
@@ -1567,14 +1567,14 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, itemARM.(ManagedClusterAgentPoolProfileARM))
+		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *itemARM.(*ManagedClusterAgentPoolProfileARM))
 	}
 	if clusters.ApiServerAccessProfile != nil {
 		apiServerAccessProfileARM, err := (*clusters.ApiServerAccessProfile).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		apiServerAccessProfile := apiServerAccessProfileARM.(ManagedClusterAPIServerAccessProfileARM)
+		apiServerAccessProfile := *apiServerAccessProfileARM.(*ManagedClusterAPIServerAccessProfileARM)
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if clusters.AutoScalerProfile != nil {
@@ -1582,7 +1582,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		autoScalerProfile := autoScalerProfileARM.(ManagedClusterPropertiesAutoScalerProfileARM)
+		autoScalerProfile := *autoScalerProfileARM.(*ManagedClusterPropertiesAutoScalerProfileARM)
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if clusters.AutoUpgradeProfile != nil {
@@ -1590,7 +1590,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		autoUpgradeProfile := autoUpgradeProfileARM.(ManagedClusterAutoUpgradeProfileARM)
+		autoUpgradeProfile := *autoUpgradeProfileARM.(*ManagedClusterAutoUpgradeProfileARM)
 		result.Properties.AutoUpgradeProfile = &autoUpgradeProfile
 	}
 	if clusters.DisableLocalAccounts != nil {
@@ -1626,7 +1626,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		httpProxyConfig := httpProxyConfigARM.(ManagedClusterHTTPProxyConfigARM)
+		httpProxyConfig := *httpProxyConfigARM.(*ManagedClusterHTTPProxyConfigARM)
 		result.Properties.HttpProxyConfig = &httpProxyConfig
 	}
 	if clusters.IdentityProfile != nil {
@@ -1636,7 +1636,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 			if err != nil {
 				return nil, err
 			}
-			result.Properties.IdentityProfile[key] = valueARM.(Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM)
+			result.Properties.IdentityProfile[key] = *valueARM.(*Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM)
 		}
 	}
 	if clusters.KubernetesVersion != nil {
@@ -1648,7 +1648,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		linuxProfile := linuxProfileARM.(ContainerServiceLinuxProfileARM)
+		linuxProfile := *linuxProfileARM.(*ContainerServiceLinuxProfileARM)
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if clusters.NetworkProfile != nil {
@@ -1656,7 +1656,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		networkProfile := networkProfileARM.(ContainerServiceNetworkProfileARM)
+		networkProfile := *networkProfileARM.(*ContainerServiceNetworkProfileARM)
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if clusters.NodeResourceGroup != nil {
@@ -1668,7 +1668,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		podIdentityProfile := podIdentityProfileARM.(ManagedClusterPodIdentityProfileARM)
+		podIdentityProfile := *podIdentityProfileARM.(*ManagedClusterPodIdentityProfileARM)
 		result.Properties.PodIdentityProfile = &podIdentityProfile
 	}
 	for _, item := range clusters.PrivateLinkResources {
@@ -1676,14 +1676,14 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.PrivateLinkResources = append(result.Properties.PrivateLinkResources, itemARM.(PrivateLinkResourceARM))
+		result.Properties.PrivateLinkResources = append(result.Properties.PrivateLinkResources, *itemARM.(*PrivateLinkResourceARM))
 	}
 	if clusters.ServicePrincipalProfile != nil {
 		servicePrincipalProfileARM, err := (*clusters.ServicePrincipalProfile).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		servicePrincipalProfile := servicePrincipalProfileARM.(ManagedClusterServicePrincipalProfileARM)
+		servicePrincipalProfile := *servicePrincipalProfileARM.(*ManagedClusterServicePrincipalProfileARM)
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if clusters.WindowsProfile != nil {
@@ -1691,7 +1691,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		windowsProfile := windowsProfileARM.(ManagedClusterWindowsProfileARM)
+		windowsProfile := *windowsProfileARM.(*ManagedClusterWindowsProfileARM)
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 
@@ -1701,7 +1701,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(ManagedClusterSKUARM)
+		sku := *skuARM.(*ManagedClusterSKUARM)
 		result.Sku = &sku
 	}
 
@@ -2725,7 +2725,7 @@ func (etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproper
 	if etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties == nil {
 		return nil, nil
 	}
-	var result Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM
+	result := &Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM{}
 
 	// Set property ‘ClientId’:
 	if etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties.ClientId != nil {
@@ -2849,7 +2849,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result ContainerServiceLinuxProfileARM
+	result := &ContainerServiceLinuxProfileARM{}
 
 	// Set property ‘AdminUsername’:
 	if profile.AdminUsername != nil {
@@ -2863,7 +2863,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		ssh := sshARM.(ContainerServiceSshConfigurationARM)
+		ssh := *sshARM.(*ContainerServiceSshConfigurationARM)
 		result.Ssh = &ssh
 	}
 	return result, nil
@@ -3087,7 +3087,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 	if profile == nil {
 		return nil, nil
 	}
-	var result ContainerServiceNetworkProfileARM
+	result := &ContainerServiceNetworkProfileARM{}
 
 	// Set property ‘DnsServiceIP’:
 	if profile.DnsServiceIP != nil {
@@ -3107,7 +3107,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		loadBalancerProfile := loadBalancerProfileARM.(ManagedClusterLoadBalancerProfileARM)
+		loadBalancerProfile := *loadBalancerProfileARM.(*ManagedClusterLoadBalancerProfileARM)
 		result.LoadBalancerProfile = &loadBalancerProfile
 	}
 
@@ -3688,7 +3688,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -3876,7 +3876,7 @@ func (profile *ManagedClusterAADProfile) ConvertToARM(resolved genruntime.Conver
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAADProfileARM
+	result := &ManagedClusterAADProfileARM{}
 
 	// Set property ‘AdminGroupObjectIDs’:
 	for _, item := range profile.AdminGroupObjectIDs {
@@ -4233,7 +4233,7 @@ func (profile *ManagedClusterAPIServerAccessProfile) ConvertToARM(resolved genru
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAPIServerAccessProfileARM
+	result := &ManagedClusterAPIServerAccessProfileARM{}
 
 	// Set property ‘AuthorizedIPRanges’:
 	for _, item := range profile.AuthorizedIPRanges {
@@ -4497,7 +4497,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAddonProfileARM
+	result := &ManagedClusterAddonProfileARM{}
 
 	// Set property ‘Config’:
 	if profile.Config != nil {
@@ -4641,7 +4641,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAgentPoolProfileARM
+	result := &ManagedClusterAgentPoolProfileARM{}
 
 	// Set property ‘AvailabilityZones’:
 	for _, item := range profile.AvailabilityZones {
@@ -4696,7 +4696,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		kubeletConfig := kubeletConfigARM.(KubeletConfigARM)
+		kubeletConfig := *kubeletConfigARM.(*KubeletConfigARM)
 		result.KubeletConfig = &kubeletConfig
 	}
 
@@ -4712,7 +4712,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		linuxOSConfig := linuxOSConfigARM.(LinuxOSConfigARM)
+		linuxOSConfig := *linuxOSConfigARM.(*LinuxOSConfigARM)
 		result.LinuxOSConfig = &linuxOSConfig
 	}
 
@@ -4853,7 +4853,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		upgradeSettings := upgradeSettingsARM.(AgentPoolUpgradeSettingsARM)
+		upgradeSettings := *upgradeSettingsARM.(*AgentPoolUpgradeSettingsARM)
 		result.UpgradeSettings = &upgradeSettings
 	}
 
@@ -6363,7 +6363,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) ConvertToARM(resolved genruntim
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAutoUpgradeProfileARM
+	result := &ManagedClusterAutoUpgradeProfileARM{}
 
 	// Set property ‘UpgradeChannel’:
 	if profile.UpgradeChannel != nil {
@@ -6517,7 +6517,7 @@ func (config *ManagedClusterHTTPProxyConfig) ConvertToARM(resolved genruntime.Co
 	if config == nil {
 		return nil, nil
 	}
-	var result ManagedClusterHTTPProxyConfigARM
+	result := &ManagedClusterHTTPProxyConfigARM{}
 
 	// Set property ‘HttpProxy’:
 	if config.HttpProxy != nil {
@@ -6739,7 +6739,7 @@ func (identity *ManagedClusterIdentity) ConvertToARM(resolved genruntime.Convert
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedClusterIdentityARM
+	result := &ManagedClusterIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -7011,7 +7011,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPodIdentityProfileARM
+	result := &ManagedClusterPodIdentityProfileARM{}
 
 	// Set property ‘AllowNetworkPluginKubenet’:
 	if profile.AllowNetworkPluginKubenet != nil {
@@ -7031,7 +7031,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		result.UserAssignedIdentities = append(result.UserAssignedIdentities, itemARM.(ManagedClusterPodIdentityARM))
+		result.UserAssignedIdentities = append(result.UserAssignedIdentities, *itemARM.(*ManagedClusterPodIdentityARM))
 	}
 
 	// Set property ‘UserAssignedIdentityExceptions’:
@@ -7040,7 +7040,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		result.UserAssignedIdentityExceptions = append(result.UserAssignedIdentityExceptions, itemARM.(ManagedClusterPodIdentityExceptionARM))
+		result.UserAssignedIdentityExceptions = append(result.UserAssignedIdentityExceptions, *itemARM.(*ManagedClusterPodIdentityExceptionARM))
 	}
 	return result, nil
 }
@@ -7433,7 +7433,7 @@ func (profile *ManagedClusterPropertiesAutoScalerProfile) ConvertToARM(resolved 
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPropertiesAutoScalerProfileARM
+	result := &ManagedClusterPropertiesAutoScalerProfileARM{}
 
 	// Set property ‘BalanceSimilarNodeGroups’:
 	if profile.BalanceSimilarNodeGroups != nil {
@@ -8081,7 +8081,7 @@ func (clusterSKU *ManagedClusterSKU) ConvertToARM(resolved genruntime.ConvertToA
 	if clusterSKU == nil {
 		return nil, nil
 	}
-	var result ManagedClusterSKUARM
+	result := &ManagedClusterSKUARM{}
 
 	// Set property ‘Name’:
 	if clusterSKU.Name != nil {
@@ -8285,7 +8285,7 @@ func (profile *ManagedClusterServicePrincipalProfile) ConvertToARM(resolved genr
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterServicePrincipalProfileARM
+	result := &ManagedClusterServicePrincipalProfileARM{}
 
 	// Set property ‘ClientId’:
 	if profile.ClientId != nil {
@@ -8452,7 +8452,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterWindowsProfileARM
+	result := &ManagedClusterWindowsProfileARM{}
 
 	// Set property ‘AdminPassword’:
 	if profile.AdminPassword != nil {
@@ -8788,7 +8788,7 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 	if resource == nil {
 		return nil, nil
 	}
-	var result PrivateLinkResourceARM
+	result := &PrivateLinkResourceARM{}
 
 	// Set property ‘GroupId’:
 	if resource.GroupId != nil {
@@ -9159,7 +9159,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 	if configuration == nil {
 		return nil, nil
 	}
-	var result ContainerServiceSshConfigurationARM
+	result := &ContainerServiceSshConfigurationARM{}
 
 	// Set property ‘PublicKeys’:
 	for _, item := range configuration.PublicKeys {
@@ -9167,7 +9167,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 		if err != nil {
 			return nil, err
 		}
-		result.PublicKeys = append(result.PublicKeys, itemARM.(ContainerServiceSshPublicKeyARM))
+		result.PublicKeys = append(result.PublicKeys, *itemARM.(*ContainerServiceSshPublicKeyARM))
 	}
 	return result, nil
 }
@@ -9557,7 +9557,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileARM
+	result := &ManagedClusterLoadBalancerProfileARM{}
 
 	// Set property ‘AllocatedOutboundPorts’:
 	if profile.AllocatedOutboundPorts != nil {
@@ -9571,7 +9571,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, itemARM.(ResourceReferenceARM))
+		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *itemARM.(*ResourceReferenceARM))
 	}
 
 	// Set property ‘IdleTimeoutInMinutes’:
@@ -9586,7 +9586,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		managedOutboundIPs := managedOutboundIPsARM.(ManagedClusterLoadBalancerProfileManagedOutboundIPsARM)
+		managedOutboundIPs := *managedOutboundIPsARM.(*ManagedClusterLoadBalancerProfileManagedOutboundIPsARM)
 		result.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
@@ -9596,7 +9596,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		outboundIPPrefixes := outboundIPPrefixesARM.(ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM)
+		outboundIPPrefixes := *outboundIPPrefixesARM.(*ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM)
 		result.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
@@ -9606,7 +9606,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		outboundIPs := outboundIPsARM.(ManagedClusterLoadBalancerProfileOutboundIPsARM)
+		outboundIPs := *outboundIPsARM.(*ManagedClusterLoadBalancerProfileOutboundIPsARM)
 		result.OutboundIPs = &outboundIPs
 	}
 	return result, nil
@@ -10093,7 +10093,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPodIdentityARM
+	result := &ManagedClusterPodIdentityARM{}
 
 	// Set property ‘BindingSelector’:
 	if identity.BindingSelector != nil {
@@ -10107,7 +10107,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		identity1 := identityARM.(UserAssignedIdentityARM)
+		identity1 := *identityARM.(*UserAssignedIdentityARM)
 		result.Identity = &identity1
 	}
 
@@ -10254,7 +10254,7 @@ func (exception *ManagedClusterPodIdentityException) ConvertToARM(resolved genru
 	if exception == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPodIdentityExceptionARM
+	result := &ManagedClusterPodIdentityExceptionARM{}
 
 	// Set property ‘Name’:
 	if exception.Name != nil {
@@ -10675,7 +10675,7 @@ func (publicKey *ContainerServiceSshPublicKey) ConvertToARM(resolved genruntime.
 	if publicKey == nil {
 		return nil, nil
 	}
-	var result ContainerServiceSshPublicKeyARM
+	result := &ContainerServiceSshPublicKeyARM{}
 
 	// Set property ‘KeyData’:
 	if publicKey.KeyData != nil {
@@ -10808,7 +10808,7 @@ func (iPs *ManagedClusterLoadBalancerProfileManagedOutboundIPs) ConvertToARM(res
 	if iPs == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileManagedOutboundIPsARM
+	result := &ManagedClusterLoadBalancerProfileManagedOutboundIPsARM{}
 
 	// Set property ‘Count’:
 	if iPs.Count != nil {
@@ -10891,7 +10891,7 @@ func (prefixes *ManagedClusterLoadBalancerProfileOutboundIPPrefixes) ConvertToAR
 	if prefixes == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM
+	result := &ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM{}
 
 	// Set property ‘PublicIPPrefixes’:
 	for _, item := range prefixes.PublicIPPrefixes {
@@ -10899,7 +10899,7 @@ func (prefixes *ManagedClusterLoadBalancerProfileOutboundIPPrefixes) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		result.PublicIPPrefixes = append(result.PublicIPPrefixes, itemARM.(ResourceReferenceARM))
+		result.PublicIPPrefixes = append(result.PublicIPPrefixes, *itemARM.(*ResourceReferenceARM))
 	}
 	return result, nil
 }
@@ -11001,7 +11001,7 @@ func (iPs *ManagedClusterLoadBalancerProfileOutboundIPs) ConvertToARM(resolved g
 	if iPs == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileOutboundIPsARM
+	result := &ManagedClusterLoadBalancerProfileOutboundIPsARM{}
 
 	// Set property ‘PublicIPs’:
 	for _, item := range iPs.PublicIPs {
@@ -11009,7 +11009,7 @@ func (iPs *ManagedClusterLoadBalancerProfileOutboundIPs) ConvertToARM(resolved g
 		if err != nil {
 			return nil, err
 		}
-		result.PublicIPs = append(result.PublicIPs, itemARM.(ResourceReferenceARM))
+		result.PublicIPs = append(result.PublicIPs, *itemARM.(*ResourceReferenceARM))
 	}
 	return result, nil
 }
@@ -11445,7 +11445,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	if reference == nil {
 		return nil, nil
 	}
-	var result ResourceReferenceARM
+	result := &ResourceReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -11588,7 +11588,7 @@ func (identity *UserAssignedIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	if identity == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentityARM
+	result := &UserAssignedIdentityARM{}
 
 	// Set property ‘ClientId’:
 	if identity.ClientId != nil {

--- a/v2/api/containerservice/v1alpha1api20210501/managed_clusters__spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_clusters__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (clusters ManagedClusters_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (clusters ManagedClusters_SpecARM) GetName() string {
+func (clusters *ManagedClusters_SpecARM) GetName() string {
 	return clusters.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ContainerService/managedClusters"
-func (clusters ManagedClusters_SpecARM) GetType() string {
+func (clusters *ManagedClusters_SpecARM) GetType() string {
 	return "Microsoft.ContainerService/managedClusters"
 }
 

--- a/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -1353,7 +1353,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 	if pools == nil {
 		return nil, nil
 	}
-	var result ManagedClustersAgentPools_SpecARM
+	result := &ManagedClustersAgentPools_SpecARM{}
 
 	// Set property ‘Location’:
 	if pools.Location != nil {
@@ -1436,7 +1436,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		kubeletConfig := kubeletConfigARM.(KubeletConfigARM)
+		kubeletConfig := *kubeletConfigARM.(*KubeletConfigARM)
 		result.Properties.KubeletConfig = &kubeletConfig
 	}
 	if pools.KubeletDiskType != nil {
@@ -1448,7 +1448,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		linuxOSConfig := linuxOSConfigARM.(LinuxOSConfigARM)
+		linuxOSConfig := *linuxOSConfigARM.(*LinuxOSConfigARM)
 		result.Properties.LinuxOSConfig = &linuxOSConfig
 	}
 	if pools.MaxCount != nil {
@@ -1543,7 +1543,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		upgradeSettings := upgradeSettingsARM.(AgentPoolUpgradeSettingsARM)
+		upgradeSettings := *upgradeSettingsARM.(*AgentPoolUpgradeSettingsARM)
 		result.Properties.UpgradeSettings = &upgradeSettings
 	}
 	if pools.VmSize != nil {
@@ -2452,7 +2452,7 @@ func (settings *AgentPoolUpgradeSettings) ConvertToARM(resolved genruntime.Conve
 	if settings == nil {
 		return nil, nil
 	}
-	var result AgentPoolUpgradeSettingsARM
+	result := &AgentPoolUpgradeSettingsARM{}
 
 	// Set property ‘MaxSurge’:
 	if settings.MaxSurge != nil {
@@ -2595,7 +2595,7 @@ func (config *KubeletConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if config == nil {
 		return nil, nil
 	}
-	var result KubeletConfigARM
+	result := &KubeletConfigARM{}
 
 	// Set property ‘AllowedUnsafeSysctls’:
 	for _, item := range config.AllowedUnsafeSysctls {
@@ -3086,7 +3086,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if config == nil {
 		return nil, nil
 	}
-	var result LinuxOSConfigARM
+	result := &LinuxOSConfigARM{}
 
 	// Set property ‘SwapFileSizeMB’:
 	if config.SwapFileSizeMB != nil {
@@ -3100,7 +3100,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		sysctls := sysctlsARM.(SysctlConfigARM)
+		sysctls := *sysctlsARM.(*SysctlConfigARM)
 		result.Sysctls = &sysctls
 	}
 
@@ -3480,7 +3480,7 @@ func (config *SysctlConfig) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if config == nil {
 		return nil, nil
 	}
-	var result SysctlConfigARM
+	result := &SysctlConfigARM{}
 
 	// Set property ‘FsAioMaxNr’:
 	if config.FsAioMaxNr != nil {

--- a/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pools__spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pools__spec_arm_types_gen.go
@@ -20,12 +20,12 @@ func (pools ManagedClustersAgentPools_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (pools ManagedClustersAgentPools_SpecARM) GetName() string {
+func (pools *ManagedClustersAgentPools_SpecARM) GetName() string {
 	return pools.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ContainerService/managedClusters/agentPools"
-func (pools ManagedClustersAgentPools_SpecARM) GetType() string {
+func (pools *ManagedClustersAgentPools_SpecARM) GetType() string {
 	return "Microsoft.ContainerService/managedClusters/agentPools"
 }
 

--- a/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen.go
@@ -1616,7 +1616,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if clusters == nil {
 		return nil, nil
 	}
-	var result ManagedClusters_SpecARM
+	result := &ManagedClusters_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if clusters.ExtendedLocation != nil {
@@ -1624,7 +1624,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1634,7 +1634,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(ManagedClusterIdentityARM)
+		identity := *identityARM.(*ManagedClusterIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1677,7 +1677,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		aadProfile := aadProfileARM.(ManagedClusterAADProfileARM)
+		aadProfile := *aadProfileARM.(*ManagedClusterAADProfileARM)
 		result.Properties.AadProfile = &aadProfile
 	}
 	if clusters.AddonProfiles != nil {
@@ -1687,7 +1687,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 			if err != nil {
 				return nil, err
 			}
-			result.Properties.AddonProfiles[key] = valueARM.(ManagedClusterAddonProfileARM)
+			result.Properties.AddonProfiles[key] = *valueARM.(*ManagedClusterAddonProfileARM)
 		}
 	}
 	for _, item := range clusters.AgentPoolProfiles {
@@ -1695,14 +1695,14 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, itemARM.(ManagedClusterAgentPoolProfileARM))
+		result.Properties.AgentPoolProfiles = append(result.Properties.AgentPoolProfiles, *itemARM.(*ManagedClusterAgentPoolProfileARM))
 	}
 	if clusters.ApiServerAccessProfile != nil {
 		apiServerAccessProfileARM, err := (*clusters.ApiServerAccessProfile).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		apiServerAccessProfile := apiServerAccessProfileARM.(ManagedClusterAPIServerAccessProfileARM)
+		apiServerAccessProfile := *apiServerAccessProfileARM.(*ManagedClusterAPIServerAccessProfileARM)
 		result.Properties.ApiServerAccessProfile = &apiServerAccessProfile
 	}
 	if clusters.AutoScalerProfile != nil {
@@ -1710,7 +1710,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		autoScalerProfile := autoScalerProfileARM.(ManagedClusterPropertiesAutoScalerProfileARM)
+		autoScalerProfile := *autoScalerProfileARM.(*ManagedClusterPropertiesAutoScalerProfileARM)
 		result.Properties.AutoScalerProfile = &autoScalerProfile
 	}
 	if clusters.AutoUpgradeProfile != nil {
@@ -1718,7 +1718,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		autoUpgradeProfile := autoUpgradeProfileARM.(ManagedClusterAutoUpgradeProfileARM)
+		autoUpgradeProfile := *autoUpgradeProfileARM.(*ManagedClusterAutoUpgradeProfileARM)
 		result.Properties.AutoUpgradeProfile = &autoUpgradeProfile
 	}
 	if clusters.DisableLocalAccounts != nil {
@@ -1754,7 +1754,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		httpProxyConfig := httpProxyConfigARM.(ManagedClusterHTTPProxyConfigARM)
+		httpProxyConfig := *httpProxyConfigARM.(*ManagedClusterHTTPProxyConfigARM)
 		result.Properties.HttpProxyConfig = &httpProxyConfig
 	}
 	if clusters.IdentityProfile != nil {
@@ -1764,7 +1764,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 			if err != nil {
 				return nil, err
 			}
-			result.Properties.IdentityProfile[key] = valueARM.(Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM)
+			result.Properties.IdentityProfile[key] = *valueARM.(*Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM)
 		}
 	}
 	if clusters.KubernetesVersion != nil {
@@ -1776,7 +1776,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		linuxProfile := linuxProfileARM.(ContainerServiceLinuxProfileARM)
+		linuxProfile := *linuxProfileARM.(*ContainerServiceLinuxProfileARM)
 		result.Properties.LinuxProfile = &linuxProfile
 	}
 	if clusters.NetworkProfile != nil {
@@ -1784,7 +1784,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		networkProfile := networkProfileARM.(ContainerServiceNetworkProfileARM)
+		networkProfile := *networkProfileARM.(*ContainerServiceNetworkProfileARM)
 		result.Properties.NetworkProfile = &networkProfile
 	}
 	if clusters.NodeResourceGroup != nil {
@@ -1796,7 +1796,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		podIdentityProfile := podIdentityProfileARM.(ManagedClusterPodIdentityProfileARM)
+		podIdentityProfile := *podIdentityProfileARM.(*ManagedClusterPodIdentityProfileARM)
 		result.Properties.PodIdentityProfile = &podIdentityProfile
 	}
 	for _, item := range clusters.PrivateLinkResources {
@@ -1804,14 +1804,14 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.PrivateLinkResources = append(result.Properties.PrivateLinkResources, itemARM.(PrivateLinkResourceARM))
+		result.Properties.PrivateLinkResources = append(result.Properties.PrivateLinkResources, *itemARM.(*PrivateLinkResourceARM))
 	}
 	if clusters.ServicePrincipalProfile != nil {
 		servicePrincipalProfileARM, err := (*clusters.ServicePrincipalProfile).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		servicePrincipalProfile := servicePrincipalProfileARM.(ManagedClusterServicePrincipalProfileARM)
+		servicePrincipalProfile := *servicePrincipalProfileARM.(*ManagedClusterServicePrincipalProfileARM)
 		result.Properties.ServicePrincipalProfile = &servicePrincipalProfile
 	}
 	if clusters.WindowsProfile != nil {
@@ -1819,7 +1819,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		windowsProfile := windowsProfileARM.(ManagedClusterWindowsProfileARM)
+		windowsProfile := *windowsProfileARM.(*ManagedClusterWindowsProfileARM)
 		result.Properties.WindowsProfile = &windowsProfile
 	}
 
@@ -1829,7 +1829,7 @@ func (clusters *ManagedClusters_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(ManagedClusterSKUARM)
+		sku := *skuARM.(*ManagedClusterSKUARM)
 		result.Sku = &sku
 	}
 
@@ -2858,7 +2858,7 @@ func (etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproper
 	if etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties == nil {
 		return nil, nil
 	}
-	var result Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM
+	result := &Componentsqit0EtschemasmanagedclusterpropertiespropertiesidentityprofileadditionalpropertiesARM{}
 
 	// Set property ‘ClientId’:
 	if etschemasmanagedclusterpropertiespropertiesidentityprofileadditionalproperties.ClientId != nil {
@@ -2984,7 +2984,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result ContainerServiceLinuxProfileARM
+	result := &ContainerServiceLinuxProfileARM{}
 
 	// Set property ‘AdminUsername’:
 	if profile.AdminUsername != nil {
@@ -2998,7 +2998,7 @@ func (profile *ContainerServiceLinuxProfile) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		ssh := sshARM.(ContainerServiceSshConfigurationARM)
+		ssh := *sshARM.(*ContainerServiceSshConfigurationARM)
 		result.Ssh = &ssh
 	}
 	return result, nil
@@ -3246,7 +3246,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 	if profile == nil {
 		return nil, nil
 	}
-	var result ContainerServiceNetworkProfileARM
+	result := &ContainerServiceNetworkProfileARM{}
 
 	// Set property ‘DnsServiceIP’:
 	if profile.DnsServiceIP != nil {
@@ -3266,7 +3266,7 @@ func (profile *ContainerServiceNetworkProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		loadBalancerProfile := loadBalancerProfileARM.(ManagedClusterLoadBalancerProfileARM)
+		loadBalancerProfile := *loadBalancerProfileARM.(*ManagedClusterLoadBalancerProfileARM)
 		result.LoadBalancerProfile = &loadBalancerProfile
 	}
 
@@ -3874,7 +3874,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -4078,7 +4078,7 @@ func (profile *ManagedClusterAADProfile) ConvertToARM(resolved genruntime.Conver
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAADProfileARM
+	result := &ManagedClusterAADProfileARM{}
 
 	// Set property ‘AdminGroupObjectIDs’:
 	for _, item := range profile.AdminGroupObjectIDs {
@@ -4460,7 +4460,7 @@ func (profile *ManagedClusterAPIServerAccessProfile) ConvertToARM(resolved genru
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAPIServerAccessProfileARM
+	result := &ManagedClusterAPIServerAccessProfileARM{}
 
 	// Set property ‘AuthorizedIPRanges’:
 	for _, item := range profile.AuthorizedIPRanges {
@@ -4737,7 +4737,7 @@ func (profile *ManagedClusterAddonProfile) ConvertToARM(resolved genruntime.Conv
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAddonProfileARM
+	result := &ManagedClusterAddonProfileARM{}
 
 	// Set property ‘Config’:
 	if profile.Config != nil {
@@ -4960,7 +4960,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAgentPoolProfileARM
+	result := &ManagedClusterAgentPoolProfileARM{}
 
 	// Set property ‘AvailabilityZones’:
 	for _, item := range profile.AvailabilityZones {
@@ -5015,7 +5015,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		kubeletConfig := kubeletConfigARM.(KubeletConfigARM)
+		kubeletConfig := *kubeletConfigARM.(*KubeletConfigARM)
 		result.KubeletConfig = &kubeletConfig
 	}
 
@@ -5031,7 +5031,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		linuxOSConfig := linuxOSConfigARM.(LinuxOSConfigARM)
+		linuxOSConfig := *linuxOSConfigARM.(*LinuxOSConfigARM)
 		result.LinuxOSConfig = &linuxOSConfig
 	}
 
@@ -5172,7 +5172,7 @@ func (profile *ManagedClusterAgentPoolProfile) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		upgradeSettings := upgradeSettingsARM.(AgentPoolUpgradeSettingsARM)
+		upgradeSettings := *upgradeSettingsARM.(*AgentPoolUpgradeSettingsARM)
 		result.UpgradeSettings = &upgradeSettings
 	}
 
@@ -6765,7 +6765,7 @@ func (profile *ManagedClusterAutoUpgradeProfile) ConvertToARM(resolved genruntim
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterAutoUpgradeProfileARM
+	result := &ManagedClusterAutoUpgradeProfileARM{}
 
 	// Set property ‘UpgradeChannel’:
 	if profile.UpgradeChannel != nil {
@@ -6927,7 +6927,7 @@ func (config *ManagedClusterHTTPProxyConfig) ConvertToARM(resolved genruntime.Co
 	if config == nil {
 		return nil, nil
 	}
-	var result ManagedClusterHTTPProxyConfigARM
+	result := &ManagedClusterHTTPProxyConfigARM{}
 
 	// Set property ‘HttpProxy’:
 	if config.HttpProxy != nil {
@@ -7160,7 +7160,7 @@ func (identity *ManagedClusterIdentity) ConvertToARM(resolved genruntime.Convert
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedClusterIdentityARM
+	result := &ManagedClusterIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -7450,7 +7450,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPodIdentityProfileARM
+	result := &ManagedClusterPodIdentityProfileARM{}
 
 	// Set property ‘AllowNetworkPluginKubenet’:
 	if profile.AllowNetworkPluginKubenet != nil {
@@ -7470,7 +7470,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		result.UserAssignedIdentities = append(result.UserAssignedIdentities, itemARM.(ManagedClusterPodIdentityARM))
+		result.UserAssignedIdentities = append(result.UserAssignedIdentities, *itemARM.(*ManagedClusterPodIdentityARM))
 	}
 
 	// Set property ‘UserAssignedIdentityExceptions’:
@@ -7479,7 +7479,7 @@ func (profile *ManagedClusterPodIdentityProfile) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		result.UserAssignedIdentityExceptions = append(result.UserAssignedIdentityExceptions, itemARM.(ManagedClusterPodIdentityExceptionARM))
+		result.UserAssignedIdentityExceptions = append(result.UserAssignedIdentityExceptions, *itemARM.(*ManagedClusterPodIdentityExceptionARM))
 	}
 	return result, nil
 }
@@ -7924,7 +7924,7 @@ func (profile *ManagedClusterPropertiesAutoScalerProfile) ConvertToARM(resolved 
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPropertiesAutoScalerProfileARM
+	result := &ManagedClusterPropertiesAutoScalerProfileARM{}
 
 	// Set property ‘BalanceSimilarNodeGroups’:
 	if profile.BalanceSimilarNodeGroups != nil {
@@ -8618,7 +8618,7 @@ func (clusterSKU *ManagedClusterSKU) ConvertToARM(resolved genruntime.ConvertToA
 	if clusterSKU == nil {
 		return nil, nil
 	}
-	var result ManagedClusterSKUARM
+	result := &ManagedClusterSKUARM{}
 
 	// Set property ‘Name’:
 	if clusterSKU.Name != nil {
@@ -8828,7 +8828,7 @@ func (profile *ManagedClusterServicePrincipalProfile) ConvertToARM(resolved genr
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterServicePrincipalProfileARM
+	result := &ManagedClusterServicePrincipalProfileARM{}
 
 	// Set property ‘ClientId’:
 	if profile.ClientId != nil {
@@ -9020,7 +9020,7 @@ func (profile *ManagedClusterWindowsProfile) ConvertToARM(resolved genruntime.Co
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterWindowsProfileARM
+	result := &ManagedClusterWindowsProfileARM{}
 
 	// Set property ‘AdminPassword’:
 	if profile.AdminPassword != nil {
@@ -9388,7 +9388,7 @@ func (resource *PrivateLinkResource) ConvertToARM(resolved genruntime.ConvertToA
 	if resource == nil {
 		return nil, nil
 	}
-	var result PrivateLinkResourceARM
+	result := &PrivateLinkResourceARM{}
 
 	// Set property ‘GroupId’:
 	if resource.GroupId != nil {
@@ -9750,7 +9750,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 	if configuration == nil {
 		return nil, nil
 	}
-	var result ContainerServiceSshConfigurationARM
+	result := &ContainerServiceSshConfigurationARM{}
 
 	// Set property ‘PublicKeys’:
 	for _, item := range configuration.PublicKeys {
@@ -9758,7 +9758,7 @@ func (configuration *ContainerServiceSshConfiguration) ConvertToARM(resolved gen
 		if err != nil {
 			return nil, err
 		}
-		result.PublicKeys = append(result.PublicKeys, itemARM.(ContainerServiceSshPublicKeyARM))
+		result.PublicKeys = append(result.PublicKeys, *itemARM.(*ContainerServiceSshPublicKeyARM))
 	}
 	return result, nil
 }
@@ -10143,7 +10143,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 	if profile == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileARM
+	result := &ManagedClusterLoadBalancerProfileARM{}
 
 	// Set property ‘AllocatedOutboundPorts’:
 	if profile.AllocatedOutboundPorts != nil {
@@ -10157,7 +10157,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, itemARM.(ResourceReferenceARM))
+		result.EffectiveOutboundIPs = append(result.EffectiveOutboundIPs, *itemARM.(*ResourceReferenceARM))
 	}
 
 	// Set property ‘IdleTimeoutInMinutes’:
@@ -10172,7 +10172,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		managedOutboundIPs := managedOutboundIPsARM.(ManagedClusterLoadBalancerProfileManagedOutboundIPsARM)
+		managedOutboundIPs := *managedOutboundIPsARM.(*ManagedClusterLoadBalancerProfileManagedOutboundIPsARM)
 		result.ManagedOutboundIPs = &managedOutboundIPs
 	}
 
@@ -10182,7 +10182,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		outboundIPPrefixes := outboundIPPrefixesARM.(ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM)
+		outboundIPPrefixes := *outboundIPPrefixesARM.(*ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM)
 		result.OutboundIPPrefixes = &outboundIPPrefixes
 	}
 
@@ -10192,7 +10192,7 @@ func (profile *ManagedClusterLoadBalancerProfile) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		outboundIPs := outboundIPsARM.(ManagedClusterLoadBalancerProfileOutboundIPsARM)
+		outboundIPs := *outboundIPsARM.(*ManagedClusterLoadBalancerProfileOutboundIPsARM)
 		result.OutboundIPs = &outboundIPs
 	}
 	return result, nil
@@ -10695,7 +10695,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPodIdentityARM
+	result := &ManagedClusterPodIdentityARM{}
 
 	// Set property ‘BindingSelector’:
 	if identity.BindingSelector != nil {
@@ -10709,7 +10709,7 @@ func (identity *ManagedClusterPodIdentity) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		identity1 := identityARM.(UserAssignedIdentityARM)
+		identity1 := *identityARM.(*UserAssignedIdentityARM)
 		result.Identity = &identity1
 	}
 
@@ -10859,7 +10859,7 @@ func (exception *ManagedClusterPodIdentityException) ConvertToARM(resolved genru
 	if exception == nil {
 		return nil, nil
 	}
-	var result ManagedClusterPodIdentityExceptionARM
+	result := &ManagedClusterPodIdentityExceptionARM{}
 
 	// Set property ‘Name’:
 	if exception.Name != nil {
@@ -11286,7 +11286,7 @@ func (publicKey *ContainerServiceSshPublicKey) ConvertToARM(resolved genruntime.
 	if publicKey == nil {
 		return nil, nil
 	}
-	var result ContainerServiceSshPublicKeyARM
+	result := &ContainerServiceSshPublicKeyARM{}
 
 	// Set property ‘KeyData’:
 	if publicKey.KeyData != nil {
@@ -11422,7 +11422,7 @@ func (iPs *ManagedClusterLoadBalancerProfileManagedOutboundIPs) ConvertToARM(res
 	if iPs == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileManagedOutboundIPsARM
+	result := &ManagedClusterLoadBalancerProfileManagedOutboundIPsARM{}
 
 	// Set property ‘Count’:
 	if iPs.Count != nil {
@@ -11506,7 +11506,7 @@ func (prefixes *ManagedClusterLoadBalancerProfileOutboundIPPrefixes) ConvertToAR
 	if prefixes == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM
+	result := &ManagedClusterLoadBalancerProfileOutboundIPPrefixesARM{}
 
 	// Set property ‘PublicIPPrefixes’:
 	for _, item := range prefixes.PublicIPPrefixes {
@@ -11514,7 +11514,7 @@ func (prefixes *ManagedClusterLoadBalancerProfileOutboundIPPrefixes) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		result.PublicIPPrefixes = append(result.PublicIPPrefixes, itemARM.(ResourceReferenceARM))
+		result.PublicIPPrefixes = append(result.PublicIPPrefixes, *itemARM.(*ResourceReferenceARM))
 	}
 	return result, nil
 }
@@ -11617,7 +11617,7 @@ func (iPs *ManagedClusterLoadBalancerProfileOutboundIPs) ConvertToARM(resolved g
 	if iPs == nil {
 		return nil, nil
 	}
-	var result ManagedClusterLoadBalancerProfileOutboundIPsARM
+	result := &ManagedClusterLoadBalancerProfileOutboundIPsARM{}
 
 	// Set property ‘PublicIPs’:
 	for _, item := range iPs.PublicIPs {
@@ -11625,7 +11625,7 @@ func (iPs *ManagedClusterLoadBalancerProfileOutboundIPs) ConvertToARM(resolved g
 		if err != nil {
 			return nil, err
 		}
-		result.PublicIPs = append(result.PublicIPs, itemARM.(ResourceReferenceARM))
+		result.PublicIPs = append(result.PublicIPs, *itemARM.(*ResourceReferenceARM))
 	}
 	return result, nil
 }
@@ -12061,7 +12061,7 @@ func (reference *ResourceReference) ConvertToARM(resolved genruntime.ConvertToAR
 	if reference == nil {
 		return nil, nil
 	}
-	var result ResourceReferenceARM
+	result := &ResourceReferenceARM{}
 
 	// Set property ‘Id’:
 	if reference.Reference != nil {
@@ -12209,7 +12209,7 @@ func (identity *UserAssignedIdentity) ConvertToARM(resolved genruntime.ConvertTo
 	if identity == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentityARM
+	result := &UserAssignedIdentityARM{}
 
 	// Set property ‘ClientId’:
 	if identity.ClientId != nil {

--- a/v2/api/containerservice/v1beta20210501/managed_clusters__spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_clusters__spec_arm_types_gen.go
@@ -39,12 +39,12 @@ func (clusters ManagedClusters_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (clusters ManagedClusters_SpecARM) GetName() string {
+func (clusters *ManagedClusters_SpecARM) GetName() string {
 	return clusters.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ContainerService/managedClusters"
-func (clusters ManagedClusters_SpecARM) GetType() string {
+func (clusters *ManagedClusters_SpecARM) GetType() string {
 	return "Microsoft.ContainerService/managedClusters"
 }
 

--- a/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen.go
@@ -1504,7 +1504,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 	if pools == nil {
 		return nil, nil
 	}
-	var result ManagedClustersAgentPools_SpecARM
+	result := &ManagedClustersAgentPools_SpecARM{}
 
 	// Set property ‘Location’:
 	if pools.Location != nil {
@@ -1587,7 +1587,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		kubeletConfig := kubeletConfigARM.(KubeletConfigARM)
+		kubeletConfig := *kubeletConfigARM.(*KubeletConfigARM)
 		result.Properties.KubeletConfig = &kubeletConfig
 	}
 	if pools.KubeletDiskType != nil {
@@ -1599,7 +1599,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		linuxOSConfig := linuxOSConfigARM.(LinuxOSConfigARM)
+		linuxOSConfig := *linuxOSConfigARM.(*LinuxOSConfigARM)
 		result.Properties.LinuxOSConfig = &linuxOSConfig
 	}
 	if pools.MaxCount != nil {
@@ -1694,7 +1694,7 @@ func (pools *ManagedClustersAgentPools_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		upgradeSettings := upgradeSettingsARM.(AgentPoolUpgradeSettingsARM)
+		upgradeSettings := *upgradeSettingsARM.(*AgentPoolUpgradeSettingsARM)
 		result.Properties.UpgradeSettings = &upgradeSettings
 	}
 	if pools.VmSize != nil {
@@ -2607,7 +2607,7 @@ func (settings *AgentPoolUpgradeSettings) ConvertToARM(resolved genruntime.Conve
 	if settings == nil {
 		return nil, nil
 	}
-	var result AgentPoolUpgradeSettingsARM
+	result := &AgentPoolUpgradeSettingsARM{}
 
 	// Set property ‘MaxSurge’:
 	if settings.MaxSurge != nil {
@@ -2779,7 +2779,7 @@ func (config *KubeletConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if config == nil {
 		return nil, nil
 	}
-	var result KubeletConfigARM
+	result := &KubeletConfigARM{}
 
 	// Set property ‘AllowedUnsafeSysctls’:
 	for _, item := range config.AllowedUnsafeSysctls {
@@ -3307,7 +3307,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if config == nil {
 		return nil, nil
 	}
-	var result LinuxOSConfigARM
+	result := &LinuxOSConfigARM{}
 
 	// Set property ‘SwapFileSizeMB’:
 	if config.SwapFileSizeMB != nil {
@@ -3321,7 +3321,7 @@ func (config *LinuxOSConfig) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		sysctls := sysctlsARM.(SysctlConfigARM)
+		sysctls := *sysctlsARM.(*SysctlConfigARM)
 		result.Sysctls = &sysctls
 	}
 
@@ -3748,7 +3748,7 @@ func (config *SysctlConfig) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if config == nil {
 		return nil, nil
 	}
-	var result SysctlConfigARM
+	result := &SysctlConfigARM{}
 
 	// Set property ‘FsAioMaxNr’:
 	if config.FsAioMaxNr != nil {

--- a/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pools__spec_arm_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pools__spec_arm_types_gen.go
@@ -24,12 +24,12 @@ func (pools ManagedClustersAgentPools_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (pools ManagedClustersAgentPools_SpecARM) GetName() string {
+func (pools *ManagedClustersAgentPools_SpecARM) GetName() string {
 	return pools.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ContainerService/managedClusters/agentPools"
-func (pools ManagedClustersAgentPools_SpecARM) GetType() string {
+func (pools *ManagedClustersAgentPools_SpecARM) GetType() string {
 	return "Microsoft.ContainerService/managedClusters/agentPools"
 }
 

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_server_types_gen.go
@@ -374,7 +374,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if servers == nil {
 		return nil, nil
 	}
-	var result FlexibleServers_SpecARM
+	result := &FlexibleServers_SpecARM{}
 
 	// Set property ‘Location’:
 	if servers.Location != nil {
@@ -422,7 +422,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		backup := backupARM.(BackupARM)
+		backup := *backupARM.(*BackupARM)
 		result.Properties.Backup = &backup
 	}
 	if servers.CreateMode != nil {
@@ -434,7 +434,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		highAvailability := highAvailabilityARM.(HighAvailabilityARM)
+		highAvailability := *highAvailabilityARM.(*HighAvailabilityARM)
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if servers.MaintenanceWindow != nil {
@@ -442,7 +442,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		maintenanceWindow := maintenanceWindowARM.(MaintenanceWindowARM)
+		maintenanceWindow := *maintenanceWindowARM.(*MaintenanceWindowARM)
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if servers.Network != nil {
@@ -450,7 +450,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		network := networkARM.(NetworkARM)
+		network := *networkARM.(*NetworkARM)
 		result.Properties.Network = &network
 	}
 	if servers.ReplicationRole != nil {
@@ -470,7 +470,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		storage := storageARM.(StorageARM)
+		storage := *storageARM.(*StorageARM)
 		result.Properties.Storage = &storage
 	}
 	if servers.Version != nil {
@@ -484,7 +484,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1770,7 +1770,7 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if backup == nil {
 		return nil, nil
 	}
-	var result BackupARM
+	result := &BackupARM{}
 
 	// Set property ‘BackupRetentionDays’:
 	if backup.BackupRetentionDays != nil {
@@ -2086,7 +2086,7 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	if availability == nil {
 		return nil, nil
 	}
-	var result HighAvailabilityARM
+	result := &HighAvailabilityARM{}
 
 	// Set property ‘Mode’:
 	if availability.Mode != nil {
@@ -2423,7 +2423,7 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if window == nil {
 		return nil, nil
 	}
-	var result MaintenanceWindowARM
+	result := &MaintenanceWindowARM{}
 
 	// Set property ‘CustomWindow’:
 	if window.CustomWindow != nil {
@@ -2648,7 +2648,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if network == nil {
 		return nil, nil
 	}
-	var result NetworkARM
+	result := &NetworkARM{}
 
 	// Set property ‘DelegatedSubnetResourceId’:
 	if network.DelegatedSubnetResourceReference != nil {
@@ -2927,7 +2927,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -3111,7 +3111,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if storage == nil {
 		return nil, nil
 	}
-	var result StorageARM
+	result := &StorageARM{}
 
 	// Set property ‘AutoGrow’:
 	if storage.AutoGrow != nil {

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers__spec_arm_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers__spec_arm_types_gen.go
@@ -22,12 +22,12 @@ func (servers FlexibleServers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (servers FlexibleServers_SpecARM) GetName() string {
+func (servers *FlexibleServers_SpecARM) GetName() string {
 	return servers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforMySQL/flexibleServers"
-func (servers FlexibleServers_SpecARM) GetType() string {
+func (servers *FlexibleServers_SpecARM) GetType() string {
 	return "Microsoft.DBforMySQL/flexibleServers"
 }
 

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen.go
@@ -567,7 +567,7 @@ func (databases *FlexibleServersDatabases_Spec) ConvertToARM(resolved genruntime
 	if databases == nil {
 		return nil, nil
 	}
-	var result FlexibleServersDatabases_SpecARM
+	result := &FlexibleServersDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_databases__spec_arm_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_databases__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (databases FlexibleServersDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases FlexibleServersDatabases_SpecARM) GetName() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforMySQL/flexibleServers/databases"
-func (databases FlexibleServersDatabases_SpecARM) GetType() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetType() string {
 	return "Microsoft.DBforMySQL/flexibleServers/databases"
 }
 

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen.go
@@ -572,7 +572,7 @@ func (rules *FlexibleServersFirewallRules_Spec) ConvertToARM(resolved genruntime
 	if rules == nil {
 		return nil, nil
 	}
-	var result FlexibleServersFirewallRules_SpecARM
+	result := &FlexibleServersFirewallRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rules__spec_arm_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rules__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (rules FlexibleServersFirewallRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules FlexibleServersFirewallRules_SpecARM) GetName() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforMySQL/flexibleServers/firewallRules"
-func (rules FlexibleServersFirewallRules_SpecARM) GetType() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetType() string {
 	return "Microsoft.DBforMySQL/flexibleServers/firewallRules"
 }
 

--- a/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen.go
@@ -391,7 +391,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if servers == nil {
 		return nil, nil
 	}
-	var result FlexibleServers_SpecARM
+	result := &FlexibleServers_SpecARM{}
 
 	// Set property ‘Location’:
 	if servers.Location != nil {
@@ -439,7 +439,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		backup := backupARM.(BackupARM)
+		backup := *backupARM.(*BackupARM)
 		result.Properties.Backup = &backup
 	}
 	if servers.CreateMode != nil {
@@ -451,7 +451,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		highAvailability := highAvailabilityARM.(HighAvailabilityARM)
+		highAvailability := *highAvailabilityARM.(*HighAvailabilityARM)
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if servers.MaintenanceWindow != nil {
@@ -459,7 +459,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		maintenanceWindow := maintenanceWindowARM.(MaintenanceWindowARM)
+		maintenanceWindow := *maintenanceWindowARM.(*MaintenanceWindowARM)
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if servers.Network != nil {
@@ -467,7 +467,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		network := networkARM.(NetworkARM)
+		network := *networkARM.(*NetworkARM)
 		result.Properties.Network = &network
 	}
 	if servers.ReplicationRole != nil {
@@ -487,7 +487,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		storage := storageARM.(StorageARM)
+		storage := *storageARM.(*StorageARM)
 		result.Properties.Storage = &storage
 	}
 	if servers.Version != nil {
@@ -501,7 +501,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1838,7 +1838,7 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if backup == nil {
 		return nil, nil
 	}
-	var result BackupARM
+	result := &BackupARM{}
 
 	// Set property ‘BackupRetentionDays’:
 	if backup.BackupRetentionDays != nil {
@@ -2170,7 +2170,7 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	if availability == nil {
 		return nil, nil
 	}
-	var result HighAvailabilityARM
+	result := &HighAvailabilityARM{}
 
 	// Set property ‘Mode’:
 	if availability.Mode != nil {
@@ -2524,7 +2524,7 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if window == nil {
 		return nil, nil
 	}
-	var result MaintenanceWindowARM
+	result := &MaintenanceWindowARM{}
 
 	// Set property ‘CustomWindow’:
 	if window.CustomWindow != nil {
@@ -2758,7 +2758,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if network == nil {
 		return nil, nil
 	}
-	var result NetworkARM
+	result := &NetworkARM{}
 
 	// Set property ‘DelegatedSubnetResourceId’:
 	if network.DelegatedSubnetResourceReference != nil {
@@ -3037,7 +3037,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -3228,7 +3228,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if storage == nil {
 		return nil, nil
 	}
-	var result StorageARM
+	result := &StorageARM{}
 
 	// Set property ‘AutoGrow’:
 	if storage.AutoGrow != nil {

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers__spec_arm_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers__spec_arm_types_gen.go
@@ -30,12 +30,12 @@ func (servers FlexibleServers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (servers FlexibleServers_SpecARM) GetName() string {
+func (servers *FlexibleServers_SpecARM) GetName() string {
 	return servers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforMySQL/flexibleServers"
-func (servers FlexibleServers_SpecARM) GetType() string {
+func (servers *FlexibleServers_SpecARM) GetType() string {
 	return "Microsoft.DBforMySQL/flexibleServers"
 }
 

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen.go
@@ -572,7 +572,7 @@ func (databases *FlexibleServersDatabases_Spec) ConvertToARM(resolved genruntime
 	if databases == nil {
 		return nil, nil
 	}
-	var result FlexibleServersDatabases_SpecARM
+	result := &FlexibleServersDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_databases__spec_arm_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_databases__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (databases FlexibleServersDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases FlexibleServersDatabases_SpecARM) GetName() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforMySQL/flexibleServers/databases"
-func (databases FlexibleServersDatabases_SpecARM) GetType() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetType() string {
 	return "Microsoft.DBforMySQL/flexibleServers/databases"
 }
 

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen.go
@@ -576,7 +576,7 @@ func (rules *FlexibleServersFirewallRules_Spec) ConvertToARM(resolved genruntime
 	if rules == nil {
 		return nil, nil
 	}
-	var result FlexibleServersFirewallRules_SpecARM
+	result := &FlexibleServersFirewallRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rules__spec_arm_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rules__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (rules FlexibleServersFirewallRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules FlexibleServersFirewallRules_SpecARM) GetName() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforMySQL/flexibleServers/firewallRules"
-func (rules FlexibleServersFirewallRules_SpecARM) GetType() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetType() string {
 	return "Microsoft.DBforMySQL/flexibleServers/firewallRules"
 }
 

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
@@ -372,7 +372,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if servers == nil {
 		return nil, nil
 	}
-	var result FlexibleServers_SpecARM
+	result := &FlexibleServers_SpecARM{}
 
 	// Set property ‘Location’:
 	if servers.Location != nil {
@@ -419,7 +419,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		backup := backupARM.(BackupARM)
+		backup := *backupARM.(*BackupARM)
 		result.Properties.Backup = &backup
 	}
 	if servers.CreateMode != nil {
@@ -431,7 +431,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		highAvailability := highAvailabilityARM.(HighAvailabilityARM)
+		highAvailability := *highAvailabilityARM.(*HighAvailabilityARM)
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if servers.MaintenanceWindow != nil {
@@ -439,7 +439,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		maintenanceWindow := maintenanceWindowARM.(MaintenanceWindowARM)
+		maintenanceWindow := *maintenanceWindowARM.(*MaintenanceWindowARM)
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if servers.Network != nil {
@@ -447,7 +447,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		network := networkARM.(NetworkARM)
+		network := *networkARM.(*NetworkARM)
 		result.Properties.Network = &network
 	}
 	if servers.PointInTimeUTC != nil {
@@ -467,7 +467,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		storage := storageARM.(StorageARM)
+		storage := *storageARM.(*StorageARM)
 		result.Properties.Storage = &storage
 	}
 	if servers.Version != nil {
@@ -481,7 +481,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1644,7 +1644,7 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if backup == nil {
 		return nil, nil
 	}
-	var result BackupARM
+	result := &BackupARM{}
 
 	// Set property ‘BackupRetentionDays’:
 	if backup.BackupRetentionDays != nil {
@@ -1840,7 +1840,7 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	if availability == nil {
 		return nil, nil
 	}
-	var result HighAvailabilityARM
+	result := &HighAvailabilityARM{}
 
 	// Set property ‘Mode’:
 	if availability.Mode != nil {
@@ -2048,7 +2048,7 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if window == nil {
 		return nil, nil
 	}
-	var result MaintenanceWindowARM
+	result := &MaintenanceWindowARM{}
 
 	// Set property ‘CustomWindow’:
 	if window.CustomWindow != nil {
@@ -2273,7 +2273,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if network == nil {
 		return nil, nil
 	}
-	var result NetworkARM
+	result := &NetworkARM{}
 
 	// Set property ‘DelegatedSubnetResourceId’:
 	if network.DelegatedSubnetResourceReference != nil {
@@ -2535,7 +2535,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -2717,7 +2717,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if storage == nil {
 		return nil, nil
 	}
-	var result StorageARM
+	result := &StorageARM{}
 
 	// Set property ‘StorageSizeGB’:
 	if storage.StorageSizeGB != nil {

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers__spec_arm_types_gen.go
@@ -22,12 +22,12 @@ func (servers FlexibleServers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (servers FlexibleServers_SpecARM) GetName() string {
+func (servers *FlexibleServers_SpecARM) GetName() string {
 	return servers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers"
-func (servers FlexibleServers_SpecARM) GetType() string {
+func (servers *FlexibleServers_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers"
 }
 

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
@@ -751,7 +751,7 @@ func (configurations *FlexibleServersConfigurations_Spec) ConvertToARM(resolved 
 	if configurations == nil {
 		return nil, nil
 	}
-	var result FlexibleServersConfigurations_SpecARM
+	result := &FlexibleServersConfigurations_SpecARM{}
 
 	// Set property ‘Location’:
 	if configurations.Location != nil {

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configurations__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configurations__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (configurations FlexibleServersConfigurations_SpecARM) GetAPIVersion() stri
 }
 
 // GetName returns the Name of the resource
-func (configurations FlexibleServersConfigurations_SpecARM) GetName() string {
+func (configurations *FlexibleServersConfigurations_SpecARM) GetName() string {
 	return configurations.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers/configurations"
-func (configurations FlexibleServersConfigurations_SpecARM) GetType() string {
+func (configurations *FlexibleServersConfigurations_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers/configurations"
 }
 

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
@@ -567,7 +567,7 @@ func (databases *FlexibleServersDatabases_Spec) ConvertToARM(resolved genruntime
 	if databases == nil {
 		return nil, nil
 	}
-	var result FlexibleServersDatabases_SpecARM
+	result := &FlexibleServersDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_databases__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_databases__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (databases FlexibleServersDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases FlexibleServersDatabases_SpecARM) GetName() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers/databases"
-func (databases FlexibleServersDatabases_SpecARM) GetType() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers/databases"
 }
 

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
@@ -572,7 +572,7 @@ func (rules *FlexibleServersFirewallRules_Spec) ConvertToARM(resolved genruntime
 	if rules == nil {
 		return nil, nil
 	}
-	var result FlexibleServersFirewallRules_SpecARM
+	result := &FlexibleServersFirewallRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rules__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rules__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (rules FlexibleServersFirewallRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules FlexibleServersFirewallRules_SpecARM) GetName() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules"
-func (rules FlexibleServersFirewallRules_SpecARM) GetType() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules"
 }
 

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen.go
@@ -389,7 +389,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if servers == nil {
 		return nil, nil
 	}
-	var result FlexibleServers_SpecARM
+	result := &FlexibleServers_SpecARM{}
 
 	// Set property ‘Location’:
 	if servers.Location != nil {
@@ -436,7 +436,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		backup := backupARM.(BackupARM)
+		backup := *backupARM.(*BackupARM)
 		result.Properties.Backup = &backup
 	}
 	if servers.CreateMode != nil {
@@ -448,7 +448,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		highAvailability := highAvailabilityARM.(HighAvailabilityARM)
+		highAvailability := *highAvailabilityARM.(*HighAvailabilityARM)
 		result.Properties.HighAvailability = &highAvailability
 	}
 	if servers.MaintenanceWindow != nil {
@@ -456,7 +456,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		maintenanceWindow := maintenanceWindowARM.(MaintenanceWindowARM)
+		maintenanceWindow := *maintenanceWindowARM.(*MaintenanceWindowARM)
 		result.Properties.MaintenanceWindow = &maintenanceWindow
 	}
 	if servers.Network != nil {
@@ -464,7 +464,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		network := networkARM.(NetworkARM)
+		network := *networkARM.(*NetworkARM)
 		result.Properties.Network = &network
 	}
 	if servers.PointInTimeUTC != nil {
@@ -484,7 +484,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		storage := storageARM.(StorageARM)
+		storage := *storageARM.(*StorageARM)
 		result.Properties.Storage = &storage
 	}
 	if servers.Version != nil {
@@ -498,7 +498,7 @@ func (servers *FlexibleServers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1708,7 +1708,7 @@ func (backup *Backup) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if backup == nil {
 		return nil, nil
 	}
-	var result BackupARM
+	result := &BackupARM{}
 
 	// Set property ‘BackupRetentionDays’:
 	if backup.BackupRetentionDays != nil {
@@ -1911,7 +1911,7 @@ func (availability *HighAvailability) ConvertToARM(resolved genruntime.ConvertTo
 	if availability == nil {
 		return nil, nil
 	}
-	var result HighAvailabilityARM
+	result := &HighAvailabilityARM{}
 
 	// Set property ‘Mode’:
 	if availability.Mode != nil {
@@ -2130,7 +2130,7 @@ func (window *MaintenanceWindow) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if window == nil {
 		return nil, nil
 	}
-	var result MaintenanceWindowARM
+	result := &MaintenanceWindowARM{}
 
 	// Set property ‘CustomWindow’:
 	if window.CustomWindow != nil {
@@ -2364,7 +2364,7 @@ func (network *Network) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if network == nil {
 		return nil, nil
 	}
-	var result NetworkARM
+	result := &NetworkARM{}
 
 	// Set property ‘DelegatedSubnetResourceId’:
 	if network.DelegatedSubnetResourceReference != nil {
@@ -2627,7 +2627,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -2812,7 +2812,7 @@ func (storage *Storage) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if storage == nil {
 		return nil, nil
 	}
-	var result StorageARM
+	result := &StorageARM{}
 
 	// Set property ‘StorageSizeGB’:
 	if storage.StorageSizeGB != nil {

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers__spec_arm_types_gen.go
@@ -30,12 +30,12 @@ func (servers FlexibleServers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (servers FlexibleServers_SpecARM) GetName() string {
+func (servers *FlexibleServers_SpecARM) GetName() string {
 	return servers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers"
-func (servers FlexibleServers_SpecARM) GetType() string {
+func (servers *FlexibleServers_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers"
 }
 

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen.go
@@ -774,7 +774,7 @@ func (configurations *FlexibleServersConfigurations_Spec) ConvertToARM(resolved 
 	if configurations == nil {
 		return nil, nil
 	}
-	var result FlexibleServersConfigurations_SpecARM
+	result := &FlexibleServersConfigurations_SpecARM{}
 
 	// Set property ‘Location’:
 	if configurations.Location != nil {

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configurations__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configurations__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (configurations FlexibleServersConfigurations_SpecARM) GetAPIVersion() stri
 }
 
 // GetName returns the Name of the resource
-func (configurations FlexibleServersConfigurations_SpecARM) GetName() string {
+func (configurations *FlexibleServersConfigurations_SpecARM) GetName() string {
 	return configurations.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers/configurations"
-func (configurations FlexibleServersConfigurations_SpecARM) GetType() string {
+func (configurations *FlexibleServersConfigurations_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers/configurations"
 }
 

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen.go
@@ -572,7 +572,7 @@ func (databases *FlexibleServersDatabases_Spec) ConvertToARM(resolved genruntime
 	if databases == nil {
 		return nil, nil
 	}
-	var result FlexibleServersDatabases_SpecARM
+	result := &FlexibleServersDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_databases__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_databases__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (databases FlexibleServersDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases FlexibleServersDatabases_SpecARM) GetName() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers/databases"
-func (databases FlexibleServersDatabases_SpecARM) GetType() string {
+func (databases *FlexibleServersDatabases_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers/databases"
 }
 

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen.go
@@ -576,7 +576,7 @@ func (rules *FlexibleServersFirewallRules_Spec) ConvertToARM(resolved genruntime
 	if rules == nil {
 		return nil, nil
 	}
-	var result FlexibleServersFirewallRules_SpecARM
+	result := &FlexibleServersFirewallRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rules__spec_arm_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rules__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (rules FlexibleServersFirewallRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules FlexibleServersFirewallRules_SpecARM) GetName() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules"
-func (rules FlexibleServersFirewallRules_SpecARM) GetType() string {
+func (rules *FlexibleServersFirewallRules_SpecARM) GetType() string {
 	return "Microsoft.DBforPostgreSQL/flexibleServers/firewallRules"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen.go
@@ -1620,7 +1620,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 	if accounts == nil {
 		return nil, nil
 	}
-	var result DatabaseAccounts_SpecARM
+	result := &DatabaseAccounts_SpecARM{}
 
 	// Set property ‘Identity’:
 	if accounts.Identity != nil {
@@ -1628,7 +1628,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(ManagedServiceIdentityARM)
+		identity := *identityARM.(*ManagedServiceIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1678,7 +1678,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		analyticalStorageConfiguration := analyticalStorageConfigurationARM.(AnalyticalStorageConfigurationARM)
+		analyticalStorageConfiguration := *analyticalStorageConfigurationARM.(*AnalyticalStorageConfigurationARM)
 		result.Properties.AnalyticalStorageConfiguration = &analyticalStorageConfiguration
 	}
 	if accounts.ApiProperties != nil {
@@ -1686,7 +1686,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		apiProperties := apiPropertiesARM.(ApiPropertiesARM)
+		apiProperties := *apiPropertiesARM.(*ApiPropertiesARM)
 		result.Properties.ApiProperties = &apiProperties
 	}
 	if accounts.BackupPolicy != nil {
@@ -1694,7 +1694,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		backupPolicy := backupPolicyARM.(BackupPolicyARM)
+		backupPolicy := *backupPolicyARM.(*BackupPolicyARM)
 		result.Properties.BackupPolicy = &backupPolicy
 	}
 	for _, item := range accounts.Capabilities {
@@ -1702,7 +1702,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Capabilities = append(result.Properties.Capabilities, itemARM.(CapabilityARM))
+		result.Properties.Capabilities = append(result.Properties.Capabilities, *itemARM.(*CapabilityARM))
 	}
 	if accounts.ConnectorOffer != nil {
 		connectorOffer := *accounts.ConnectorOffer
@@ -1713,7 +1713,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		consistencyPolicy := consistencyPolicyARM.(ConsistencyPolicyARM)
+		consistencyPolicy := *consistencyPolicyARM.(*ConsistencyPolicyARM)
 		result.Properties.ConsistencyPolicy = &consistencyPolicy
 	}
 	for _, item := range accounts.Cors {
@@ -1721,7 +1721,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Cors = append(result.Properties.Cors, itemARM.(CorsPolicyARM))
+		result.Properties.Cors = append(result.Properties.Cors, *itemARM.(*CorsPolicyARM))
 	}
 	if accounts.DatabaseAccountOfferType != nil {
 		databaseAccountOfferType := *accounts.DatabaseAccountOfferType
@@ -1760,7 +1760,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpRules = append(result.Properties.IpRules, itemARM.(IpAddressOrRangeARM))
+		result.Properties.IpRules = append(result.Properties.IpRules, *itemARM.(*IpAddressOrRangeARM))
 	}
 	if accounts.IsVirtualNetworkFilterEnabled != nil {
 		isVirtualNetworkFilterEnabled := *accounts.IsVirtualNetworkFilterEnabled
@@ -1775,7 +1775,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Locations = append(result.Properties.Locations, itemARM.(LocationARM))
+		result.Properties.Locations = append(result.Properties.Locations, *itemARM.(*LocationARM))
 	}
 	if accounts.NetworkAclBypass != nil {
 		networkAclBypass := *accounts.NetworkAclBypass
@@ -1793,7 +1793,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.VirtualNetworkRules = append(result.Properties.VirtualNetworkRules, itemARM.(VirtualNetworkRuleARM))
+		result.Properties.VirtualNetworkRules = append(result.Properties.VirtualNetworkRules, *itemARM.(*VirtualNetworkRuleARM))
 	}
 
 	// Set property ‘Tags’:
@@ -2773,7 +2773,7 @@ func (configuration *AnalyticalStorageConfiguration) ConvertToARM(resolved genru
 	if configuration == nil {
 		return nil, nil
 	}
-	var result AnalyticalStorageConfigurationARM
+	result := &AnalyticalStorageConfigurationARM{}
 
 	// Set property ‘SchemaType’:
 	if configuration.SchemaType != nil {
@@ -2924,7 +2924,7 @@ func (properties *ApiProperties) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if properties == nil {
 		return nil, nil
 	}
-	var result ApiPropertiesARM
+	result := &ApiPropertiesARM{}
 
 	// Set property ‘ServerVersion’:
 	if properties.ServerVersion != nil {
@@ -3076,7 +3076,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if policy == nil {
 		return nil, nil
 	}
-	var result BackupPolicyARM
+	result := &BackupPolicyARM{}
 
 	// Set property ‘Continuous’:
 	if policy.Continuous != nil {
@@ -3084,7 +3084,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		if err != nil {
 			return nil, err
 		}
-		continuous := continuousARM.(ContinuousModeBackupPolicyARM)
+		continuous := *continuousARM.(*ContinuousModeBackupPolicyARM)
 		result.Continuous = &continuous
 	}
 
@@ -3094,7 +3094,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		if err != nil {
 			return nil, err
 		}
-		periodic := periodicARM.(PeriodicModeBackupPolicyARM)
+		periodic := *periodicARM.(*PeriodicModeBackupPolicyARM)
 		result.Periodic = &periodic
 	}
 	return result, nil
@@ -3289,7 +3289,7 @@ func (capability *Capability) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if capability == nil {
 		return nil, nil
 	}
-	var result CapabilityARM
+	result := &CapabilityARM{}
 
 	// Set property ‘Name’:
 	if capability.Name != nil {
@@ -3434,7 +3434,7 @@ func (policy *ConsistencyPolicy) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if policy == nil {
 		return nil, nil
 	}
-	var result ConsistencyPolicyARM
+	result := &ConsistencyPolicyARM{}
 
 	// Set property ‘DefaultConsistencyLevel’:
 	if policy.DefaultConsistencyLevel != nil {
@@ -3676,7 +3676,7 @@ func (policy *CorsPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if policy == nil {
 		return nil, nil
 	}
-	var result CorsPolicyARM
+	result := &CorsPolicyARM{}
 
 	// Set property ‘AllowedHeaders’:
 	if policy.AllowedHeaders != nil {
@@ -4117,7 +4117,7 @@ func (orRange *IpAddressOrRange) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if orRange == nil {
 		return nil, nil
 	}
-	var result IpAddressOrRangeARM
+	result := &IpAddressOrRangeARM{}
 
 	// Set property ‘IpAddressOrRange’:
 	if orRange.IpAddressOrRange != nil {
@@ -4251,7 +4251,7 @@ func (location *Location) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if location == nil {
 		return nil, nil
 	}
-	var result LocationARM
+	result := &LocationARM{}
 
 	// Set property ‘FailoverPriority’:
 	if location.FailoverPriority != nil {
@@ -4513,7 +4513,7 @@ func (identity *ManagedServiceIdentity) ConvertToARM(resolved genruntime.Convert
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedServiceIdentityARM
+	result := &ManagedServiceIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -4815,7 +4815,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if rule == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkRuleARM
+	result := &VirtualNetworkRuleARM{}
 
 	// Set property ‘Id’:
 	if rule.Reference != nil {
@@ -5078,7 +5078,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 	if policy == nil {
 		return nil, nil
 	}
-	var result ContinuousModeBackupPolicyARM
+	result := &ContinuousModeBackupPolicyARM{}
 
 	// Set property ‘Type’:
 	if policy.Type != nil {
@@ -5356,7 +5356,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 	if policy == nil {
 		return nil, nil
 	}
-	var result PeriodicModeBackupPolicyARM
+	result := &PeriodicModeBackupPolicyARM{}
 
 	// Set property ‘PeriodicModeProperties’:
 	if policy.PeriodicModeProperties != nil {
@@ -5364,7 +5364,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		periodicModeProperties := periodicModePropertiesARM.(PeriodicModePropertiesARM)
+		periodicModeProperties := *periodicModePropertiesARM.(*PeriodicModePropertiesARM)
 		result.PeriodicModeProperties = &periodicModeProperties
 	}
 
@@ -5496,7 +5496,7 @@ func (properties *PeriodicModeProperties) ConvertToARM(resolved genruntime.Conve
 	if properties == nil {
 		return nil, nil
 	}
-	var result PeriodicModePropertiesARM
+	result := &PeriodicModePropertiesARM{}
 
 	// Set property ‘BackupIntervalInMinutes’:
 	if properties.BackupIntervalInMinutes != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts__spec_arm_types_gen.go
@@ -26,12 +26,12 @@ func (accounts DatabaseAccounts_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (accounts DatabaseAccounts_SpecARM) GetName() string {
+func (accounts *DatabaseAccounts_SpecARM) GetName() string {
 	return accounts.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts"
-func (accounts DatabaseAccounts_SpecARM) GetType() string {
+func (accounts *DatabaseAccounts_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (databases DatabaseAccountsMongodbDatabases_SpecARM) GetAPIVersion() string
 }
 
 // GetName returns the Name of the resource
-func (databases DatabaseAccountsMongodbDatabases_SpecARM) GetName() string {
+func (databases *DatabaseAccountsMongodbDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases"
-func (databases DatabaseAccountsMongodbDatabases_SpecARM) GetType() string {
+func (databases *DatabaseAccountsMongodbDatabases_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases_collections__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases_collections__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (collections DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetAPIVer
 }
 
 // GetName returns the Name of the resource
-func (collections DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetName() string {
+func (collections *DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetName() string {
 	return collections.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections"
-func (collections DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetType() string {
+func (collections *DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases_collections_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases_collections_throughput_settings__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (settings DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spe
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings"
-func (settings DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_mongodb_databases_throughput_settings__spec_arm_types_gen.go
@@ -21,11 +21,11 @@ func (settings DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetAP
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings"
-func (settings DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings"
 }

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (databases DatabaseAccountsSqlDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases DatabaseAccountsSqlDatabases_SpecARM) GetName() string {
+func (databases *DatabaseAccountsSqlDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
-func (databases DatabaseAccountsSqlDatabases_SpecARM) GetType() string {
+func (databases *DatabaseAccountsSqlDatabases_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (containers DatabaseAccountsSqlDatabasesContainers_SpecARM) GetAPIVersion()
 }
 
 // GetName returns the Name of the resource
-func (containers DatabaseAccountsSqlDatabasesContainers_SpecARM) GetName() string {
+func (containers *DatabaseAccountsSqlDatabasesContainers_SpecARM) GetName() string {
 	return containers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers"
-func (containers DatabaseAccountsSqlDatabasesContainers_SpecARM) GetType() string {
+func (containers *DatabaseAccountsSqlDatabasesContainers_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_stored_procedures__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_stored_procedures__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (procedures DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM)
 }
 
 // GetName returns the Name of the resource
-func (procedures DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetName() string {
+func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetName() string {
 	return procedures.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures"
-func (procedures DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetType() string {
+func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_throughput_settings__spec_arm_types_gen.go
@@ -21,11 +21,11 @@ func (settings DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM)
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings"
-func (settings DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings"
 }

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_triggers__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_triggers__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (triggers DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetAPIVer
 }
 
 // GetName returns the Name of the resource
-func (triggers DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetName() string {
+func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetName() string {
 	return triggers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers"
-func (triggers DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetType() string {
+func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_user_defined_functions__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_containers_user_defined_functions__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (functions DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecA
 }
 
 // GetName returns the Name of the resource
-func (functions DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetName() string {
+func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetName() string {
 	return functions.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions"
-func (functions DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetType() string {
+func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions"
 }
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_accounts_sql_databases_throughput_settings__spec_arm_types_gen.go
@@ -21,11 +21,11 @@ func (settings DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetAPIVer
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings"
-func (settings DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings"
 }

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -345,7 +345,7 @@ func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Sp
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM
+	result := &DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -365,7 +365,7 @@ func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Sp
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -954,7 +954,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 	if resource == nil {
 		return nil, nil
 	}
-	var result ThroughputSettingsResourceARM
+	result := &ThroughputSettingsResourceARM{}
 
 	// Set property ‘AutoscaleSettings’:
 	if resource.AutoscaleSettings != nil {
@@ -962,7 +962,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		autoscaleSettings := autoscaleSettingsARM.(AutoscaleSettingsResourceARM)
+		autoscaleSettings := *autoscaleSettingsARM.(*AutoscaleSettingsResourceARM)
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
@@ -1075,7 +1075,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 	if resource == nil {
 		return nil, nil
 	}
-	var result AutoscaleSettingsResourceARM
+	result := &AutoscaleSettingsResourceARM{}
 
 	// Set property ‘AutoUpgradePolicy’:
 	if resource.AutoUpgradePolicy != nil {
@@ -1083,7 +1083,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		autoUpgradePolicy := autoUpgradePolicyARM.(AutoUpgradePolicyResourceARM)
+		autoUpgradePolicy := *autoUpgradePolicyARM.(*AutoUpgradePolicyResourceARM)
 		result.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
@@ -1300,7 +1300,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 	if resource == nil {
 		return nil, nil
 	}
-	var result AutoUpgradePolicyResourceARM
+	result := &AutoUpgradePolicyResourceARM{}
 
 	// Set property ‘ThroughputPolicy’:
 	if resource.ThroughputPolicy != nil {
@@ -1308,7 +1308,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		throughputPolicy := throughputPolicyARM.(ThroughputPolicyResourceARM)
+		throughputPolicy := *throughputPolicyARM.(*ThroughputPolicyResourceARM)
 		result.ThroughputPolicy = &throughputPolicy
 	}
 	return result, nil
@@ -1482,7 +1482,7 @@ func (resource *ThroughputPolicyResource) ConvertToARM(resolved genruntime.Conve
 	if resource == nil {
 		return nil, nil
 	}
-	var result ThroughputPolicyResourceARM
+	result := &ThroughputPolicyResourceARM{}
 
 	// Set property ‘IncrementPercent’:
 	if resource.IncrementPercent != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
@@ -356,7 +356,7 @@ func (collections *DatabaseAccountsMongodbDatabasesCollections_Spec) ConvertToAR
 	if collections == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabasesCollections_SpecARM
+	result := &DatabaseAccountsMongodbDatabasesCollections_SpecARM{}
 
 	// Set property ‘Location’:
 	if collections.Location != nil {
@@ -376,7 +376,7 @@ func (collections *DatabaseAccountsMongodbDatabasesCollections_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if collections.Resource != nil {
@@ -384,7 +384,7 @@ func (collections *DatabaseAccountsMongodbDatabasesCollections_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(MongoDBCollectionResourceARM)
+		resource := *resourceARM.(*MongoDBCollectionResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1081,7 +1081,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 	if resource == nil {
 		return nil, nil
 	}
-	var result MongoDBCollectionResourceARM
+	result := &MongoDBCollectionResourceARM{}
 
 	// Set property ‘AnalyticalStorageTtl’:
 	if resource.AnalyticalStorageTtl != nil {
@@ -1101,7 +1101,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		result.Indexes = append(result.Indexes, itemARM.(MongoIndexARM))
+		result.Indexes = append(result.Indexes, *itemARM.(*MongoIndexARM))
 	}
 
 	// Set property ‘ShardKey’:
@@ -1250,7 +1250,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if index == nil {
 		return nil, nil
 	}
-	var result MongoIndexARM
+	result := &MongoIndexARM{}
 
 	// Set property ‘Key’:
 	if index.Key != nil {
@@ -1258,7 +1258,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		key := keyARM.(MongoIndexKeysARM)
+		key := *keyARM.(*MongoIndexKeysARM)
 		result.Key = &key
 	}
 
@@ -1268,7 +1268,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(MongoIndexOptionsARM)
+		options := *optionsARM.(*MongoIndexOptionsARM)
 		result.Options = &options
 	}
 	return result, nil
@@ -1512,7 +1512,7 @@ func (keys *MongoIndexKeys) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if keys == nil {
 		return nil, nil
 	}
-	var result MongoIndexKeysARM
+	result := &MongoIndexKeysARM{}
 
 	// Set property ‘Keys’:
 	for _, item := range keys.Keys {
@@ -1641,7 +1641,7 @@ func (options *MongoIndexOptions) ConvertToARM(resolved genruntime.ConvertToARMR
 	if options == nil {
 		return nil, nil
 	}
-	var result MongoIndexOptionsARM
+	result := &MongoIndexOptionsARM{}
 
 	// Set property ‘ExpireAfterSeconds’:
 	if options.ExpireAfterSeconds != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
@@ -345,7 +345,7 @@ func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_Spec) Convert
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM
+	result := &DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -365,7 +365,7 @@ func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_Spec) Convert
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
@@ -356,7 +356,7 @@ func (databases *DatabaseAccountsMongodbDatabases_Spec) ConvertToARM(resolved ge
 	if databases == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabases_SpecARM
+	result := &DatabaseAccountsMongodbDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {
@@ -376,7 +376,7 @@ func (databases *DatabaseAccountsMongodbDatabases_Spec) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if databases.Resource != nil {
@@ -384,7 +384,7 @@ func (databases *DatabaseAccountsMongodbDatabases_Spec) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(MongoDBDatabaseResourceARM)
+		resource := *resourceARM.(*MongoDBDatabaseResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -895,7 +895,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 	if options == nil {
 		return nil, nil
 	}
-	var result CreateUpdateOptionsARM
+	result := &CreateUpdateOptionsARM{}
 
 	// Set property ‘AutoscaleSettings’:
 	if options.AutoscaleSettings != nil {
@@ -903,7 +903,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		autoscaleSettings := autoscaleSettingsARM.(AutoscaleSettingsARM)
+		autoscaleSettings := *autoscaleSettingsARM.(*AutoscaleSettingsARM)
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
@@ -1121,7 +1121,7 @@ func (resource *MongoDBDatabaseResource) ConvertToARM(resolved genruntime.Conver
 	if resource == nil {
 		return nil, nil
 	}
-	var result MongoDBDatabaseResourceARM
+	result := &MongoDBDatabaseResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Id != nil {
@@ -1288,7 +1288,7 @@ func (settings *AutoscaleSettings) ConvertToARM(resolved genruntime.ConvertToARM
 	if settings == nil {
 		return nil, nil
 	}
-	var result AutoscaleSettingsARM
+	result := &AutoscaleSettingsARM{}
 
 	// Set property ‘MaxThroughput’:
 	if settings.MaxThroughput != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
@@ -356,7 +356,7 @@ func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec) C
 	if procedures == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM{}
 
 	// Set property ‘Location’:
 	if procedures.Location != nil {
@@ -376,7 +376,7 @@ func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec) C
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if procedures.Resource != nil {
@@ -384,7 +384,7 @@ func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec) C
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlStoredProcedureResourceARM)
+		resource := *resourceARM.(*SqlStoredProcedureResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -978,7 +978,7 @@ func (resource *SqlStoredProcedureResource) ConvertToARM(resolved genruntime.Con
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlStoredProcedureResourceARM
+	result := &SqlStoredProcedureResourceARM{}
 
 	// Set property ‘Body’:
 	if resource.Body != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
@@ -345,7 +345,7 @@ func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec) C
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -365,7 +365,7 @@ func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec) C
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
@@ -356,7 +356,7 @@ func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_Spec) ConvertToAR
 	if triggers == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM{}
 
 	// Set property ‘Location’:
 	if triggers.Location != nil {
@@ -376,7 +376,7 @@ func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if triggers.Resource != nil {
@@ -384,7 +384,7 @@ func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlTriggerResourceARM)
+		resource := *resourceARM.(*SqlTriggerResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1026,7 +1026,7 @@ func (resource *SqlTriggerResource) ConvertToARM(resolved genruntime.ConvertToAR
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlTriggerResourceARM
+	result := &SqlTriggerResourceARM{}
 
 	// Set property ‘Body’:
 	if resource.Body != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
@@ -356,7 +356,7 @@ func (containers *DatabaseAccountsSqlDatabasesContainers_Spec) ConvertToARM(reso
 	if containers == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainers_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainers_SpecARM{}
 
 	// Set property ‘Location’:
 	if containers.Location != nil {
@@ -376,7 +376,7 @@ func (containers *DatabaseAccountsSqlDatabasesContainers_Spec) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if containers.Resource != nil {
@@ -384,7 +384,7 @@ func (containers *DatabaseAccountsSqlDatabasesContainers_Spec) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlContainerResourceARM)
+		resource := *resourceARM.(*SqlContainerResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1179,7 +1179,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlContainerResourceARM
+	result := &SqlContainerResourceARM{}
 
 	// Set property ‘AnalyticalStorageTtl’:
 	if resource.AnalyticalStorageTtl != nil {
@@ -1193,7 +1193,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		conflictResolutionPolicy := conflictResolutionPolicyARM.(ConflictResolutionPolicyARM)
+		conflictResolutionPolicy := *conflictResolutionPolicyARM.(*ConflictResolutionPolicyARM)
 		result.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
@@ -1215,7 +1215,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		indexingPolicy := indexingPolicyARM.(IndexingPolicyARM)
+		indexingPolicy := *indexingPolicyARM.(*IndexingPolicyARM)
 		result.IndexingPolicy = &indexingPolicy
 	}
 
@@ -1225,7 +1225,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		partitionKey := partitionKeyARM.(ContainerPartitionKeyARM)
+		partitionKey := *partitionKeyARM.(*ContainerPartitionKeyARM)
 		result.PartitionKey = &partitionKey
 	}
 
@@ -1235,7 +1235,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		uniqueKeyPolicy := uniqueKeyPolicyARM.(UniqueKeyPolicyARM)
+		uniqueKeyPolicy := *uniqueKeyPolicyARM.(*UniqueKeyPolicyARM)
 		result.UniqueKeyPolicy = &uniqueKeyPolicy
 	}
 	return result, nil
@@ -1470,7 +1470,7 @@ func (policy *ConflictResolutionPolicy) ConvertToARM(resolved genruntime.Convert
 	if policy == nil {
 		return nil, nil
 	}
-	var result ConflictResolutionPolicyARM
+	result := &ConflictResolutionPolicyARM{}
 
 	// Set property ‘ConflictResolutionPath’:
 	if policy.ConflictResolutionPath != nil {
@@ -1688,7 +1688,7 @@ func (partitionKey *ContainerPartitionKey) ConvertToARM(resolved genruntime.Conv
 	if partitionKey == nil {
 		return nil, nil
 	}
-	var result ContainerPartitionKeyARM
+	result := &ContainerPartitionKeyARM{}
 
 	// Set property ‘Kind’:
 	if partitionKey.Kind != nil {
@@ -1936,7 +1936,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if policy == nil {
 		return nil, nil
 	}
-	var result IndexingPolicyARM
+	result := &IndexingPolicyARM{}
 
 	// Set property ‘Automatic’:
 	if policy.Automatic != nil {
@@ -1952,7 +1952,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 			if err != nil {
 				return nil, err
 			}
-			itemTemp = append(itemTemp, item1ARM.(CompositePathARM))
+			itemTemp = append(itemTemp, *item1ARM.(*CompositePathARM))
 		}
 		result.CompositeIndexes = append(result.CompositeIndexes, itemTemp)
 	}
@@ -1963,7 +1963,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.ExcludedPaths = append(result.ExcludedPaths, itemARM.(ExcludedPathARM))
+		result.ExcludedPaths = append(result.ExcludedPaths, *itemARM.(*ExcludedPathARM))
 	}
 
 	// Set property ‘IncludedPaths’:
@@ -1972,7 +1972,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.IncludedPaths = append(result.IncludedPaths, itemARM.(IncludedPathARM))
+		result.IncludedPaths = append(result.IncludedPaths, *itemARM.(*IncludedPathARM))
 	}
 
 	// Set property ‘IndexingMode’:
@@ -1987,7 +1987,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.SpatialIndexes = append(result.SpatialIndexes, itemARM.(SpatialSpecARM))
+		result.SpatialIndexes = append(result.SpatialIndexes, *itemARM.(*SpatialSpecARM))
 	}
 	return result, nil
 }
@@ -2598,7 +2598,7 @@ func (policy *UniqueKeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if policy == nil {
 		return nil, nil
 	}
-	var result UniqueKeyPolicyARM
+	result := &UniqueKeyPolicyARM{}
 
 	// Set property ‘UniqueKeys’:
 	for _, item := range policy.UniqueKeys {
@@ -2606,7 +2606,7 @@ func (policy *UniqueKeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.UniqueKeys = append(result.UniqueKeys, itemARM.(UniqueKeyARM))
+		result.UniqueKeys = append(result.UniqueKeys, *itemARM.(*UniqueKeyARM))
 	}
 	return result, nil
 }
@@ -2801,7 +2801,7 @@ func (path *CompositePath) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if path == nil {
 		return nil, nil
 	}
-	var result CompositePathARM
+	result := &CompositePathARM{}
 
 	// Set property ‘Order’:
 	if path.Order != nil {
@@ -2983,7 +2983,7 @@ func (path *ExcludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if path == nil {
 		return nil, nil
 	}
-	var result ExcludedPathARM
+	result := &ExcludedPathARM{}
 
 	// Set property ‘Path’:
 	if path.Path != nil {
@@ -3115,7 +3115,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if path == nil {
 		return nil, nil
 	}
-	var result IncludedPathARM
+	result := &IncludedPathARM{}
 
 	// Set property ‘Indexes’:
 	for _, item := range path.Indexes {
@@ -3123,7 +3123,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		result.Indexes = append(result.Indexes, itemARM.(IndexesARM))
+		result.Indexes = append(result.Indexes, *itemARM.(*IndexesARM))
 	}
 
 	// Set property ‘Path’:
@@ -3349,7 +3349,7 @@ func (spatial *SpatialSpec) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if spatial == nil {
 		return nil, nil
 	}
-	var result SpatialSpecARM
+	result := &SpatialSpecARM{}
 
 	// Set property ‘Path’:
 	if spatial.Path != nil {
@@ -3548,7 +3548,7 @@ func (uniqueKey *UniqueKey) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if uniqueKey == nil {
 		return nil, nil
 	}
-	var result UniqueKeyARM
+	result := &UniqueKeyARM{}
 
 	// Set property ‘Paths’:
 	for _, item := range uniqueKey.Paths {
@@ -3678,7 +3678,7 @@ func (indexes *Indexes) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if indexes == nil {
 		return nil, nil
 	}
-	var result IndexesARM
+	result := &IndexesARM{}
 
 	// Set property ‘DataType’:
 	if indexes.DataType != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
@@ -356,7 +356,7 @@ func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
 	if functions == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM{}
 
 	// Set property ‘Location’:
 	if functions.Location != nil {
@@ -376,7 +376,7 @@ func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if functions.Resource != nil {
@@ -384,7 +384,7 @@ func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlUserDefinedFunctionResourceARM)
+		resource := *resourceARM.(*SqlUserDefinedFunctionResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -978,7 +978,7 @@ func (resource *SqlUserDefinedFunctionResource) ConvertToARM(resolved genruntime
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlUserDefinedFunctionResourceARM
+	result := &SqlUserDefinedFunctionResourceARM{}
 
 	// Set property ‘Body’:
 	if resource.Body != nil {

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
@@ -345,7 +345,7 @@ func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_Spec) ConvertToAR
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM
+	result := &DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -365,7 +365,7 @@ func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_types_gen.go
@@ -356,7 +356,7 @@ func (databases *DatabaseAccountsSqlDatabases_Spec) ConvertToARM(resolved genrun
 	if databases == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabases_SpecARM
+	result := &DatabaseAccountsSqlDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {
@@ -376,7 +376,7 @@ func (databases *DatabaseAccountsSqlDatabases_Spec) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if databases.Resource != nil {
@@ -384,7 +384,7 @@ func (databases *DatabaseAccountsSqlDatabases_Spec) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlDatabaseResourceARM)
+		resource := *resourceARM.(*SqlDatabaseResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1028,7 +1028,7 @@ func (resource *SqlDatabaseResource) ConvertToARM(resolved genruntime.ConvertToA
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlDatabaseResourceARM
+	result := &SqlDatabaseResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Id != nil {

--- a/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
@@ -1730,7 +1730,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 	if accounts == nil {
 		return nil, nil
 	}
-	var result DatabaseAccounts_SpecARM
+	result := &DatabaseAccounts_SpecARM{}
 
 	// Set property ‘Identity’:
 	if accounts.Identity != nil {
@@ -1738,7 +1738,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(ManagedServiceIdentityARM)
+		identity := *identityARM.(*ManagedServiceIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1788,7 +1788,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		analyticalStorageConfiguration := analyticalStorageConfigurationARM.(AnalyticalStorageConfigurationARM)
+		analyticalStorageConfiguration := *analyticalStorageConfigurationARM.(*AnalyticalStorageConfigurationARM)
 		result.Properties.AnalyticalStorageConfiguration = &analyticalStorageConfiguration
 	}
 	if accounts.ApiProperties != nil {
@@ -1796,7 +1796,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		apiProperties := apiPropertiesARM.(ApiPropertiesARM)
+		apiProperties := *apiPropertiesARM.(*ApiPropertiesARM)
 		result.Properties.ApiProperties = &apiProperties
 	}
 	if accounts.BackupPolicy != nil {
@@ -1804,7 +1804,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		backupPolicy := backupPolicyARM.(BackupPolicyARM)
+		backupPolicy := *backupPolicyARM.(*BackupPolicyARM)
 		result.Properties.BackupPolicy = &backupPolicy
 	}
 	for _, item := range accounts.Capabilities {
@@ -1812,7 +1812,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Capabilities = append(result.Properties.Capabilities, itemARM.(CapabilityARM))
+		result.Properties.Capabilities = append(result.Properties.Capabilities, *itemARM.(*CapabilityARM))
 	}
 	if accounts.ConnectorOffer != nil {
 		connectorOffer := *accounts.ConnectorOffer
@@ -1823,7 +1823,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		consistencyPolicy := consistencyPolicyARM.(ConsistencyPolicyARM)
+		consistencyPolicy := *consistencyPolicyARM.(*ConsistencyPolicyARM)
 		result.Properties.ConsistencyPolicy = &consistencyPolicy
 	}
 	for _, item := range accounts.Cors {
@@ -1831,7 +1831,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Cors = append(result.Properties.Cors, itemARM.(CorsPolicyARM))
+		result.Properties.Cors = append(result.Properties.Cors, *itemARM.(*CorsPolicyARM))
 	}
 	if accounts.DatabaseAccountOfferType != nil {
 		databaseAccountOfferType := *accounts.DatabaseAccountOfferType
@@ -1870,7 +1870,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpRules = append(result.Properties.IpRules, itemARM.(IpAddressOrRangeARM))
+		result.Properties.IpRules = append(result.Properties.IpRules, *itemARM.(*IpAddressOrRangeARM))
 	}
 	if accounts.IsVirtualNetworkFilterEnabled != nil {
 		isVirtualNetworkFilterEnabled := *accounts.IsVirtualNetworkFilterEnabled
@@ -1885,7 +1885,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Locations = append(result.Properties.Locations, itemARM.(LocationARM))
+		result.Properties.Locations = append(result.Properties.Locations, *itemARM.(*LocationARM))
 	}
 	if accounts.NetworkAclBypass != nil {
 		networkAclBypass := *accounts.NetworkAclBypass
@@ -1903,7 +1903,7 @@ func (accounts *DatabaseAccounts_Spec) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.VirtualNetworkRules = append(result.Properties.VirtualNetworkRules, itemARM.(VirtualNetworkRuleARM))
+		result.Properties.VirtualNetworkRules = append(result.Properties.VirtualNetworkRules, *itemARM.(*VirtualNetworkRuleARM))
 	}
 
 	// Set property ‘Tags’:
@@ -2883,7 +2883,7 @@ func (configuration *AnalyticalStorageConfiguration) ConvertToARM(resolved genru
 	if configuration == nil {
 		return nil, nil
 	}
-	var result AnalyticalStorageConfigurationARM
+	result := &AnalyticalStorageConfigurationARM{}
 
 	// Set property ‘SchemaType’:
 	if configuration.SchemaType != nil {
@@ -3034,7 +3034,7 @@ func (properties *ApiProperties) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if properties == nil {
 		return nil, nil
 	}
-	var result ApiPropertiesARM
+	result := &ApiPropertiesARM{}
 
 	// Set property ‘ServerVersion’:
 	if properties.ServerVersion != nil {
@@ -3189,7 +3189,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if policy == nil {
 		return nil, nil
 	}
-	var result BackupPolicyARM
+	result := &BackupPolicyARM{}
 
 	// Set property ‘Continuous’:
 	if policy.Continuous != nil {
@@ -3197,7 +3197,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		if err != nil {
 			return nil, err
 		}
-		continuous := continuousARM.(ContinuousModeBackupPolicyARM)
+		continuous := *continuousARM.(*ContinuousModeBackupPolicyARM)
 		result.Continuous = &continuous
 	}
 
@@ -3207,7 +3207,7 @@ func (policy *BackupPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolve
 		if err != nil {
 			return nil, err
 		}
-		periodic := periodicARM.(PeriodicModeBackupPolicyARM)
+		periodic := *periodicARM.(*PeriodicModeBackupPolicyARM)
 		result.Periodic = &periodic
 	}
 	return result, nil
@@ -3403,7 +3403,7 @@ func (capability *Capability) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if capability == nil {
 		return nil, nil
 	}
-	var result CapabilityARM
+	result := &CapabilityARM{}
 
 	// Set property ‘Name’:
 	if capability.Name != nil {
@@ -3555,7 +3555,7 @@ func (policy *ConsistencyPolicy) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if policy == nil {
 		return nil, nil
 	}
-	var result ConsistencyPolicyARM
+	result := &ConsistencyPolicyARM{}
 
 	// Set property ‘DefaultConsistencyLevel’:
 	if policy.DefaultConsistencyLevel != nil {
@@ -3813,7 +3813,7 @@ func (policy *CorsPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if policy == nil {
 		return nil, nil
 	}
-	var result CorsPolicyARM
+	result := &CorsPolicyARM{}
 
 	// Set property ‘AllowedHeaders’:
 	if policy.AllowedHeaders != nil {
@@ -4265,7 +4265,7 @@ func (orRange *IpAddressOrRange) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if orRange == nil {
 		return nil, nil
 	}
-	var result IpAddressOrRangeARM
+	result := &IpAddressOrRangeARM{}
 
 	// Set property ‘IpAddressOrRange’:
 	if orRange.IpAddressOrRange != nil {
@@ -4409,7 +4409,7 @@ func (location *Location) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if location == nil {
 		return nil, nil
 	}
-	var result LocationARM
+	result := &LocationARM{}
 
 	// Set property ‘FailoverPriority’:
 	if location.FailoverPriority != nil {
@@ -4684,7 +4684,7 @@ func (identity *ManagedServiceIdentity) ConvertToARM(resolved genruntime.Convert
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedServiceIdentityARM
+	result := &ManagedServiceIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -5000,7 +5000,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if rule == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkRuleARM
+	result := &VirtualNetworkRuleARM{}
 
 	// Set property ‘Id’:
 	if rule.Reference != nil {
@@ -5256,7 +5256,7 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 	if policy == nil {
 		return nil, nil
 	}
-	var result ContinuousModeBackupPolicyARM
+	result := &ContinuousModeBackupPolicyARM{}
 
 	// Set property ‘Type’:
 	if policy.Type != nil {
@@ -5537,7 +5537,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 	if policy == nil {
 		return nil, nil
 	}
-	var result PeriodicModeBackupPolicyARM
+	result := &PeriodicModeBackupPolicyARM{}
 
 	// Set property ‘PeriodicModeProperties’:
 	if policy.PeriodicModeProperties != nil {
@@ -5545,7 +5545,7 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		periodicModeProperties := periodicModePropertiesARM.(PeriodicModePropertiesARM)
+		periodicModeProperties := *periodicModePropertiesARM.(*PeriodicModePropertiesARM)
 		result.PeriodicModeProperties = &periodicModeProperties
 	}
 
@@ -5677,7 +5677,7 @@ func (properties *PeriodicModeProperties) ConvertToARM(resolved genruntime.Conve
 	if properties == nil {
 		return nil, nil
 	}
-	var result PeriodicModePropertiesARM
+	result := &PeriodicModePropertiesARM{}
 
 	// Set property ‘BackupIntervalInMinutes’:
 	if properties.BackupIntervalInMinutes != nil {

--- a/v2/api/documentdb/v1beta20210515/database_accounts__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts__spec_arm_types_gen.go
@@ -40,12 +40,12 @@ func (accounts DatabaseAccounts_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (accounts DatabaseAccounts_SpecARM) GetName() string {
+func (accounts *DatabaseAccounts_SpecARM) GetName() string {
 	return accounts.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts"
-func (accounts DatabaseAccounts_SpecARM) GetType() string {
+func (accounts *DatabaseAccounts_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (databases DatabaseAccountsMongodbDatabases_SpecARM) GetAPIVersion() string
 }
 
 // GetName returns the Name of the resource
-func (databases DatabaseAccountsMongodbDatabases_SpecARM) GetName() string {
+func (databases *DatabaseAccountsMongodbDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases"
-func (databases DatabaseAccountsMongodbDatabases_SpecARM) GetType() string {
+func (databases *DatabaseAccountsMongodbDatabases_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases_collections__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases_collections__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (collections DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetAPIVer
 }
 
 // GetName returns the Name of the resource
-func (collections DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetName() string {
+func (collections *DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetName() string {
 	return collections.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections"
-func (collections DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetType() string {
+func (collections *DatabaseAccountsMongodbDatabasesCollections_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases_collections_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases_collections_throughput_settings__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (settings DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Spe
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings"
-func (settings DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_mongodb_databases_throughput_settings__spec_arm_types_gen.go
@@ -31,11 +31,11 @@ func (settings DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetAP
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings"
-func (settings DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings"
 }

--- a/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (databases DatabaseAccountsSqlDatabases_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (databases DatabaseAccountsSqlDatabases_SpecARM) GetName() string {
+func (databases *DatabaseAccountsSqlDatabases_SpecARM) GetName() string {
 	return databases.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
-func (databases DatabaseAccountsSqlDatabases_SpecARM) GetType() string {
+func (databases *DatabaseAccountsSqlDatabases_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (containers DatabaseAccountsSqlDatabasesContainers_SpecARM) GetAPIVersion()
 }
 
 // GetName returns the Name of the resource
-func (containers DatabaseAccountsSqlDatabasesContainers_SpecARM) GetName() string {
+func (containers *DatabaseAccountsSqlDatabasesContainers_SpecARM) GetName() string {
 	return containers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers"
-func (containers DatabaseAccountsSqlDatabasesContainers_SpecARM) GetType() string {
+func (containers *DatabaseAccountsSqlDatabasesContainers_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_stored_procedures__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_stored_procedures__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (procedures DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM)
 }
 
 // GetName returns the Name of the resource
-func (procedures DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetName() string {
+func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetName() string {
 	return procedures.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures"
-func (procedures DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetType() string {
+func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_throughput_settings__spec_arm_types_gen.go
@@ -31,11 +31,11 @@ func (settings DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM)
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings"
-func (settings DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings"
 }

--- a/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_triggers__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_triggers__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (triggers DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetAPIVer
 }
 
 // GetName returns the Name of the resource
-func (triggers DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetName() string {
+func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetName() string {
 	return triggers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers"
-func (triggers DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetType() string {
+func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_user_defined_functions__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_containers_user_defined_functions__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (functions DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecA
 }
 
 // GetName returns the Name of the resource
-func (functions DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetName() string {
+func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetName() string {
 	return functions.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions"
-func (functions DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetType() string {
+func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions"
 }
 

--- a/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_throughput_settings__spec_arm_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_accounts_sql_databases_throughput_settings__spec_arm_types_gen.go
@@ -31,11 +31,11 @@ func (settings DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetAPIVer
 }
 
 // GetName returns the Name of the resource
-func (settings DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetName() string {
+func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetName() string {
 	return settings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings"
-func (settings DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetType() string {
+func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM) GetType() string {
 	return "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings"
 }

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -340,7 +340,7 @@ func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Sp
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM
+	result := &DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -360,7 +360,7 @@ func (settings *DatabaseAccountsMongodbDatabasesCollectionsThroughputSettings_Sp
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -974,7 +974,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 	if resource == nil {
 		return nil, nil
 	}
-	var result ThroughputSettingsResourceARM
+	result := &ThroughputSettingsResourceARM{}
 
 	// Set property ‘AutoscaleSettings’:
 	if resource.AutoscaleSettings != nil {
@@ -982,7 +982,7 @@ func (resource *ThroughputSettingsResource) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		autoscaleSettings := autoscaleSettingsARM.(AutoscaleSettingsResourceARM)
+		autoscaleSettings := *autoscaleSettingsARM.(*AutoscaleSettingsResourceARM)
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
@@ -1097,7 +1097,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 	if resource == nil {
 		return nil, nil
 	}
-	var result AutoscaleSettingsResourceARM
+	result := &AutoscaleSettingsResourceARM{}
 
 	// Set property ‘AutoUpgradePolicy’:
 	if resource.AutoUpgradePolicy != nil {
@@ -1105,7 +1105,7 @@ func (resource *AutoscaleSettingsResource) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		autoUpgradePolicy := autoUpgradePolicyARM.(AutoUpgradePolicyResourceARM)
+		autoUpgradePolicy := *autoUpgradePolicyARM.(*AutoUpgradePolicyResourceARM)
 		result.AutoUpgradePolicy = &autoUpgradePolicy
 	}
 
@@ -1328,7 +1328,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 	if resource == nil {
 		return nil, nil
 	}
-	var result AutoUpgradePolicyResourceARM
+	result := &AutoUpgradePolicyResourceARM{}
 
 	// Set property ‘ThroughputPolicy’:
 	if resource.ThroughputPolicy != nil {
@@ -1336,7 +1336,7 @@ func (resource *AutoUpgradePolicyResource) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		throughputPolicy := throughputPolicyARM.(ThroughputPolicyResourceARM)
+		throughputPolicy := *throughputPolicyARM.(*ThroughputPolicyResourceARM)
 		result.ThroughputPolicy = &throughputPolicy
 	}
 	return result, nil
@@ -1513,7 +1513,7 @@ func (resource *ThroughputPolicyResource) ConvertToARM(resolved genruntime.Conve
 	if resource == nil {
 		return nil, nil
 	}
-	var result ThroughputPolicyResourceARM
+	result := &ThroughputPolicyResourceARM{}
 
 	// Set property ‘IncrementPercent’:
 	if resource.IncrementPercent != nil {

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen.go
@@ -354,7 +354,7 @@ func (collections *DatabaseAccountsMongodbDatabasesCollections_Spec) ConvertToAR
 	if collections == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabasesCollections_SpecARM
+	result := &DatabaseAccountsMongodbDatabasesCollections_SpecARM{}
 
 	// Set property ‘Location’:
 	if collections.Location != nil {
@@ -374,7 +374,7 @@ func (collections *DatabaseAccountsMongodbDatabasesCollections_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if collections.Resource != nil {
@@ -382,7 +382,7 @@ func (collections *DatabaseAccountsMongodbDatabasesCollections_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(MongoDBCollectionResourceARM)
+		resource := *resourceARM.(*MongoDBCollectionResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1104,7 +1104,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 	if resource == nil {
 		return nil, nil
 	}
-	var result MongoDBCollectionResourceARM
+	result := &MongoDBCollectionResourceARM{}
 
 	// Set property ‘AnalyticalStorageTtl’:
 	if resource.AnalyticalStorageTtl != nil {
@@ -1124,7 +1124,7 @@ func (resource *MongoDBCollectionResource) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		result.Indexes = append(result.Indexes, itemARM.(MongoIndexARM))
+		result.Indexes = append(result.Indexes, *itemARM.(*MongoIndexARM))
 	}
 
 	// Set property ‘ShardKey’:
@@ -1276,7 +1276,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if index == nil {
 		return nil, nil
 	}
-	var result MongoIndexARM
+	result := &MongoIndexARM{}
 
 	// Set property ‘Key’:
 	if index.Key != nil {
@@ -1284,7 +1284,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		key := keyARM.(MongoIndexKeysARM)
+		key := *keyARM.(*MongoIndexKeysARM)
 		result.Key = &key
 	}
 
@@ -1294,7 +1294,7 @@ func (index *MongoIndex) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(MongoIndexOptionsARM)
+		options := *optionsARM.(*MongoIndexOptionsARM)
 		result.Options = &options
 	}
 	return result, nil
@@ -1541,7 +1541,7 @@ func (keys *MongoIndexKeys) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if keys == nil {
 		return nil, nil
 	}
-	var result MongoIndexKeysARM
+	result := &MongoIndexKeysARM{}
 
 	// Set property ‘Keys’:
 	for _, item := range keys.Keys {
@@ -1673,7 +1673,7 @@ func (options *MongoIndexOptions) ConvertToARM(resolved genruntime.ConvertToARMR
 	if options == nil {
 		return nil, nil
 	}
-	var result MongoIndexOptionsARM
+	result := &MongoIndexOptionsARM{}
 
 	// Set property ‘ExpireAfterSeconds’:
 	if options.ExpireAfterSeconds != nil {

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen.go
@@ -340,7 +340,7 @@ func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_Spec) Convert
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM
+	result := &DatabaseAccountsMongodbDatabasesThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -360,7 +360,7 @@ func (settings *DatabaseAccountsMongodbDatabasesThroughputSettings_Spec) Convert
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen.go
@@ -354,7 +354,7 @@ func (databases *DatabaseAccountsMongodbDatabases_Spec) ConvertToARM(resolved ge
 	if databases == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsMongodbDatabases_SpecARM
+	result := &DatabaseAccountsMongodbDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {
@@ -374,7 +374,7 @@ func (databases *DatabaseAccountsMongodbDatabases_Spec) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if databases.Resource != nil {
@@ -382,7 +382,7 @@ func (databases *DatabaseAccountsMongodbDatabases_Spec) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(MongoDBDatabaseResourceARM)
+		resource := *resourceARM.(*MongoDBDatabaseResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -902,7 +902,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 	if options == nil {
 		return nil, nil
 	}
-	var result CreateUpdateOptionsARM
+	result := &CreateUpdateOptionsARM{}
 
 	// Set property ‘AutoscaleSettings’:
 	if options.AutoscaleSettings != nil {
@@ -910,7 +910,7 @@ func (options *CreateUpdateOptions) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		autoscaleSettings := autoscaleSettingsARM.(AutoscaleSettingsARM)
+		autoscaleSettings := *autoscaleSettingsARM.(*AutoscaleSettingsARM)
 		result.AutoscaleSettings = &autoscaleSettings
 	}
 
@@ -1135,7 +1135,7 @@ func (resource *MongoDBDatabaseResource) ConvertToARM(resolved genruntime.Conver
 	if resource == nil {
 		return nil, nil
 	}
-	var result MongoDBDatabaseResourceARM
+	result := &MongoDBDatabaseResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Id != nil {
@@ -1306,7 +1306,7 @@ func (settings *AutoscaleSettings) ConvertToARM(resolved genruntime.ConvertToARM
 	if settings == nil {
 		return nil, nil
 	}
-	var result AutoscaleSettingsARM
+	result := &AutoscaleSettingsARM{}
 
 	// Set property ‘MaxThroughput’:
 	if settings.MaxThroughput != nil {

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen.go
@@ -354,7 +354,7 @@ func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec) C
 	if procedures == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersStoredProcedures_SpecARM{}
 
 	// Set property ‘Location’:
 	if procedures.Location != nil {
@@ -374,7 +374,7 @@ func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec) C
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if procedures.Resource != nil {
@@ -382,7 +382,7 @@ func (procedures *DatabaseAccountsSqlDatabasesContainersStoredProcedures_Spec) C
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlStoredProcedureResourceARM)
+		resource := *resourceARM.(*SqlStoredProcedureResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -993,7 +993,7 @@ func (resource *SqlStoredProcedureResource) ConvertToARM(resolved genruntime.Con
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlStoredProcedureResourceARM
+	result := &SqlStoredProcedureResourceARM{}
 
 	// Set property ‘Body’:
 	if resource.Body != nil {

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen.go
@@ -340,7 +340,7 @@ func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec) C
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -360,7 +360,7 @@ func (settings *DatabaseAccountsSqlDatabasesContainersThroughputSettings_Spec) C
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen.go
@@ -354,7 +354,7 @@ func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_Spec) ConvertToAR
 	if triggers == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersTriggers_SpecARM{}
 
 	// Set property ‘Location’:
 	if triggers.Location != nil {
@@ -374,7 +374,7 @@ func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if triggers.Resource != nil {
@@ -382,7 +382,7 @@ func (triggers *DatabaseAccountsSqlDatabasesContainersTriggers_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlTriggerResourceARM)
+		resource := *resourceARM.(*SqlTriggerResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1049,7 +1049,7 @@ func (resource *SqlTriggerResource) ConvertToARM(resolved genruntime.ConvertToAR
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlTriggerResourceARM
+	result := &SqlTriggerResourceARM{}
 
 	// Set property ‘Body’:
 	if resource.Body != nil {

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen.go
@@ -354,7 +354,7 @@ func (containers *DatabaseAccountsSqlDatabasesContainers_Spec) ConvertToARM(reso
 	if containers == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainers_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainers_SpecARM{}
 
 	// Set property ‘Location’:
 	if containers.Location != nil {
@@ -374,7 +374,7 @@ func (containers *DatabaseAccountsSqlDatabasesContainers_Spec) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if containers.Resource != nil {
@@ -382,7 +382,7 @@ func (containers *DatabaseAccountsSqlDatabasesContainers_Spec) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlContainerResourceARM)
+		resource := *resourceARM.(*SqlContainerResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1217,7 +1217,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlContainerResourceARM
+	result := &SqlContainerResourceARM{}
 
 	// Set property ‘AnalyticalStorageTtl’:
 	if resource.AnalyticalStorageTtl != nil {
@@ -1231,7 +1231,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		conflictResolutionPolicy := conflictResolutionPolicyARM.(ConflictResolutionPolicyARM)
+		conflictResolutionPolicy := *conflictResolutionPolicyARM.(*ConflictResolutionPolicyARM)
 		result.ConflictResolutionPolicy = &conflictResolutionPolicy
 	}
 
@@ -1253,7 +1253,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		indexingPolicy := indexingPolicyARM.(IndexingPolicyARM)
+		indexingPolicy := *indexingPolicyARM.(*IndexingPolicyARM)
 		result.IndexingPolicy = &indexingPolicy
 	}
 
@@ -1263,7 +1263,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		partitionKey := partitionKeyARM.(ContainerPartitionKeyARM)
+		partitionKey := *partitionKeyARM.(*ContainerPartitionKeyARM)
 		result.PartitionKey = &partitionKey
 	}
 
@@ -1273,7 +1273,7 @@ func (resource *SqlContainerResource) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		uniqueKeyPolicy := uniqueKeyPolicyARM.(UniqueKeyPolicyARM)
+		uniqueKeyPolicy := *uniqueKeyPolicyARM.(*UniqueKeyPolicyARM)
 		result.UniqueKeyPolicy = &uniqueKeyPolicy
 	}
 	return result, nil
@@ -1513,7 +1513,7 @@ func (policy *ConflictResolutionPolicy) ConvertToARM(resolved genruntime.Convert
 	if policy == nil {
 		return nil, nil
 	}
-	var result ConflictResolutionPolicyARM
+	result := &ConflictResolutionPolicyARM{}
 
 	// Set property ‘ConflictResolutionPath’:
 	if policy.ConflictResolutionPath != nil {
@@ -1740,7 +1740,7 @@ func (partitionKey *ContainerPartitionKey) ConvertToARM(resolved genruntime.Conv
 	if partitionKey == nil {
 		return nil, nil
 	}
-	var result ContainerPartitionKeyARM
+	result := &ContainerPartitionKeyARM{}
 
 	// Set property ‘Kind’:
 	if partitionKey.Kind != nil {
@@ -2006,7 +2006,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if policy == nil {
 		return nil, nil
 	}
-	var result IndexingPolicyARM
+	result := &IndexingPolicyARM{}
 
 	// Set property ‘Automatic’:
 	if policy.Automatic != nil {
@@ -2022,7 +2022,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 			if err != nil {
 				return nil, err
 			}
-			itemTemp = append(itemTemp, item1ARM.(CompositePathARM))
+			itemTemp = append(itemTemp, *item1ARM.(*CompositePathARM))
 		}
 		result.CompositeIndexes = append(result.CompositeIndexes, itemTemp)
 	}
@@ -2033,7 +2033,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.ExcludedPaths = append(result.ExcludedPaths, itemARM.(ExcludedPathARM))
+		result.ExcludedPaths = append(result.ExcludedPaths, *itemARM.(*ExcludedPathARM))
 	}
 
 	// Set property ‘IncludedPaths’:
@@ -2042,7 +2042,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.IncludedPaths = append(result.IncludedPaths, itemARM.(IncludedPathARM))
+		result.IncludedPaths = append(result.IncludedPaths, *itemARM.(*IncludedPathARM))
 	}
 
 	// Set property ‘IndexingMode’:
@@ -2057,7 +2057,7 @@ func (policy *IndexingPolicy) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.SpatialIndexes = append(result.SpatialIndexes, itemARM.(SpatialSpecARM))
+		result.SpatialIndexes = append(result.SpatialIndexes, *itemARM.(*SpatialSpecARM))
 	}
 	return result, nil
 }
@@ -2680,7 +2680,7 @@ func (policy *UniqueKeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if policy == nil {
 		return nil, nil
 	}
-	var result UniqueKeyPolicyARM
+	result := &UniqueKeyPolicyARM{}
 
 	// Set property ‘UniqueKeys’:
 	for _, item := range policy.UniqueKeys {
@@ -2688,7 +2688,7 @@ func (policy *UniqueKeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.UniqueKeys = append(result.UniqueKeys, itemARM.(UniqueKeyARM))
+		result.UniqueKeys = append(result.UniqueKeys, *itemARM.(*UniqueKeyARM))
 	}
 	return result, nil
 }
@@ -2888,7 +2888,7 @@ func (path *CompositePath) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if path == nil {
 		return nil, nil
 	}
-	var result CompositePathARM
+	result := &CompositePathARM{}
 
 	// Set property ‘Order’:
 	if path.Order != nil {
@@ -3075,7 +3075,7 @@ func (path *ExcludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if path == nil {
 		return nil, nil
 	}
-	var result ExcludedPathARM
+	result := &ExcludedPathARM{}
 
 	// Set property ‘Path’:
 	if path.Path != nil {
@@ -3212,7 +3212,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if path == nil {
 		return nil, nil
 	}
-	var result IncludedPathARM
+	result := &IncludedPathARM{}
 
 	// Set property ‘Indexes’:
 	for _, item := range path.Indexes {
@@ -3220,7 +3220,7 @@ func (path *IncludedPath) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 		if err != nil {
 			return nil, err
 		}
-		result.Indexes = append(result.Indexes, itemARM.(IndexesARM))
+		result.Indexes = append(result.Indexes, *itemARM.(*IndexesARM))
 	}
 
 	// Set property ‘Path’:
@@ -3453,7 +3453,7 @@ func (spatial *SpatialSpec) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if spatial == nil {
 		return nil, nil
 	}
-	var result SpatialSpecARM
+	result := &SpatialSpecARM{}
 
 	// Set property ‘Path’:
 	if spatial.Path != nil {
@@ -3656,7 +3656,7 @@ func (uniqueKey *UniqueKey) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if uniqueKey == nil {
 		return nil, nil
 	}
-	var result UniqueKeyARM
+	result := &UniqueKeyARM{}
 
 	// Set property ‘Paths’:
 	for _, item := range uniqueKey.Paths {
@@ -3791,7 +3791,7 @@ func (indexes *Indexes) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if indexes == nil {
 		return nil, nil
 	}
-	var result IndexesARM
+	result := &IndexesARM{}
 
 	// Set property ‘DataType’:
 	if indexes.DataType != nil {

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen.go
@@ -354,7 +354,7 @@ func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
 	if functions == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM
+	result := &DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_SpecARM{}
 
 	// Set property ‘Location’:
 	if functions.Location != nil {
@@ -374,7 +374,7 @@ func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if functions.Resource != nil {
@@ -382,7 +382,7 @@ func (functions *DatabaseAccountsSqlDatabasesContainersUserDefinedFunctions_Spec
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlUserDefinedFunctionResourceARM)
+		resource := *resourceARM.(*SqlUserDefinedFunctionResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -993,7 +993,7 @@ func (resource *SqlUserDefinedFunctionResource) ConvertToARM(resolved genruntime
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlUserDefinedFunctionResourceARM
+	result := &SqlUserDefinedFunctionResourceARM{}
 
 	// Set property ‘Body’:
 	if resource.Body != nil {

--- a/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen.go
@@ -340,7 +340,7 @@ func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_Spec) ConvertToAR
 	if settings == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM
+	result := &DatabaseAccountsSqlDatabasesThroughputSettings_SpecARM{}
 
 	// Set property ‘Location’:
 	if settings.Location != nil {
@@ -360,7 +360,7 @@ func (settings *DatabaseAccountsSqlDatabasesThroughputSettings_Spec) ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(ThroughputSettingsResourceARM)
+		resource := *resourceARM.(*ThroughputSettingsResourceARM)
 		result.Properties.Resource = &resource
 	}
 

--- a/v2/api/documentdb/v1beta20210515/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_types_gen.go
@@ -354,7 +354,7 @@ func (databases *DatabaseAccountsSqlDatabases_Spec) ConvertToARM(resolved genrun
 	if databases == nil {
 		return nil, nil
 	}
-	var result DatabaseAccountsSqlDatabases_SpecARM
+	result := &DatabaseAccountsSqlDatabases_SpecARM{}
 
 	// Set property ‘Location’:
 	if databases.Location != nil {
@@ -374,7 +374,7 @@ func (databases *DatabaseAccountsSqlDatabases_Spec) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		options := optionsARM.(CreateUpdateOptionsARM)
+		options := *optionsARM.(*CreateUpdateOptionsARM)
 		result.Properties.Options = &options
 	}
 	if databases.Resource != nil {
@@ -382,7 +382,7 @@ func (databases *DatabaseAccountsSqlDatabases_Spec) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		resource := resourceARM.(SqlDatabaseResourceARM)
+		resource := *resourceARM.(*SqlDatabaseResourceARM)
 		result.Properties.Resource = &resource
 	}
 
@@ -1044,7 +1044,7 @@ func (resource *SqlDatabaseResource) ConvertToARM(resolved genruntime.ConvertToA
 	if resource == nil {
 		return nil, nil
 	}
-	var result SqlDatabaseResourceARM
+	result := &SqlDatabaseResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Id != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen.go
@@ -819,7 +819,7 @@ func (domains *Domains_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if domains == nil {
 		return nil, nil
 	}
-	var result Domains_SpecARM
+	result := &Domains_SpecARM{}
 
 	// Set property ‘Location’:
 	if domains.Location != nil {
@@ -842,7 +842,7 @@ func (domains *Domains_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.InboundIpRules = append(result.Properties.InboundIpRules, itemARM.(InboundIpRuleARM))
+		result.Properties.InboundIpRules = append(result.Properties.InboundIpRules, *itemARM.(*InboundIpRuleARM))
 	}
 	if domains.InputSchema != nil {
 		inputSchema := *domains.InputSchema
@@ -853,7 +853,7 @@ func (domains *Domains_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		inputSchemaMapping := inputSchemaMappingARM.(JsonInputSchemaMappingARM)
+		inputSchemaMapping := *inputSchemaMappingARM.(*JsonInputSchemaMappingARM)
 		result.Properties.InputSchemaMapping = &inputSchemaMapping
 	}
 	if domains.PublicNetworkAccess != nil {
@@ -1227,7 +1227,7 @@ func (rule *InboundIpRule) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if rule == nil {
 		return nil, nil
 	}
-	var result InboundIpRuleARM
+	result := &InboundIpRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -1479,7 +1479,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 	if mapping == nil {
 		return nil, nil
 	}
-	var result JsonInputSchemaMappingARM
+	result := &JsonInputSchemaMappingARM{}
 
 	// Set property ‘InputSchemaMappingType’:
 	if mapping.InputSchemaMappingType != nil {
@@ -1493,7 +1493,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(JsonInputSchemaMappingPropertiesARM)
+		properties := *propertiesARM.(*JsonInputSchemaMappingPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1837,7 +1837,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 	if properties == nil {
 		return nil, nil
 	}
-	var result JsonInputSchemaMappingPropertiesARM
+	result := &JsonInputSchemaMappingPropertiesARM{}
 
 	// Set property ‘DataVersion’:
 	if properties.DataVersion != nil {
@@ -1845,7 +1845,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		dataVersion := dataVersionARM.(JsonFieldWithDefaultARM)
+		dataVersion := *dataVersionARM.(*JsonFieldWithDefaultARM)
 		result.DataVersion = &dataVersion
 	}
 
@@ -1855,7 +1855,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		eventTime := eventTimeARM.(JsonFieldARM)
+		eventTime := *eventTimeARM.(*JsonFieldARM)
 		result.EventTime = &eventTime
 	}
 
@@ -1865,7 +1865,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		eventType := eventTypeARM.(JsonFieldWithDefaultARM)
+		eventType := *eventTypeARM.(*JsonFieldWithDefaultARM)
 		result.EventType = &eventType
 	}
 
@@ -1875,7 +1875,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		id := idARM.(JsonFieldARM)
+		id := *idARM.(*JsonFieldARM)
 		result.Id = &id
 	}
 
@@ -1885,7 +1885,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		subject := subjectARM.(JsonFieldWithDefaultARM)
+		subject := *subjectARM.(*JsonFieldWithDefaultARM)
 		result.Subject = &subject
 	}
 
@@ -1895,7 +1895,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		topic := topicARM.(JsonFieldARM)
+		topic := *topicARM.(*JsonFieldARM)
 		result.Topic = &topic
 	}
 	return result, nil
@@ -2162,7 +2162,7 @@ func (field *JsonField) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if field == nil {
 		return nil, nil
 	}
-	var result JsonFieldARM
+	result := &JsonFieldARM{}
 
 	// Set property ‘SourceField’:
 	if field.SourceField != nil {
@@ -2236,7 +2236,7 @@ func (withDefault *JsonFieldWithDefault) ConvertToARM(resolved genruntime.Conver
 	if withDefault == nil {
 		return nil, nil
 	}
-	var result JsonFieldWithDefaultARM
+	result := &JsonFieldWithDefaultARM{}
 
 	// Set property ‘DefaultValue’:
 	if withDefault.DefaultValue != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601/domains__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domains__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (domains Domains_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (domains Domains_SpecARM) GetName() string {
+func (domains *Domains_SpecARM) GetName() string {
 	return domains.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/domains"
-func (domains Domains_SpecARM) GetType() string {
+func (domains *Domains_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/domains"
 }
 

--- a/v2/api/eventgrid/v1alpha1api20200601/domains_topic_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domains_topic_types_gen.go
@@ -558,7 +558,7 @@ func (topics *DomainsTopics_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	if topics == nil {
 		return nil, nil
 	}
-	var result DomainsTopics_SpecARM
+	result := &DomainsTopics_SpecARM{}
 
 	// Set property ‘Location’:
 	if topics.Location != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601/domains_topics__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domains_topics__spec_arm_types_gen.go
@@ -20,11 +20,11 @@ func (topics DomainsTopics_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (topics DomainsTopics_SpecARM) GetName() string {
+func (topics *DomainsTopics_SpecARM) GetName() string {
 	return topics.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/domains/topics"
-func (topics DomainsTopics_SpecARM) GetType() string {
+func (topics *DomainsTopics_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/domains/topics"
 }

--- a/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen.go
@@ -793,7 +793,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 	if subscriptions == nil {
 		return nil, nil
 	}
-	var result EventSubscriptions_SpecARM
+	result := &EventSubscriptions_SpecARM{}
 
 	// Set property ‘Location’:
 	if subscriptions.Location != nil {
@@ -819,7 +819,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		deadLetterDestination := deadLetterDestinationARM.(StorageBlobDeadLetterDestinationARM)
+		deadLetterDestination := *deadLetterDestinationARM.(*StorageBlobDeadLetterDestinationARM)
 		result.Properties.DeadLetterDestination = &deadLetterDestination
 	}
 	if subscriptions.Destination != nil {
@@ -827,7 +827,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		destination := destinationARM.(EventSubscriptionDestinationARM)
+		destination := *destinationARM.(*EventSubscriptionDestinationARM)
 		result.Properties.Destination = &destination
 	}
 	if subscriptions.EventDeliverySchema != nil {
@@ -843,7 +843,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		filter := filterARM.(EventSubscriptionFilterARM)
+		filter := *filterARM.(*EventSubscriptionFilterARM)
 		result.Properties.Filter = &filter
 	}
 	for _, item := range subscriptions.Labels {
@@ -854,7 +854,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		retryPolicy := retryPolicyARM.(RetryPolicyARM)
+		retryPolicy := *retryPolicyARM.(*RetryPolicyARM)
 		result.Properties.RetryPolicy = &retryPolicy
 	}
 
@@ -1326,7 +1326,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 	if destination == nil {
 		return nil, nil
 	}
-	var result EventSubscriptionDestinationARM
+	result := &EventSubscriptionDestinationARM{}
 
 	// Set property ‘AzureFunction’:
 	if destination.AzureFunction != nil {
@@ -1334,7 +1334,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		azureFunction := azureFunctionARM.(AzureFunctionEventSubscriptionDestinationARM)
+		azureFunction := *azureFunctionARM.(*AzureFunctionEventSubscriptionDestinationARM)
 		result.AzureFunction = &azureFunction
 	}
 
@@ -1344,7 +1344,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		eventHub := eventHubARM.(EventHubEventSubscriptionDestinationARM)
+		eventHub := *eventHubARM.(*EventHubEventSubscriptionDestinationARM)
 		result.EventHub = &eventHub
 	}
 
@@ -1354,7 +1354,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		hybridConnection := hybridConnectionARM.(HybridConnectionEventSubscriptionDestinationARM)
+		hybridConnection := *hybridConnectionARM.(*HybridConnectionEventSubscriptionDestinationARM)
 		result.HybridConnection = &hybridConnection
 	}
 
@@ -1364,7 +1364,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		serviceBusQueue := serviceBusQueueARM.(ServiceBusQueueEventSubscriptionDestinationARM)
+		serviceBusQueue := *serviceBusQueueARM.(*ServiceBusQueueEventSubscriptionDestinationARM)
 		result.ServiceBusQueue = &serviceBusQueue
 	}
 
@@ -1374,7 +1374,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		serviceBusTopic := serviceBusTopicARM.(ServiceBusTopicEventSubscriptionDestinationARM)
+		serviceBusTopic := *serviceBusTopicARM.(*ServiceBusTopicEventSubscriptionDestinationARM)
 		result.ServiceBusTopic = &serviceBusTopic
 	}
 
@@ -1384,7 +1384,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		storageQueue := storageQueueARM.(StorageQueueEventSubscriptionDestinationARM)
+		storageQueue := *storageQueueARM.(*StorageQueueEventSubscriptionDestinationARM)
 		result.StorageQueue = &storageQueue
 	}
 
@@ -1394,7 +1394,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		webHook := webHookARM.(WebHookEventSubscriptionDestinationARM)
+		webHook := *webHookARM.(*WebHookEventSubscriptionDestinationARM)
 		result.WebHook = &webHook
 	}
 	return result, nil
@@ -1768,7 +1768,7 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 	if filter == nil {
 		return nil, nil
 	}
-	var result EventSubscriptionFilterARM
+	result := &EventSubscriptionFilterARM{}
 
 	// Set property ‘AdvancedFilters’:
 	for _, item := range filter.AdvancedFilters {
@@ -1776,7 +1776,7 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.AdvancedFilters = append(result.AdvancedFilters, itemARM.(AdvancedFilterARM))
+		result.AdvancedFilters = append(result.AdvancedFilters, *itemARM.(*AdvancedFilterARM))
 	}
 
 	// Set property ‘IncludedEventTypes’:
@@ -2147,7 +2147,7 @@ func (policy *RetryPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if policy == nil {
 		return nil, nil
 	}
-	var result RetryPolicyARM
+	result := &RetryPolicyARM{}
 
 	// Set property ‘EventTimeToLiveInMinutes’:
 	if policy.EventTimeToLiveInMinutes != nil {
@@ -2311,7 +2311,7 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 	if destination == nil {
 		return nil, nil
 	}
-	var result StorageBlobDeadLetterDestinationARM
+	result := &StorageBlobDeadLetterDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -2325,7 +2325,7 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(StorageBlobDeadLetterDestinationPropertiesARM)
+		properties := *propertiesARM.(*StorageBlobDeadLetterDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -2450,7 +2450,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if filter == nil {
 		return nil, nil
 	}
-	var result AdvancedFilterARM
+	result := &AdvancedFilterARM{}
 
 	// Set property ‘BoolEquals’:
 	if filter.BoolEquals != nil {
@@ -2458,7 +2458,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		boolEquals := boolEqualsARM.(AdvancedFilter_BoolEqualsARM)
+		boolEquals := *boolEqualsARM.(*AdvancedFilter_BoolEqualsARM)
 		result.BoolEquals = &boolEquals
 	}
 
@@ -2468,7 +2468,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberGreaterThan := numberGreaterThanARM.(AdvancedFilter_NumberGreaterThanARM)
+		numberGreaterThan := *numberGreaterThanARM.(*AdvancedFilter_NumberGreaterThanARM)
 		result.NumberGreaterThan = &numberGreaterThan
 	}
 
@@ -2478,7 +2478,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberGreaterThanOrEquals := numberGreaterThanOrEqualsARM.(AdvancedFilter_NumberGreaterThanOrEqualsARM)
+		numberGreaterThanOrEquals := *numberGreaterThanOrEqualsARM.(*AdvancedFilter_NumberGreaterThanOrEqualsARM)
 		result.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
@@ -2488,7 +2488,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberIn := numberInARM.(AdvancedFilter_NumberInARM)
+		numberIn := *numberInARM.(*AdvancedFilter_NumberInARM)
 		result.NumberIn = &numberIn
 	}
 
@@ -2498,7 +2498,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberLessThan := numberLessThanARM.(AdvancedFilter_NumberLessThanARM)
+		numberLessThan := *numberLessThanARM.(*AdvancedFilter_NumberLessThanARM)
 		result.NumberLessThan = &numberLessThan
 	}
 
@@ -2508,7 +2508,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberLessThanOrEquals := numberLessThanOrEqualsARM.(AdvancedFilter_NumberLessThanOrEqualsARM)
+		numberLessThanOrEquals := *numberLessThanOrEqualsARM.(*AdvancedFilter_NumberLessThanOrEqualsARM)
 		result.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
@@ -2518,7 +2518,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberNotIn := numberNotInARM.(AdvancedFilter_NumberNotInARM)
+		numberNotIn := *numberNotInARM.(*AdvancedFilter_NumberNotInARM)
 		result.NumberNotIn = &numberNotIn
 	}
 
@@ -2528,7 +2528,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringBeginsWith := stringBeginsWithARM.(AdvancedFilter_StringBeginsWithARM)
+		stringBeginsWith := *stringBeginsWithARM.(*AdvancedFilter_StringBeginsWithARM)
 		result.StringBeginsWith = &stringBeginsWith
 	}
 
@@ -2538,7 +2538,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringContains := stringContainsARM.(AdvancedFilter_StringContainsARM)
+		stringContains := *stringContainsARM.(*AdvancedFilter_StringContainsARM)
 		result.StringContains = &stringContains
 	}
 
@@ -2548,7 +2548,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringEndsWith := stringEndsWithARM.(AdvancedFilter_StringEndsWithARM)
+		stringEndsWith := *stringEndsWithARM.(*AdvancedFilter_StringEndsWithARM)
 		result.StringEndsWith = &stringEndsWith
 	}
 
@@ -2558,7 +2558,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringIn := stringInARM.(AdvancedFilter_StringInARM)
+		stringIn := *stringInARM.(*AdvancedFilter_StringInARM)
 		result.StringIn = &stringIn
 	}
 
@@ -2568,7 +2568,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringNotIn := stringNotInARM.(AdvancedFilter_StringNotInARM)
+		stringNotIn := *stringNotInARM.(*AdvancedFilter_StringNotInARM)
 		result.StringNotIn = &stringNotIn
 	}
 	return result, nil
@@ -3128,7 +3128,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 	if destination == nil {
 		return nil, nil
 	}
-	var result AzureFunctionEventSubscriptionDestinationARM
+	result := &AzureFunctionEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3141,7 +3141,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(AzureFunctionEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*AzureFunctionEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3260,7 +3260,7 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 	if destination == nil {
 		return nil, nil
 	}
-	var result EventHubEventSubscriptionDestinationARM
+	result := &EventHubEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3273,7 +3273,7 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(EventHubEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*EventHubEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3400,7 +3400,7 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 	if destination == nil {
 		return nil, nil
 	}
-	var result HybridConnectionEventSubscriptionDestinationARM
+	result := &HybridConnectionEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3413,7 +3413,7 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(HybridConnectionEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*HybridConnectionEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3526,7 +3526,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 	if destination == nil {
 		return nil, nil
 	}
-	var result ServiceBusQueueEventSubscriptionDestinationARM
+	result := &ServiceBusQueueEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3539,7 +3539,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(ServiceBusQueueEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*ServiceBusQueueEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3652,7 +3652,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 	if destination == nil {
 		return nil, nil
 	}
-	var result ServiceBusTopicEventSubscriptionDestinationARM
+	result := &ServiceBusTopicEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3665,7 +3665,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(ServiceBusTopicEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*ServiceBusTopicEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3784,7 +3784,7 @@ func (properties *StorageBlobDeadLetterDestinationProperties) ConvertToARM(resol
 	if properties == nil {
 		return nil, nil
 	}
-	var result StorageBlobDeadLetterDestinationPropertiesARM
+	result := &StorageBlobDeadLetterDestinationPropertiesARM{}
 
 	// Set property ‘BlobContainerName’:
 	if properties.BlobContainerName != nil {
@@ -3887,7 +3887,7 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 	if destination == nil {
 		return nil, nil
 	}
-	var result StorageQueueEventSubscriptionDestinationARM
+	result := &StorageQueueEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3900,7 +3900,7 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(StorageQueueEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*StorageQueueEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -4013,7 +4013,7 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 	if destination == nil {
 		return nil, nil
 	}
-	var result WebHookEventSubscriptionDestinationARM
+	result := &WebHookEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -4026,7 +4026,7 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(WebHookEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*WebHookEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -4159,7 +4159,7 @@ func (equals *AdvancedFilter_BoolEquals) ConvertToARM(resolved genruntime.Conver
 	if equals == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_BoolEqualsARM
+	result := &AdvancedFilter_BoolEqualsARM{}
 
 	// Set property ‘Key’:
 	if equals.Key != nil {
@@ -4288,7 +4288,7 @@ func (than *AdvancedFilter_NumberGreaterThan) ConvertToARM(resolved genruntime.C
 	if than == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberGreaterThanARM
+	result := &AdvancedFilter_NumberGreaterThanARM{}
 
 	// Set property ‘Key’:
 	if than.Key != nil {
@@ -4417,7 +4417,7 @@ func (equals *AdvancedFilter_NumberGreaterThanOrEquals) ConvertToARM(resolved ge
 	if equals == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberGreaterThanOrEqualsARM
+	result := &AdvancedFilter_NumberGreaterThanOrEqualsARM{}
 
 	// Set property ‘Key’:
 	if equals.Key != nil {
@@ -4546,7 +4546,7 @@ func (numberIn *AdvancedFilter_NumberIn) ConvertToARM(resolved genruntime.Conver
 	if numberIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberInARM
+	result := &AdvancedFilter_NumberInARM{}
 
 	// Set property ‘Key’:
 	if numberIn.Key != nil {
@@ -4683,7 +4683,7 @@ func (than *AdvancedFilter_NumberLessThan) ConvertToARM(resolved genruntime.Conv
 	if than == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberLessThanARM
+	result := &AdvancedFilter_NumberLessThanARM{}
 
 	// Set property ‘Key’:
 	if than.Key != nil {
@@ -4812,7 +4812,7 @@ func (equals *AdvancedFilter_NumberLessThanOrEquals) ConvertToARM(resolved genru
 	if equals == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberLessThanOrEqualsARM
+	result := &AdvancedFilter_NumberLessThanOrEqualsARM{}
 
 	// Set property ‘Key’:
 	if equals.Key != nil {
@@ -4941,7 +4941,7 @@ func (notIn *AdvancedFilter_NumberNotIn) ConvertToARM(resolved genruntime.Conver
 	if notIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberNotInARM
+	result := &AdvancedFilter_NumberNotInARM{}
 
 	// Set property ‘Key’:
 	if notIn.Key != nil {
@@ -5078,7 +5078,7 @@ func (with *AdvancedFilter_StringBeginsWith) ConvertToARM(resolved genruntime.Co
 	if with == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringBeginsWithARM
+	result := &AdvancedFilter_StringBeginsWithARM{}
 
 	// Set property ‘Key’:
 	if with.Key != nil {
@@ -5195,7 +5195,7 @@ func (contains *AdvancedFilter_StringContains) ConvertToARM(resolved genruntime.
 	if contains == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringContainsARM
+	result := &AdvancedFilter_StringContainsARM{}
 
 	// Set property ‘Key’:
 	if contains.Key != nil {
@@ -5312,7 +5312,7 @@ func (with *AdvancedFilter_StringEndsWith) ConvertToARM(resolved genruntime.Conv
 	if with == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringEndsWithARM
+	result := &AdvancedFilter_StringEndsWithARM{}
 
 	// Set property ‘Key’:
 	if with.Key != nil {
@@ -5429,7 +5429,7 @@ func (stringIn *AdvancedFilter_StringIn) ConvertToARM(resolved genruntime.Conver
 	if stringIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringInARM
+	result := &AdvancedFilter_StringInARM{}
 
 	// Set property ‘Key’:
 	if stringIn.Key != nil {
@@ -5546,7 +5546,7 @@ func (notIn *AdvancedFilter_StringNotIn) ConvertToARM(resolved genruntime.Conver
 	if notIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringNotInARM
+	result := &AdvancedFilter_StringNotInARM{}
 
 	// Set property ‘Key’:
 	if notIn.Key != nil {
@@ -5668,7 +5668,7 @@ func (properties *AzureFunctionEventSubscriptionDestinationProperties) ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result AzureFunctionEventSubscriptionDestinationPropertiesARM
+	result := &AzureFunctionEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘MaxEventsPerBatch’:
 	if properties.MaxEventsPerBatch != nil {
@@ -5794,7 +5794,7 @@ func (properties *EventHubEventSubscriptionDestinationProperties) ConvertToARM(r
 	if properties == nil {
 		return nil, nil
 	}
-	var result EventHubEventSubscriptionDestinationPropertiesARM
+	result := &EventHubEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -5884,7 +5884,7 @@ func (properties *HybridConnectionEventSubscriptionDestinationProperties) Conver
 	if properties == nil {
 		return nil, nil
 	}
-	var result HybridConnectionEventSubscriptionDestinationPropertiesARM
+	result := &HybridConnectionEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -5974,7 +5974,7 @@ func (properties *ServiceBusQueueEventSubscriptionDestinationProperties) Convert
 	if properties == nil {
 		return nil, nil
 	}
-	var result ServiceBusQueueEventSubscriptionDestinationPropertiesARM
+	result := &ServiceBusQueueEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -6064,7 +6064,7 @@ func (properties *ServiceBusTopicEventSubscriptionDestinationProperties) Convert
 	if properties == nil {
 		return nil, nil
 	}
-	var result ServiceBusTopicEventSubscriptionDestinationPropertiesARM
+	result := &ServiceBusTopicEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -6155,7 +6155,7 @@ func (properties *StorageQueueEventSubscriptionDestinationProperties) ConvertToA
 	if properties == nil {
 		return nil, nil
 	}
-	var result StorageQueueEventSubscriptionDestinationPropertiesARM
+	result := &StorageQueueEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘QueueName’:
 	if properties.QueueName != nil {
@@ -6267,7 +6267,7 @@ func (properties *WebHookEventSubscriptionDestinationProperties) ConvertToARM(re
 	if properties == nil {
 		return nil, nil
 	}
-	var result WebHookEventSubscriptionDestinationPropertiesARM
+	result := &WebHookEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘AzureActiveDirectoryApplicationIdOrUri’:
 	if properties.AzureActiveDirectoryApplicationIdOrUri != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601/event_subscriptions__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/event_subscriptions__spec_arm_types_gen.go
@@ -24,12 +24,12 @@ func (subscriptions EventSubscriptions_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (subscriptions EventSubscriptions_SpecARM) GetName() string {
+func (subscriptions *EventSubscriptions_SpecARM) GetName() string {
 	return subscriptions.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/eventSubscriptions"
-func (subscriptions EventSubscriptions_SpecARM) GetType() string {
+func (subscriptions *EventSubscriptions_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/eventSubscriptions"
 }
 

--- a/v2/api/eventgrid/v1alpha1api20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/topic_types_gen.go
@@ -809,7 +809,7 @@ func (topics *Topics_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if topics == nil {
 		return nil, nil
 	}
-	var result Topics_SpecARM
+	result := &Topics_SpecARM{}
 
 	// Set property ‘Location’:
 	if topics.Location != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601/topics__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/topics__spec_arm_types_gen.go
@@ -20,11 +20,11 @@ func (topics Topics_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (topics Topics_SpecARM) GetName() string {
+func (topics *Topics_SpecARM) GetName() string {
 	return topics.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/topics"
-func (topics Topics_SpecARM) GetType() string {
+func (topics *Topics_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/topics"
 }

--- a/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
@@ -851,7 +851,7 @@ func (domains *Domains_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if domains == nil {
 		return nil, nil
 	}
-	var result Domains_SpecARM
+	result := &Domains_SpecARM{}
 
 	// Set property ‘Location’:
 	if domains.Location != nil {
@@ -874,7 +874,7 @@ func (domains *Domains_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.InboundIpRules = append(result.Properties.InboundIpRules, itemARM.(InboundIpRuleARM))
+		result.Properties.InboundIpRules = append(result.Properties.InboundIpRules, *itemARM.(*InboundIpRuleARM))
 	}
 	if domains.InputSchema != nil {
 		inputSchema := *domains.InputSchema
@@ -885,7 +885,7 @@ func (domains *Domains_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		inputSchemaMapping := inputSchemaMappingARM.(JsonInputSchemaMappingARM)
+		inputSchemaMapping := *inputSchemaMappingARM.(*JsonInputSchemaMappingARM)
 		result.Properties.InputSchemaMapping = &inputSchemaMapping
 	}
 	if domains.PublicNetworkAccess != nil {
@@ -1255,7 +1255,7 @@ func (rule *InboundIpRule) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if rule == nil {
 		return nil, nil
 	}
-	var result InboundIpRuleARM
+	result := &InboundIpRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -1512,7 +1512,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 	if mapping == nil {
 		return nil, nil
 	}
-	var result JsonInputSchemaMappingARM
+	result := &JsonInputSchemaMappingARM{}
 
 	// Set property ‘InputSchemaMappingType’:
 	if mapping.InputSchemaMappingType != nil {
@@ -1526,7 +1526,7 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(JsonInputSchemaMappingPropertiesARM)
+		properties := *propertiesARM.(*JsonInputSchemaMappingPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1900,7 +1900,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 	if properties == nil {
 		return nil, nil
 	}
-	var result JsonInputSchemaMappingPropertiesARM
+	result := &JsonInputSchemaMappingPropertiesARM{}
 
 	// Set property ‘DataVersion’:
 	if properties.DataVersion != nil {
@@ -1908,7 +1908,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		dataVersion := dataVersionARM.(JsonFieldWithDefaultARM)
+		dataVersion := *dataVersionARM.(*JsonFieldWithDefaultARM)
 		result.DataVersion = &dataVersion
 	}
 
@@ -1918,7 +1918,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		eventTime := eventTimeARM.(JsonFieldARM)
+		eventTime := *eventTimeARM.(*JsonFieldARM)
 		result.EventTime = &eventTime
 	}
 
@@ -1928,7 +1928,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		eventType := eventTypeARM.(JsonFieldWithDefaultARM)
+		eventType := *eventTypeARM.(*JsonFieldWithDefaultARM)
 		result.EventType = &eventType
 	}
 
@@ -1938,7 +1938,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		id := idARM.(JsonFieldARM)
+		id := *idARM.(*JsonFieldARM)
 		result.Id = &id
 	}
 
@@ -1948,7 +1948,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		subject := subjectARM.(JsonFieldWithDefaultARM)
+		subject := *subjectARM.(*JsonFieldWithDefaultARM)
 		result.Subject = &subject
 	}
 
@@ -1958,7 +1958,7 @@ func (properties *JsonInputSchemaMappingProperties) ConvertToARM(resolved genrun
 		if err != nil {
 			return nil, err
 		}
-		topic := topicARM.(JsonFieldARM)
+		topic := *topicARM.(*JsonFieldARM)
 		result.Topic = &topic
 	}
 	return result, nil
@@ -2226,7 +2226,7 @@ func (field *JsonField) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if field == nil {
 		return nil, nil
 	}
-	var result JsonFieldARM
+	result := &JsonFieldARM{}
 
 	// Set property ‘SourceField’:
 	if field.SourceField != nil {
@@ -2304,7 +2304,7 @@ func (withDefault *JsonFieldWithDefault) ConvertToARM(resolved genruntime.Conver
 	if withDefault == nil {
 		return nil, nil
 	}
-	var result JsonFieldWithDefaultARM
+	result := &JsonFieldWithDefaultARM{}
 
 	// Set property ‘DefaultValue’:
 	if withDefault.DefaultValue != nil {

--- a/v2/api/eventgrid/v1beta20200601/domains__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domains__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (domains Domains_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (domains Domains_SpecARM) GetName() string {
+func (domains *Domains_SpecARM) GetName() string {
 	return domains.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/domains"
-func (domains Domains_SpecARM) GetType() string {
+func (domains *Domains_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/domains"
 }
 

--- a/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen.go
@@ -557,7 +557,7 @@ func (topics *DomainsTopics_Spec) ConvertToARM(resolved genruntime.ConvertToARMR
 	if topics == nil {
 		return nil, nil
 	}
-	var result DomainsTopics_SpecARM
+	result := &DomainsTopics_SpecARM{}
 
 	// Set property ‘Location’:
 	if topics.Location != nil {

--- a/v2/api/eventgrid/v1beta20200601/domains_topics__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domains_topics__spec_arm_types_gen.go
@@ -24,11 +24,11 @@ func (topics DomainsTopics_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (topics DomainsTopics_SpecARM) GetName() string {
+func (topics *DomainsTopics_SpecARM) GetName() string {
 	return topics.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/domains/topics"
-func (topics DomainsTopics_SpecARM) GetType() string {
+func (topics *DomainsTopics_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/domains/topics"
 }

--- a/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen.go
@@ -825,7 +825,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 	if subscriptions == nil {
 		return nil, nil
 	}
-	var result EventSubscriptions_SpecARM
+	result := &EventSubscriptions_SpecARM{}
 
 	// Set property ‘Location’:
 	if subscriptions.Location != nil {
@@ -851,7 +851,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		deadLetterDestination := deadLetterDestinationARM.(StorageBlobDeadLetterDestinationARM)
+		deadLetterDestination := *deadLetterDestinationARM.(*StorageBlobDeadLetterDestinationARM)
 		result.Properties.DeadLetterDestination = &deadLetterDestination
 	}
 	if subscriptions.Destination != nil {
@@ -859,7 +859,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		destination := destinationARM.(EventSubscriptionDestinationARM)
+		destination := *destinationARM.(*EventSubscriptionDestinationARM)
 		result.Properties.Destination = &destination
 	}
 	if subscriptions.EventDeliverySchema != nil {
@@ -875,7 +875,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		filter := filterARM.(EventSubscriptionFilterARM)
+		filter := *filterARM.(*EventSubscriptionFilterARM)
 		result.Properties.Filter = &filter
 	}
 	for _, item := range subscriptions.Labels {
@@ -886,7 +886,7 @@ func (subscriptions *EventSubscriptions_Spec) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		retryPolicy := retryPolicyARM.(RetryPolicyARM)
+		retryPolicy := *retryPolicyARM.(*RetryPolicyARM)
 		result.Properties.RetryPolicy = &retryPolicy
 	}
 
@@ -1371,7 +1371,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 	if destination == nil {
 		return nil, nil
 	}
-	var result EventSubscriptionDestinationARM
+	result := &EventSubscriptionDestinationARM{}
 
 	// Set property ‘AzureFunction’:
 	if destination.AzureFunction != nil {
@@ -1379,7 +1379,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		azureFunction := azureFunctionARM.(AzureFunctionEventSubscriptionDestinationARM)
+		azureFunction := *azureFunctionARM.(*AzureFunctionEventSubscriptionDestinationARM)
 		result.AzureFunction = &azureFunction
 	}
 
@@ -1389,7 +1389,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		eventHub := eventHubARM.(EventHubEventSubscriptionDestinationARM)
+		eventHub := *eventHubARM.(*EventHubEventSubscriptionDestinationARM)
 		result.EventHub = &eventHub
 	}
 
@@ -1399,7 +1399,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		hybridConnection := hybridConnectionARM.(HybridConnectionEventSubscriptionDestinationARM)
+		hybridConnection := *hybridConnectionARM.(*HybridConnectionEventSubscriptionDestinationARM)
 		result.HybridConnection = &hybridConnection
 	}
 
@@ -1409,7 +1409,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		serviceBusQueue := serviceBusQueueARM.(ServiceBusQueueEventSubscriptionDestinationARM)
+		serviceBusQueue := *serviceBusQueueARM.(*ServiceBusQueueEventSubscriptionDestinationARM)
 		result.ServiceBusQueue = &serviceBusQueue
 	}
 
@@ -1419,7 +1419,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		serviceBusTopic := serviceBusTopicARM.(ServiceBusTopicEventSubscriptionDestinationARM)
+		serviceBusTopic := *serviceBusTopicARM.(*ServiceBusTopicEventSubscriptionDestinationARM)
 		result.ServiceBusTopic = &serviceBusTopic
 	}
 
@@ -1429,7 +1429,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		storageQueue := storageQueueARM.(StorageQueueEventSubscriptionDestinationARM)
+		storageQueue := *storageQueueARM.(*StorageQueueEventSubscriptionDestinationARM)
 		result.StorageQueue = &storageQueue
 	}
 
@@ -1439,7 +1439,7 @@ func (destination *EventSubscriptionDestination) ConvertToARM(resolved genruntim
 		if err != nil {
 			return nil, err
 		}
-		webHook := webHookARM.(WebHookEventSubscriptionDestinationARM)
+		webHook := *webHookARM.(*WebHookEventSubscriptionDestinationARM)
 		result.WebHook = &webHook
 	}
 	return result, nil
@@ -1827,7 +1827,7 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 	if filter == nil {
 		return nil, nil
 	}
-	var result EventSubscriptionFilterARM
+	result := &EventSubscriptionFilterARM{}
 
 	// Set property ‘AdvancedFilters’:
 	for _, item := range filter.AdvancedFilters {
@@ -1835,7 +1835,7 @@ func (filter *EventSubscriptionFilter) ConvertToARM(resolved genruntime.ConvertT
 		if err != nil {
 			return nil, err
 		}
-		result.AdvancedFilters = append(result.AdvancedFilters, itemARM.(AdvancedFilterARM))
+		result.AdvancedFilters = append(result.AdvancedFilters, *itemARM.(*AdvancedFilterARM))
 	}
 
 	// Set property ‘IncludedEventTypes’:
@@ -2216,7 +2216,7 @@ func (policy *RetryPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if policy == nil {
 		return nil, nil
 	}
-	var result RetryPolicyARM
+	result := &RetryPolicyARM{}
 
 	// Set property ‘EventTimeToLiveInMinutes’:
 	if policy.EventTimeToLiveInMinutes != nil {
@@ -2384,7 +2384,7 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 	if destination == nil {
 		return nil, nil
 	}
-	var result StorageBlobDeadLetterDestinationARM
+	result := &StorageBlobDeadLetterDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -2398,7 +2398,7 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(StorageBlobDeadLetterDestinationPropertiesARM)
+		properties := *propertiesARM.(*StorageBlobDeadLetterDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -2546,7 +2546,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if filter == nil {
 		return nil, nil
 	}
-	var result AdvancedFilterARM
+	result := &AdvancedFilterARM{}
 
 	// Set property ‘BoolEquals’:
 	if filter.BoolEquals != nil {
@@ -2554,7 +2554,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		boolEquals := boolEqualsARM.(AdvancedFilter_BoolEqualsARM)
+		boolEquals := *boolEqualsARM.(*AdvancedFilter_BoolEqualsARM)
 		result.BoolEquals = &boolEquals
 	}
 
@@ -2564,7 +2564,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberGreaterThan := numberGreaterThanARM.(AdvancedFilter_NumberGreaterThanARM)
+		numberGreaterThan := *numberGreaterThanARM.(*AdvancedFilter_NumberGreaterThanARM)
 		result.NumberGreaterThan = &numberGreaterThan
 	}
 
@@ -2574,7 +2574,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberGreaterThanOrEquals := numberGreaterThanOrEqualsARM.(AdvancedFilter_NumberGreaterThanOrEqualsARM)
+		numberGreaterThanOrEquals := *numberGreaterThanOrEqualsARM.(*AdvancedFilter_NumberGreaterThanOrEqualsARM)
 		result.NumberGreaterThanOrEquals = &numberGreaterThanOrEquals
 	}
 
@@ -2584,7 +2584,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberIn := numberInARM.(AdvancedFilter_NumberInARM)
+		numberIn := *numberInARM.(*AdvancedFilter_NumberInARM)
 		result.NumberIn = &numberIn
 	}
 
@@ -2594,7 +2594,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberLessThan := numberLessThanARM.(AdvancedFilter_NumberLessThanARM)
+		numberLessThan := *numberLessThanARM.(*AdvancedFilter_NumberLessThanARM)
 		result.NumberLessThan = &numberLessThan
 	}
 
@@ -2604,7 +2604,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberLessThanOrEquals := numberLessThanOrEqualsARM.(AdvancedFilter_NumberLessThanOrEqualsARM)
+		numberLessThanOrEquals := *numberLessThanOrEqualsARM.(*AdvancedFilter_NumberLessThanOrEqualsARM)
 		result.NumberLessThanOrEquals = &numberLessThanOrEquals
 	}
 
@@ -2614,7 +2614,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		numberNotIn := numberNotInARM.(AdvancedFilter_NumberNotInARM)
+		numberNotIn := *numberNotInARM.(*AdvancedFilter_NumberNotInARM)
 		result.NumberNotIn = &numberNotIn
 	}
 
@@ -2624,7 +2624,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringBeginsWith := stringBeginsWithARM.(AdvancedFilter_StringBeginsWithARM)
+		stringBeginsWith := *stringBeginsWithARM.(*AdvancedFilter_StringBeginsWithARM)
 		result.StringBeginsWith = &stringBeginsWith
 	}
 
@@ -2634,7 +2634,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringContains := stringContainsARM.(AdvancedFilter_StringContainsARM)
+		stringContains := *stringContainsARM.(*AdvancedFilter_StringContainsARM)
 		result.StringContains = &stringContains
 	}
 
@@ -2644,7 +2644,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringEndsWith := stringEndsWithARM.(AdvancedFilter_StringEndsWithARM)
+		stringEndsWith := *stringEndsWithARM.(*AdvancedFilter_StringEndsWithARM)
 		result.StringEndsWith = &stringEndsWith
 	}
 
@@ -2654,7 +2654,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringIn := stringInARM.(AdvancedFilter_StringInARM)
+		stringIn := *stringInARM.(*AdvancedFilter_StringInARM)
 		result.StringIn = &stringIn
 	}
 
@@ -2664,7 +2664,7 @@ func (filter *AdvancedFilter) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		stringNotIn := stringNotInARM.(AdvancedFilter_StringNotInARM)
+		stringNotIn := *stringNotInARM.(*AdvancedFilter_StringNotInARM)
 		result.StringNotIn = &stringNotIn
 	}
 	return result, nil
@@ -3228,7 +3228,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 	if destination == nil {
 		return nil, nil
 	}
-	var result AzureFunctionEventSubscriptionDestinationARM
+	result := &AzureFunctionEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3241,7 +3241,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(AzureFunctionEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*AzureFunctionEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3360,7 +3360,7 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 	if destination == nil {
 		return nil, nil
 	}
-	var result EventHubEventSubscriptionDestinationARM
+	result := &EventHubEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3373,7 +3373,7 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(EventHubEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*EventHubEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3500,7 +3500,7 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 	if destination == nil {
 		return nil, nil
 	}
-	var result HybridConnectionEventSubscriptionDestinationARM
+	result := &HybridConnectionEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3513,7 +3513,7 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(HybridConnectionEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*HybridConnectionEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3628,7 +3628,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 	if destination == nil {
 		return nil, nil
 	}
-	var result ServiceBusQueueEventSubscriptionDestinationARM
+	result := &ServiceBusQueueEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3641,7 +3641,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(ServiceBusQueueEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*ServiceBusQueueEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3756,7 +3756,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 	if destination == nil {
 		return nil, nil
 	}
-	var result ServiceBusTopicEventSubscriptionDestinationARM
+	result := &ServiceBusTopicEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -3769,7 +3769,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(ServiceBusTopicEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*ServiceBusTopicEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -3889,7 +3889,7 @@ func (properties *StorageBlobDeadLetterDestinationProperties) ConvertToARM(resol
 	if properties == nil {
 		return nil, nil
 	}
-	var result StorageBlobDeadLetterDestinationPropertiesARM
+	result := &StorageBlobDeadLetterDestinationPropertiesARM{}
 
 	// Set property ‘BlobContainerName’:
 	if properties.BlobContainerName != nil {
@@ -3994,7 +3994,7 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 	if destination == nil {
 		return nil, nil
 	}
-	var result StorageQueueEventSubscriptionDestinationARM
+	result := &StorageQueueEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -4007,7 +4007,7 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(StorageQueueEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*StorageQueueEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -4122,7 +4122,7 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 	if destination == nil {
 		return nil, nil
 	}
-	var result WebHookEventSubscriptionDestinationARM
+	result := &WebHookEventSubscriptionDestinationARM{}
 
 	// Set property ‘EndpointType’:
 	if destination.EndpointType != nil {
@@ -4135,7 +4135,7 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(WebHookEventSubscriptionDestinationPropertiesARM)
+		properties := *propertiesARM.(*WebHookEventSubscriptionDestinationPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -4269,7 +4269,7 @@ func (equals *AdvancedFilter_BoolEquals) ConvertToARM(resolved genruntime.Conver
 	if equals == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_BoolEqualsARM
+	result := &AdvancedFilter_BoolEqualsARM{}
 
 	// Set property ‘Key’:
 	if equals.Key != nil {
@@ -4400,7 +4400,7 @@ func (than *AdvancedFilter_NumberGreaterThan) ConvertToARM(resolved genruntime.C
 	if than == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberGreaterThanARM
+	result := &AdvancedFilter_NumberGreaterThanARM{}
 
 	// Set property ‘Key’:
 	if than.Key != nil {
@@ -4531,7 +4531,7 @@ func (equals *AdvancedFilter_NumberGreaterThanOrEquals) ConvertToARM(resolved ge
 	if equals == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberGreaterThanOrEqualsARM
+	result := &AdvancedFilter_NumberGreaterThanOrEqualsARM{}
 
 	// Set property ‘Key’:
 	if equals.Key != nil {
@@ -4662,7 +4662,7 @@ func (numberIn *AdvancedFilter_NumberIn) ConvertToARM(resolved genruntime.Conver
 	if numberIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberInARM
+	result := &AdvancedFilter_NumberInARM{}
 
 	// Set property ‘Key’:
 	if numberIn.Key != nil {
@@ -4801,7 +4801,7 @@ func (than *AdvancedFilter_NumberLessThan) ConvertToARM(resolved genruntime.Conv
 	if than == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberLessThanARM
+	result := &AdvancedFilter_NumberLessThanARM{}
 
 	// Set property ‘Key’:
 	if than.Key != nil {
@@ -4932,7 +4932,7 @@ func (equals *AdvancedFilter_NumberLessThanOrEquals) ConvertToARM(resolved genru
 	if equals == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberLessThanOrEqualsARM
+	result := &AdvancedFilter_NumberLessThanOrEqualsARM{}
 
 	// Set property ‘Key’:
 	if equals.Key != nil {
@@ -5063,7 +5063,7 @@ func (notIn *AdvancedFilter_NumberNotIn) ConvertToARM(resolved genruntime.Conver
 	if notIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_NumberNotInARM
+	result := &AdvancedFilter_NumberNotInARM{}
 
 	// Set property ‘Key’:
 	if notIn.Key != nil {
@@ -5202,7 +5202,7 @@ func (with *AdvancedFilter_StringBeginsWith) ConvertToARM(resolved genruntime.Co
 	if with == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringBeginsWithARM
+	result := &AdvancedFilter_StringBeginsWithARM{}
 
 	// Set property ‘Key’:
 	if with.Key != nil {
@@ -5321,7 +5321,7 @@ func (contains *AdvancedFilter_StringContains) ConvertToARM(resolved genruntime.
 	if contains == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringContainsARM
+	result := &AdvancedFilter_StringContainsARM{}
 
 	// Set property ‘Key’:
 	if contains.Key != nil {
@@ -5440,7 +5440,7 @@ func (with *AdvancedFilter_StringEndsWith) ConvertToARM(resolved genruntime.Conv
 	if with == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringEndsWithARM
+	result := &AdvancedFilter_StringEndsWithARM{}
 
 	// Set property ‘Key’:
 	if with.Key != nil {
@@ -5559,7 +5559,7 @@ func (stringIn *AdvancedFilter_StringIn) ConvertToARM(resolved genruntime.Conver
 	if stringIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringInARM
+	result := &AdvancedFilter_StringInARM{}
 
 	// Set property ‘Key’:
 	if stringIn.Key != nil {
@@ -5678,7 +5678,7 @@ func (notIn *AdvancedFilter_StringNotIn) ConvertToARM(resolved genruntime.Conver
 	if notIn == nil {
 		return nil, nil
 	}
-	var result AdvancedFilter_StringNotInARM
+	result := &AdvancedFilter_StringNotInARM{}
 
 	// Set property ‘Key’:
 	if notIn.Key != nil {
@@ -5804,7 +5804,7 @@ func (properties *AzureFunctionEventSubscriptionDestinationProperties) ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result AzureFunctionEventSubscriptionDestinationPropertiesARM
+	result := &AzureFunctionEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘MaxEventsPerBatch’:
 	if properties.MaxEventsPerBatch != nil {
@@ -5930,7 +5930,7 @@ func (properties *EventHubEventSubscriptionDestinationProperties) ConvertToARM(r
 	if properties == nil {
 		return nil, nil
 	}
-	var result EventHubEventSubscriptionDestinationPropertiesARM
+	result := &EventHubEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -6019,7 +6019,7 @@ func (properties *HybridConnectionEventSubscriptionDestinationProperties) Conver
 	if properties == nil {
 		return nil, nil
 	}
-	var result HybridConnectionEventSubscriptionDestinationPropertiesARM
+	result := &HybridConnectionEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -6109,7 +6109,7 @@ func (properties *ServiceBusQueueEventSubscriptionDestinationProperties) Convert
 	if properties == nil {
 		return nil, nil
 	}
-	var result ServiceBusQueueEventSubscriptionDestinationPropertiesARM
+	result := &ServiceBusQueueEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -6199,7 +6199,7 @@ func (properties *ServiceBusTopicEventSubscriptionDestinationProperties) Convert
 	if properties == nil {
 		return nil, nil
 	}
-	var result ServiceBusTopicEventSubscriptionDestinationPropertiesARM
+	result := &ServiceBusTopicEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘ResourceId’:
 	if properties.ResourceReference != nil {
@@ -6292,7 +6292,7 @@ func (properties *StorageQueueEventSubscriptionDestinationProperties) ConvertToA
 	if properties == nil {
 		return nil, nil
 	}
-	var result StorageQueueEventSubscriptionDestinationPropertiesARM
+	result := &StorageQueueEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘QueueName’:
 	if properties.QueueName != nil {
@@ -6413,7 +6413,7 @@ func (properties *WebHookEventSubscriptionDestinationProperties) ConvertToARM(re
 	if properties == nil {
 		return nil, nil
 	}
-	var result WebHookEventSubscriptionDestinationPropertiesARM
+	result := &WebHookEventSubscriptionDestinationPropertiesARM{}
 
 	// Set property ‘AzureActiveDirectoryApplicationIdOrUri’:
 	if properties.AzureActiveDirectoryApplicationIdOrUri != nil {

--- a/v2/api/eventgrid/v1beta20200601/event_subscriptions__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscriptions__spec_arm_types_gen.go
@@ -31,12 +31,12 @@ func (subscriptions EventSubscriptions_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (subscriptions EventSubscriptions_SpecARM) GetName() string {
+func (subscriptions *EventSubscriptions_SpecARM) GetName() string {
 	return subscriptions.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/eventSubscriptions"
-func (subscriptions EventSubscriptions_SpecARM) GetType() string {
+func (subscriptions *EventSubscriptions_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/eventSubscriptions"
 }
 

--- a/v2/api/eventgrid/v1beta20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/topic_types_gen.go
@@ -828,7 +828,7 @@ func (topics *Topics_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if topics == nil {
 		return nil, nil
 	}
-	var result Topics_SpecARM
+	result := &Topics_SpecARM{}
 
 	// Set property ‘Location’:
 	if topics.Location != nil {

--- a/v2/api/eventgrid/v1beta20200601/topics__spec_arm_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/topics__spec_arm_types_gen.go
@@ -24,11 +24,11 @@ func (topics Topics_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (topics Topics_SpecARM) GetName() string {
+func (topics *Topics_SpecARM) GetName() string {
 	return topics.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventGrid/topics"
-func (topics Topics_SpecARM) GetType() string {
+func (topics *Topics_SpecARM) GetType() string {
 	return "Microsoft.EventGrid/topics"
 }

--- a/v2/api/eventhub/v1alpha1api20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespace_types_gen.go
@@ -990,7 +990,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if namespaces == nil {
 		return nil, nil
 	}
-	var result Namespaces_SpecARM
+	result := &Namespaces_SpecARM{}
 
 	// Set property ‘Identity’:
 	if namespaces.Identity != nil {
@@ -998,7 +998,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityARM)
+		identity := *identityARM.(*IdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1044,7 +1044,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if namespaces.IsAutoInflateEnabled != nil {
@@ -1064,7 +1064,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.PrivateEndpointConnections = append(result.Properties.PrivateEndpointConnections, itemARM.(Namespaces_Spec_Properties_PrivateEndpointConnectionsARM))
+		result.Properties.PrivateEndpointConnections = append(result.Properties.PrivateEndpointConnections, *itemARM.(*Namespaces_Spec_Properties_PrivateEndpointConnectionsARM))
 	}
 	if namespaces.ZoneRedundant != nil {
 		zoneRedundant := *namespaces.ZoneRedundant
@@ -1077,7 +1077,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1566,7 +1566,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘KeySource’:
 	if encryption.KeySource != nil {
@@ -1580,7 +1580,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.KeyVaultProperties = append(result.KeyVaultProperties, itemARM.(KeyVaultPropertiesARM))
+		result.KeyVaultProperties = append(result.KeyVaultProperties, *itemARM.(*KeyVaultPropertiesARM))
 	}
 
 	// Set property ‘RequireInfrastructureEncryption’:
@@ -1870,7 +1870,7 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if identity == nil {
 		return nil, nil
 	}
-	var result IdentityARM
+	result := &IdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -2097,7 +2097,7 @@ func (connections *Namespaces_Spec_Properties_PrivateEndpointConnections) Conver
 	if connections == nil {
 		return nil, nil
 	}
-	var result Namespaces_Spec_Properties_PrivateEndpointConnectionsARM
+	result := &Namespaces_Spec_Properties_PrivateEndpointConnectionsARM{}
 
 	// Set property ‘Properties’:
 	if connections.PrivateEndpoint != nil {
@@ -2108,7 +2108,7 @@ func (connections *Namespaces_Spec_Properties_PrivateEndpointConnections) Conver
 		if err != nil {
 			return nil, err
 		}
-		privateEndpoint := privateEndpointARM.(PrivateEndpointARM)
+		privateEndpoint := *privateEndpointARM.(*PrivateEndpointARM)
 		result.Properties.PrivateEndpoint = &privateEndpoint
 	}
 	return result, nil
@@ -2302,7 +2302,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {
@@ -2697,7 +2697,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Identity’:
 	if properties.Identity != nil {
@@ -2705,7 +2705,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(UserAssignedIdentityPropertiesARM)
+		identity := *identityARM.(*UserAssignedIdentityPropertiesARM)
 		result.Identity = &identity
 	}
 
@@ -2971,7 +2971,7 @@ func (endpoint *PrivateEndpoint) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if endpoint == nil {
 		return nil, nil
 	}
-	var result PrivateEndpointARM
+	result := &PrivateEndpointARM{}
 
 	// Set property ‘Id’:
 	if endpoint.Reference != nil {
@@ -3125,7 +3125,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	if properties == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentityPropertiesARM
+	result := &UserAssignedIdentityPropertiesARM{}
 
 	// Set property ‘UserAssignedIdentity’:
 	if properties.UserAssignedIdentityReference != nil {

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces__spec_arm_types_gen.go
@@ -23,12 +23,12 @@ func (namespaces Namespaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (namespaces Namespaces_SpecARM) GetName() string {
+func (namespaces *Namespaces_SpecARM) GetName() string {
 	return namespaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces"
-func (namespaces Namespaces_SpecARM) GetType() string {
+func (namespaces *Namespaces_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces"
 }
 

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
@@ -584,7 +584,7 @@ func (rules *NamespacesAuthorizationRules_Spec) ConvertToARM(resolved genruntime
 	if rules == nil {
 		return nil, nil
 	}
-	var result NamespacesAuthorizationRules_SpecARM
+	result := &NamespacesAuthorizationRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rules__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rules__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (rules NamespacesAuthorizationRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules NamespacesAuthorizationRules_SpecARM) GetName() string {
+func (rules *NamespacesAuthorizationRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/authorizationRules"
-func (rules NamespacesAuthorizationRules_SpecARM) GetType() string {
+func (rules *NamespacesAuthorizationRules_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/authorizationRules"
 }
 

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
@@ -699,7 +699,7 @@ func (eventhubs *NamespacesEventhubs_Spec) ConvertToARM(resolved genruntime.Conv
 	if eventhubs == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubs_SpecARM
+	result := &NamespacesEventhubs_SpecARM{}
 
 	// Set property ‘Location’:
 	if eventhubs.Location != nil {
@@ -721,7 +721,7 @@ func (eventhubs *NamespacesEventhubs_Spec) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		captureDescription := captureDescriptionARM.(NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM)
+		captureDescription := *captureDescriptionARM.(*NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM)
 		result.Properties.CaptureDescription = &captureDescription
 	}
 	if eventhubs.MessageRetentionInDays != nil {
@@ -1182,7 +1182,7 @@ func (description *NamespacesEventhubs_Spec_Properties_CaptureDescription) Conve
 	if description == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM
+	result := &NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM{}
 
 	// Set property ‘Destination’:
 	if description.Destination != nil {
@@ -1190,7 +1190,7 @@ func (description *NamespacesEventhubs_Spec_Properties_CaptureDescription) Conve
 		if err != nil {
 			return nil, err
 		}
-		destination := destinationARM.(NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM)
+		destination := *destinationARM.(*NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM)
 		result.Destination = &destination
 	}
 
@@ -1574,7 +1574,7 @@ func (destination *NamespacesEventhubs_Spec_Properties_CaptureDescription_Destin
 	if destination == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM
+	result := &NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM{}
 
 	// Set property ‘Name’:
 	if destination.Name != nil {

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (eventhubs NamespacesEventhubs_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (eventhubs NamespacesEventhubs_SpecARM) GetName() string {
+func (eventhubs *NamespacesEventhubs_SpecARM) GetName() string {
 	return eventhubs.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/eventhubs"
-func (eventhubs NamespacesEventhubs_SpecARM) GetType() string {
+func (eventhubs *NamespacesEventhubs_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/eventhubs"
 }
 

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -356,7 +356,7 @@ func (rules *NamespacesEventhubsAuthorizationRules_Spec) ConvertToARM(resolved g
 	if rules == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubsAuthorizationRules_SpecARM
+	result := &NamespacesEventhubsAuthorizationRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rules__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rules__spec_arm_types_gen.go
@@ -21,11 +21,11 @@ func (rules NamespacesEventhubsAuthorizationRules_SpecARM) GetAPIVersion() strin
 }
 
 // GetName returns the Name of the resource
-func (rules NamespacesEventhubsAuthorizationRules_SpecARM) GetName() string {
+func (rules *NamespacesEventhubsAuthorizationRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/eventhubs/authorizationRules"
-func (rules NamespacesEventhubsAuthorizationRules_SpecARM) GetType() string {
+func (rules *NamespacesEventhubsAuthorizationRules_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/eventhubs/authorizationRules"
 }

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -596,7 +596,7 @@ func (consumergroups *NamespacesEventhubsConsumergroups_Spec) ConvertToARM(resol
 	if consumergroups == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubsConsumergroups_SpecARM
+	result := &NamespacesEventhubsConsumergroups_SpecARM{}
 
 	// Set property ‘Location’:
 	if consumergroups.Location != nil {

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumergroups__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumergroups__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (consumergroups NamespacesEventhubsConsumergroups_SpecARM) GetAPIVersion() 
 }
 
 // GetName returns the Name of the resource
-func (consumergroups NamespacesEventhubsConsumergroups_SpecARM) GetName() string {
+func (consumergroups *NamespacesEventhubsConsumergroups_SpecARM) GetName() string {
 	return consumergroups.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/eventhubs/consumergroups"
-func (consumergroups NamespacesEventhubsConsumergroups_SpecARM) GetType() string {
+func (consumergroups *NamespacesEventhubsConsumergroups_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/eventhubs/consumergroups"
 }
 

--- a/v2/api/eventhub/v1beta20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespace_types_gen.go
@@ -1047,7 +1047,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if namespaces == nil {
 		return nil, nil
 	}
-	var result Namespaces_SpecARM
+	result := &Namespaces_SpecARM{}
 
 	// Set property ‘Identity’:
 	if namespaces.Identity != nil {
@@ -1055,7 +1055,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityARM)
+		identity := *identityARM.(*IdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1101,7 +1101,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if namespaces.IsAutoInflateEnabled != nil {
@@ -1121,7 +1121,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.PrivateEndpointConnections = append(result.Properties.PrivateEndpointConnections, itemARM.(Namespaces_Spec_Properties_PrivateEndpointConnectionsARM))
+		result.Properties.PrivateEndpointConnections = append(result.Properties.PrivateEndpointConnections, *itemARM.(*Namespaces_Spec_Properties_PrivateEndpointConnectionsARM))
 	}
 	if namespaces.ZoneRedundant != nil {
 		zoneRedundant := *namespaces.ZoneRedundant
@@ -1134,7 +1134,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -1628,7 +1628,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘KeySource’:
 	if encryption.KeySource != nil {
@@ -1642,7 +1642,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.KeyVaultProperties = append(result.KeyVaultProperties, itemARM.(KeyVaultPropertiesARM))
+		result.KeyVaultProperties = append(result.KeyVaultProperties, *itemARM.(*KeyVaultPropertiesARM))
 	}
 
 	// Set property ‘RequireInfrastructureEncryption’:
@@ -1937,7 +1937,7 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if identity == nil {
 		return nil, nil
 	}
-	var result IdentityARM
+	result := &IdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -2170,7 +2170,7 @@ func (connections *Namespaces_Spec_Properties_PrivateEndpointConnections) Conver
 	if connections == nil {
 		return nil, nil
 	}
-	var result Namespaces_Spec_Properties_PrivateEndpointConnectionsARM
+	result := &Namespaces_Spec_Properties_PrivateEndpointConnectionsARM{}
 
 	// Set property ‘Properties’:
 	if connections.PrivateEndpoint != nil {
@@ -2181,7 +2181,7 @@ func (connections *Namespaces_Spec_Properties_PrivateEndpointConnections) Conver
 		if err != nil {
 			return nil, err
 		}
-		privateEndpoint := privateEndpointARM.(PrivateEndpointARM)
+		privateEndpoint := *privateEndpointARM.(*PrivateEndpointARM)
 		result.Properties.PrivateEndpoint = &privateEndpoint
 	}
 	return result, nil
@@ -2383,7 +2383,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Capacity’:
 	if sku.Capacity != nil {
@@ -2798,7 +2798,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Identity’:
 	if properties.Identity != nil {
@@ -2806,7 +2806,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(UserAssignedIdentityPropertiesARM)
+		identity := *identityARM.(*UserAssignedIdentityPropertiesARM)
 		result.Identity = &identity
 	}
 
@@ -3078,7 +3078,7 @@ func (endpoint *PrivateEndpoint) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if endpoint == nil {
 		return nil, nil
 	}
-	var result PrivateEndpointARM
+	result := &PrivateEndpointARM{}
 
 	// Set property ‘Id’:
 	if endpoint.Reference != nil {
@@ -3235,7 +3235,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	if properties == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentityPropertiesARM
+	result := &UserAssignedIdentityPropertiesARM{}
 
 	// Set property ‘UserAssignedIdentity’:
 	if properties.UserAssignedIdentityReference != nil {

--- a/v2/api/eventhub/v1beta20211101/namespaces__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces__spec_arm_types_gen.go
@@ -33,12 +33,12 @@ func (namespaces Namespaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (namespaces Namespaces_SpecARM) GetName() string {
+func (namespaces *Namespaces_SpecARM) GetName() string {
 	return namespaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces"
-func (namespaces Namespaces_SpecARM) GetType() string {
+func (namespaces *Namespaces_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces"
 }
 

--- a/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen.go
@@ -587,7 +587,7 @@ func (rules *NamespacesAuthorizationRules_Spec) ConvertToARM(resolved genruntime
 	if rules == nil {
 		return nil, nil
 	}
-	var result NamespacesAuthorizationRules_SpecARM
+	result := &NamespacesAuthorizationRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/eventhub/v1beta20211101/namespaces_authorization_rules__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_authorization_rules__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (rules NamespacesAuthorizationRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules NamespacesAuthorizationRules_SpecARM) GetName() string {
+func (rules *NamespacesAuthorizationRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/authorizationRules"
-func (rules NamespacesAuthorizationRules_SpecARM) GetType() string {
+func (rules *NamespacesAuthorizationRules_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/authorizationRules"
 }
 

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen.go
@@ -716,7 +716,7 @@ func (eventhubs *NamespacesEventhubs_Spec) ConvertToARM(resolved genruntime.Conv
 	if eventhubs == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubs_SpecARM
+	result := &NamespacesEventhubs_SpecARM{}
 
 	// Set property ‘Location’:
 	if eventhubs.Location != nil {
@@ -738,7 +738,7 @@ func (eventhubs *NamespacesEventhubs_Spec) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		captureDescription := captureDescriptionARM.(NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM)
+		captureDescription := *captureDescriptionARM.(*NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM)
 		result.Properties.CaptureDescription = &captureDescription
 	}
 	if eventhubs.MessageRetentionInDays != nil {
@@ -1225,7 +1225,7 @@ func (description *NamespacesEventhubs_Spec_Properties_CaptureDescription) Conve
 	if description == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM
+	result := &NamespacesEventhubs_Spec_Properties_CaptureDescriptionARM{}
 
 	// Set property ‘Destination’:
 	if description.Destination != nil {
@@ -1233,7 +1233,7 @@ func (description *NamespacesEventhubs_Spec_Properties_CaptureDescription) Conve
 		if err != nil {
 			return nil, err
 		}
-		destination := destinationARM.(NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM)
+		destination := *destinationARM.(*NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM)
 		result.Destination = &destination
 	}
 
@@ -1642,7 +1642,7 @@ func (destination *NamespacesEventhubs_Spec_Properties_CaptureDescription_Destin
 	if destination == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM
+	result := &NamespacesEventhubs_Spec_Properties_CaptureDescription_DestinationARM{}
 
 	// Set property ‘Name’:
 	if destination.Name != nil {

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (eventhubs NamespacesEventhubs_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (eventhubs NamespacesEventhubs_SpecARM) GetName() string {
+func (eventhubs *NamespacesEventhubs_SpecARM) GetName() string {
 	return eventhubs.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/eventhubs"
-func (eventhubs NamespacesEventhubs_SpecARM) GetType() string {
+func (eventhubs *NamespacesEventhubs_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/eventhubs"
 }
 

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -347,7 +347,7 @@ func (rules *NamespacesEventhubsAuthorizationRules_Spec) ConvertToARM(resolved g
 	if rules == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubsAuthorizationRules_SpecARM
+	result := &NamespacesEventhubsAuthorizationRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rules__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rules__spec_arm_types_gen.go
@@ -27,11 +27,11 @@ func (rules NamespacesEventhubsAuthorizationRules_SpecARM) GetAPIVersion() strin
 }
 
 // GetName returns the Name of the resource
-func (rules NamespacesEventhubsAuthorizationRules_SpecARM) GetName() string {
+func (rules *NamespacesEventhubsAuthorizationRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/eventhubs/authorizationRules"
-func (rules NamespacesEventhubsAuthorizationRules_SpecARM) GetType() string {
+func (rules *NamespacesEventhubsAuthorizationRules_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/eventhubs/authorizationRules"
 }

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -608,7 +608,7 @@ func (consumergroups *NamespacesEventhubsConsumergroups_Spec) ConvertToARM(resol
 	if consumergroups == nil {
 		return nil, nil
 	}
-	var result NamespacesEventhubsConsumergroups_SpecARM
+	result := &NamespacesEventhubsConsumergroups_SpecARM{}
 
 	// Set property ‘Location’:
 	if consumergroups.Location != nil {

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumergroups__spec_arm_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumergroups__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (consumergroups NamespacesEventhubsConsumergroups_SpecARM) GetAPIVersion() 
 }
 
 // GetName returns the Name of the resource
-func (consumergroups NamespacesEventhubsConsumergroups_SpecARM) GetName() string {
+func (consumergroups *NamespacesEventhubsConsumergroups_SpecARM) GetName() string {
 	return consumergroups.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.EventHub/namespaces/eventhubs/consumergroups"
-func (consumergroups NamespacesEventhubsConsumergroups_SpecARM) GetType() string {
+func (consumergroups *NamespacesEventhubsConsumergroups_SpecARM) GetType() string {
 	return "Microsoft.EventHub/namespaces/eventhubs/consumergroups"
 }
 

--- a/v2/api/insights/v1alpha1api20180501preview/webtest_types_gen.go
+++ b/v2/api/insights/v1alpha1api20180501preview/webtest_types_gen.go
@@ -900,7 +900,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if webtests == nil {
 		return nil, nil
 	}
-	var result Webtests_SpecARM
+	result := &Webtests_SpecARM{}
 
 	// Set property ‘Location’:
 	if webtests.Location != nil {
@@ -931,7 +931,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		configuration := configurationARM.(WebTestPropertiesConfigurationARM)
+		configuration := *configurationARM.(*WebTestPropertiesConfigurationARM)
 		result.Properties.Configuration = &configuration
 	}
 	if webtests.Description != nil {
@@ -955,7 +955,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Locations = append(result.Properties.Locations, itemARM.(WebTestGeolocationARM))
+		result.Properties.Locations = append(result.Properties.Locations, *itemARM.(*WebTestGeolocationARM))
 	}
 	if webtests.Name != nil {
 		name := *webtests.Name
@@ -966,7 +966,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		request := requestARM.(WebTestPropertiesRequestARM)
+		request := *requestARM.(*WebTestPropertiesRequestARM)
 		result.Properties.Request = &request
 	}
 	if webtests.RetryEnabled != nil {
@@ -986,7 +986,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		validationRules := validationRulesARM.(WebTestPropertiesValidationRulesARM)
+		validationRules := *validationRulesARM.(*WebTestPropertiesValidationRulesARM)
 		result.Properties.ValidationRules = &validationRules
 	}
 
@@ -1481,7 +1481,7 @@ func (geolocation *WebTestGeolocation) ConvertToARM(resolved genruntime.ConvertT
 	if geolocation == nil {
 		return nil, nil
 	}
-	var result WebTestGeolocationARM
+	result := &WebTestGeolocationARM{}
 
 	// Set property ‘Id’:
 	if geolocation.Id != nil {
@@ -1612,7 +1612,7 @@ func (configuration *WebTestPropertiesConfiguration) ConvertToARM(resolved genru
 	if configuration == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesConfigurationARM
+	result := &WebTestPropertiesConfigurationARM{}
 
 	// Set property ‘WebTest’:
 	if configuration.WebTest != nil {
@@ -1701,7 +1701,7 @@ func (request *WebTestPropertiesRequest) ConvertToARM(resolved genruntime.Conver
 	if request == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesRequestARM
+	result := &WebTestPropertiesRequestARM{}
 
 	// Set property ‘FollowRedirects’:
 	if request.FollowRedirects != nil {
@@ -1715,7 +1715,7 @@ func (request *WebTestPropertiesRequest) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Headers = append(result.Headers, itemARM.(HeaderFieldARM))
+		result.Headers = append(result.Headers, *itemARM.(*HeaderFieldARM))
 	}
 
 	// Set property ‘HttpVerb’:
@@ -1925,7 +1925,7 @@ func (rules *WebTestPropertiesValidationRules) ConvertToARM(resolved genruntime.
 	if rules == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesValidationRulesARM
+	result := &WebTestPropertiesValidationRulesARM{}
 
 	// Set property ‘ContentValidation’:
 	if rules.ContentValidation != nil {
@@ -1933,7 +1933,7 @@ func (rules *WebTestPropertiesValidationRules) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		contentValidation := contentValidationARM.(WebTestPropertiesValidationRulesContentValidationARM)
+		contentValidation := *contentValidationARM.(*WebTestPropertiesValidationRulesContentValidationARM)
 		result.ContentValidation = &contentValidation
 	}
 
@@ -2506,7 +2506,7 @@ func (field *HeaderField) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if field == nil {
 		return nil, nil
 	}
-	var result HeaderFieldARM
+	result := &HeaderFieldARM{}
 
 	// Set property ‘Key’:
 	if field.Key != nil {
@@ -2670,7 +2670,7 @@ func (validation *WebTestPropertiesValidationRulesContentValidation) ConvertToAR
 	if validation == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesValidationRulesContentValidationARM
+	result := &WebTestPropertiesValidationRulesContentValidationARM{}
 
 	// Set property ‘ContentMatch’:
 	if validation.ContentMatch != nil {

--- a/v2/api/insights/v1alpha1api20180501preview/webtests__spec_arm_types_gen.go
+++ b/v2/api/insights/v1alpha1api20180501preview/webtests__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (webtests Webtests_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (webtests Webtests_SpecARM) GetName() string {
+func (webtests *Webtests_SpecARM) GetName() string {
 	return webtests.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Insights/webtests"
-func (webtests Webtests_SpecARM) GetType() string {
+func (webtests *Webtests_SpecARM) GetType() string {
 	return "Microsoft.Insights/webtests"
 }
 

--- a/v2/api/insights/v1alpha1api20200202/component_types_gen.go
+++ b/v2/api/insights/v1alpha1api20200202/component_types_gen.go
@@ -1130,7 +1130,7 @@ func (components *Components_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if components == nil {
 		return nil, nil
 	}
-	var result Components_SpecARM
+	result := &Components_SpecARM{}
 
 	// Set property ‘Etag’:
 	if components.Etag != nil {

--- a/v2/api/insights/v1alpha1api20200202/components__spec_arm_types_gen.go
+++ b/v2/api/insights/v1alpha1api20200202/components__spec_arm_types_gen.go
@@ -23,12 +23,12 @@ func (components Components_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (components Components_SpecARM) GetName() string {
+func (components *Components_SpecARM) GetName() string {
 	return components.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Insights/components"
-func (components Components_SpecARM) GetType() string {
+func (components *Components_SpecARM) GetType() string {
 	return "Microsoft.Insights/components"
 }
 

--- a/v2/api/insights/v1beta20180501preview/webtest_types_gen.go
+++ b/v2/api/insights/v1beta20180501preview/webtest_types_gen.go
@@ -948,7 +948,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if webtests == nil {
 		return nil, nil
 	}
-	var result Webtests_SpecARM
+	result := &Webtests_SpecARM{}
 
 	// Set property ‘Location’:
 	if webtests.Location != nil {
@@ -979,7 +979,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		configuration := configurationARM.(WebTestPropertiesConfigurationARM)
+		configuration := *configurationARM.(*WebTestPropertiesConfigurationARM)
 		result.Properties.Configuration = &configuration
 	}
 	if webtests.Description != nil {
@@ -1003,7 +1003,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Locations = append(result.Properties.Locations, itemARM.(WebTestGeolocationARM))
+		result.Properties.Locations = append(result.Properties.Locations, *itemARM.(*WebTestGeolocationARM))
 	}
 	if webtests.Name != nil {
 		name := *webtests.Name
@@ -1014,7 +1014,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		request := requestARM.(WebTestPropertiesRequestARM)
+		request := *requestARM.(*WebTestPropertiesRequestARM)
 		result.Properties.Request = &request
 	}
 	if webtests.RetryEnabled != nil {
@@ -1034,7 +1034,7 @@ func (webtests *Webtests_Spec) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		validationRules := validationRulesARM.(WebTestPropertiesValidationRulesARM)
+		validationRules := *validationRulesARM.(*WebTestPropertiesValidationRulesARM)
 		result.Properties.ValidationRules = &validationRules
 	}
 
@@ -1530,7 +1530,7 @@ func (geolocation *WebTestGeolocation) ConvertToARM(resolved genruntime.ConvertT
 	if geolocation == nil {
 		return nil, nil
 	}
-	var result WebTestGeolocationARM
+	result := &WebTestGeolocationARM{}
 
 	// Set property ‘Id’:
 	if geolocation.Id != nil {
@@ -1662,7 +1662,7 @@ func (configuration *WebTestPropertiesConfiguration) ConvertToARM(resolved genru
 	if configuration == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesConfigurationARM
+	result := &WebTestPropertiesConfigurationARM{}
 
 	// Set property ‘WebTest’:
 	if configuration.WebTest != nil {
@@ -1761,7 +1761,7 @@ func (request *WebTestPropertiesRequest) ConvertToARM(resolved genruntime.Conver
 	if request == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesRequestARM
+	result := &WebTestPropertiesRequestARM{}
 
 	// Set property ‘FollowRedirects’:
 	if request.FollowRedirects != nil {
@@ -1775,7 +1775,7 @@ func (request *WebTestPropertiesRequest) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Headers = append(result.Headers, itemARM.(HeaderFieldARM))
+		result.Headers = append(result.Headers, *itemARM.(*HeaderFieldARM))
 	}
 
 	// Set property ‘HttpVerb’:
@@ -1995,7 +1995,7 @@ func (rules *WebTestPropertiesValidationRules) ConvertToARM(resolved genruntime.
 	if rules == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesValidationRulesARM
+	result := &WebTestPropertiesValidationRulesARM{}
 
 	// Set property ‘ContentValidation’:
 	if rules.ContentValidation != nil {
@@ -2003,7 +2003,7 @@ func (rules *WebTestPropertiesValidationRules) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		contentValidation := contentValidationARM.(WebTestPropertiesValidationRulesContentValidationARM)
+		contentValidation := *contentValidationARM.(*WebTestPropertiesValidationRulesContentValidationARM)
 		result.ContentValidation = &contentValidation
 	}
 
@@ -2598,7 +2598,7 @@ func (field *HeaderField) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if field == nil {
 		return nil, nil
 	}
-	var result HeaderFieldARM
+	result := &HeaderFieldARM{}
 
 	// Set property ‘Key’:
 	if field.Key != nil {
@@ -2770,7 +2770,7 @@ func (validation *WebTestPropertiesValidationRulesContentValidation) ConvertToAR
 	if validation == nil {
 		return nil, nil
 	}
-	var result WebTestPropertiesValidationRulesContentValidationARM
+	result := &WebTestPropertiesValidationRulesContentValidationARM{}
 
 	// Set property ‘ContentMatch’:
 	if validation.ContentMatch != nil {

--- a/v2/api/insights/v1beta20180501preview/webtests__spec_arm_types_gen.go
+++ b/v2/api/insights/v1beta20180501preview/webtests__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (webtests Webtests_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (webtests Webtests_SpecARM) GetName() string {
+func (webtests *Webtests_SpecARM) GetName() string {
 	return webtests.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Insights/webtests"
-func (webtests Webtests_SpecARM) GetType() string {
+func (webtests *Webtests_SpecARM) GetType() string {
 	return "Microsoft.Insights/webtests"
 }
 

--- a/v2/api/insights/v1beta20200202/component_types_gen.go
+++ b/v2/api/insights/v1beta20200202/component_types_gen.go
@@ -1227,7 +1227,7 @@ func (components *Components_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if components == nil {
 		return nil, nil
 	}
-	var result Components_SpecARM
+	result := &Components_SpecARM{}
 
 	// Set property ‘Etag’:
 	if components.Etag != nil {

--- a/v2/api/insights/v1beta20200202/components__spec_arm_types_gen.go
+++ b/v2/api/insights/v1beta20200202/components__spec_arm_types_gen.go
@@ -34,12 +34,12 @@ func (components Components_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (components Components_SpecARM) GetName() string {
+func (components *Components_SpecARM) GetName() string {
 	return components.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Insights/components"
-func (components Components_SpecARM) GetType() string {
+func (components *Components_SpecARM) GetType() string {
 	return "Microsoft.Insights/components"
 }
 

--- a/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identities__spec_arm_types_gen.go
+++ b/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identities__spec_arm_types_gen.go
@@ -20,11 +20,11 @@ func (identities UserAssignedIdentities_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (identities UserAssignedIdentities_SpecARM) GetName() string {
+func (identities *UserAssignedIdentities_SpecARM) GetName() string {
 	return identities.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ManagedIdentity/userAssignedIdentities"
-func (identities UserAssignedIdentities_SpecARM) GetType() string {
+func (identities *UserAssignedIdentities_SpecARM) GetType() string {
 	return "Microsoft.ManagedIdentity/userAssignedIdentities"
 }

--- a/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
@@ -579,7 +579,7 @@ func (identities *UserAssignedIdentities_Spec) ConvertToARM(resolved genruntime.
 	if identities == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentities_SpecARM
+	result := &UserAssignedIdentities_SpecARM{}
 
 	// Set property ‘Location’:
 	if identities.Location != nil {

--- a/v2/api/managedidentity/v1beta20181130/user_assigned_identities__spec_arm_types_gen.go
+++ b/v2/api/managedidentity/v1beta20181130/user_assigned_identities__spec_arm_types_gen.go
@@ -24,11 +24,11 @@ func (identities UserAssignedIdentities_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (identities UserAssignedIdentities_SpecARM) GetName() string {
+func (identities *UserAssignedIdentities_SpecARM) GetName() string {
 	return identities.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ManagedIdentity/userAssignedIdentities"
-func (identities UserAssignedIdentities_SpecARM) GetType() string {
+func (identities *UserAssignedIdentities_SpecARM) GetType() string {
 	return "Microsoft.ManagedIdentity/userAssignedIdentities"
 }

--- a/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen.go
@@ -583,7 +583,7 @@ func (identities *UserAssignedIdentities_Spec) ConvertToARM(resolved genruntime.
 	if identities == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentities_SpecARM
+	result := &UserAssignedIdentities_SpecARM{}
 
 	// Set property ‘Location’:
 	if identities.Location != nil {

--- a/v2/api/network/v1alpha1api20201101/load_balancer_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/load_balancer_types_gen.go
@@ -1016,7 +1016,7 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if balancers == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_SpecARM
+	result := &LoadBalancers_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if balancers.ExtendedLocation != nil {
@@ -1024,7 +1024,7 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1051,42 +1051,42 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.BackendAddressPools = append(result.Properties.BackendAddressPools, itemARM.(LoadBalancers_Spec_Properties_BackendAddressPoolsARM))
+		result.Properties.BackendAddressPools = append(result.Properties.BackendAddressPools, *itemARM.(*LoadBalancers_Spec_Properties_BackendAddressPoolsARM))
 	}
 	for _, item := range balancers.FrontendIPConfigurations {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, itemARM.(LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM))
+		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, *itemARM.(*LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM))
 	}
 	for _, item := range balancers.InboundNatPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.InboundNatPools = append(result.Properties.InboundNatPools, itemARM.(LoadBalancers_Spec_Properties_InboundNatPoolsARM))
+		result.Properties.InboundNatPools = append(result.Properties.InboundNatPools, *itemARM.(*LoadBalancers_Spec_Properties_InboundNatPoolsARM))
 	}
 	for _, item := range balancers.LoadBalancingRules {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancingRules = append(result.Properties.LoadBalancingRules, itemARM.(LoadBalancers_Spec_Properties_LoadBalancingRulesARM))
+		result.Properties.LoadBalancingRules = append(result.Properties.LoadBalancingRules, *itemARM.(*LoadBalancers_Spec_Properties_LoadBalancingRulesARM))
 	}
 	for _, item := range balancers.OutboundRules {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.OutboundRules = append(result.Properties.OutboundRules, itemARM.(LoadBalancers_Spec_Properties_OutboundRulesARM))
+		result.Properties.OutboundRules = append(result.Properties.OutboundRules, *itemARM.(*LoadBalancers_Spec_Properties_OutboundRulesARM))
 	}
 	for _, item := range balancers.Probes {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Probes = append(result.Properties.Probes, itemARM.(LoadBalancers_Spec_Properties_ProbesARM))
+		result.Properties.Probes = append(result.Properties.Probes, *itemARM.(*LoadBalancers_Spec_Properties_ProbesARM))
 	}
 
 	// Set property ‘Sku’:
@@ -1095,7 +1095,7 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(LoadBalancerSkuARM)
+		sku := *skuARM.(*LoadBalancerSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1703,7 +1703,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -2768,7 +2768,7 @@ func (balancerSku *LoadBalancerSku) ConvertToARM(resolved genruntime.ConvertToAR
 	if balancerSku == nil {
 		return nil, nil
 	}
-	var result LoadBalancerSkuARM
+	result := &LoadBalancerSkuARM{}
 
 	// Set property ‘Name’:
 	if balancerSku.Name != nil {
@@ -2974,7 +2974,7 @@ func (pools *LoadBalancers_Spec_Properties_BackendAddressPools) ConvertToARM(res
 	if pools == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_BackendAddressPoolsARM
+	result := &LoadBalancers_Spec_Properties_BackendAddressPoolsARM{}
 
 	// Set property ‘Name’:
 	if pools.Name != nil {
@@ -2991,7 +2991,7 @@ func (pools *LoadBalancers_Spec_Properties_BackendAddressPools) ConvertToARM(res
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerBackendAddresses = append(result.Properties.LoadBalancerBackendAddresses, itemARM.(LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM))
+		result.Properties.LoadBalancerBackendAddresses = append(result.Properties.LoadBalancerBackendAddresses, *itemARM.(*LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM))
 	}
 	if pools.Location != nil {
 		location := *pools.Location
@@ -3135,7 +3135,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 	if configurations == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM
+	result := &LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM{}
 
 	// Set property ‘Name’:
 	if configurations.Name != nil {
@@ -3169,7 +3169,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddress := publicIPAddressARM.(SubResourceARM)
+		publicIPAddress := *publicIPAddressARM.(*SubResourceARM)
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configurations.PublicIPPrefix != nil {
@@ -3177,7 +3177,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 		if err != nil {
 			return nil, err
 		}
-		publicIPPrefix := publicIPPrefixARM.(SubResourceARM)
+		publicIPPrefix := *publicIPPrefixARM.(*SubResourceARM)
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	if configurations.Subnet != nil {
@@ -3185,7 +3185,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 
@@ -3468,7 +3468,7 @@ func (pools *LoadBalancers_Spec_Properties_InboundNatPools) ConvertToARM(resolve
 	if pools == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_InboundNatPoolsARM
+	result := &LoadBalancers_Spec_Properties_InboundNatPoolsARM{}
 
 	// Set property ‘Name’:
 	if pools.Name != nil {
@@ -3504,7 +3504,7 @@ func (pools *LoadBalancers_Spec_Properties_InboundNatPools) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		frontendIPConfiguration := frontendIPConfigurationARM.(SubResourceARM)
+		frontendIPConfiguration := *frontendIPConfigurationARM.(*SubResourceARM)
 		result.Properties.FrontendIPConfiguration = &frontendIPConfiguration
 	}
 	if pools.FrontendPortRangeEnd != nil {
@@ -3783,7 +3783,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 	if rules == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_LoadBalancingRulesARM
+	result := &LoadBalancers_Spec_Properties_LoadBalancingRulesARM{}
 
 	// Set property ‘Name’:
 	if rules.Name != nil {
@@ -3810,7 +3810,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		backendAddressPool := backendAddressPoolARM.(SubResourceARM)
+		backendAddressPool := *backendAddressPoolARM.(*SubResourceARM)
 		result.Properties.BackendAddressPool = &backendAddressPool
 	}
 	if rules.BackendPort != nil {
@@ -3834,7 +3834,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		frontendIPConfiguration := frontendIPConfigurationARM.(SubResourceARM)
+		frontendIPConfiguration := *frontendIPConfigurationARM.(*SubResourceARM)
 		result.Properties.FrontendIPConfiguration = &frontendIPConfiguration
 	}
 	if rules.FrontendPort != nil {
@@ -3854,7 +3854,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		probe := probeARM.(SubResourceARM)
+		probe := *probeARM.(*SubResourceARM)
 		result.Properties.Probe = &probe
 	}
 	if rules.Protocol != nil {
@@ -4223,7 +4223,7 @@ func (rules *LoadBalancers_Spec_Properties_OutboundRules) ConvertToARM(resolved 
 	if rules == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_OutboundRulesARM
+	result := &LoadBalancers_Spec_Properties_OutboundRulesARM{}
 
 	// Set property ‘Name’:
 	if rules.Name != nil {
@@ -4249,7 +4249,7 @@ func (rules *LoadBalancers_Spec_Properties_OutboundRules) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		backendAddressPool := backendAddressPoolARM.(SubResourceARM)
+		backendAddressPool := *backendAddressPoolARM.(*SubResourceARM)
 		result.Properties.BackendAddressPool = &backendAddressPool
 	}
 	if rules.EnableTcpReset != nil {
@@ -4261,7 +4261,7 @@ func (rules *LoadBalancers_Spec_Properties_OutboundRules) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, itemARM.(SubResourceARM))
+		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, *itemARM.(*SubResourceARM))
 	}
 	if rules.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *rules.IdleTimeoutInMinutes
@@ -4517,7 +4517,7 @@ func (probes *LoadBalancers_Spec_Properties_Probes) ConvertToARM(resolved genrun
 	if probes == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_ProbesARM
+	result := &LoadBalancers_Spec_Properties_ProbesARM{}
 
 	// Set property ‘Name’:
 	if probes.Name != nil {
@@ -5726,7 +5726,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 	if addresses == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM
+	result := &LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM{}
 
 	// Set property ‘Name’:
 	if addresses.Name != nil {
@@ -5750,7 +5750,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 		if err != nil {
 			return nil, err
 		}
-		loadBalancerFrontendIPConfiguration := loadBalancerFrontendIPConfigurationARM.(SubResourceARM)
+		loadBalancerFrontendIPConfiguration := *loadBalancerFrontendIPConfigurationARM.(*SubResourceARM)
 		result.Properties.LoadBalancerFrontendIPConfiguration = &loadBalancerFrontendIPConfiguration
 	}
 	if addresses.Subnet != nil {
@@ -5758,7 +5758,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 	if addresses.VirtualNetwork != nil {
@@ -5766,7 +5766,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 		if err != nil {
 			return nil, err
 		}
-		virtualNetwork := virtualNetworkARM.(SubResourceARM)
+		virtualNetwork := *virtualNetworkARM.(*SubResourceARM)
 		result.Properties.VirtualNetwork = &virtualNetwork
 	}
 	return result, nil

--- a/v2/api/network/v1alpha1api20201101/load_balancers__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/load_balancers__spec_arm_types_gen.go
@@ -23,12 +23,12 @@ func (balancers LoadBalancers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (balancers LoadBalancers_SpecARM) GetName() string {
+func (balancers *LoadBalancers_SpecARM) GetName() string {
 	return balancers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/loadBalancers"
-func (balancers LoadBalancers_SpecARM) GetType() string {
+func (balancers *LoadBalancers_SpecARM) GetType() string {
 	return "Microsoft.Network/loadBalancers"
 }
 

--- a/v2/api/network/v1alpha1api20201101/network_interface_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_interface_types_gen.go
@@ -1118,7 +1118,7 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 	if interfaces == nil {
 		return nil, nil
 	}
-	var result NetworkInterfaces_SpecARM
+	result := &NetworkInterfaces_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if interfaces.ExtendedLocation != nil {
@@ -1126,7 +1126,7 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1152,7 +1152,7 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(NetworkInterfaceDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*NetworkInterfaceDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if interfaces.EnableAcceleratedNetworking != nil {
@@ -1168,14 +1168,14 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, itemARM.(NetworkInterfaces_Spec_Properties_IpConfigurationsARM))
+		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *itemARM.(*NetworkInterfaces_Spec_Properties_IpConfigurationsARM))
 	}
 	if interfaces.NetworkSecurityGroup != nil {
 		networkSecurityGroupARM, err := (*interfaces.NetworkSecurityGroup).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		networkSecurityGroup := networkSecurityGroupARM.(SubResourceARM)
+		networkSecurityGroup := *networkSecurityGroupARM.(*SubResourceARM)
 		result.Properties.NetworkSecurityGroup = &networkSecurityGroup
 	}
 
@@ -1570,7 +1570,7 @@ func (settings *NetworkInterfaceDnsSettings) ConvertToARM(resolved genruntime.Co
 	if settings == nil {
 		return nil, nil
 	}
-	var result NetworkInterfaceDnsSettingsARM
+	result := &NetworkInterfaceDnsSettingsARM{}
 
 	// Set property ‘DnsServers’:
 	for _, item := range settings.DnsServers {
@@ -2443,7 +2443,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 	if configurations == nil {
 		return nil, nil
 	}
-	var result NetworkInterfaces_Spec_Properties_IpConfigurationsARM
+	result := &NetworkInterfaces_Spec_Properties_IpConfigurationsARM{}
 
 	// Set property ‘Name’:
 	if configurations.Name != nil {
@@ -2470,28 +2470,28 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.ApplicationSecurityGroups {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerBackendAddressPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerInboundNatRules {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerInboundNatRules = append(result.Properties.LoadBalancerInboundNatRules, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerInboundNatRules = append(result.Properties.LoadBalancerInboundNatRules, *itemARM.(*SubResourceARM))
 	}
 	if configurations.Primary != nil {
 		primary := *configurations.Primary
@@ -2514,7 +2514,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddress := publicIPAddressARM.(SubResourceARM)
+		publicIPAddress := *publicIPAddressARM.(*SubResourceARM)
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configurations.Subnet != nil {
@@ -2522,7 +2522,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 	for _, item := range configurations.VirtualNetworkTaps {
@@ -2530,7 +2530,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.VirtualNetworkTaps = append(result.Properties.VirtualNetworkTaps, itemARM.(SubResourceARM))
+		result.Properties.VirtualNetworkTaps = append(result.Properties.VirtualNetworkTaps, *itemARM.(*SubResourceARM))
 	}
 	return result, nil
 }
@@ -3256,7 +3256,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if resource == nil {
 		return nil, nil
 	}
-	var result SubResourceARM
+	result := &SubResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {

--- a/v2/api/network/v1alpha1api20201101/network_interfaces__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_interfaces__spec_arm_types_gen.go
@@ -22,12 +22,12 @@ func (interfaces NetworkInterfaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (interfaces NetworkInterfaces_SpecARM) GetName() string {
+func (interfaces *NetworkInterfaces_SpecARM) GetName() string {
 	return interfaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/networkInterfaces"
-func (interfaces NetworkInterfaces_SpecARM) GetType() string {
+func (interfaces *NetworkInterfaces_SpecARM) GetType() string {
 	return "Microsoft.Network/networkInterfaces"
 }
 

--- a/v2/api/network/v1alpha1api20201101/network_security_group_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_group_types_gen.go
@@ -829,7 +829,7 @@ func (groups *NetworkSecurityGroups_Spec) ConvertToARM(resolved genruntime.Conve
 	if groups == nil {
 		return nil, nil
 	}
-	var result NetworkSecurityGroups_SpecARM
+	result := &NetworkSecurityGroups_SpecARM{}
 
 	// Set property ‘Location’:
 	if groups.Location != nil {

--- a/v2/api/network/v1alpha1api20201101/network_security_groups__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_groups__spec_arm_types_gen.go
@@ -20,11 +20,11 @@ func (groups NetworkSecurityGroups_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (groups NetworkSecurityGroups_SpecARM) GetName() string {
+func (groups *NetworkSecurityGroups_SpecARM) GetName() string {
 	return groups.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/networkSecurityGroups"
-func (groups NetworkSecurityGroups_SpecARM) GetType() string {
+func (groups *NetworkSecurityGroups_SpecARM) GetType() string {
 	return "Microsoft.Network/networkSecurityGroups"
 }

--- a/v2/api/network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
@@ -375,7 +375,7 @@ func (rules *NetworkSecurityGroupsSecurityRules_Spec) ConvertToARM(resolved genr
 	if rules == nil {
 		return nil, nil
 	}
-	var result NetworkSecurityGroupsSecurityRules_SpecARM
+	result := &NetworkSecurityGroupsSecurityRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {
@@ -424,7 +424,7 @@ func (rules *NetworkSecurityGroupsSecurityRules_Spec) ConvertToARM(resolved genr
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.DestinationApplicationSecurityGroups = append(result.Properties.DestinationApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.DestinationApplicationSecurityGroups = append(result.Properties.DestinationApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	if rules.DestinationPortRange != nil {
 		destinationPortRange := *rules.DestinationPortRange
@@ -457,7 +457,7 @@ func (rules *NetworkSecurityGroupsSecurityRules_Spec) ConvertToARM(resolved genr
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.SourceApplicationSecurityGroups = append(result.Properties.SourceApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.SourceApplicationSecurityGroups = append(result.Properties.SourceApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	if rules.SourcePortRange != nil {
 		sourcePortRange := *rules.SourcePortRange

--- a/v2/api/network/v1alpha1api20201101/network_security_groups_security_rules__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_groups_security_rules__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (rules NetworkSecurityGroupsSecurityRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules NetworkSecurityGroupsSecurityRules_SpecARM) GetName() string {
+func (rules *NetworkSecurityGroupsSecurityRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/networkSecurityGroups/securityRules"
-func (rules NetworkSecurityGroupsSecurityRules_SpecARM) GetType() string {
+func (rules *NetworkSecurityGroupsSecurityRules_SpecARM) GetType() string {
 	return "Microsoft.Network/networkSecurityGroups/securityRules"
 }
 

--- a/v2/api/network/v1alpha1api20201101/public_ip_address_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/public_ip_address_types_gen.go
@@ -1031,7 +1031,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 	if addresses == nil {
 		return nil, nil
 	}
-	var result PublicIPAddresses_SpecARM
+	result := &PublicIPAddresses_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if addresses.ExtendedLocation != nil {
@@ -1039,7 +1039,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1068,7 +1068,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		ddosSettings := ddosSettingsARM.(DdosSettingsARM)
+		ddosSettings := *ddosSettingsARM.(*DdosSettingsARM)
 		result.Properties.DdosSettings = &ddosSettings
 	}
 	if addresses.DnsSettings != nil {
@@ -1076,7 +1076,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(PublicIPAddressDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*PublicIPAddressDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if addresses.IdleTimeoutInMinutes != nil {
@@ -1092,7 +1092,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpTags = append(result.Properties.IpTags, itemARM.(IpTagARM))
+		result.Properties.IpTags = append(result.Properties.IpTags, *itemARM.(*IpTagARM))
 	}
 	if addresses.PublicIPAddressVersion != nil {
 		publicIPAddressVersion := *addresses.PublicIPAddressVersion
@@ -1107,7 +1107,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		publicIPPrefix := publicIPPrefixARM.(SubResourceARM)
+		publicIPPrefix := *publicIPPrefixARM.(*SubResourceARM)
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 
@@ -1117,7 +1117,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(PublicIPAddressSkuARM)
+		sku := *skuARM.(*PublicIPAddressSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1632,7 +1632,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if settings == nil {
 		return nil, nil
 	}
-	var result DdosSettingsARM
+	result := &DdosSettingsARM{}
 
 	// Set property ‘DdosCustomPolicy’:
 	if settings.DdosCustomPolicy != nil {
@@ -1640,7 +1640,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		ddosCustomPolicy := ddosCustomPolicyARM.(SubResourceARM)
+		ddosCustomPolicy := *ddosCustomPolicyARM.(*SubResourceARM)
 		result.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
@@ -2123,7 +2123,7 @@ func (ipTag *IpTag) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if ipTag == nil {
 		return nil, nil
 	}
-	var result IpTagARM
+	result := &IpTagARM{}
 
 	// Set property ‘IpTagType’:
 	if ipTag.IpTagType != nil {
@@ -2394,7 +2394,7 @@ func (settings *PublicIPAddressDnsSettings) ConvertToARM(resolved genruntime.Con
 	if settings == nil {
 		return nil, nil
 	}
-	var result PublicIPAddressDnsSettingsARM
+	result := &PublicIPAddressDnsSettingsARM{}
 
 	// Set property ‘DomainNameLabel’:
 	if settings.DomainNameLabel != nil {
@@ -2620,7 +2620,7 @@ func (addressSku *PublicIPAddressSku) ConvertToARM(resolved genruntime.ConvertTo
 	if addressSku == nil {
 		return nil, nil
 	}
-	var result PublicIPAddressSkuARM
+	result := &PublicIPAddressSkuARM{}
 
 	// Set property ‘Name’:
 	if addressSku.Name != nil {

--- a/v2/api/network/v1alpha1api20201101/public_ip_addresses__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/public_ip_addresses__spec_arm_types_gen.go
@@ -24,12 +24,12 @@ func (addresses PublicIPAddresses_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (addresses PublicIPAddresses_SpecARM) GetName() string {
+func (addresses *PublicIPAddresses_SpecARM) GetName() string {
 	return addresses.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/publicIPAddresses"
-func (addresses PublicIPAddresses_SpecARM) GetType() string {
+func (addresses *PublicIPAddresses_SpecARM) GetType() string {
 	return "Microsoft.Network/publicIPAddresses"
 }
 

--- a/v2/api/network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
@@ -1091,7 +1091,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 	if gateways == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_SpecARM
+	result := &VirtualNetworkGateways_SpecARM{}
 
 	// Set property ‘Location’:
 	if gateways.Location != nil {
@@ -1129,7 +1129,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		bgpSettings := bgpSettingsARM.(BgpSettingsARM)
+		bgpSettings := *bgpSettingsARM.(*BgpSettingsARM)
 		result.Properties.BgpSettings = &bgpSettings
 	}
 	if gateways.CustomRoutes != nil {
@@ -1137,7 +1137,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		customRoutes := customRoutesARM.(AddressSpaceARM)
+		customRoutes := *customRoutesARM.(*AddressSpaceARM)
 		result.Properties.CustomRoutes = &customRoutes
 	}
 	if gateways.EnableBgp != nil {
@@ -1157,7 +1157,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		gatewayDefaultSite := gatewayDefaultSiteARM.(SubResourceARM)
+		gatewayDefaultSite := *gatewayDefaultSiteARM.(*SubResourceARM)
 		result.Properties.GatewayDefaultSite = &gatewayDefaultSite
 	}
 	if gateways.GatewayType != nil {
@@ -1169,14 +1169,14 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, itemARM.(VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM))
+		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *itemARM.(*VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM))
 	}
 	if gateways.Sku != nil {
 		skuARM, err := (*gateways.Sku).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(VirtualNetworkGatewaySkuARM)
+		sku := *skuARM.(*VirtualNetworkGatewaySkuARM)
 		result.Properties.Sku = &sku
 	}
 	if gateways.VNetExtendedLocationResourceReference != nil {
@@ -1192,7 +1192,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		virtualNetworkExtendedLocation := virtualNetworkExtendedLocationARM.(ExtendedLocationARM)
+		virtualNetworkExtendedLocation := *virtualNetworkExtendedLocationARM.(*ExtendedLocationARM)
 		result.Properties.VirtualNetworkExtendedLocation = &virtualNetworkExtendedLocation
 	}
 	if gateways.VpnClientConfiguration != nil {
@@ -1200,7 +1200,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		vpnClientConfiguration := vpnClientConfigurationARM.(VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM)
+		vpnClientConfiguration := *vpnClientConfigurationARM.(*VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM)
 		result.Properties.VpnClientConfiguration = &vpnClientConfiguration
 	}
 	if gateways.VpnGatewayGeneration != nil {
@@ -1865,7 +1865,7 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if settings == nil {
 		return nil, nil
 	}
-	var result BgpSettingsARM
+	result := &BgpSettingsARM{}
 
 	// Set property ‘Asn’:
 	if settings.Asn != nil {
@@ -1885,7 +1885,7 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		result.BgpPeeringAddresses = append(result.BgpPeeringAddresses, itemARM.(IPConfigurationBgpPeeringAddressARM))
+		result.BgpPeeringAddresses = append(result.BgpPeeringAddresses, *itemARM.(*IPConfigurationBgpPeeringAddressARM))
 	}
 
 	// Set property ‘PeerWeight’:
@@ -2440,7 +2440,7 @@ func (gatewaySku *VirtualNetworkGatewaySku) ConvertToARM(resolved genruntime.Con
 	if gatewaySku == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGatewaySkuARM
+	result := &VirtualNetworkGatewaySkuARM{}
 
 	// Set property ‘Name’:
 	if gatewaySku.Name != nil {
@@ -2691,7 +2691,7 @@ func (configurations *VirtualNetworkGateways_Spec_Properties_IpConfigurations) C
 	if configurations == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM
+	result := &VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM{}
 
 	// Set property ‘Name’:
 	if configurations.Name != nil {
@@ -2714,7 +2714,7 @@ func (configurations *VirtualNetworkGateways_Spec_Properties_IpConfigurations) C
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddress := publicIPAddressARM.(SubResourceARM)
+		publicIPAddress := *publicIPAddressARM.(*SubResourceARM)
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configurations.Subnet != nil {
@@ -2722,7 +2722,7 @@ func (configurations *VirtualNetworkGateways_Spec_Properties_IpConfigurations) C
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 	return result, nil
@@ -2903,7 +2903,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 	if configuration == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM
+	result := &VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM{}
 
 	// Set property ‘AadAudience’:
 	if configuration.AadAudience != nil {
@@ -2941,7 +2941,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.RadiusServers = append(result.RadiusServers, itemARM.(RadiusServerARM))
+		result.RadiusServers = append(result.RadiusServers, *itemARM.(*RadiusServerARM))
 	}
 
 	// Set property ‘VpnAuthenticationTypes’:
@@ -2955,7 +2955,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		vpnClientAddressPool := vpnClientAddressPoolARM.(AddressSpaceARM)
+		vpnClientAddressPool := *vpnClientAddressPoolARM.(*AddressSpaceARM)
 		result.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
@@ -2965,7 +2965,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.VpnClientIpsecPolicies = append(result.VpnClientIpsecPolicies, itemARM.(IpsecPolicyARM))
+		result.VpnClientIpsecPolicies = append(result.VpnClientIpsecPolicies, *itemARM.(*IpsecPolicyARM))
 	}
 
 	// Set property ‘VpnClientProtocols’:
@@ -2979,7 +2979,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.VpnClientRevokedCertificates = append(result.VpnClientRevokedCertificates, itemARM.(VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM))
+		result.VpnClientRevokedCertificates = append(result.VpnClientRevokedCertificates, *itemARM.(*VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM))
 	}
 
 	// Set property ‘VpnClientRootCertificates’:
@@ -2988,7 +2988,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.VpnClientRootCertificates = append(result.VpnClientRootCertificates, itemARM.(VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM))
+		result.VpnClientRootCertificates = append(result.VpnClientRootCertificates, *itemARM.(*VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM))
 	}
 	return result, nil
 }
@@ -3784,7 +3784,7 @@ func (address *IPConfigurationBgpPeeringAddress) ConvertToARM(resolved genruntim
 	if address == nil {
 		return nil, nil
 	}
-	var result IPConfigurationBgpPeeringAddressARM
+	result := &IPConfigurationBgpPeeringAddressARM{}
 
 	// Set property ‘CustomBgpIpAddresses’:
 	for _, item := range address.CustomBgpIpAddresses {
@@ -3989,7 +3989,7 @@ func (policy *IpsecPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if policy == nil {
 		return nil, nil
 	}
-	var result IpsecPolicyARM
+	result := &IpsecPolicyARM{}
 
 	// Set property ‘DhGroup’:
 	if policy.DhGroup != nil {
@@ -4460,7 +4460,7 @@ func (server *RadiusServer) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if server == nil {
 		return nil, nil
 	}
-	var result RadiusServerARM
+	result := &RadiusServerARM{}
 
 	// Set property ‘RadiusServerAddress’:
 	if server.RadiusServerAddress != nil {
@@ -4780,7 +4780,7 @@ func (certificates *VirtualNetworkGateways_Spec_Properties_VpnClientConfiguratio
 	if certificates == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM
+	result := &VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM{}
 
 	// Set property ‘Name’:
 	if certificates.Name != nil {
@@ -4880,7 +4880,7 @@ func (certificates *VirtualNetworkGateways_Spec_Properties_VpnClientConfiguratio
 	if certificates == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM
+	result := &VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM{}
 
 	// Set property ‘Name’:
 	if certificates.Name != nil {

--- a/v2/api/network/v1alpha1api20201101/virtual_network_gateways__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_network_gateways__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (gateways VirtualNetworkGateways_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (gateways VirtualNetworkGateways_SpecARM) GetName() string {
+func (gateways *VirtualNetworkGateways_SpecARM) GetName() string {
 	return gateways.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworkGateways"
-func (gateways VirtualNetworkGateways_SpecARM) GetType() string {
+func (gateways *VirtualNetworkGateways_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworkGateways"
 }
 

--- a/v2/api/network/v1alpha1api20201101/virtual_network_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_network_types_gen.go
@@ -884,7 +884,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if networks == nil {
 		return nil, nil
 	}
-	var result VirtualNetworks_SpecARM
+	result := &VirtualNetworks_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if networks.ExtendedLocation != nil {
@@ -892,7 +892,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -920,7 +920,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		addressSpace := addressSpaceARM.(AddressSpaceARM)
+		addressSpace := *addressSpaceARM.(*AddressSpaceARM)
 		result.Properties.AddressSpace = &addressSpace
 	}
 	if networks.BgpCommunities != nil {
@@ -928,7 +928,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		bgpCommunities := bgpCommunitiesARM.(VirtualNetworkBgpCommunitiesARM)
+		bgpCommunities := *bgpCommunitiesARM.(*VirtualNetworkBgpCommunitiesARM)
 		result.Properties.BgpCommunities = &bgpCommunities
 	}
 	if networks.DdosProtectionPlan != nil {
@@ -936,7 +936,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		ddosProtectionPlan := ddosProtectionPlanARM.(SubResourceARM)
+		ddosProtectionPlan := *ddosProtectionPlanARM.(*SubResourceARM)
 		result.Properties.DdosProtectionPlan = &ddosProtectionPlan
 	}
 	if networks.DhcpOptions != nil {
@@ -944,7 +944,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		dhcpOptions := dhcpOptionsARM.(DhcpOptionsARM)
+		dhcpOptions := *dhcpOptionsARM.(*DhcpOptionsARM)
 		result.Properties.DhcpOptions = &dhcpOptions
 	}
 	if networks.EnableDdosProtection != nil {
@@ -960,7 +960,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpAllocations = append(result.Properties.IpAllocations, itemARM.(SubResourceARM))
+		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *itemARM.(*SubResourceARM))
 	}
 
 	// Set property ‘Tags’:
@@ -1428,7 +1428,7 @@ func (space *AddressSpace) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if space == nil {
 		return nil, nil
 	}
-	var result AddressSpaceARM
+	result := &AddressSpaceARM{}
 
 	// Set property ‘AddressPrefixes’:
 	for _, item := range space.AddressPrefixes {
@@ -1557,7 +1557,7 @@ func (options *DhcpOptions) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if options == nil {
 		return nil, nil
 	}
-	var result DhcpOptionsARM
+	result := &DhcpOptionsARM{}
 
 	// Set property ‘DnsServers’:
 	for _, item := range options.DnsServers {
@@ -1686,7 +1686,7 @@ func (communities *VirtualNetworkBgpCommunities) ConvertToARM(resolved genruntim
 	if communities == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkBgpCommunitiesARM
+	result := &VirtualNetworkBgpCommunitiesARM{}
 
 	// Set property ‘VirtualNetworkCommunity’:
 	if communities.VirtualNetworkCommunity != nil {

--- a/v2/api/network/v1alpha1api20201101/virtual_networks__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks__spec_arm_types_gen.go
@@ -22,12 +22,12 @@ func (networks VirtualNetworks_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (networks VirtualNetworks_SpecARM) GetName() string {
+func (networks *VirtualNetworks_SpecARM) GetName() string {
 	return networks.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworks"
-func (networks VirtualNetworks_SpecARM) GetType() string {
+func (networks *VirtualNetworks_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworks"
 }
 

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
@@ -1263,7 +1263,7 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 	if subnets == nil {
 		return nil, nil
 	}
-	var result VirtualNetworksSubnets_SpecARM
+	result := &VirtualNetworksSubnets_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -1294,21 +1294,21 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Delegations = append(result.Properties.Delegations, itemARM.(VirtualNetworksSubnets_Spec_Properties_DelegationsARM))
+		result.Properties.Delegations = append(result.Properties.Delegations, *itemARM.(*VirtualNetworksSubnets_Spec_Properties_DelegationsARM))
 	}
 	for _, item := range subnets.IpAllocations {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpAllocations = append(result.Properties.IpAllocations, itemARM.(SubResourceARM))
+		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *itemARM.(*SubResourceARM))
 	}
 	if subnets.NatGateway != nil {
 		natGatewayARM, err := (*subnets.NatGateway).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		natGateway := natGatewayARM.(SubResourceARM)
+		natGateway := *natGatewayARM.(*SubResourceARM)
 		result.Properties.NatGateway = &natGateway
 	}
 	if subnets.NetworkSecurityGroup != nil {
@@ -1316,7 +1316,7 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		networkSecurityGroup := networkSecurityGroupARM.(SubResourceARM)
+		networkSecurityGroup := *networkSecurityGroupARM.(*SubResourceARM)
 		result.Properties.NetworkSecurityGroup = &networkSecurityGroup
 	}
 	if subnets.PrivateEndpointNetworkPolicies != nil {
@@ -1332,7 +1332,7 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		routeTable := routeTableARM.(SubResourceARM)
+		routeTable := *routeTableARM.(*SubResourceARM)
 		result.Properties.RouteTable = &routeTable
 	}
 	for _, item := range subnets.ServiceEndpointPolicies {
@@ -1340,14 +1340,14 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ServiceEndpointPolicies = append(result.Properties.ServiceEndpointPolicies, itemARM.(SubResourceARM))
+		result.Properties.ServiceEndpointPolicies = append(result.Properties.ServiceEndpointPolicies, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range subnets.ServiceEndpoints {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ServiceEndpoints = append(result.Properties.ServiceEndpoints, itemARM.(ServiceEndpointPropertiesFormatARM))
+		result.Properties.ServiceEndpoints = append(result.Properties.ServiceEndpoints, *itemARM.(*ServiceEndpointPropertiesFormatARM))
 	}
 	return result, nil
 }
@@ -3128,7 +3128,7 @@ func (format *ServiceEndpointPropertiesFormat) ConvertToARM(resolved genruntime.
 	if format == nil {
 		return nil, nil
 	}
-	var result ServiceEndpointPropertiesFormatARM
+	result := &ServiceEndpointPropertiesFormatARM{}
 
 	// Set property ‘Locations’:
 	for _, item := range format.Locations {
@@ -3312,7 +3312,7 @@ func (delegations *VirtualNetworksSubnets_Spec_Properties_Delegations) ConvertTo
 	if delegations == nil {
 		return nil, nil
 	}
-	var result VirtualNetworksSubnets_Spec_Properties_DelegationsARM
+	result := &VirtualNetworksSubnets_Spec_Properties_DelegationsARM{}
 
 	// Set property ‘Name’:
 	if delegations.Name != nil {

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_subnets__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_subnets__spec_arm_types_gen.go
@@ -19,12 +19,12 @@ func (subnets VirtualNetworksSubnets_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (subnets VirtualNetworksSubnets_SpecARM) GetName() string {
+func (subnets *VirtualNetworksSubnets_SpecARM) GetName() string {
 	return subnets.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworks/subnets"
-func (subnets VirtualNetworksSubnets_SpecARM) GetType() string {
+func (subnets *VirtualNetworksSubnets_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworks/subnets"
 }
 

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -836,7 +836,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 	if peerings == nil {
 		return nil, nil
 	}
-	var result VirtualNetworksVirtualNetworkPeerings_SpecARM
+	result := &VirtualNetworksVirtualNetworkPeerings_SpecARM{}
 
 	// Set property ‘Location’:
 	if peerings.Location != nil {
@@ -879,7 +879,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		remoteAddressSpace := remoteAddressSpaceARM.(AddressSpaceARM)
+		remoteAddressSpace := *remoteAddressSpaceARM.(*AddressSpaceARM)
 		result.Properties.RemoteAddressSpace = &remoteAddressSpace
 	}
 	if peerings.RemoteBgpCommunities != nil {
@@ -887,7 +887,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		remoteBgpCommunities := remoteBgpCommunitiesARM.(VirtualNetworkBgpCommunitiesARM)
+		remoteBgpCommunities := *remoteBgpCommunitiesARM.(*VirtualNetworkBgpCommunitiesARM)
 		result.Properties.RemoteBgpCommunities = &remoteBgpCommunities
 	}
 	if peerings.RemoteVirtualNetwork != nil {
@@ -895,7 +895,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		remoteVirtualNetwork := remoteVirtualNetworkARM.(SubResourceARM)
+		remoteVirtualNetwork := *remoteVirtualNetworkARM.(*SubResourceARM)
 		result.Properties.RemoteVirtualNetwork = &remoteVirtualNetwork
 	}
 	if peerings.UseRemoteGateways != nil {

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peerings__spec_arm_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peerings__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (peerings VirtualNetworksVirtualNetworkPeerings_SpecARM) GetAPIVersion() st
 }
 
 // GetName returns the Name of the resource
-func (peerings VirtualNetworksVirtualNetworkPeerings_SpecARM) GetName() string {
+func (peerings *VirtualNetworksVirtualNetworkPeerings_SpecARM) GetName() string {
 	return peerings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
-func (peerings VirtualNetworksVirtualNetworkPeerings_SpecARM) GetType() string {
+func (peerings *VirtualNetworksVirtualNetworkPeerings_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
 }
 

--- a/v2/api/network/v1beta20201101/load_balancer_types_gen.go
+++ b/v2/api/network/v1beta20201101/load_balancer_types_gen.go
@@ -1064,7 +1064,7 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if balancers == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_SpecARM
+	result := &LoadBalancers_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if balancers.ExtendedLocation != nil {
@@ -1072,7 +1072,7 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1099,42 +1099,42 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.BackendAddressPools = append(result.Properties.BackendAddressPools, itemARM.(LoadBalancers_Spec_Properties_BackendAddressPoolsARM))
+		result.Properties.BackendAddressPools = append(result.Properties.BackendAddressPools, *itemARM.(*LoadBalancers_Spec_Properties_BackendAddressPoolsARM))
 	}
 	for _, item := range balancers.FrontendIPConfigurations {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, itemARM.(LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM))
+		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, *itemARM.(*LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM))
 	}
 	for _, item := range balancers.InboundNatPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.InboundNatPools = append(result.Properties.InboundNatPools, itemARM.(LoadBalancers_Spec_Properties_InboundNatPoolsARM))
+		result.Properties.InboundNatPools = append(result.Properties.InboundNatPools, *itemARM.(*LoadBalancers_Spec_Properties_InboundNatPoolsARM))
 	}
 	for _, item := range balancers.LoadBalancingRules {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancingRules = append(result.Properties.LoadBalancingRules, itemARM.(LoadBalancers_Spec_Properties_LoadBalancingRulesARM))
+		result.Properties.LoadBalancingRules = append(result.Properties.LoadBalancingRules, *itemARM.(*LoadBalancers_Spec_Properties_LoadBalancingRulesARM))
 	}
 	for _, item := range balancers.OutboundRules {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.OutboundRules = append(result.Properties.OutboundRules, itemARM.(LoadBalancers_Spec_Properties_OutboundRulesARM))
+		result.Properties.OutboundRules = append(result.Properties.OutboundRules, *itemARM.(*LoadBalancers_Spec_Properties_OutboundRulesARM))
 	}
 	for _, item := range balancers.Probes {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Probes = append(result.Properties.Probes, itemARM.(LoadBalancers_Spec_Properties_ProbesARM))
+		result.Properties.Probes = append(result.Properties.Probes, *itemARM.(*LoadBalancers_Spec_Properties_ProbesARM))
 	}
 
 	// Set property ‘Sku’:
@@ -1143,7 +1143,7 @@ func (balancers *LoadBalancers_Spec) ConvertToARM(resolved genruntime.ConvertToA
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(LoadBalancerSkuARM)
+		sku := *skuARM.(*LoadBalancerSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1753,7 +1753,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -2885,7 +2885,7 @@ func (balancerSku *LoadBalancerSku) ConvertToARM(resolved genruntime.ConvertToAR
 	if balancerSku == nil {
 		return nil, nil
 	}
-	var result LoadBalancerSkuARM
+	result := &LoadBalancerSkuARM{}
 
 	// Set property ‘Name’:
 	if balancerSku.Name != nil {
@@ -3097,7 +3097,7 @@ func (pools *LoadBalancers_Spec_Properties_BackendAddressPools) ConvertToARM(res
 	if pools == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_BackendAddressPoolsARM
+	result := &LoadBalancers_Spec_Properties_BackendAddressPoolsARM{}
 
 	// Set property ‘Name’:
 	if pools.Name != nil {
@@ -3114,7 +3114,7 @@ func (pools *LoadBalancers_Spec_Properties_BackendAddressPools) ConvertToARM(res
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerBackendAddresses = append(result.Properties.LoadBalancerBackendAddresses, itemARM.(LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM))
+		result.Properties.LoadBalancerBackendAddresses = append(result.Properties.LoadBalancerBackendAddresses, *itemARM.(*LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM))
 	}
 	if pools.Location != nil {
 		location := *pools.Location
@@ -3273,7 +3273,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 	if configurations == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM
+	result := &LoadBalancers_Spec_Properties_FrontendIPConfigurationsARM{}
 
 	// Set property ‘Name’:
 	if configurations.Name != nil {
@@ -3307,7 +3307,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddress := publicIPAddressARM.(SubResourceARM)
+		publicIPAddress := *publicIPAddressARM.(*SubResourceARM)
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configurations.PublicIPPrefix != nil {
@@ -3315,7 +3315,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 		if err != nil {
 			return nil, err
 		}
-		publicIPPrefix := publicIPPrefixARM.(SubResourceARM)
+		publicIPPrefix := *publicIPPrefixARM.(*SubResourceARM)
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 	if configurations.Subnet != nil {
@@ -3323,7 +3323,7 @@ func (configurations *LoadBalancers_Spec_Properties_FrontendIPConfigurations) Co
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 
@@ -3624,7 +3624,7 @@ func (pools *LoadBalancers_Spec_Properties_InboundNatPools) ConvertToARM(resolve
 	if pools == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_InboundNatPoolsARM
+	result := &LoadBalancers_Spec_Properties_InboundNatPoolsARM{}
 
 	// Set property ‘Name’:
 	if pools.Name != nil {
@@ -3660,7 +3660,7 @@ func (pools *LoadBalancers_Spec_Properties_InboundNatPools) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		frontendIPConfiguration := frontendIPConfigurationARM.(SubResourceARM)
+		frontendIPConfiguration := *frontendIPConfigurationARM.(*SubResourceARM)
 		result.Properties.FrontendIPConfiguration = &frontendIPConfiguration
 	}
 	if pools.FrontendPortRangeEnd != nil {
@@ -3965,7 +3965,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 	if rules == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_LoadBalancingRulesARM
+	result := &LoadBalancers_Spec_Properties_LoadBalancingRulesARM{}
 
 	// Set property ‘Name’:
 	if rules.Name != nil {
@@ -3992,7 +3992,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		backendAddressPool := backendAddressPoolARM.(SubResourceARM)
+		backendAddressPool := *backendAddressPoolARM.(*SubResourceARM)
 		result.Properties.BackendAddressPool = &backendAddressPool
 	}
 	if rules.BackendPort != nil {
@@ -4016,7 +4016,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		frontendIPConfiguration := frontendIPConfigurationARM.(SubResourceARM)
+		frontendIPConfiguration := *frontendIPConfigurationARM.(*SubResourceARM)
 		result.Properties.FrontendIPConfiguration = &frontendIPConfiguration
 	}
 	if rules.FrontendPort != nil {
@@ -4036,7 +4036,7 @@ func (rules *LoadBalancers_Spec_Properties_LoadBalancingRules) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		probe := probeARM.(SubResourceARM)
+		probe := *probeARM.(*SubResourceARM)
 		result.Properties.Probe = &probe
 	}
 	if rules.Protocol != nil {
@@ -4417,7 +4417,7 @@ func (rules *LoadBalancers_Spec_Properties_OutboundRules) ConvertToARM(resolved 
 	if rules == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_OutboundRulesARM
+	result := &LoadBalancers_Spec_Properties_OutboundRulesARM{}
 
 	// Set property ‘Name’:
 	if rules.Name != nil {
@@ -4443,7 +4443,7 @@ func (rules *LoadBalancers_Spec_Properties_OutboundRules) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		backendAddressPool := backendAddressPoolARM.(SubResourceARM)
+		backendAddressPool := *backendAddressPoolARM.(*SubResourceARM)
 		result.Properties.BackendAddressPool = &backendAddressPool
 	}
 	if rules.EnableTcpReset != nil {
@@ -4455,7 +4455,7 @@ func (rules *LoadBalancers_Spec_Properties_OutboundRules) ConvertToARM(resolved 
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, itemARM.(SubResourceARM))
+		result.Properties.FrontendIPConfigurations = append(result.Properties.FrontendIPConfigurations, *itemARM.(*SubResourceARM))
 	}
 	if rules.IdleTimeoutInMinutes != nil {
 		idleTimeoutInMinutes := *rules.IdleTimeoutInMinutes
@@ -4725,7 +4725,7 @@ func (probes *LoadBalancers_Spec_Properties_Probes) ConvertToARM(resolved genrun
 	if probes == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_ProbesARM
+	result := &LoadBalancers_Spec_Properties_ProbesARM{}
 
 	// Set property ‘Name’:
 	if probes.Name != nil {
@@ -6025,7 +6025,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 	if addresses == nil {
 		return nil, nil
 	}
-	var result LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM
+	result := &LoadBalancers_Spec_Properties_BackendAddressPools_Properties_LoadBalancerBackendAddressesARM{}
 
 	// Set property ‘Name’:
 	if addresses.Name != nil {
@@ -6049,7 +6049,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 		if err != nil {
 			return nil, err
 		}
-		loadBalancerFrontendIPConfiguration := loadBalancerFrontendIPConfigurationARM.(SubResourceARM)
+		loadBalancerFrontendIPConfiguration := *loadBalancerFrontendIPConfigurationARM.(*SubResourceARM)
 		result.Properties.LoadBalancerFrontendIPConfiguration = &loadBalancerFrontendIPConfiguration
 	}
 	if addresses.Subnet != nil {
@@ -6057,7 +6057,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 	if addresses.VirtualNetwork != nil {
@@ -6065,7 +6065,7 @@ func (addresses *LoadBalancers_Spec_Properties_BackendAddressPools_Properties_Lo
 		if err != nil {
 			return nil, err
 		}
-		virtualNetwork := virtualNetworkARM.(SubResourceARM)
+		virtualNetwork := *virtualNetworkARM.(*SubResourceARM)
 		result.Properties.VirtualNetwork = &virtualNetwork
 	}
 	return result, nil

--- a/v2/api/network/v1beta20201101/load_balancers__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/load_balancers__spec_arm_types_gen.go
@@ -33,12 +33,12 @@ func (balancers LoadBalancers_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (balancers LoadBalancers_SpecARM) GetName() string {
+func (balancers *LoadBalancers_SpecARM) GetName() string {
 	return balancers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/loadBalancers"
-func (balancers LoadBalancers_SpecARM) GetType() string {
+func (balancers *LoadBalancers_SpecARM) GetType() string {
 	return "Microsoft.Network/loadBalancers"
 }
 

--- a/v2/api/network/v1beta20201101/network_interface_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_interface_types_gen.go
@@ -1166,7 +1166,7 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 	if interfaces == nil {
 		return nil, nil
 	}
-	var result NetworkInterfaces_SpecARM
+	result := &NetworkInterfaces_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if interfaces.ExtendedLocation != nil {
@@ -1174,7 +1174,7 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1200,7 +1200,7 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(NetworkInterfaceDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*NetworkInterfaceDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if interfaces.EnableAcceleratedNetworking != nil {
@@ -1216,14 +1216,14 @@ func (interfaces *NetworkInterfaces_Spec) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, itemARM.(NetworkInterfaces_Spec_Properties_IpConfigurationsARM))
+		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *itemARM.(*NetworkInterfaces_Spec_Properties_IpConfigurationsARM))
 	}
 	if interfaces.NetworkSecurityGroup != nil {
 		networkSecurityGroupARM, err := (*interfaces.NetworkSecurityGroup).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		networkSecurityGroup := networkSecurityGroupARM.(SubResourceARM)
+		networkSecurityGroup := *networkSecurityGroupARM.(*SubResourceARM)
 		result.Properties.NetworkSecurityGroup = &networkSecurityGroup
 	}
 
@@ -1623,7 +1623,7 @@ func (settings *NetworkInterfaceDnsSettings) ConvertToARM(resolved genruntime.Co
 	if settings == nil {
 		return nil, nil
 	}
-	var result NetworkInterfaceDnsSettingsARM
+	result := &NetworkInterfaceDnsSettingsARM{}
 
 	// Set property ‘DnsServers’:
 	for _, item := range settings.DnsServers {
@@ -2558,7 +2558,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 	if configurations == nil {
 		return nil, nil
 	}
-	var result NetworkInterfaces_Spec_Properties_IpConfigurationsARM
+	result := &NetworkInterfaces_Spec_Properties_IpConfigurationsARM{}
 
 	// Set property ‘Name’:
 	if configurations.Name != nil {
@@ -2585,28 +2585,28 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.ApplicationGatewayBackendAddressPools = append(result.Properties.ApplicationGatewayBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.ApplicationSecurityGroups {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.ApplicationSecurityGroups = append(result.Properties.ApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerBackendAddressPools {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerBackendAddressPools = append(result.Properties.LoadBalancerBackendAddressPools, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range configurations.LoadBalancerInboundNatRules {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.LoadBalancerInboundNatRules = append(result.Properties.LoadBalancerInboundNatRules, itemARM.(SubResourceARM))
+		result.Properties.LoadBalancerInboundNatRules = append(result.Properties.LoadBalancerInboundNatRules, *itemARM.(*SubResourceARM))
 	}
 	if configurations.Primary != nil {
 		primary := *configurations.Primary
@@ -2629,7 +2629,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddress := publicIPAddressARM.(SubResourceARM)
+		publicIPAddress := *publicIPAddressARM.(*SubResourceARM)
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configurations.Subnet != nil {
@@ -2637,7 +2637,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 	for _, item := range configurations.VirtualNetworkTaps {
@@ -2645,7 +2645,7 @@ func (configurations *NetworkInterfaces_Spec_Properties_IpConfigurations) Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.VirtualNetworkTaps = append(result.Properties.VirtualNetworkTaps, itemARM.(SubResourceARM))
+		result.Properties.VirtualNetworkTaps = append(result.Properties.VirtualNetworkTaps, *itemARM.(*SubResourceARM))
 	}
 	return result, nil
 }
@@ -3376,7 +3376,7 @@ func (resource *SubResource) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if resource == nil {
 		return nil, nil
 	}
-	var result SubResourceARM
+	result := &SubResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {

--- a/v2/api/network/v1beta20201101/network_interfaces__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_interfaces__spec_arm_types_gen.go
@@ -30,12 +30,12 @@ func (interfaces NetworkInterfaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (interfaces NetworkInterfaces_SpecARM) GetName() string {
+func (interfaces *NetworkInterfaces_SpecARM) GetName() string {
 	return interfaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/networkInterfaces"
-func (interfaces NetworkInterfaces_SpecARM) GetType() string {
+func (interfaces *NetworkInterfaces_SpecARM) GetType() string {
 	return "Microsoft.Network/networkInterfaces"
 }
 

--- a/v2/api/network/v1beta20201101/network_security_group_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_group_types_gen.go
@@ -844,7 +844,7 @@ func (groups *NetworkSecurityGroups_Spec) ConvertToARM(resolved genruntime.Conve
 	if groups == nil {
 		return nil, nil
 	}
-	var result NetworkSecurityGroups_SpecARM
+	result := &NetworkSecurityGroups_SpecARM{}
 
 	// Set property ‘Location’:
 	if groups.Location != nil {

--- a/v2/api/network/v1beta20201101/network_security_groups__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_groups__spec_arm_types_gen.go
@@ -24,11 +24,11 @@ func (groups NetworkSecurityGroups_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (groups NetworkSecurityGroups_SpecARM) GetName() string {
+func (groups *NetworkSecurityGroups_SpecARM) GetName() string {
 	return groups.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/networkSecurityGroups"
-func (groups NetworkSecurityGroups_SpecARM) GetType() string {
+func (groups *NetworkSecurityGroups_SpecARM) GetType() string {
 	return "Microsoft.Network/networkSecurityGroups"
 }

--- a/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen.go
@@ -397,7 +397,7 @@ func (rules *NetworkSecurityGroupsSecurityRules_Spec) ConvertToARM(resolved genr
 	if rules == nil {
 		return nil, nil
 	}
-	var result NetworkSecurityGroupsSecurityRules_SpecARM
+	result := &NetworkSecurityGroupsSecurityRules_SpecARM{}
 
 	// Set property ‘Location’:
 	if rules.Location != nil {
@@ -446,7 +446,7 @@ func (rules *NetworkSecurityGroupsSecurityRules_Spec) ConvertToARM(resolved genr
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.DestinationApplicationSecurityGroups = append(result.Properties.DestinationApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.DestinationApplicationSecurityGroups = append(result.Properties.DestinationApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	if rules.DestinationPortRange != nil {
 		destinationPortRange := *rules.DestinationPortRange
@@ -479,7 +479,7 @@ func (rules *NetworkSecurityGroupsSecurityRules_Spec) ConvertToARM(resolved genr
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.SourceApplicationSecurityGroups = append(result.Properties.SourceApplicationSecurityGroups, itemARM.(SubResourceARM))
+		result.Properties.SourceApplicationSecurityGroups = append(result.Properties.SourceApplicationSecurityGroups, *itemARM.(*SubResourceARM))
 	}
 	if rules.SourcePortRange != nil {
 		sourcePortRange := *rules.SourcePortRange

--- a/v2/api/network/v1beta20201101/network_security_groups_security_rules__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_groups_security_rules__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (rules NetworkSecurityGroupsSecurityRules_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (rules NetworkSecurityGroupsSecurityRules_SpecARM) GetName() string {
+func (rules *NetworkSecurityGroupsSecurityRules_SpecARM) GetName() string {
 	return rules.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/networkSecurityGroups/securityRules"
-func (rules NetworkSecurityGroupsSecurityRules_SpecARM) GetType() string {
+func (rules *NetworkSecurityGroupsSecurityRules_SpecARM) GetType() string {
 	return "Microsoft.Network/networkSecurityGroups/securityRules"
 }
 

--- a/v2/api/network/v1beta20201101/public_ip_address_types_gen.go
+++ b/v2/api/network/v1beta20201101/public_ip_address_types_gen.go
@@ -1085,7 +1085,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 	if addresses == nil {
 		return nil, nil
 	}
-	var result PublicIPAddresses_SpecARM
+	result := &PublicIPAddresses_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if addresses.ExtendedLocation != nil {
@@ -1093,7 +1093,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1122,7 +1122,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		ddosSettings := ddosSettingsARM.(DdosSettingsARM)
+		ddosSettings := *ddosSettingsARM.(*DdosSettingsARM)
 		result.Properties.DdosSettings = &ddosSettings
 	}
 	if addresses.DnsSettings != nil {
@@ -1130,7 +1130,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		dnsSettings := dnsSettingsARM.(PublicIPAddressDnsSettingsARM)
+		dnsSettings := *dnsSettingsARM.(*PublicIPAddressDnsSettingsARM)
 		result.Properties.DnsSettings = &dnsSettings
 	}
 	if addresses.IdleTimeoutInMinutes != nil {
@@ -1146,7 +1146,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpTags = append(result.Properties.IpTags, itemARM.(IpTagARM))
+		result.Properties.IpTags = append(result.Properties.IpTags, *itemARM.(*IpTagARM))
 	}
 	if addresses.PublicIPAddressVersion != nil {
 		publicIPAddressVersion := *addresses.PublicIPAddressVersion
@@ -1161,7 +1161,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		publicIPPrefix := publicIPPrefixARM.(SubResourceARM)
+		publicIPPrefix := *publicIPPrefixARM.(*SubResourceARM)
 		result.Properties.PublicIPPrefix = &publicIPPrefix
 	}
 
@@ -1171,7 +1171,7 @@ func (addresses *PublicIPAddresses_Spec) ConvertToARM(resolved genruntime.Conver
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(PublicIPAddressSkuARM)
+		sku := *skuARM.(*PublicIPAddressSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1692,7 +1692,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if settings == nil {
 		return nil, nil
 	}
-	var result DdosSettingsARM
+	result := &DdosSettingsARM{}
 
 	// Set property ‘DdosCustomPolicy’:
 	if settings.DdosCustomPolicy != nil {
@@ -1700,7 +1700,7 @@ func (settings *DdosSettings) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		ddosCustomPolicy := ddosCustomPolicyARM.(SubResourceARM)
+		ddosCustomPolicy := *ddosCustomPolicyARM.(*SubResourceARM)
 		result.DdosCustomPolicy = &ddosCustomPolicy
 	}
 
@@ -2201,7 +2201,7 @@ func (ipTag *IpTag) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if ipTag == nil {
 		return nil, nil
 	}
-	var result IpTagARM
+	result := &IpTagARM{}
 
 	// Set property ‘IpTagType’:
 	if ipTag.IpTagType != nil {
@@ -2488,7 +2488,7 @@ func (settings *PublicIPAddressDnsSettings) ConvertToARM(resolved genruntime.Con
 	if settings == nil {
 		return nil, nil
 	}
-	var result PublicIPAddressDnsSettingsARM
+	result := &PublicIPAddressDnsSettingsARM{}
 
 	// Set property ‘DomainNameLabel’:
 	if settings.DomainNameLabel != nil {
@@ -2720,7 +2720,7 @@ func (addressSku *PublicIPAddressSku) ConvertToARM(resolved genruntime.ConvertTo
 	if addressSku == nil {
 		return nil, nil
 	}
-	var result PublicIPAddressSkuARM
+	result := &PublicIPAddressSkuARM{}
 
 	// Set property ‘Name’:
 	if addressSku.Name != nil {

--- a/v2/api/network/v1beta20201101/public_ip_addresses__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/public_ip_addresses__spec_arm_types_gen.go
@@ -36,12 +36,12 @@ func (addresses PublicIPAddresses_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (addresses PublicIPAddresses_SpecARM) GetName() string {
+func (addresses *PublicIPAddresses_SpecARM) GetName() string {
 	return addresses.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/publicIPAddresses"
-func (addresses PublicIPAddresses_SpecARM) GetType() string {
+func (addresses *PublicIPAddresses_SpecARM) GetType() string {
 	return "Microsoft.Network/publicIPAddresses"
 }
 

--- a/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen.go
@@ -1166,7 +1166,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 	if gateways == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_SpecARM
+	result := &VirtualNetworkGateways_SpecARM{}
 
 	// Set property ‘Location’:
 	if gateways.Location != nil {
@@ -1204,7 +1204,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		bgpSettings := bgpSettingsARM.(BgpSettingsARM)
+		bgpSettings := *bgpSettingsARM.(*BgpSettingsARM)
 		result.Properties.BgpSettings = &bgpSettings
 	}
 	if gateways.CustomRoutes != nil {
@@ -1212,7 +1212,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		customRoutes := customRoutesARM.(AddressSpaceARM)
+		customRoutes := *customRoutesARM.(*AddressSpaceARM)
 		result.Properties.CustomRoutes = &customRoutes
 	}
 	if gateways.EnableBgp != nil {
@@ -1232,7 +1232,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		gatewayDefaultSite := gatewayDefaultSiteARM.(SubResourceARM)
+		gatewayDefaultSite := *gatewayDefaultSiteARM.(*SubResourceARM)
 		result.Properties.GatewayDefaultSite = &gatewayDefaultSite
 	}
 	if gateways.GatewayType != nil {
@@ -1244,14 +1244,14 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, itemARM.(VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM))
+		result.Properties.IpConfigurations = append(result.Properties.IpConfigurations, *itemARM.(*VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM))
 	}
 	if gateways.Sku != nil {
 		skuARM, err := (*gateways.Sku).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(VirtualNetworkGatewaySkuARM)
+		sku := *skuARM.(*VirtualNetworkGatewaySkuARM)
 		result.Properties.Sku = &sku
 	}
 	if gateways.VNetExtendedLocationResourceReference != nil {
@@ -1267,7 +1267,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		virtualNetworkExtendedLocation := virtualNetworkExtendedLocationARM.(ExtendedLocationARM)
+		virtualNetworkExtendedLocation := *virtualNetworkExtendedLocationARM.(*ExtendedLocationARM)
 		result.Properties.VirtualNetworkExtendedLocation = &virtualNetworkExtendedLocation
 	}
 	if gateways.VpnClientConfiguration != nil {
@@ -1275,7 +1275,7 @@ func (gateways *VirtualNetworkGateways_Spec) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		vpnClientConfiguration := vpnClientConfigurationARM.(VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM)
+		vpnClientConfiguration := *vpnClientConfigurationARM.(*VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM)
 		result.Properties.VpnClientConfiguration = &vpnClientConfiguration
 	}
 	if gateways.VpnGatewayGeneration != nil {
@@ -1947,7 +1947,7 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if settings == nil {
 		return nil, nil
 	}
-	var result BgpSettingsARM
+	result := &BgpSettingsARM{}
 
 	// Set property ‘Asn’:
 	if settings.Asn != nil {
@@ -1967,7 +1967,7 @@ func (settings *BgpSettings) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		result.BgpPeeringAddresses = append(result.BgpPeeringAddresses, itemARM.(IPConfigurationBgpPeeringAddressARM))
+		result.BgpPeeringAddresses = append(result.BgpPeeringAddresses, *itemARM.(*IPConfigurationBgpPeeringAddressARM))
 	}
 
 	// Set property ‘PeerWeight’:
@@ -2539,7 +2539,7 @@ func (gatewaySku *VirtualNetworkGatewaySku) ConvertToARM(resolved genruntime.Con
 	if gatewaySku == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGatewaySkuARM
+	result := &VirtualNetworkGatewaySkuARM{}
 
 	// Set property ‘Name’:
 	if gatewaySku.Name != nil {
@@ -2794,7 +2794,7 @@ func (configurations *VirtualNetworkGateways_Spec_Properties_IpConfigurations) C
 	if configurations == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM
+	result := &VirtualNetworkGateways_Spec_Properties_IpConfigurationsARM{}
 
 	// Set property ‘Name’:
 	if configurations.Name != nil {
@@ -2817,7 +2817,7 @@ func (configurations *VirtualNetworkGateways_Spec_Properties_IpConfigurations) C
 		if err != nil {
 			return nil, err
 		}
-		publicIPAddress := publicIPAddressARM.(SubResourceARM)
+		publicIPAddress := *publicIPAddressARM.(*SubResourceARM)
 		result.Properties.PublicIPAddress = &publicIPAddress
 	}
 	if configurations.Subnet != nil {
@@ -2825,7 +2825,7 @@ func (configurations *VirtualNetworkGateways_Spec_Properties_IpConfigurations) C
 		if err != nil {
 			return nil, err
 		}
-		subnet := subnetARM.(SubResourceARM)
+		subnet := *subnetARM.(*SubResourceARM)
 		result.Properties.Subnet = &subnet
 	}
 	return result, nil
@@ -3031,7 +3031,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 	if configuration == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM
+	result := &VirtualNetworkGateways_Spec_Properties_VpnClientConfigurationARM{}
 
 	// Set property ‘AadAudience’:
 	if configuration.AadAudience != nil {
@@ -3069,7 +3069,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.RadiusServers = append(result.RadiusServers, itemARM.(RadiusServerARM))
+		result.RadiusServers = append(result.RadiusServers, *itemARM.(*RadiusServerARM))
 	}
 
 	// Set property ‘VpnAuthenticationTypes’:
@@ -3083,7 +3083,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		vpnClientAddressPool := vpnClientAddressPoolARM.(AddressSpaceARM)
+		vpnClientAddressPool := *vpnClientAddressPoolARM.(*AddressSpaceARM)
 		result.VpnClientAddressPool = &vpnClientAddressPool
 	}
 
@@ -3093,7 +3093,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.VpnClientIpsecPolicies = append(result.VpnClientIpsecPolicies, itemARM.(IpsecPolicyARM))
+		result.VpnClientIpsecPolicies = append(result.VpnClientIpsecPolicies, *itemARM.(*IpsecPolicyARM))
 	}
 
 	// Set property ‘VpnClientProtocols’:
@@ -3107,7 +3107,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.VpnClientRevokedCertificates = append(result.VpnClientRevokedCertificates, itemARM.(VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM))
+		result.VpnClientRevokedCertificates = append(result.VpnClientRevokedCertificates, *itemARM.(*VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM))
 	}
 
 	// Set property ‘VpnClientRootCertificates’:
@@ -3116,7 +3116,7 @@ func (configuration *VirtualNetworkGateways_Spec_Properties_VpnClientConfigurati
 		if err != nil {
 			return nil, err
 		}
-		result.VpnClientRootCertificates = append(result.VpnClientRootCertificates, itemARM.(VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM))
+		result.VpnClientRootCertificates = append(result.VpnClientRootCertificates, *itemARM.(*VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM))
 	}
 	return result, nil
 }
@@ -3940,7 +3940,7 @@ func (address *IPConfigurationBgpPeeringAddress) ConvertToARM(resolved genruntim
 	if address == nil {
 		return nil, nil
 	}
-	var result IPConfigurationBgpPeeringAddressARM
+	result := &IPConfigurationBgpPeeringAddressARM{}
 
 	// Set property ‘CustomBgpIpAddresses’:
 	for _, item := range address.CustomBgpIpAddresses {
@@ -4161,7 +4161,7 @@ func (policy *IpsecPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if policy == nil {
 		return nil, nil
 	}
-	var result IpsecPolicyARM
+	result := &IpsecPolicyARM{}
 
 	// Set property ‘DhGroup’:
 	if policy.DhGroup != nil {
@@ -4653,7 +4653,7 @@ func (server *RadiusServer) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if server == nil {
 		return nil, nil
 	}
-	var result RadiusServerARM
+	result := &RadiusServerARM{}
 
 	// Set property ‘RadiusServerAddress’:
 	if server.RadiusServerAddress != nil {
@@ -4969,7 +4969,7 @@ func (certificates *VirtualNetworkGateways_Spec_Properties_VpnClientConfiguratio
 	if certificates == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM
+	result := &VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRevokedCertificatesARM{}
 
 	// Set property ‘Name’:
 	if certificates.Name != nil {
@@ -5070,7 +5070,7 @@ func (certificates *VirtualNetworkGateways_Spec_Properties_VpnClientConfiguratio
 	if certificates == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM
+	result := &VirtualNetworkGateways_Spec_Properties_VpnClientConfiguration_VpnClientRootCertificatesARM{}
 
 	// Set property ‘Name’:
 	if certificates.Name != nil {

--- a/v2/api/network/v1beta20201101/virtual_network_gateways__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_network_gateways__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (gateways VirtualNetworkGateways_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (gateways VirtualNetworkGateways_SpecARM) GetName() string {
+func (gateways *VirtualNetworkGateways_SpecARM) GetName() string {
 	return gateways.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworkGateways"
-func (gateways VirtualNetworkGateways_SpecARM) GetType() string {
+func (gateways *VirtualNetworkGateways_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworkGateways"
 }
 

--- a/v2/api/network/v1beta20201101/virtual_network_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_network_types_gen.go
@@ -921,7 +921,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if networks == nil {
 		return nil, nil
 	}
-	var result VirtualNetworks_SpecARM
+	result := &VirtualNetworks_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if networks.ExtendedLocation != nil {
@@ -929,7 +929,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -957,7 +957,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		addressSpace := addressSpaceARM.(AddressSpaceARM)
+		addressSpace := *addressSpaceARM.(*AddressSpaceARM)
 		result.Properties.AddressSpace = &addressSpace
 	}
 	if networks.BgpCommunities != nil {
@@ -965,7 +965,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		bgpCommunities := bgpCommunitiesARM.(VirtualNetworkBgpCommunitiesARM)
+		bgpCommunities := *bgpCommunitiesARM.(*VirtualNetworkBgpCommunitiesARM)
 		result.Properties.BgpCommunities = &bgpCommunities
 	}
 	if networks.DdosProtectionPlan != nil {
@@ -973,7 +973,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		ddosProtectionPlan := ddosProtectionPlanARM.(SubResourceARM)
+		ddosProtectionPlan := *ddosProtectionPlanARM.(*SubResourceARM)
 		result.Properties.DdosProtectionPlan = &ddosProtectionPlan
 	}
 	if networks.DhcpOptions != nil {
@@ -981,7 +981,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		dhcpOptions := dhcpOptionsARM.(DhcpOptionsARM)
+		dhcpOptions := *dhcpOptionsARM.(*DhcpOptionsARM)
 		result.Properties.DhcpOptions = &dhcpOptions
 	}
 	if networks.EnableDdosProtection != nil {
@@ -997,7 +997,7 @@ func (networks *VirtualNetworks_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpAllocations = append(result.Properties.IpAllocations, itemARM.(SubResourceARM))
+		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *itemARM.(*SubResourceARM))
 	}
 
 	// Set property ‘Tags’:
@@ -1466,7 +1466,7 @@ func (space *AddressSpace) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if space == nil {
 		return nil, nil
 	}
-	var result AddressSpaceARM
+	result := &AddressSpaceARM{}
 
 	// Set property ‘AddressPrefixes’:
 	for _, item := range space.AddressPrefixes {
@@ -1596,7 +1596,7 @@ func (options *DhcpOptions) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if options == nil {
 		return nil, nil
 	}
-	var result DhcpOptionsARM
+	result := &DhcpOptionsARM{}
 
 	// Set property ‘DnsServers’:
 	for _, item := range options.DnsServers {
@@ -1726,7 +1726,7 @@ func (communities *VirtualNetworkBgpCommunities) ConvertToARM(resolved genruntim
 	if communities == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkBgpCommunitiesARM
+	result := &VirtualNetworkBgpCommunitiesARM{}
 
 	// Set property ‘VirtualNetworkCommunity’:
 	if communities.VirtualNetworkCommunity != nil {

--- a/v2/api/network/v1beta20201101/virtual_networks__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks__spec_arm_types_gen.go
@@ -30,12 +30,12 @@ func (networks VirtualNetworks_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (networks VirtualNetworks_SpecARM) GetName() string {
+func (networks *VirtualNetworks_SpecARM) GetName() string {
 	return networks.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworks"
-func (networks VirtualNetworks_SpecARM) GetType() string {
+func (networks *VirtualNetworks_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworks"
 }
 

--- a/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen.go
@@ -1315,7 +1315,7 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 	if subnets == nil {
 		return nil, nil
 	}
-	var result VirtualNetworksSubnets_SpecARM
+	result := &VirtualNetworksSubnets_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -1346,21 +1346,21 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Delegations = append(result.Properties.Delegations, itemARM.(VirtualNetworksSubnets_Spec_Properties_DelegationsARM))
+		result.Properties.Delegations = append(result.Properties.Delegations, *itemARM.(*VirtualNetworksSubnets_Spec_Properties_DelegationsARM))
 	}
 	for _, item := range subnets.IpAllocations {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.IpAllocations = append(result.Properties.IpAllocations, itemARM.(SubResourceARM))
+		result.Properties.IpAllocations = append(result.Properties.IpAllocations, *itemARM.(*SubResourceARM))
 	}
 	if subnets.NatGateway != nil {
 		natGatewayARM, err := (*subnets.NatGateway).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		natGateway := natGatewayARM.(SubResourceARM)
+		natGateway := *natGatewayARM.(*SubResourceARM)
 		result.Properties.NatGateway = &natGateway
 	}
 	if subnets.NetworkSecurityGroup != nil {
@@ -1368,7 +1368,7 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		networkSecurityGroup := networkSecurityGroupARM.(SubResourceARM)
+		networkSecurityGroup := *networkSecurityGroupARM.(*SubResourceARM)
 		result.Properties.NetworkSecurityGroup = &networkSecurityGroup
 	}
 	if subnets.PrivateEndpointNetworkPolicies != nil {
@@ -1384,7 +1384,7 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		routeTable := routeTableARM.(SubResourceARM)
+		routeTable := *routeTableARM.(*SubResourceARM)
 		result.Properties.RouteTable = &routeTable
 	}
 	for _, item := range subnets.ServiceEndpointPolicies {
@@ -1392,14 +1392,14 @@ func (subnets *VirtualNetworksSubnets_Spec) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ServiceEndpointPolicies = append(result.Properties.ServiceEndpointPolicies, itemARM.(SubResourceARM))
+		result.Properties.ServiceEndpointPolicies = append(result.Properties.ServiceEndpointPolicies, *itemARM.(*SubResourceARM))
 	}
 	for _, item := range subnets.ServiceEndpoints {
 		itemARM, err := item.ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.ServiceEndpoints = append(result.Properties.ServiceEndpoints, itemARM.(ServiceEndpointPropertiesFormatARM))
+		result.Properties.ServiceEndpoints = append(result.Properties.ServiceEndpoints, *itemARM.(*ServiceEndpointPropertiesFormatARM))
 	}
 	return result, nil
 }
@@ -3257,7 +3257,7 @@ func (format *ServiceEndpointPropertiesFormat) ConvertToARM(resolved genruntime.
 	if format == nil {
 		return nil, nil
 	}
-	var result ServiceEndpointPropertiesFormatARM
+	result := &ServiceEndpointPropertiesFormatARM{}
 
 	// Set property ‘Locations’:
 	for _, item := range format.Locations {
@@ -3447,7 +3447,7 @@ func (delegations *VirtualNetworksSubnets_Spec_Properties_Delegations) ConvertTo
 	if delegations == nil {
 		return nil, nil
 	}
-	var result VirtualNetworksSubnets_Spec_Properties_DelegationsARM
+	result := &VirtualNetworksSubnets_Spec_Properties_DelegationsARM{}
 
 	// Set property ‘Name’:
 	if delegations.Name != nil {

--- a/v2/api/network/v1beta20201101/virtual_networks_subnets__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_subnets__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (subnets VirtualNetworksSubnets_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (subnets VirtualNetworksSubnets_SpecARM) GetName() string {
+func (subnets *VirtualNetworksSubnets_SpecARM) GetName() string {
 	return subnets.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworks/subnets"
-func (subnets VirtualNetworksSubnets_SpecARM) GetType() string {
+func (subnets *VirtualNetworksSubnets_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworks/subnets"
 }
 

--- a/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -882,7 +882,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 	if peerings == nil {
 		return nil, nil
 	}
-	var result VirtualNetworksVirtualNetworkPeerings_SpecARM
+	result := &VirtualNetworksVirtualNetworkPeerings_SpecARM{}
 
 	// Set property ‘Location’:
 	if peerings.Location != nil {
@@ -925,7 +925,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		remoteAddressSpace := remoteAddressSpaceARM.(AddressSpaceARM)
+		remoteAddressSpace := *remoteAddressSpaceARM.(*AddressSpaceARM)
 		result.Properties.RemoteAddressSpace = &remoteAddressSpace
 	}
 	if peerings.RemoteBgpCommunities != nil {
@@ -933,7 +933,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		remoteBgpCommunities := remoteBgpCommunitiesARM.(VirtualNetworkBgpCommunitiesARM)
+		remoteBgpCommunities := *remoteBgpCommunitiesARM.(*VirtualNetworkBgpCommunitiesARM)
 		result.Properties.RemoteBgpCommunities = &remoteBgpCommunities
 	}
 	if peerings.RemoteVirtualNetwork != nil {
@@ -941,7 +941,7 @@ func (peerings *VirtualNetworksVirtualNetworkPeerings_Spec) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		remoteVirtualNetwork := remoteVirtualNetworkARM.(SubResourceARM)
+		remoteVirtualNetwork := *remoteVirtualNetworkARM.(*SubResourceARM)
 		result.Properties.RemoteVirtualNetwork = &remoteVirtualNetwork
 	}
 	if peerings.UseRemoteGateways != nil {

--- a/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peerings__spec_arm_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peerings__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (peerings VirtualNetworksVirtualNetworkPeerings_SpecARM) GetAPIVersion() st
 }
 
 // GetName returns the Name of the resource
-func (peerings VirtualNetworksVirtualNetworkPeerings_SpecARM) GetName() string {
+func (peerings *VirtualNetworksVirtualNetworkPeerings_SpecARM) GetName() string {
 	return peerings.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
-func (peerings VirtualNetworksVirtualNetworkPeerings_SpecARM) GetType() string {
+func (peerings *VirtualNetworksVirtualNetworkPeerings_SpecARM) GetType() string {
 	return "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
 }
 

--- a/v2/api/operationalinsights/v1alpha1api20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1alpha1api20210601/workspace_types_gen.go
@@ -891,7 +891,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if workspaces == nil {
 		return nil, nil
 	}
-	var result Workspaces_SpecARM
+	result := &Workspaces_SpecARM{}
 
 	// Set property ‘ETag’:
 	if workspaces.ETag != nil {
@@ -924,7 +924,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		features := featuresARM.(WorkspaceFeaturesARM)
+		features := *featuresARM.(*WorkspaceFeaturesARM)
 		result.Properties.Features = &features
 	}
 	if workspaces.ForceCmkForQuery != nil {
@@ -952,7 +952,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(WorkspaceSkuARM)
+		sku := *skuARM.(*WorkspaceSkuARM)
 		result.Properties.Sku = &sku
 	}
 	if workspaces.WorkspaceCapping != nil {
@@ -960,7 +960,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		workspaceCapping := workspaceCappingARM.(WorkspaceCappingARM)
+		workspaceCapping := *workspaceCappingARM.(*WorkspaceCappingARM)
 		result.Properties.WorkspaceCapping = &workspaceCapping
 	}
 
@@ -1462,7 +1462,7 @@ func (capping *WorkspaceCapping) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if capping == nil {
 		return nil, nil
 	}
-	var result WorkspaceCappingARM
+	result := &WorkspaceCappingARM{}
 
 	// Set property ‘DailyQuotaGb’:
 	if capping.DailyQuotaGb != nil {
@@ -1654,7 +1654,7 @@ func (features *WorkspaceFeatures) ConvertToARM(resolved genruntime.ConvertToARM
 	if features == nil {
 		return nil, nil
 	}
-	var result WorkspaceFeaturesARM
+	result := &WorkspaceFeaturesARM{}
 
 	// Set property ‘AdditionalProperties’:
 	if features.AdditionalProperties != nil {
@@ -2093,7 +2093,7 @@ func (workspaceSku *WorkspaceSku) ConvertToARM(resolved genruntime.ConvertToARMR
 	if workspaceSku == nil {
 		return nil, nil
 	}
-	var result WorkspaceSkuARM
+	result := &WorkspaceSkuARM{}
 
 	// Set property ‘CapacityReservationLevel’:
 	if workspaceSku.CapacityReservationLevel != nil {

--- a/v2/api/operationalinsights/v1alpha1api20210601/workspaces__spec_arm_types_gen.go
+++ b/v2/api/operationalinsights/v1alpha1api20210601/workspaces__spec_arm_types_gen.go
@@ -25,12 +25,12 @@ func (workspaces Workspaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (workspaces Workspaces_SpecARM) GetName() string {
+func (workspaces *Workspaces_SpecARM) GetName() string {
 	return workspaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.OperationalInsights/workspaces"
-func (workspaces Workspaces_SpecARM) GetType() string {
+func (workspaces *Workspaces_SpecARM) GetType() string {
 	return "Microsoft.OperationalInsights/workspaces"
 }
 

--- a/v2/api/operationalinsights/v1beta20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1beta20210601/workspace_types_gen.go
@@ -936,7 +936,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if workspaces == nil {
 		return nil, nil
 	}
-	var result Workspaces_SpecARM
+	result := &Workspaces_SpecARM{}
 
 	// Set property ‘ETag’:
 	if workspaces.ETag != nil {
@@ -969,7 +969,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		features := featuresARM.(WorkspaceFeaturesARM)
+		features := *featuresARM.(*WorkspaceFeaturesARM)
 		result.Properties.Features = &features
 	}
 	if workspaces.ForceCmkForQuery != nil {
@@ -997,7 +997,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(WorkspaceSkuARM)
+		sku := *skuARM.(*WorkspaceSkuARM)
 		result.Properties.Sku = &sku
 	}
 	if workspaces.WorkspaceCapping != nil {
@@ -1005,7 +1005,7 @@ func (workspaces *Workspaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		workspaceCapping := workspaceCappingARM.(WorkspaceCappingARM)
+		workspaceCapping := *workspaceCappingARM.(*WorkspaceCappingARM)
 		result.Properties.WorkspaceCapping = &workspaceCapping
 	}
 
@@ -1509,7 +1509,7 @@ func (capping *WorkspaceCapping) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if capping == nil {
 		return nil, nil
 	}
-	var result WorkspaceCappingARM
+	result := &WorkspaceCappingARM{}
 
 	// Set property ‘DailyQuotaGb’:
 	if capping.DailyQuotaGb != nil {
@@ -1716,7 +1716,7 @@ func (features *WorkspaceFeatures) ConvertToARM(resolved genruntime.ConvertToARM
 	if features == nil {
 		return nil, nil
 	}
-	var result WorkspaceFeaturesARM
+	result := &WorkspaceFeaturesARM{}
 
 	// Set property ‘AdditionalProperties’:
 	if features.AdditionalProperties != nil {
@@ -2158,7 +2158,7 @@ func (workspaceSku *WorkspaceSku) ConvertToARM(resolved genruntime.ConvertToARMR
 	if workspaceSku == nil {
 		return nil, nil
 	}
-	var result WorkspaceSkuARM
+	result := &WorkspaceSkuARM{}
 
 	// Set property ‘CapacityReservationLevel’:
 	if workspaceSku.CapacityReservationLevel != nil {

--- a/v2/api/operationalinsights/v1beta20210601/workspaces__spec_arm_types_gen.go
+++ b/v2/api/operationalinsights/v1beta20210601/workspaces__spec_arm_types_gen.go
@@ -33,12 +33,12 @@ func (workspaces Workspaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (workspaces Workspaces_SpecARM) GetName() string {
+func (workspaces *Workspaces_SpecARM) GetName() string {
 	return workspaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.OperationalInsights/workspaces"
-func (workspaces Workspaces_SpecARM) GetType() string {
+func (workspaces *Workspaces_SpecARM) GetType() string {
 	return "Microsoft.OperationalInsights/workspaces"
 }
 

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespace_types_gen.go
@@ -362,7 +362,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if namespaces == nil {
 		return nil, nil
 	}
-	var result Namespaces_SpecARM
+	result := &Namespaces_SpecARM{}
 
 	// Set property ‘Identity’:
 	if namespaces.Identity != nil {
@@ -370,7 +370,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityARM)
+		identity := *identityARM.(*IdentityARM)
 		result.Identity = &identity
 	}
 
@@ -392,7 +392,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if namespaces.ZoneRedundant != nil {
@@ -406,7 +406,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SBSkuARM)
+		sku := *skuARM.(*SBSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1214,7 +1214,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘KeySource’:
 	if encryption.KeySource != nil {
@@ -1228,7 +1228,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.KeyVaultProperties = append(result.KeyVaultProperties, itemARM.(KeyVaultPropertiesARM))
+		result.KeyVaultProperties = append(result.KeyVaultProperties, *itemARM.(*KeyVaultPropertiesARM))
 	}
 
 	// Set property ‘RequireInfrastructureEncryption’:
@@ -1518,7 +1518,7 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if identity == nil {
 		return nil, nil
 	}
-	var result IdentityARM
+	result := &IdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -1843,7 +1843,7 @@ func (sbSku *SBSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if sbSku == nil {
 		return nil, nil
 	}
-	var result SBSkuARM
+	result := &SBSkuARM{}
 
 	// Set property ‘Capacity’:
 	if sbSku.Capacity != nil {
@@ -2304,7 +2304,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Identity’:
 	if properties.Identity != nil {
@@ -2312,7 +2312,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(UserAssignedIdentityPropertiesARM)
+		identity := *identityARM.(*UserAssignedIdentityPropertiesARM)
 		result.Identity = &identity
 	}
 
@@ -2578,7 +2578,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	if properties == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentityPropertiesARM
+	result := &UserAssignedIdentityPropertiesARM{}
 
 	// Set property ‘UserAssignedIdentity’:
 	if properties.UserAssignedIdentityReference != nil {

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces__spec_arm_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces__spec_arm_types_gen.go
@@ -23,12 +23,12 @@ func (namespaces Namespaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (namespaces Namespaces_SpecARM) GetName() string {
+func (namespaces *Namespaces_SpecARM) GetName() string {
 	return namespaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ServiceBus/namespaces"
-func (namespaces Namespaces_SpecARM) GetType() string {
+func (namespaces *Namespaces_SpecARM) GetType() string {
 	return "Microsoft.ServiceBus/namespaces"
 }
 

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
@@ -368,7 +368,7 @@ func (queues *NamespacesQueues_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if queues == nil {
 		return nil, nil
 	}
-	var result NamespacesQueues_SpecARM
+	result := &NamespacesQueues_SpecARM{}
 
 	// Set property ‘Location’:
 	if queues.Location != nil {

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queues__spec_arm_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queues__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (queues NamespacesQueues_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (queues NamespacesQueues_SpecARM) GetName() string {
+func (queues *NamespacesQueues_SpecARM) GetName() string {
 	return queues.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ServiceBus/namespaces/queues"
-func (queues NamespacesQueues_SpecARM) GetType() string {
+func (queues *NamespacesQueues_SpecARM) GetType() string {
 	return "Microsoft.ServiceBus/namespaces/queues"
 }
 

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
@@ -363,7 +363,7 @@ func (topics *NamespacesTopics_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if topics == nil {
 		return nil, nil
 	}
-	var result NamespacesTopics_SpecARM
+	result := &NamespacesTopics_SpecARM{}
 
 	// Set property ‘Location’:
 	if topics.Location != nil {

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topics__spec_arm_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topics__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (topics NamespacesTopics_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (topics NamespacesTopics_SpecARM) GetName() string {
+func (topics *NamespacesTopics_SpecARM) GetName() string {
 	return topics.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ServiceBus/namespaces/topics"
-func (topics NamespacesTopics_SpecARM) GetType() string {
+func (topics *NamespacesTopics_SpecARM) GetType() string {
 	return "Microsoft.ServiceBus/namespaces/topics"
 }
 

--- a/v2/api/servicebus/v1beta20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespace_types_gen.go
@@ -359,7 +359,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if namespaces == nil {
 		return nil, nil
 	}
-	var result Namespaces_SpecARM
+	result := &Namespaces_SpecARM{}
 
 	// Set property ‘Identity’:
 	if namespaces.Identity != nil {
@@ -367,7 +367,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityARM)
+		identity := *identityARM.(*IdentityARM)
 		result.Identity = &identity
 	}
 
@@ -389,7 +389,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if namespaces.ZoneRedundant != nil {
@@ -403,7 +403,7 @@ func (namespaces *Namespaces_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SBSkuARM)
+		sku := *skuARM.(*SBSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1249,7 +1249,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘KeySource’:
 	if encryption.KeySource != nil {
@@ -1263,7 +1263,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		result.KeyVaultProperties = append(result.KeyVaultProperties, itemARM.(KeyVaultPropertiesARM))
+		result.KeyVaultProperties = append(result.KeyVaultProperties, *itemARM.(*KeyVaultPropertiesARM))
 	}
 
 	// Set property ‘RequireInfrastructureEncryption’:
@@ -1558,7 +1558,7 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if identity == nil {
 		return nil, nil
 	}
-	var result IdentityARM
+	result := &IdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -1895,7 +1895,7 @@ func (sbSku *SBSku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if sbSku == nil {
 		return nil, nil
 	}
-	var result SBSkuARM
+	result := &SBSkuARM{}
 
 	// Set property ‘Capacity’:
 	if sbSku.Capacity != nil {
@@ -2376,7 +2376,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Identity’:
 	if properties.Identity != nil {
@@ -2384,7 +2384,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(UserAssignedIdentityPropertiesARM)
+		identity := *identityARM.(*UserAssignedIdentityPropertiesARM)
 		result.Identity = &identity
 	}
 
@@ -2656,7 +2656,7 @@ func (properties *UserAssignedIdentityProperties) ConvertToARM(resolved genrunti
 	if properties == nil {
 		return nil, nil
 	}
-	var result UserAssignedIdentityPropertiesARM
+	result := &UserAssignedIdentityPropertiesARM{}
 
 	// Set property ‘UserAssignedIdentity’:
 	if properties.UserAssignedIdentityReference != nil {

--- a/v2/api/servicebus/v1beta20210101preview/namespaces__spec_arm_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces__spec_arm_types_gen.go
@@ -33,12 +33,12 @@ func (namespaces Namespaces_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (namespaces Namespaces_SpecARM) GetName() string {
+func (namespaces *Namespaces_SpecARM) GetName() string {
 	return namespaces.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ServiceBus/namespaces"
-func (namespaces Namespaces_SpecARM) GetType() string {
+func (namespaces *Namespaces_SpecARM) GetType() string {
 	return "Microsoft.ServiceBus/namespaces"
 }
 

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen.go
@@ -394,7 +394,7 @@ func (queues *NamespacesQueues_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if queues == nil {
 		return nil, nil
 	}
-	var result NamespacesQueues_SpecARM
+	result := &NamespacesQueues_SpecARM{}
 
 	// Set property ‘Location’:
 	if queues.Location != nil {

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_queues__spec_arm_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_queues__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (queues NamespacesQueues_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (queues NamespacesQueues_SpecARM) GetName() string {
+func (queues *NamespacesQueues_SpecARM) GetName() string {
 	return queues.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ServiceBus/namespaces/queues"
-func (queues NamespacesQueues_SpecARM) GetType() string {
+func (queues *NamespacesQueues_SpecARM) GetType() string {
 	return "Microsoft.ServiceBus/namespaces/queues"
 }
 

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen.go
@@ -376,7 +376,7 @@ func (topics *NamespacesTopics_Spec) ConvertToARM(resolved genruntime.ConvertToA
 	if topics == nil {
 		return nil, nil
 	}
-	var result NamespacesTopics_SpecARM
+	result := &NamespacesTopics_SpecARM{}
 
 	// Set property ‘Location’:
 	if topics.Location != nil {

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topics__spec_arm_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topics__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (topics NamespacesTopics_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (topics NamespacesTopics_SpecARM) GetName() string {
+func (topics *NamespacesTopics_SpecARM) GetName() string {
 	return topics.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.ServiceBus/namespaces/topics"
-func (topics NamespacesTopics_SpecARM) GetType() string {
+func (topics *NamespacesTopics_SpecARM) GetType() string {
 	return "Microsoft.ServiceBus/namespaces/topics"
 }
 

--- a/v2/api/signalrservice/v1alpha1api20211001/signal_r__spec_arm_types_gen.go
+++ b/v2/api/signalrservice/v1alpha1api20211001/signal_r__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (signalR SignalR_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (signalR SignalR_SpecARM) GetName() string {
+func (signalR *SignalR_SpecARM) GetName() string {
 	return signalR.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.SignalRService/signalR"
-func (signalR SignalR_SpecARM) GetType() string {
+func (signalR *SignalR_SpecARM) GetType() string {
 	return "Microsoft.SignalRService/signalR"
 }
 

--- a/v2/api/signalrservice/v1alpha1api20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1alpha1api20211001/signal_r_types_gen.go
@@ -1209,7 +1209,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if signalR == nil {
 		return nil, nil
 	}
-	var result SignalR_SpecARM
+	result := &SignalR_SpecARM{}
 
 	// Set property ‘Identity’:
 	if signalR.Identity != nil {
@@ -1217,7 +1217,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(ManagedIdentityARM)
+		identity := *identityARM.(*ManagedIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1253,7 +1253,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		cors := corsARM.(SignalRCorsSettingsARM)
+		cors := *corsARM.(*SignalRCorsSettingsARM)
 		result.Properties.Cors = &cors
 	}
 	if signalR.DisableAadAuth != nil {
@@ -1269,14 +1269,14 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Features = append(result.Properties.Features, itemARM.(SignalRFeatureARM))
+		result.Properties.Features = append(result.Properties.Features, *itemARM.(*SignalRFeatureARM))
 	}
 	if signalR.NetworkACLs != nil {
 		networkACLsARM, err := (*signalR.NetworkACLs).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		networkACLs := networkACLsARM.(SignalRNetworkACLsARM)
+		networkACLs := *networkACLsARM.(*SignalRNetworkACLsARM)
 		result.Properties.NetworkACLs = &networkACLs
 	}
 	if signalR.PublicNetworkAccess != nil {
@@ -1288,7 +1288,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		resourceLogConfiguration := resourceLogConfigurationARM.(ResourceLogConfigurationARM)
+		resourceLogConfiguration := *resourceLogConfigurationARM.(*ResourceLogConfigurationARM)
 		result.Properties.ResourceLogConfiguration = &resourceLogConfiguration
 	}
 	if signalR.Tls != nil {
@@ -1296,7 +1296,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		tls := tlsARM.(SignalRTlsSettingsARM)
+		tls := *tlsARM.(*SignalRTlsSettingsARM)
 		result.Properties.Tls = &tls
 	}
 	if signalR.Upstream != nil {
@@ -1304,7 +1304,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		upstream := upstreamARM.(ServerlessUpstreamSettingsARM)
+		upstream := *upstreamARM.(*ServerlessUpstreamSettingsARM)
 		result.Properties.Upstream = &upstream
 	}
 
@@ -1314,7 +1314,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(ResourceSkuARM)
+		sku := *skuARM.(*ResourceSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1893,7 +1893,7 @@ func (identity *ManagedIdentity) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedIdentityARM
+	result := &ManagedIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -2271,7 +2271,7 @@ func (configuration *ResourceLogConfiguration) ConvertToARM(resolved genruntime.
 	if configuration == nil {
 		return nil, nil
 	}
-	var result ResourceLogConfigurationARM
+	result := &ResourceLogConfigurationARM{}
 
 	// Set property ‘Categories’:
 	for _, item := range configuration.Categories {
@@ -2279,7 +2279,7 @@ func (configuration *ResourceLogConfiguration) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		result.Categories = append(result.Categories, itemARM.(ResourceLogCategoryARM))
+		result.Categories = append(result.Categories, *itemARM.(*ResourceLogCategoryARM))
 	}
 	return result, nil
 }
@@ -2477,7 +2477,7 @@ func (resourceSku *ResourceSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if resourceSku == nil {
 		return nil, nil
 	}
-	var result ResourceSkuARM
+	result := &ResourceSkuARM{}
 
 	// Set property ‘Capacity’:
 	if resourceSku.Capacity != nil {
@@ -2716,7 +2716,7 @@ func (settings *ServerlessUpstreamSettings) ConvertToARM(resolved genruntime.Con
 	if settings == nil {
 		return nil, nil
 	}
-	var result ServerlessUpstreamSettingsARM
+	result := &ServerlessUpstreamSettingsARM{}
 
 	// Set property ‘Templates’:
 	for _, item := range settings.Templates {
@@ -2724,7 +2724,7 @@ func (settings *ServerlessUpstreamSettings) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		result.Templates = append(result.Templates, itemARM.(UpstreamTemplateARM))
+		result.Templates = append(result.Templates, *itemARM.(*UpstreamTemplateARM))
 	}
 	return result, nil
 }
@@ -3012,7 +3012,7 @@ func (settings *SignalRCorsSettings) ConvertToARM(resolved genruntime.ConvertToA
 	if settings == nil {
 		return nil, nil
 	}
-	var result SignalRCorsSettingsARM
+	result := &SignalRCorsSettingsARM{}
 
 	// Set property ‘AllowedOrigins’:
 	for _, item := range settings.AllowedOrigins {
@@ -3147,7 +3147,7 @@ func (feature *SignalRFeature) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if feature == nil {
 		return nil, nil
 	}
-	var result SignalRFeatureARM
+	result := &SignalRFeatureARM{}
 
 	// Set property ‘Flag’:
 	if feature.Flag != nil {
@@ -3378,7 +3378,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if acLs == nil {
 		return nil, nil
 	}
-	var result SignalRNetworkACLsARM
+	result := &SignalRNetworkACLsARM{}
 
 	// Set property ‘DefaultAction’:
 	if acLs.DefaultAction != nil {
@@ -3392,7 +3392,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		result.PrivateEndpoints = append(result.PrivateEndpoints, itemARM.(PrivateEndpointACLARM))
+		result.PrivateEndpoints = append(result.PrivateEndpoints, *itemARM.(*PrivateEndpointACLARM))
 	}
 
 	// Set property ‘PublicNetwork’:
@@ -3401,7 +3401,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		publicNetwork := publicNetworkARM.(NetworkACLARM)
+		publicNetwork := *publicNetworkARM.(*NetworkACLARM)
 		result.PublicNetwork = &publicNetwork
 	}
 	return result, nil
@@ -3712,7 +3712,7 @@ func (settings *SignalRTlsSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	if settings == nil {
 		return nil, nil
 	}
-	var result SignalRTlsSettingsARM
+	result := &SignalRTlsSettingsARM{}
 
 	// Set property ‘ClientCertEnabled’:
 	if settings.ClientCertEnabled != nil {
@@ -4025,7 +4025,7 @@ func (networkACL *NetworkACL) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if networkACL == nil {
 		return nil, nil
 	}
-	var result NetworkACLARM
+	result := &NetworkACLARM{}
 
 	// Set property ‘Allow’:
 	for _, item := range networkACL.Allow {
@@ -4265,7 +4265,7 @@ func (endpointACL *PrivateEndpointACL) ConvertToARM(resolved genruntime.ConvertT
 	if endpointACL == nil {
 		return nil, nil
 	}
-	var result PrivateEndpointACLARM
+	result := &PrivateEndpointACLARM{}
 
 	// Set property ‘Allow’:
 	for _, item := range endpointACL.Allow {
@@ -4533,7 +4533,7 @@ func (category *ResourceLogCategory) ConvertToARM(resolved genruntime.ConvertToA
 	if category == nil {
 		return nil, nil
 	}
-	var result ResourceLogCategoryARM
+	result := &ResourceLogCategoryARM{}
 
 	// Set property ‘Enabled’:
 	if category.Enabled != nil {
@@ -4721,7 +4721,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 	if template == nil {
 		return nil, nil
 	}
-	var result UpstreamTemplateARM
+	result := &UpstreamTemplateARM{}
 
 	// Set property ‘Auth’:
 	if template.Auth != nil {
@@ -4729,7 +4729,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 		if err != nil {
 			return nil, err
 		}
-		auth := authARM.(UpstreamAuthSettingsARM)
+		auth := *authARM.(*UpstreamAuthSettingsARM)
 		result.Auth = &auth
 	}
 
@@ -5152,7 +5152,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 	if settings == nil {
 		return nil, nil
 	}
-	var result UpstreamAuthSettingsARM
+	result := &UpstreamAuthSettingsARM{}
 
 	// Set property ‘ManagedIdentity’:
 	if settings.ManagedIdentity != nil {
@@ -5160,7 +5160,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		managedIdentity := managedIdentityARM.(ManagedIdentitySettingsARM)
+		managedIdentity := *managedIdentityARM.(*ManagedIdentitySettingsARM)
 		result.ManagedIdentity = &managedIdentity
 	}
 
@@ -5384,7 +5384,7 @@ func (settings *ManagedIdentitySettings) ConvertToARM(resolved genruntime.Conver
 	if settings == nil {
 		return nil, nil
 	}
-	var result ManagedIdentitySettingsARM
+	result := &ManagedIdentitySettingsARM{}
 
 	// Set property ‘Resource’:
 	if settings.Resource != nil {

--- a/v2/api/signalrservice/v1beta20211001/signal_r__spec_arm_types_gen.go
+++ b/v2/api/signalrservice/v1beta20211001/signal_r__spec_arm_types_gen.go
@@ -37,12 +37,12 @@ func (signalR SignalR_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (signalR SignalR_SpecARM) GetName() string {
+func (signalR *SignalR_SpecARM) GetName() string {
 	return signalR.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.SignalRService/signalR"
-func (signalR SignalR_SpecARM) GetType() string {
+func (signalR *SignalR_SpecARM) GetType() string {
 	return "Microsoft.SignalRService/signalR"
 }
 

--- a/v2/api/signalrservice/v1beta20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1beta20211001/signal_r_types_gen.go
@@ -1273,7 +1273,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 	if signalR == nil {
 		return nil, nil
 	}
-	var result SignalR_SpecARM
+	result := &SignalR_SpecARM{}
 
 	// Set property ‘Identity’:
 	if signalR.Identity != nil {
@@ -1281,7 +1281,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(ManagedIdentityARM)
+		identity := *identityARM.(*ManagedIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1317,7 +1317,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		cors := corsARM.(SignalRCorsSettingsARM)
+		cors := *corsARM.(*SignalRCorsSettingsARM)
 		result.Properties.Cors = &cors
 	}
 	if signalR.DisableAadAuth != nil {
@@ -1333,14 +1333,14 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		result.Properties.Features = append(result.Properties.Features, itemARM.(SignalRFeatureARM))
+		result.Properties.Features = append(result.Properties.Features, *itemARM.(*SignalRFeatureARM))
 	}
 	if signalR.NetworkACLs != nil {
 		networkACLsARM, err := (*signalR.NetworkACLs).ConvertToARM(resolved)
 		if err != nil {
 			return nil, err
 		}
-		networkACLs := networkACLsARM.(SignalRNetworkACLsARM)
+		networkACLs := *networkACLsARM.(*SignalRNetworkACLsARM)
 		result.Properties.NetworkACLs = &networkACLs
 	}
 	if signalR.PublicNetworkAccess != nil {
@@ -1352,7 +1352,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		resourceLogConfiguration := resourceLogConfigurationARM.(ResourceLogConfigurationARM)
+		resourceLogConfiguration := *resourceLogConfigurationARM.(*ResourceLogConfigurationARM)
 		result.Properties.ResourceLogConfiguration = &resourceLogConfiguration
 	}
 	if signalR.Tls != nil {
@@ -1360,7 +1360,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		tls := tlsARM.(SignalRTlsSettingsARM)
+		tls := *tlsARM.(*SignalRTlsSettingsARM)
 		result.Properties.Tls = &tls
 	}
 	if signalR.Upstream != nil {
@@ -1368,7 +1368,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		upstream := upstreamARM.(ServerlessUpstreamSettingsARM)
+		upstream := *upstreamARM.(*ServerlessUpstreamSettingsARM)
 		result.Properties.Upstream = &upstream
 	}
 
@@ -1378,7 +1378,7 @@ func (signalR *SignalR_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolv
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(ResourceSkuARM)
+		sku := *skuARM.(*ResourceSkuARM)
 		result.Sku = &sku
 	}
 
@@ -1959,7 +1959,7 @@ func (identity *ManagedIdentity) ConvertToARM(resolved genruntime.ConvertToARMRe
 	if identity == nil {
 		return nil, nil
 	}
-	var result ManagedIdentityARM
+	result := &ManagedIdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -2343,7 +2343,7 @@ func (configuration *ResourceLogConfiguration) ConvertToARM(resolved genruntime.
 	if configuration == nil {
 		return nil, nil
 	}
-	var result ResourceLogConfigurationARM
+	result := &ResourceLogConfigurationARM{}
 
 	// Set property ‘Categories’:
 	for _, item := range configuration.Categories {
@@ -2351,7 +2351,7 @@ func (configuration *ResourceLogConfiguration) ConvertToARM(resolved genruntime.
 		if err != nil {
 			return nil, err
 		}
-		result.Categories = append(result.Categories, itemARM.(ResourceLogCategoryARM))
+		result.Categories = append(result.Categories, *itemARM.(*ResourceLogCategoryARM))
 	}
 	return result, nil
 }
@@ -2555,7 +2555,7 @@ func (resourceSku *ResourceSku) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if resourceSku == nil {
 		return nil, nil
 	}
-	var result ResourceSkuARM
+	result := &ResourceSkuARM{}
 
 	// Set property ‘Capacity’:
 	if resourceSku.Capacity != nil {
@@ -2805,7 +2805,7 @@ func (settings *ServerlessUpstreamSettings) ConvertToARM(resolved genruntime.Con
 	if settings == nil {
 		return nil, nil
 	}
-	var result ServerlessUpstreamSettingsARM
+	result := &ServerlessUpstreamSettingsARM{}
 
 	// Set property ‘Templates’:
 	for _, item := range settings.Templates {
@@ -2813,7 +2813,7 @@ func (settings *ServerlessUpstreamSettings) ConvertToARM(resolved genruntime.Con
 		if err != nil {
 			return nil, err
 		}
-		result.Templates = append(result.Templates, itemARM.(UpstreamTemplateARM))
+		result.Templates = append(result.Templates, *itemARM.(*UpstreamTemplateARM))
 	}
 	return result, nil
 }
@@ -3103,7 +3103,7 @@ func (settings *SignalRCorsSettings) ConvertToARM(resolved genruntime.ConvertToA
 	if settings == nil {
 		return nil, nil
 	}
-	var result SignalRCorsSettingsARM
+	result := &SignalRCorsSettingsARM{}
 
 	// Set property ‘AllowedOrigins’:
 	for _, item := range settings.AllowedOrigins {
@@ -3243,7 +3243,7 @@ func (feature *SignalRFeature) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if feature == nil {
 		return nil, nil
 	}
-	var result SignalRFeatureARM
+	result := &SignalRFeatureARM{}
 
 	// Set property ‘Flag’:
 	if feature.Flag != nil {
@@ -3482,7 +3482,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if acLs == nil {
 		return nil, nil
 	}
-	var result SignalRNetworkACLsARM
+	result := &SignalRNetworkACLsARM{}
 
 	// Set property ‘DefaultAction’:
 	if acLs.DefaultAction != nil {
@@ -3496,7 +3496,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		result.PrivateEndpoints = append(result.PrivateEndpoints, itemARM.(PrivateEndpointACLARM))
+		result.PrivateEndpoints = append(result.PrivateEndpoints, *itemARM.(*PrivateEndpointACLARM))
 	}
 
 	// Set property ‘PublicNetwork’:
@@ -3505,7 +3505,7 @@ func (acLs *SignalRNetworkACLs) ConvertToARM(resolved genruntime.ConvertToARMRes
 		if err != nil {
 			return nil, err
 		}
-		publicNetwork := publicNetworkARM.(NetworkACLARM)
+		publicNetwork := *publicNetworkARM.(*NetworkACLARM)
 		result.PublicNetwork = &publicNetwork
 	}
 	return result, nil
@@ -3818,7 +3818,7 @@ func (settings *SignalRTlsSettings) ConvertToARM(resolved genruntime.ConvertToAR
 	if settings == nil {
 		return nil, nil
 	}
-	var result SignalRTlsSettingsARM
+	result := &SignalRTlsSettingsARM{}
 
 	// Set property ‘ClientCertEnabled’:
 	if settings.ClientCertEnabled != nil {
@@ -4142,7 +4142,7 @@ func (networkACL *NetworkACL) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if networkACL == nil {
 		return nil, nil
 	}
-	var result NetworkACLARM
+	result := &NetworkACLARM{}
 
 	// Set property ‘Allow’:
 	for _, item := range networkACL.Allow {
@@ -4388,7 +4388,7 @@ func (endpointACL *PrivateEndpointACL) ConvertToARM(resolved genruntime.ConvertT
 	if endpointACL == nil {
 		return nil, nil
 	}
-	var result PrivateEndpointACLARM
+	result := &PrivateEndpointACLARM{}
 
 	// Set property ‘Allow’:
 	for _, item := range endpointACL.Allow {
@@ -4667,7 +4667,7 @@ func (category *ResourceLogCategory) ConvertToARM(resolved genruntime.ConvertToA
 	if category == nil {
 		return nil, nil
 	}
-	var result ResourceLogCategoryARM
+	result := &ResourceLogCategoryARM{}
 
 	// Set property ‘Enabled’:
 	if category.Enabled != nil {
@@ -4883,7 +4883,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 	if template == nil {
 		return nil, nil
 	}
-	var result UpstreamTemplateARM
+	result := &UpstreamTemplateARM{}
 
 	// Set property ‘Auth’:
 	if template.Auth != nil {
@@ -4891,7 +4891,7 @@ func (template *UpstreamTemplate) ConvertToARM(resolved genruntime.ConvertToARMR
 		if err != nil {
 			return nil, err
 		}
-		auth := authARM.(UpstreamAuthSettingsARM)
+		auth := *authARM.(*UpstreamAuthSettingsARM)
 		result.Auth = &auth
 	}
 
@@ -5335,7 +5335,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 	if settings == nil {
 		return nil, nil
 	}
-	var result UpstreamAuthSettingsARM
+	result := &UpstreamAuthSettingsARM{}
 
 	// Set property ‘ManagedIdentity’:
 	if settings.ManagedIdentity != nil {
@@ -5343,7 +5343,7 @@ func (settings *UpstreamAuthSettings) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		managedIdentity := managedIdentityARM.(ManagedIdentitySettingsARM)
+		managedIdentity := *managedIdentityARM.(*ManagedIdentitySettingsARM)
 		result.ManagedIdentity = &managedIdentity
 	}
 
@@ -5568,7 +5568,7 @@ func (settings *ManagedIdentitySettings) ConvertToARM(resolved genruntime.Conver
 	if settings == nil {
 		return nil, nil
 	}
-	var result ManagedIdentitySettingsARM
+	result := &ManagedIdentitySettingsARM{}
 
 	// Set property ‘Resource’:
 	if settings.Resource != nil {

--- a/v2/api/storage/v1alpha1api20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_account_types_gen.go
@@ -1638,7 +1638,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if accounts == nil {
 		return nil, nil
 	}
-	var result StorageAccounts_SpecARM
+	result := &StorageAccounts_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if accounts.ExtendedLocation != nil {
@@ -1646,7 +1646,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1656,7 +1656,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityARM)
+		identity := *identityARM.(*IdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1715,7 +1715,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		azureFilesIdentityBasedAuthentication := azureFilesIdentityBasedAuthenticationARM.(AzureFilesIdentityBasedAuthenticationARM)
+		azureFilesIdentityBasedAuthentication := *azureFilesIdentityBasedAuthenticationARM.(*AzureFilesIdentityBasedAuthenticationARM)
 		result.Properties.AzureFilesIdentityBasedAuthentication = &azureFilesIdentityBasedAuthentication
 	}
 	if accounts.CustomDomain != nil {
@@ -1723,7 +1723,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		customDomain := customDomainARM.(CustomDomainARM)
+		customDomain := *customDomainARM.(*CustomDomainARM)
 		result.Properties.CustomDomain = &customDomain
 	}
 	if accounts.Encryption != nil {
@@ -1731,7 +1731,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if accounts.IsHnsEnabled != nil {
@@ -1747,7 +1747,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		keyPolicy := keyPolicyARM.(KeyPolicyARM)
+		keyPolicy := *keyPolicyARM.(*KeyPolicyARM)
 		result.Properties.KeyPolicy = &keyPolicy
 	}
 	if accounts.LargeFileSharesState != nil {
@@ -1763,7 +1763,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		networkAcls := networkAclsARM.(NetworkRuleSetARM)
+		networkAcls := *networkAclsARM.(*NetworkRuleSetARM)
 		result.Properties.NetworkAcls = &networkAcls
 	}
 	if accounts.RoutingPreference != nil {
@@ -1771,7 +1771,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		routingPreference := routingPreferenceARM.(RoutingPreferenceARM)
+		routingPreference := *routingPreferenceARM.(*RoutingPreferenceARM)
 		result.Properties.RoutingPreference = &routingPreference
 	}
 	if accounts.SasPolicy != nil {
@@ -1779,7 +1779,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		sasPolicy := sasPolicyARM.(SasPolicyARM)
+		sasPolicy := *sasPolicyARM.(*SasPolicyARM)
 		result.Properties.SasPolicy = &sasPolicy
 	}
 	if accounts.SupportsHttpsTrafficOnly != nil {
@@ -1793,7 +1793,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -2623,7 +2623,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 	if authentication == nil {
 		return nil, nil
 	}
-	var result AzureFilesIdentityBasedAuthenticationARM
+	result := &AzureFilesIdentityBasedAuthenticationARM{}
 
 	// Set property ‘ActiveDirectoryProperties’:
 	if authentication.ActiveDirectoryProperties != nil {
@@ -2631,7 +2631,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 		if err != nil {
 			return nil, err
 		}
-		activeDirectoryProperties := activeDirectoryPropertiesARM.(ActiveDirectoryPropertiesARM)
+		activeDirectoryProperties := *activeDirectoryPropertiesARM.(*ActiveDirectoryPropertiesARM)
 		result.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
@@ -3038,7 +3038,7 @@ func (domain *CustomDomain) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if domain == nil {
 		return nil, nil
 	}
-	var result CustomDomainARM
+	result := &CustomDomainARM{}
 
 	// Set property ‘Name’:
 	if domain.Name != nil {
@@ -3226,7 +3226,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘Identity’:
 	if encryption.Identity != nil {
@@ -3234,7 +3234,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(EncryptionIdentityARM)
+		identity := *identityARM.(*EncryptionIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -3250,7 +3250,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		keyvaultproperties := keyvaultpropertiesARM.(KeyVaultPropertiesARM)
+		keyvaultproperties := *keyvaultpropertiesARM.(*KeyVaultPropertiesARM)
 		result.Keyvaultproperties = &keyvaultproperties
 	}
 
@@ -3266,7 +3266,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		services := servicesARM.(EncryptionServicesARM)
+		services := *servicesARM.(*EncryptionServicesARM)
 		result.Services = &services
 	}
 	return result, nil
@@ -3867,7 +3867,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -4154,7 +4154,7 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if identity == nil {
 		return nil, nil
 	}
-	var result IdentityARM
+	result := &IdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -4453,7 +4453,7 @@ func (policy *KeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if policy == nil {
 		return nil, nil
 	}
-	var result KeyPolicyARM
+	result := &KeyPolicyARM{}
 
 	// Set property ‘KeyExpirationPeriodInDays’:
 	if policy.KeyExpirationPeriodInDays != nil {
@@ -4590,7 +4590,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if ruleSet == nil {
 		return nil, nil
 	}
-	var result NetworkRuleSetARM
+	result := &NetworkRuleSetARM{}
 
 	// Set property ‘Bypass’:
 	if ruleSet.Bypass != nil {
@@ -4610,7 +4610,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.IpRules = append(result.IpRules, itemARM.(IPRuleARM))
+		result.IpRules = append(result.IpRules, *itemARM.(*IPRuleARM))
 	}
 
 	// Set property ‘ResourceAccessRules’:
@@ -4619,7 +4619,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.ResourceAccessRules = append(result.ResourceAccessRules, itemARM.(ResourceAccessRuleARM))
+		result.ResourceAccessRules = append(result.ResourceAccessRules, *itemARM.(*ResourceAccessRuleARM))
 	}
 
 	// Set property ‘VirtualNetworkRules’:
@@ -4628,7 +4628,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.VirtualNetworkRules = append(result.VirtualNetworkRules, itemARM.(VirtualNetworkRuleARM))
+		result.VirtualNetworkRules = append(result.VirtualNetworkRules, *itemARM.(*VirtualNetworkRuleARM))
 	}
 	return result, nil
 }
@@ -5158,7 +5158,7 @@ func (preference *RoutingPreference) ConvertToARM(resolved genruntime.ConvertToA
 	if preference == nil {
 		return nil, nil
 	}
-	var result RoutingPreferenceARM
+	result := &RoutingPreferenceARM{}
 
 	// Set property ‘PublishInternetEndpoints’:
 	if preference.PublishInternetEndpoints != nil {
@@ -5415,7 +5415,7 @@ func (policy *SasPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if policy == nil {
 		return nil, nil
 	}
-	var result SasPolicyARM
+	result := &SasPolicyARM{}
 
 	// Set property ‘ExpirationAction’:
 	if policy.ExpirationAction != nil {
@@ -5599,7 +5599,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -5957,7 +5957,7 @@ func (properties *ActiveDirectoryProperties) ConvertToARM(resolved genruntime.Co
 	if properties == nil {
 		return nil, nil
 	}
-	var result ActiveDirectoryPropertiesARM
+	result := &ActiveDirectoryPropertiesARM{}
 
 	// Set property ‘AzureStorageSid’:
 	if properties.AzureStorageSid != nil {
@@ -6403,7 +6403,7 @@ func (identity *EncryptionIdentity) ConvertToARM(resolved genruntime.ConvertToAR
 	if identity == nil {
 		return nil, nil
 	}
-	var result EncryptionIdentityARM
+	result := &EncryptionIdentityARM{}
 
 	// Set property ‘UserAssignedIdentity’:
 	if identity.UserAssignedIdentityReference != nil {
@@ -6556,7 +6556,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 	if services == nil {
 		return nil, nil
 	}
-	var result EncryptionServicesARM
+	result := &EncryptionServicesARM{}
 
 	// Set property ‘Blob’:
 	if services.Blob != nil {
@@ -6564,7 +6564,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		blob := blobARM.(EncryptionServiceARM)
+		blob := *blobARM.(*EncryptionServiceARM)
 		result.Blob = &blob
 	}
 
@@ -6574,7 +6574,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		file := fileARM.(EncryptionServiceARM)
+		file := *fileARM.(*EncryptionServiceARM)
 		result.File = &file
 	}
 
@@ -6584,7 +6584,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		queue := queueARM.(EncryptionServiceARM)
+		queue := *queueARM.(*EncryptionServiceARM)
 		result.Queue = &queue
 	}
 
@@ -6594,7 +6594,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		table := tableARM.(EncryptionServiceARM)
+		table := *tableARM.(*EncryptionServiceARM)
 		result.Table = &table
 	}
 	return result, nil
@@ -7000,7 +7000,7 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if rule == nil {
 		return nil, nil
 	}
-	var result IPRuleARM
+	result := &IPRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -7184,7 +7184,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Keyname’:
 	if properties.Keyname != nil {
@@ -7442,7 +7442,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if rule == nil {
 		return nil, nil
 	}
-	var result ResourceAccessRuleARM
+	result := &ResourceAccessRuleARM{}
 
 	// Set property ‘ResourceId’:
 	if rule.ResourceReference != nil {
@@ -8121,7 +8121,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if rule == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkRuleARM
+	result := &VirtualNetworkRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -8436,7 +8436,7 @@ func (service *EncryptionService) ConvertToARM(resolved genruntime.ConvertToARMR
 	if service == nil {
 		return nil, nil
 	}
-	var result EncryptionServiceARM
+	result := &EncryptionServiceARM{}
 
 	// Set property ‘Enabled’:
 	if service.Enabled != nil {

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts__spec_arm_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts__spec_arm_types_gen.go
@@ -25,12 +25,12 @@ func (accounts StorageAccounts_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (accounts StorageAccounts_SpecARM) GetName() string {
+func (accounts *StorageAccounts_SpecARM) GetName() string {
 	return accounts.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts"
-func (accounts StorageAccounts_SpecARM) GetType() string {
+func (accounts *StorageAccounts_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts"
 }
 

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
@@ -834,7 +834,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 	if services == nil {
 		return nil, nil
 	}
-	var result StorageAccountsBlobServices_SpecARM
+	result := &StorageAccountsBlobServices_SpecARM{}
 
 	// Set property ‘Location’:
 	if services.Location != nil {
@@ -866,7 +866,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		changeFeed := changeFeedARM.(ChangeFeedARM)
+		changeFeed := *changeFeedARM.(*ChangeFeedARM)
 		result.Properties.ChangeFeed = &changeFeed
 	}
 	if services.ContainerDeleteRetentionPolicy != nil {
@@ -874,7 +874,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		containerDeleteRetentionPolicy := containerDeleteRetentionPolicyARM.(DeleteRetentionPolicyARM)
+		containerDeleteRetentionPolicy := *containerDeleteRetentionPolicyARM.(*DeleteRetentionPolicyARM)
 		result.Properties.ContainerDeleteRetentionPolicy = &containerDeleteRetentionPolicy
 	}
 	if services.Cors != nil {
@@ -882,7 +882,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		cors := corsARM.(CorsRulesARM)
+		cors := *corsARM.(*CorsRulesARM)
 		result.Properties.Cors = &cors
 	}
 	if services.DefaultServiceVersion != nil {
@@ -894,7 +894,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		deleteRetentionPolicy := deleteRetentionPolicyARM.(DeleteRetentionPolicyARM)
+		deleteRetentionPolicy := *deleteRetentionPolicyARM.(*DeleteRetentionPolicyARM)
 		result.Properties.DeleteRetentionPolicy = &deleteRetentionPolicy
 	}
 	if services.IsVersioningEnabled != nil {
@@ -906,7 +906,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		lastAccessTimeTrackingPolicy := lastAccessTimeTrackingPolicyARM.(LastAccessTimeTrackingPolicyARM)
+		lastAccessTimeTrackingPolicy := *lastAccessTimeTrackingPolicyARM.(*LastAccessTimeTrackingPolicyARM)
 		result.Properties.LastAccessTimeTrackingPolicy = &lastAccessTimeTrackingPolicy
 	}
 	if services.RestorePolicy != nil {
@@ -914,7 +914,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		restorePolicy := restorePolicyARM.(RestorePolicyPropertiesARM)
+		restorePolicy := *restorePolicyARM.(*RestorePolicyPropertiesARM)
 		result.Properties.RestorePolicy = &restorePolicy
 	}
 
@@ -1381,7 +1381,7 @@ func (feed *ChangeFeed) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if feed == nil {
 		return nil, nil
 	}
-	var result ChangeFeedARM
+	result := &ChangeFeedARM{}
 
 	// Set property ‘Enabled’:
 	if feed.Enabled != nil {
@@ -1573,7 +1573,7 @@ func (rules *CorsRules) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if rules == nil {
 		return nil, nil
 	}
-	var result CorsRulesARM
+	result := &CorsRulesARM{}
 
 	// Set property ‘CorsRules’:
 	for _, item := range rules.CorsRules {
@@ -1581,7 +1581,7 @@ func (rules *CorsRules) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		if err != nil {
 			return nil, err
 		}
-		result.CorsRules = append(result.CorsRules, itemARM.(CorsRuleARM))
+		result.CorsRules = append(result.CorsRules, *itemARM.(*CorsRuleARM))
 	}
 	return result, nil
 }
@@ -1778,7 +1778,7 @@ func (policy *DeleteRetentionPolicy) ConvertToARM(resolved genruntime.ConvertToA
 	if policy == nil {
 		return nil, nil
 	}
-	var result DeleteRetentionPolicyARM
+	result := &DeleteRetentionPolicyARM{}
 
 	// Set property ‘Days’:
 	if policy.Days != nil {
@@ -1975,7 +1975,7 @@ func (policy *LastAccessTimeTrackingPolicy) ConvertToARM(resolved genruntime.Con
 	if policy == nil {
 		return nil, nil
 	}
-	var result LastAccessTimeTrackingPolicyARM
+	result := &LastAccessTimeTrackingPolicyARM{}
 
 	// Set property ‘BlobType’:
 	for _, item := range policy.BlobType {
@@ -2241,7 +2241,7 @@ func (properties *RestorePolicyProperties) ConvertToARM(resolved genruntime.Conv
 	if properties == nil {
 		return nil, nil
 	}
-	var result RestorePolicyPropertiesARM
+	result := &RestorePolicyPropertiesARM{}
 
 	// Set property ‘Days’:
 	if properties.Days != nil {
@@ -2472,7 +2472,7 @@ func (rule *CorsRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if rule == nil {
 		return nil, nil
 	}
-	var result CorsRuleARM
+	result := &CorsRuleARM{}
 
 	// Set property ‘AllowedHeaders’:
 	for _, item := range rule.AllowedHeaders {

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services__spec_arm_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (services StorageAccountsBlobServices_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (services StorageAccountsBlobServices_SpecARM) GetName() string {
+func (services *StorageAccountsBlobServices_SpecARM) GetName() string {
 	return services.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/blobServices"
-func (services StorageAccountsBlobServices_SpecARM) GetType() string {
+func (services *StorageAccountsBlobServices_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/blobServices"
 }
 

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
@@ -939,7 +939,7 @@ func (containers *StorageAccountsBlobServicesContainers_Spec) ConvertToARM(resol
 	if containers == nil {
 		return nil, nil
 	}
-	var result StorageAccountsBlobServicesContainers_SpecARM
+	result := &StorageAccountsBlobServicesContainers_SpecARM{}
 
 	// Set property ‘Location’:
 	if containers.Location != nil {
@@ -971,7 +971,7 @@ func (containers *StorageAccountsBlobServicesContainers_Spec) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		immutableStorageWithVersioning := immutableStorageWithVersioningARM.(ImmutableStorageWithVersioningARM)
+		immutableStorageWithVersioning := *immutableStorageWithVersioningARM.(*ImmutableStorageWithVersioningARM)
 		result.Properties.ImmutableStorageWithVersioning = &immutableStorageWithVersioning
 	}
 	if containers.Metadata != nil {
@@ -1468,7 +1468,7 @@ func (versioning *ImmutableStorageWithVersioning) ConvertToARM(resolved genrunti
 	if versioning == nil {
 		return nil, nil
 	}
-	var result ImmutableStorageWithVersioningARM
+	result := &ImmutableStorageWithVersioningARM{}
 
 	// Set property ‘Enabled’:
 	if versioning.Enabled != nil {

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_containers__spec_arm_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_containers__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (containers StorageAccountsBlobServicesContainers_SpecARM) GetAPIVersion() 
 }
 
 // GetName returns the Name of the resource
-func (containers StorageAccountsBlobServicesContainers_SpecARM) GetName() string {
+func (containers *StorageAccountsBlobServicesContainers_SpecARM) GetName() string {
 	return containers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/blobServices/containers"
-func (containers StorageAccountsBlobServicesContainers_SpecARM) GetType() string {
+func (containers *StorageAccountsBlobServicesContainers_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/blobServices/containers"
 }
 

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_service_types_gen.go
@@ -526,7 +526,7 @@ func (services *StorageAccountsQueueServices_Spec) ConvertToARM(resolved genrunt
 	if services == nil {
 		return nil, nil
 	}
-	var result StorageAccountsQueueServices_SpecARM
+	result := &StorageAccountsQueueServices_SpecARM{}
 
 	// Set property ‘Location’:
 	if services.Location != nil {
@@ -546,7 +546,7 @@ func (services *StorageAccountsQueueServices_Spec) ConvertToARM(resolved genrunt
 		if err != nil {
 			return nil, err
 		}
-		cors := corsARM.(CorsRulesARM)
+		cors := *corsARM.(*CorsRulesARM)
 		result.Properties.Cors = &cors
 	}
 

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services__spec_arm_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (services StorageAccountsQueueServices_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (services StorageAccountsQueueServices_SpecARM) GetName() string {
+func (services *StorageAccountsQueueServices_SpecARM) GetName() string {
 	return services.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/queueServices"
-func (services StorageAccountsQueueServices_SpecARM) GetType() string {
+func (services *StorageAccountsQueueServices_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/queueServices"
 }
 

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queue_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queue_types_gen.go
@@ -355,7 +355,7 @@ func (queues *StorageAccountsQueueServicesQueues_Spec) ConvertToARM(resolved gen
 	if queues == nil {
 		return nil, nil
 	}
-	var result StorageAccountsQueueServicesQueues_SpecARM
+	result := &StorageAccountsQueueServicesQueues_SpecARM{}
 
 	// Set property ‘Location’:
 	if queues.Location != nil {

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queues__spec_arm_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queues__spec_arm_types_gen.go
@@ -21,12 +21,12 @@ func (queues StorageAccountsQueueServicesQueues_SpecARM) GetAPIVersion() string 
 }
 
 // GetName returns the Name of the resource
-func (queues StorageAccountsQueueServicesQueues_SpecARM) GetName() string {
+func (queues *StorageAccountsQueueServicesQueues_SpecARM) GetName() string {
 	return queues.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/queueServices/queues"
-func (queues StorageAccountsQueueServicesQueues_SpecARM) GetType() string {
+func (queues *StorageAccountsQueueServicesQueues_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/queueServices/queues"
 }
 

--- a/v2/api/storage/v1beta20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_account_types_gen.go
@@ -1764,7 +1764,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 	if accounts == nil {
 		return nil, nil
 	}
-	var result StorageAccounts_SpecARM
+	result := &StorageAccounts_SpecARM{}
 
 	// Set property ‘ExtendedLocation’:
 	if accounts.ExtendedLocation != nil {
@@ -1772,7 +1772,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		extendedLocation := extendedLocationARM.(ExtendedLocationARM)
+		extendedLocation := *extendedLocationARM.(*ExtendedLocationARM)
 		result.ExtendedLocation = &extendedLocation
 	}
 
@@ -1782,7 +1782,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(IdentityARM)
+		identity := *identityARM.(*IdentityARM)
 		result.Identity = &identity
 	}
 
@@ -1841,7 +1841,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		azureFilesIdentityBasedAuthentication := azureFilesIdentityBasedAuthenticationARM.(AzureFilesIdentityBasedAuthenticationARM)
+		azureFilesIdentityBasedAuthentication := *azureFilesIdentityBasedAuthenticationARM.(*AzureFilesIdentityBasedAuthenticationARM)
 		result.Properties.AzureFilesIdentityBasedAuthentication = &azureFilesIdentityBasedAuthentication
 	}
 	if accounts.CustomDomain != nil {
@@ -1849,7 +1849,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		customDomain := customDomainARM.(CustomDomainARM)
+		customDomain := *customDomainARM.(*CustomDomainARM)
 		result.Properties.CustomDomain = &customDomain
 	}
 	if accounts.Encryption != nil {
@@ -1857,7 +1857,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		encryption := encryptionARM.(EncryptionARM)
+		encryption := *encryptionARM.(*EncryptionARM)
 		result.Properties.Encryption = &encryption
 	}
 	if accounts.IsHnsEnabled != nil {
@@ -1873,7 +1873,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		keyPolicy := keyPolicyARM.(KeyPolicyARM)
+		keyPolicy := *keyPolicyARM.(*KeyPolicyARM)
 		result.Properties.KeyPolicy = &keyPolicy
 	}
 	if accounts.LargeFileSharesState != nil {
@@ -1889,7 +1889,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		networkAcls := networkAclsARM.(NetworkRuleSetARM)
+		networkAcls := *networkAclsARM.(*NetworkRuleSetARM)
 		result.Properties.NetworkAcls = &networkAcls
 	}
 	if accounts.RoutingPreference != nil {
@@ -1897,7 +1897,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		routingPreference := routingPreferenceARM.(RoutingPreferenceARM)
+		routingPreference := *routingPreferenceARM.(*RoutingPreferenceARM)
 		result.Properties.RoutingPreference = &routingPreference
 	}
 	if accounts.SasPolicy != nil {
@@ -1905,7 +1905,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		sasPolicy := sasPolicyARM.(SasPolicyARM)
+		sasPolicy := *sasPolicyARM.(*SasPolicyARM)
 		result.Properties.SasPolicy = &sasPolicy
 	}
 	if accounts.SupportsHttpsTrafficOnly != nil {
@@ -1919,7 +1919,7 @@ func (accounts *StorageAccounts_Spec) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		sku := skuARM.(SkuARM)
+		sku := *skuARM.(*SkuARM)
 		result.Sku = &sku
 	}
 
@@ -2753,7 +2753,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 	if authentication == nil {
 		return nil, nil
 	}
-	var result AzureFilesIdentityBasedAuthenticationARM
+	result := &AzureFilesIdentityBasedAuthenticationARM{}
 
 	// Set property ‘ActiveDirectoryProperties’:
 	if authentication.ActiveDirectoryProperties != nil {
@@ -2761,7 +2761,7 @@ func (authentication *AzureFilesIdentityBasedAuthentication) ConvertToARM(resolv
 		if err != nil {
 			return nil, err
 		}
-		activeDirectoryProperties := activeDirectoryPropertiesARM.(ActiveDirectoryPropertiesARM)
+		activeDirectoryProperties := *activeDirectoryPropertiesARM.(*ActiveDirectoryPropertiesARM)
 		result.ActiveDirectoryProperties = &activeDirectoryProperties
 	}
 
@@ -3183,7 +3183,7 @@ func (domain *CustomDomain) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	if domain == nil {
 		return nil, nil
 	}
-	var result CustomDomainARM
+	result := &CustomDomainARM{}
 
 	// Set property ‘Name’:
 	if domain.Name != nil {
@@ -3384,7 +3384,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if encryption == nil {
 		return nil, nil
 	}
-	var result EncryptionARM
+	result := &EncryptionARM{}
 
 	// Set property ‘Identity’:
 	if encryption.Identity != nil {
@@ -3392,7 +3392,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		identity := identityARM.(EncryptionIdentityARM)
+		identity := *identityARM.(*EncryptionIdentityARM)
 		result.Identity = &identity
 	}
 
@@ -3408,7 +3408,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		keyvaultproperties := keyvaultpropertiesARM.(KeyVaultPropertiesARM)
+		keyvaultproperties := *keyvaultpropertiesARM.(*KeyVaultPropertiesARM)
 		result.Keyvaultproperties = &keyvaultproperties
 	}
 
@@ -3424,7 +3424,7 @@ func (encryption *Encryption) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		services := servicesARM.(EncryptionServicesARM)
+		services := *servicesARM.(*EncryptionServicesARM)
 		result.Services = &services
 	}
 	return result, nil
@@ -4052,7 +4052,7 @@ func (location *ExtendedLocation) ConvertToARM(resolved genruntime.ConvertToARMR
 	if location == nil {
 		return nil, nil
 	}
-	var result ExtendedLocationARM
+	result := &ExtendedLocationARM{}
 
 	// Set property ‘Name’:
 	if location.Name != nil {
@@ -4351,7 +4351,7 @@ func (identity *Identity) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	if identity == nil {
 		return nil, nil
 	}
-	var result IdentityARM
+	result := &IdentityARM{}
 
 	// Set property ‘Type’:
 	if identity.Type != nil {
@@ -4658,7 +4658,7 @@ func (policy *KeyPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if policy == nil {
 		return nil, nil
 	}
-	var result KeyPolicyARM
+	result := &KeyPolicyARM{}
 
 	// Set property ‘KeyExpirationPeriodInDays’:
 	if policy.KeyExpirationPeriodInDays != nil {
@@ -4804,7 +4804,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if ruleSet == nil {
 		return nil, nil
 	}
-	var result NetworkRuleSetARM
+	result := &NetworkRuleSetARM{}
 
 	// Set property ‘Bypass’:
 	if ruleSet.Bypass != nil {
@@ -4824,7 +4824,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.IpRules = append(result.IpRules, itemARM.(IPRuleARM))
+		result.IpRules = append(result.IpRules, *itemARM.(*IPRuleARM))
 	}
 
 	// Set property ‘ResourceAccessRules’:
@@ -4833,7 +4833,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.ResourceAccessRules = append(result.ResourceAccessRules, itemARM.(ResourceAccessRuleARM))
+		result.ResourceAccessRules = append(result.ResourceAccessRules, *itemARM.(*ResourceAccessRuleARM))
 	}
 
 	// Set property ‘VirtualNetworkRules’:
@@ -4842,7 +4842,7 @@ func (ruleSet *NetworkRuleSet) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		result.VirtualNetworkRules = append(result.VirtualNetworkRules, itemARM.(VirtualNetworkRuleARM))
+		result.VirtualNetworkRules = append(result.VirtualNetworkRules, *itemARM.(*VirtualNetworkRuleARM))
 	}
 	return result, nil
 }
@@ -5387,7 +5387,7 @@ func (preference *RoutingPreference) ConvertToARM(resolved genruntime.ConvertToA
 	if preference == nil {
 		return nil, nil
 	}
-	var result RoutingPreferenceARM
+	result := &RoutingPreferenceARM{}
 
 	// Set property ‘PublishInternetEndpoints’:
 	if preference.PublishInternetEndpoints != nil {
@@ -5650,7 +5650,7 @@ func (policy *SasPolicy) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if policy == nil {
 		return nil, nil
 	}
-	var result SasPolicyARM
+	result := &SasPolicyARM{}
 
 	// Set property ‘ExpirationAction’:
 	if policy.ExpirationAction != nil {
@@ -5836,7 +5836,7 @@ func (sku *Sku) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if sku == nil {
 		return nil, nil
 	}
-	var result SkuARM
+	result := &SkuARM{}
 
 	// Set property ‘Name’:
 	if sku.Name != nil {
@@ -6181,7 +6181,7 @@ func (properties *ActiveDirectoryProperties) ConvertToARM(resolved genruntime.Co
 	if properties == nil {
 		return nil, nil
 	}
-	var result ActiveDirectoryPropertiesARM
+	result := &ActiveDirectoryPropertiesARM{}
 
 	// Set property ‘AzureStorageSid’:
 	if properties.AzureStorageSid != nil {
@@ -6632,7 +6632,7 @@ func (identity *EncryptionIdentity) ConvertToARM(resolved genruntime.ConvertToAR
 	if identity == nil {
 		return nil, nil
 	}
-	var result EncryptionIdentityARM
+	result := &EncryptionIdentityARM{}
 
 	// Set property ‘UserAssignedIdentity’:
 	if identity.UserAssignedIdentityReference != nil {
@@ -6792,7 +6792,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 	if services == nil {
 		return nil, nil
 	}
-	var result EncryptionServicesARM
+	result := &EncryptionServicesARM{}
 
 	// Set property ‘Blob’:
 	if services.Blob != nil {
@@ -6800,7 +6800,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		blob := blobARM.(EncryptionServiceARM)
+		blob := *blobARM.(*EncryptionServiceARM)
 		result.Blob = &blob
 	}
 
@@ -6810,7 +6810,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		file := fileARM.(EncryptionServiceARM)
+		file := *fileARM.(*EncryptionServiceARM)
 		result.File = &file
 	}
 
@@ -6820,7 +6820,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		queue := queueARM.(EncryptionServiceARM)
+		queue := *queueARM.(*EncryptionServiceARM)
 		result.Queue = &queue
 	}
 
@@ -6830,7 +6830,7 @@ func (services *EncryptionServices) ConvertToARM(resolved genruntime.ConvertToAR
 		if err != nil {
 			return nil, err
 		}
-		table := tableARM.(EncryptionServiceARM)
+		table := *tableARM.(*EncryptionServiceARM)
 		result.Table = &table
 	}
 	return result, nil
@@ -7242,7 +7242,7 @@ func (rule *IPRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails
 	if rule == nil {
 		return nil, nil
 	}
-	var result IPRuleARM
+	result := &IPRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -7433,7 +7433,7 @@ func (properties *KeyVaultProperties) ConvertToARM(resolved genruntime.ConvertTo
 	if properties == nil {
 		return nil, nil
 	}
-	var result KeyVaultPropertiesARM
+	result := &KeyVaultPropertiesARM{}
 
 	// Set property ‘Keyname’:
 	if properties.Keyname != nil {
@@ -7698,7 +7698,7 @@ func (rule *ResourceAccessRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if rule == nil {
 		return nil, nil
 	}
-	var result ResourceAccessRuleARM
+	result := &ResourceAccessRuleARM{}
 
 	// Set property ‘ResourceId’:
 	if rule.ResourceReference != nil {
@@ -8397,7 +8397,7 @@ func (rule *VirtualNetworkRule) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if rule == nil {
 		return nil, nil
 	}
-	var result VirtualNetworkRuleARM
+	result := &VirtualNetworkRuleARM{}
 
 	// Set property ‘Action’:
 	if rule.Action != nil {
@@ -8723,7 +8723,7 @@ func (service *EncryptionService) ConvertToARM(resolved genruntime.ConvertToARMR
 	if service == nil {
 		return nil, nil
 	}
-	var result EncryptionServiceARM
+	result := &EncryptionServiceARM{}
 
 	// Set property ‘Enabled’:
 	if service.Enabled != nil {

--- a/v2/api/storage/v1beta20210401/storage_accounts__spec_arm_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts__spec_arm_types_gen.go
@@ -44,12 +44,12 @@ func (accounts StorageAccounts_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (accounts StorageAccounts_SpecARM) GetName() string {
+func (accounts *StorageAccounts_SpecARM) GetName() string {
 	return accounts.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts"
-func (accounts StorageAccounts_SpecARM) GetType() string {
+func (accounts *StorageAccounts_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts"
 }
 

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen.go
@@ -870,7 +870,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 	if services == nil {
 		return nil, nil
 	}
-	var result StorageAccountsBlobServices_SpecARM
+	result := &StorageAccountsBlobServices_SpecARM{}
 
 	// Set property ‘Location’:
 	if services.Location != nil {
@@ -902,7 +902,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		changeFeed := changeFeedARM.(ChangeFeedARM)
+		changeFeed := *changeFeedARM.(*ChangeFeedARM)
 		result.Properties.ChangeFeed = &changeFeed
 	}
 	if services.ContainerDeleteRetentionPolicy != nil {
@@ -910,7 +910,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		containerDeleteRetentionPolicy := containerDeleteRetentionPolicyARM.(DeleteRetentionPolicyARM)
+		containerDeleteRetentionPolicy := *containerDeleteRetentionPolicyARM.(*DeleteRetentionPolicyARM)
 		result.Properties.ContainerDeleteRetentionPolicy = &containerDeleteRetentionPolicy
 	}
 	if services.Cors != nil {
@@ -918,7 +918,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		cors := corsARM.(CorsRulesARM)
+		cors := *corsARM.(*CorsRulesARM)
 		result.Properties.Cors = &cors
 	}
 	if services.DefaultServiceVersion != nil {
@@ -930,7 +930,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		deleteRetentionPolicy := deleteRetentionPolicyARM.(DeleteRetentionPolicyARM)
+		deleteRetentionPolicy := *deleteRetentionPolicyARM.(*DeleteRetentionPolicyARM)
 		result.Properties.DeleteRetentionPolicy = &deleteRetentionPolicy
 	}
 	if services.IsVersioningEnabled != nil {
@@ -942,7 +942,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		lastAccessTimeTrackingPolicy := lastAccessTimeTrackingPolicyARM.(LastAccessTimeTrackingPolicyARM)
+		lastAccessTimeTrackingPolicy := *lastAccessTimeTrackingPolicyARM.(*LastAccessTimeTrackingPolicyARM)
 		result.Properties.LastAccessTimeTrackingPolicy = &lastAccessTimeTrackingPolicy
 	}
 	if services.RestorePolicy != nil {
@@ -950,7 +950,7 @@ func (services *StorageAccountsBlobServices_Spec) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		restorePolicy := restorePolicyARM.(RestorePolicyPropertiesARM)
+		restorePolicy := *restorePolicyARM.(*RestorePolicyPropertiesARM)
 		result.Properties.RestorePolicy = &restorePolicy
 	}
 
@@ -1420,7 +1420,7 @@ func (feed *ChangeFeed) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if feed == nil {
 		return nil, nil
 	}
-	var result ChangeFeedARM
+	result := &ChangeFeedARM{}
 
 	// Set property ‘Enabled’:
 	if feed.Enabled != nil {
@@ -1616,7 +1616,7 @@ func (rules *CorsRules) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 	if rules == nil {
 		return nil, nil
 	}
-	var result CorsRulesARM
+	result := &CorsRulesARM{}
 
 	// Set property ‘CorsRules’:
 	for _, item := range rules.CorsRules {
@@ -1624,7 +1624,7 @@ func (rules *CorsRules) ConvertToARM(resolved genruntime.ConvertToARMResolvedDet
 		if err != nil {
 			return nil, err
 		}
-		result.CorsRules = append(result.CorsRules, itemARM.(CorsRuleARM))
+		result.CorsRules = append(result.CorsRules, *itemARM.(*CorsRuleARM))
 	}
 	return result, nil
 }
@@ -1825,7 +1825,7 @@ func (policy *DeleteRetentionPolicy) ConvertToARM(resolved genruntime.ConvertToA
 	if policy == nil {
 		return nil, nil
 	}
-	var result DeleteRetentionPolicyARM
+	result := &DeleteRetentionPolicyARM{}
 
 	// Set property ‘Days’:
 	if policy.Days != nil {
@@ -2033,7 +2033,7 @@ func (policy *LastAccessTimeTrackingPolicy) ConvertToARM(resolved genruntime.Con
 	if policy == nil {
 		return nil, nil
 	}
-	var result LastAccessTimeTrackingPolicyARM
+	result := &LastAccessTimeTrackingPolicyARM{}
 
 	// Set property ‘BlobType’:
 	for _, item := range policy.BlobType {
@@ -2309,7 +2309,7 @@ func (properties *RestorePolicyProperties) ConvertToARM(resolved genruntime.Conv
 	if properties == nil {
 		return nil, nil
 	}
-	var result RestorePolicyPropertiesARM
+	result := &RestorePolicyPropertiesARM{}
 
 	// Set property ‘Days’:
 	if properties.Days != nil {
@@ -2555,7 +2555,7 @@ func (rule *CorsRule) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetai
 	if rule == nil {
 		return nil, nil
 	}
-	var result CorsRuleARM
+	result := &CorsRuleARM{}
 
 	// Set property ‘AllowedHeaders’:
 	for _, item := range rule.AllowedHeaders {

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_services__spec_arm_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_services__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (services StorageAccountsBlobServices_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (services StorageAccountsBlobServices_SpecARM) GetName() string {
+func (services *StorageAccountsBlobServices_SpecARM) GetName() string {
 	return services.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/blobServices"
-func (services StorageAccountsBlobServices_SpecARM) GetType() string {
+func (services *StorageAccountsBlobServices_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/blobServices"
 }
 

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen.go
@@ -987,7 +987,7 @@ func (containers *StorageAccountsBlobServicesContainers_Spec) ConvertToARM(resol
 	if containers == nil {
 		return nil, nil
 	}
-	var result StorageAccountsBlobServicesContainers_SpecARM
+	result := &StorageAccountsBlobServicesContainers_SpecARM{}
 
 	// Set property ‘Location’:
 	if containers.Location != nil {
@@ -1019,7 +1019,7 @@ func (containers *StorageAccountsBlobServicesContainers_Spec) ConvertToARM(resol
 		if err != nil {
 			return nil, err
 		}
-		immutableStorageWithVersioning := immutableStorageWithVersioningARM.(ImmutableStorageWithVersioningARM)
+		immutableStorageWithVersioning := *immutableStorageWithVersioningARM.(*ImmutableStorageWithVersioningARM)
 		result.Properties.ImmutableStorageWithVersioning = &immutableStorageWithVersioning
 	}
 	if containers.Metadata != nil {
@@ -1528,7 +1528,7 @@ func (versioning *ImmutableStorageWithVersioning) ConvertToARM(resolved genrunti
 	if versioning == nil {
 		return nil, nil
 	}
-	var result ImmutableStorageWithVersioningARM
+	result := &ImmutableStorageWithVersioningARM{}
 
 	// Set property ‘Enabled’:
 	if versioning.Enabled != nil {

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_services_containers__spec_arm_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_services_containers__spec_arm_types_gen.go
@@ -29,12 +29,12 @@ func (containers StorageAccountsBlobServicesContainers_SpecARM) GetAPIVersion() 
 }
 
 // GetName returns the Name of the resource
-func (containers StorageAccountsBlobServicesContainers_SpecARM) GetName() string {
+func (containers *StorageAccountsBlobServicesContainers_SpecARM) GetName() string {
 	return containers.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/blobServices/containers"
-func (containers StorageAccountsBlobServicesContainers_SpecARM) GetType() string {
+func (containers *StorageAccountsBlobServicesContainers_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/blobServices/containers"
 }
 

--- a/v2/api/storage/v1beta20210401/storage_accounts_management_policies__spec_arm_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_management_policies__spec_arm_types_gen.go
@@ -24,12 +24,12 @@ func (policies StorageAccountsManagementPolicies_SpecARM) GetAPIVersion() string
 }
 
 // GetName returns the Name of the resource
-func (policies StorageAccountsManagementPolicies_SpecARM) GetName() string {
+func (policies *StorageAccountsManagementPolicies_SpecARM) GetName() string {
 	return policies.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/managementPolicies"
-func (policies StorageAccountsManagementPolicies_SpecARM) GetType() string {
+func (policies *StorageAccountsManagementPolicies_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/managementPolicies"
 }
 

--- a/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen.go
@@ -543,7 +543,7 @@ func (policies *StorageAccountsManagementPolicies_Spec) ConvertToARM(resolved ge
 	if policies == nil {
 		return nil, nil
 	}
-	var result StorageAccountsManagementPolicies_SpecARM
+	result := &StorageAccountsManagementPolicies_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -557,7 +557,7 @@ func (policies *StorageAccountsManagementPolicies_Spec) ConvertToARM(resolved ge
 		if err != nil {
 			return nil, err
 		}
-		policy := policyARM.(ManagementPolicySchemaARM)
+		policy := *policyARM.(*ManagementPolicySchemaARM)
 		result.Properties.Policy = &policy
 	}
 
@@ -756,7 +756,7 @@ func (schema *ManagementPolicySchema) ConvertToARM(resolved genruntime.ConvertTo
 	if schema == nil {
 		return nil, nil
 	}
-	var result ManagementPolicySchemaARM
+	result := &ManagementPolicySchemaARM{}
 
 	// Set property ‘Rules’:
 	for _, item := range schema.Rules {
@@ -764,7 +764,7 @@ func (schema *ManagementPolicySchema) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.Rules = append(result.Rules, itemARM.(ManagementPolicyRuleARM))
+		result.Rules = append(result.Rules, *itemARM.(*ManagementPolicyRuleARM))
 	}
 	return result, nil
 }
@@ -973,7 +973,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 	if rule == nil {
 		return nil, nil
 	}
-	var result ManagementPolicyRuleARM
+	result := &ManagementPolicyRuleARM{}
 
 	// Set property ‘Definition’:
 	if rule.Definition != nil {
@@ -981,7 +981,7 @@ func (rule *ManagementPolicyRule) ConvertToARM(resolved genruntime.ConvertToARMR
 		if err != nil {
 			return nil, err
 		}
-		definition := definitionARM.(ManagementPolicyDefinitionARM)
+		definition := *definitionARM.(*ManagementPolicyDefinitionARM)
 		result.Definition = &definition
 	}
 
@@ -1300,7 +1300,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 	if definition == nil {
 		return nil, nil
 	}
-	var result ManagementPolicyDefinitionARM
+	result := &ManagementPolicyDefinitionARM{}
 
 	// Set property ‘Actions’:
 	if definition.Actions != nil {
@@ -1308,7 +1308,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		actions := actionsARM.(ManagementPolicyActionARM)
+		actions := *actionsARM.(*ManagementPolicyActionARM)
 		result.Actions = &actions
 	}
 
@@ -1318,7 +1318,7 @@ func (definition *ManagementPolicyDefinition) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		filters := filtersARM.(ManagementPolicyFilterARM)
+		filters := *filtersARM.(*ManagementPolicyFilterARM)
 		result.Filters = &filters
 	}
 	return result, nil
@@ -1571,7 +1571,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 	if action == nil {
 		return nil, nil
 	}
-	var result ManagementPolicyActionARM
+	result := &ManagementPolicyActionARM{}
 
 	// Set property ‘BaseBlob’:
 	if action.BaseBlob != nil {
@@ -1579,7 +1579,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		baseBlob := baseBlobARM.(ManagementPolicyBaseBlobARM)
+		baseBlob := *baseBlobARM.(*ManagementPolicyBaseBlobARM)
 		result.BaseBlob = &baseBlob
 	}
 
@@ -1589,7 +1589,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		snapshot := snapshotARM.(ManagementPolicySnapShotARM)
+		snapshot := *snapshotARM.(*ManagementPolicySnapShotARM)
 		result.Snapshot = &snapshot
 	}
 
@@ -1599,7 +1599,7 @@ func (action *ManagementPolicyAction) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		version := versionARM.(ManagementPolicyVersionARM)
+		version := *versionARM.(*ManagementPolicyVersionARM)
 		result.Version = &version
 	}
 	return result, nil
@@ -1927,7 +1927,7 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 	if filter == nil {
 		return nil, nil
 	}
-	var result ManagementPolicyFilterARM
+	result := &ManagementPolicyFilterARM{}
 
 	// Set property ‘BlobIndexMatch’:
 	for _, item := range filter.BlobIndexMatch {
@@ -1935,7 +1935,7 @@ func (filter *ManagementPolicyFilter) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		result.BlobIndexMatch = append(result.BlobIndexMatch, itemARM.(TagFilterARM))
+		result.BlobIndexMatch = append(result.BlobIndexMatch, *itemARM.(*TagFilterARM))
 	}
 
 	// Set property ‘BlobTypes’:
@@ -2204,7 +2204,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 	if blob == nil {
 		return nil, nil
 	}
-	var result ManagementPolicyBaseBlobARM
+	result := &ManagementPolicyBaseBlobARM{}
 
 	// Set property ‘Delete’:
 	if blob.Delete != nil {
@@ -2212,7 +2212,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		delete := deleteARM.(DateAfterModificationARM)
+		delete := *deleteARM.(*DateAfterModificationARM)
 		result.Delete = &delete
 	}
 
@@ -2228,7 +2228,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		tierToArchive := tierToArchiveARM.(DateAfterModificationARM)
+		tierToArchive := *tierToArchiveARM.(*DateAfterModificationARM)
 		result.TierToArchive = &tierToArchive
 	}
 
@@ -2238,7 +2238,7 @@ func (blob *ManagementPolicyBaseBlob) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		tierToCool := tierToCoolARM.(DateAfterModificationARM)
+		tierToCool := *tierToCoolARM.(*DateAfterModificationARM)
 		result.TierToCool = &tierToCool
 	}
 	return result, nil
@@ -2612,7 +2612,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 	if shot == nil {
 		return nil, nil
 	}
-	var result ManagementPolicySnapShotARM
+	result := &ManagementPolicySnapShotARM{}
 
 	// Set property ‘Delete’:
 	if shot.Delete != nil {
@@ -2620,7 +2620,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		delete := deleteARM.(DateAfterCreationARM)
+		delete := *deleteARM.(*DateAfterCreationARM)
 		result.Delete = &delete
 	}
 
@@ -2630,7 +2630,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		tierToArchive := tierToArchiveARM.(DateAfterCreationARM)
+		tierToArchive := *tierToArchiveARM.(*DateAfterCreationARM)
 		result.TierToArchive = &tierToArchive
 	}
 
@@ -2640,7 +2640,7 @@ func (shot *ManagementPolicySnapShot) ConvertToARM(resolved genruntime.ConvertTo
 		if err != nil {
 			return nil, err
 		}
-		tierToCool := tierToCoolARM.(DateAfterCreationARM)
+		tierToCool := *tierToCoolARM.(*DateAfterCreationARM)
 		result.TierToCool = &tierToCool
 	}
 	return result, nil
@@ -2966,7 +2966,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 	if version == nil {
 		return nil, nil
 	}
-	var result ManagementPolicyVersionARM
+	result := &ManagementPolicyVersionARM{}
 
 	// Set property ‘Delete’:
 	if version.Delete != nil {
@@ -2974,7 +2974,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		delete := deleteARM.(DateAfterCreationARM)
+		delete := *deleteARM.(*DateAfterCreationARM)
 		result.Delete = &delete
 	}
 
@@ -2984,7 +2984,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		tierToArchive := tierToArchiveARM.(DateAfterCreationARM)
+		tierToArchive := *tierToArchiveARM.(*DateAfterCreationARM)
 		result.TierToArchive = &tierToArchive
 	}
 
@@ -2994,7 +2994,7 @@ func (version *ManagementPolicyVersion) ConvertToARM(resolved genruntime.Convert
 		if err != nil {
 			return nil, err
 		}
-		tierToCool := tierToCoolARM.(DateAfterCreationARM)
+		tierToCool := *tierToCoolARM.(*DateAfterCreationARM)
 		result.TierToCool = &tierToCool
 	}
 	return result, nil
@@ -3328,7 +3328,7 @@ func (filter *TagFilter) ConvertToARM(resolved genruntime.ConvertToARMResolvedDe
 	if filter == nil {
 		return nil, nil
 	}
-	var result TagFilterARM
+	result := &TagFilterARM{}
 
 	// Set property ‘Name’:
 	if filter.Name != nil {
@@ -3550,7 +3550,7 @@ func (creation *DateAfterCreation) ConvertToARM(resolved genruntime.ConvertToARM
 	if creation == nil {
 		return nil, nil
 	}
-	var result DateAfterCreationARM
+	result := &DateAfterCreationARM{}
 
 	// Set property ‘DaysAfterCreationGreaterThan’:
 	if creation.DaysAfterCreationGreaterThan != nil {
@@ -3710,7 +3710,7 @@ func (modification *DateAfterModification) ConvertToARM(resolved genruntime.Conv
 	if modification == nil {
 		return nil, nil
 	}
-	var result DateAfterModificationARM
+	result := &DateAfterModificationARM{}
 
 	// Set property ‘DaysAfterLastAccessTimeGreaterThan’:
 	if modification.DaysAfterLastAccessTimeGreaterThan != nil {

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen.go
@@ -527,7 +527,7 @@ func (services *StorageAccountsQueueServices_Spec) ConvertToARM(resolved genrunt
 	if services == nil {
 		return nil, nil
 	}
-	var result StorageAccountsQueueServices_SpecARM
+	result := &StorageAccountsQueueServices_SpecARM{}
 
 	// Set property ‘Location’:
 	if services.Location != nil {
@@ -547,7 +547,7 @@ func (services *StorageAccountsQueueServices_Spec) ConvertToARM(resolved genrunt
 		if err != nil {
 			return nil, err
 		}
-		cors := corsARM.(CorsRulesARM)
+		cors := *corsARM.(*CorsRulesARM)
 		result.Properties.Cors = &cors
 	}
 

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_services__spec_arm_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_services__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (services StorageAccountsQueueServices_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (services StorageAccountsQueueServices_SpecARM) GetName() string {
+func (services *StorageAccountsQueueServices_SpecARM) GetName() string {
 	return services.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/queueServices"
-func (services StorageAccountsQueueServices_SpecARM) GetType() string {
+func (services *StorageAccountsQueueServices_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/queueServices"
 }
 

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen.go
@@ -347,7 +347,7 @@ func (queues *StorageAccountsQueueServicesQueues_Spec) ConvertToARM(resolved gen
 	if queues == nil {
 		return nil, nil
 	}
-	var result StorageAccountsQueueServicesQueues_SpecARM
+	result := &StorageAccountsQueueServicesQueues_SpecARM{}
 
 	// Set property ‘Location’:
 	if queues.Location != nil {

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queues__spec_arm_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queues__spec_arm_types_gen.go
@@ -27,12 +27,12 @@ func (queues StorageAccountsQueueServicesQueues_SpecARM) GetAPIVersion() string 
 }
 
 // GetName returns the Name of the resource
-func (queues StorageAccountsQueueServicesQueues_SpecARM) GetName() string {
+func (queues *StorageAccountsQueueServicesQueues_SpecARM) GetName() string {
 	return queues.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Storage/storageAccounts/queueServices/queues"
-func (queues StorageAccountsQueueServicesQueues_SpecARM) GetType() string {
+func (queues *StorageAccountsQueueServicesQueues_SpecARM) GetType() string {
 	return "Microsoft.Storage/storageAccounts/queueServices/queues"
 }
 

--- a/v2/tools/generator/internal/armconversion/arm_spec_interface.go
+++ b/v2/tools/generator/internal/armconversion/arm_spec_interface.go
@@ -41,7 +41,7 @@ func NewARMSpecInterfaceImpl(
 	getNameFunc := functions.NewObjectFunction("Get"+astmodel.NameProperty, idFactory, getNameFunction)
 	getNameFunc.AddPackageReference(astmodel.GenRuntimeReference)
 
-	getTypeFunc := functions.NewGetTypeFunction(resource.ARMType(), idFactory, functions.ReceiverTypeStruct)
+	getTypeFunc := functions.NewGetTypeFunction(resource.ARMType(), idFactory, functions.ReceiverTypePtr)
 
 	getAPIVersionFunc := functions.NewGetAPIVersionFunction(
 		resource.APIVersionTypeName(),
@@ -97,13 +97,8 @@ func armSpecInterfaceSimpleGetFunction(
 	details := &astbuilder.FuncDetails{
 		Name:          methodName,
 		ReceiverIdent: receiverIdent,
-		// TODO: We're too loosey-goosey here with ptr vs value receiver.
-		// TODO: We basically need to use a value receiver right now because
-		// TODO: ConvertToARM always returns a value, but for other interface impls
-		// TODO: for example on resource we use ptr receiver... the inconsistency is
-		// TODO: awkward...
-		ReceiverType: receiverType,
-		Body:         astbuilder.Statements(retResult),
+		ReceiverType:  astbuilder.Dereference(receiverType),
+		Body:          astbuilder.Statements(retResult),
 	}
 
 	details.AddComments(fmt.Sprintf("returns the %s of the resource", propertyName))

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
@@ -284,12 +284,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -318,7 +318,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -329,7 +329,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(PropertiesARM)
+		properties := *propertiesARM.(*PropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -588,7 +588,7 @@ func (properties *Properties) ConvertToARM(resolved genruntime.ConvertToARMResol
 	if properties == nil {
 		return nil, nil
 	}
-	var result PropertiesARM
+	result := &PropertiesARM{}
 
 	// Set property ‘Bar’:
 	if properties.Bar != nil {
@@ -596,7 +596,7 @@ func (properties *Properties) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		bar := barARM.(BarARM)
+		bar := *barARM.(*BarARM)
 		result.Bar = &bar
 	}
 
@@ -606,7 +606,7 @@ func (properties *Properties) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		baz := bazARM.(BazARM)
+		baz := *bazARM.(*BazARM)
 		result.Baz = &baz
 	}
 
@@ -616,7 +616,7 @@ func (properties *Properties) ConvertToARM(resolved genruntime.ConvertToARMResol
 		if err != nil {
 			return nil, err
 		}
-		foo := fooARM.(FooARM)
+		foo := *fooARM.(*FooARM)
 		result.Foo = &foo
 	}
 	return result, nil
@@ -782,7 +782,7 @@ func (bar *Bar) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if bar == nil {
 		return nil, nil
 	}
-	var result BarARM
+	result := &BarARM{}
 
 	// Set property ‘Discrim’:
 	if bar.Discrim != nil {
@@ -888,7 +888,7 @@ func (baz *Baz) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if baz == nil {
 		return nil, nil
 	}
-	var result BazARM
+	result := &BazARM{}
 
 	// Set property ‘Discrim’:
 	if baz.Discrim != nil {
@@ -1002,7 +1002,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if foo == nil {
 		return nil, nil
 	}
-	var result FooARM
+	result := &FooARM{}
 
 	// Set property ‘Discrim’:
 	if foo.Discrim != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
@@ -280,12 +280,12 @@ func (a A_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (a A_SpecARM) GetName() string {
+func (a *A_SpecARM) GetName() string {
 	return a.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/A"
-func (a A_SpecARM) GetType() string {
+func (a *A_SpecARM) GetType() string {
 	return "Microsoft.Azure/A"
 }
 
@@ -551,12 +551,12 @@ func (b B_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (b B_SpecARM) GetName() string {
+func (b *B_SpecARM) GetName() string {
 	return b.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/B"
-func (b B_SpecARM) GetType() string {
+func (b *B_SpecARM) GetType() string {
 	return "Microsoft.Azure/B"
 }
 
@@ -822,12 +822,12 @@ func (c C_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (c C_SpecARM) GetName() string {
+func (c *C_SpecARM) GetName() string {
 	return c.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/C"
-func (c C_SpecARM) GetType() string {
+func (c *C_SpecARM) GetType() string {
 	return "Microsoft.Azure/C"
 }
 
@@ -1093,12 +1093,12 @@ func (d D_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (d D_SpecARM) GetName() string {
+func (d *D_SpecARM) GetName() string {
 	return d.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/D"
-func (d D_SpecARM) GetType() string {
+func (d *D_SpecARM) GetType() string {
 	return "Microsoft.Azure/D"
 }
 
@@ -1126,7 +1126,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if a == nil {
 		return nil, nil
 	}
-	var result A_SpecARM
+	result := &A_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -1282,7 +1282,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if b == nil {
 		return nil, nil
 	}
-	var result B_SpecARM
+	result := &B_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -1438,7 +1438,7 @@ func (c *C_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if c == nil {
 		return nil, nil
 	}
-	var result C_SpecARM
+	result := &C_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -1594,7 +1594,7 @@ func (d *D_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if d == nil {
 		return nil, nil
 	}
-	var result D_SpecARM
+	result := &D_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
@@ -281,12 +281,12 @@ func (a A_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (a A_SpecARM) GetName() string {
+func (a *A_SpecARM) GetName() string {
 	return a.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/A"
-func (a A_SpecARM) GetType() string {
+func (a *A_SpecARM) GetType() string {
 	return "Microsoft.Azure/A"
 }
 
@@ -553,12 +553,12 @@ func (b B_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (b B_SpecARM) GetName() string {
+func (b *B_SpecARM) GetName() string {
 	return b.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/B"
-func (b B_SpecARM) GetType() string {
+func (b *B_SpecARM) GetType() string {
 	return "Microsoft.Azure/B"
 }
 
@@ -593,7 +593,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if a == nil {
 		return nil, nil
 	}
-	var result A_SpecARM
+	result := &A_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -604,7 +604,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(APropertiesARM)
+		properties := *propertiesARM.(*APropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -800,7 +800,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if b == nil {
 		return nil, nil
 	}
-	var result B_SpecARM
+	result := &B_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -811,7 +811,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(BPropertiesARM)
+		properties := *propertiesARM.(*BPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -995,7 +995,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result APropertiesARM
+	result := &APropertiesARM{}
 
 	// Set property ‘IntField’:
 	if properties.IntField != nil {
@@ -1086,7 +1086,7 @@ func (properties *BProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result BPropertiesARM
+	result := &BPropertiesARM{}
 
 	// Set property ‘EnumField’:
 	if properties.EnumField != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
@@ -281,12 +281,12 @@ func (a A_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (a A_SpecARM) GetName() string {
+func (a *A_SpecARM) GetName() string {
 	return a.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/A"
-func (a A_SpecARM) GetType() string {
+func (a *A_SpecARM) GetType() string {
 	return "Microsoft.Azure/A"
 }
 
@@ -553,12 +553,12 @@ func (b B_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (b B_SpecARM) GetName() string {
+func (b *B_SpecARM) GetName() string {
 	return b.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/B"
-func (b B_SpecARM) GetType() string {
+func (b *B_SpecARM) GetType() string {
 	return "Microsoft.Azure/B"
 }
 
@@ -825,12 +825,12 @@ func (c C_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (c C_SpecARM) GetName() string {
+func (c *C_SpecARM) GetName() string {
 	return c.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/C"
-func (c C_SpecARM) GetType() string {
+func (c *C_SpecARM) GetType() string {
 	return "Microsoft.Azure/C"
 }
 
@@ -866,7 +866,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if a == nil {
 		return nil, nil
 	}
-	var result A_SpecARM
+	result := &A_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -877,7 +877,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(APropertiesARM)
+		properties := *propertiesARM.(*APropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1074,7 +1074,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if b == nil {
 		return nil, nil
 	}
-	var result B_SpecARM
+	result := &B_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -1085,7 +1085,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(BPropertiesARM)
+		properties := *propertiesARM.(*BPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1282,7 +1282,7 @@ func (c *C_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if c == nil {
 		return nil, nil
 	}
-	var result C_SpecARM
+	result := &C_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -1293,7 +1293,7 @@ func (c *C_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(CPropertiesARM)
+		properties := *propertiesARM.(*CPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1478,7 +1478,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result APropertiesARM
+	result := &APropertiesARM{}
 
 	// Set property ‘IntField’:
 	if properties.IntField != nil {
@@ -1492,7 +1492,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		refField := refFieldARM.(BResourceARM)
+		refField := *refFieldARM.(*BResourceARM)
 		result.RefField = &refField
 	}
 
@@ -1615,7 +1615,7 @@ func (properties *BProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result BPropertiesARM
+	result := &BPropertiesARM{}
 
 	// Set property ‘EnumField’:
 	if properties.EnumField != nil {
@@ -1629,7 +1629,7 @@ func (properties *BProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		refField := refFieldARM.(CResourceARM)
+		refField := *refFieldARM.(*CResourceARM)
 		result.RefField = &refField
 	}
 	return result, nil
@@ -1754,7 +1754,7 @@ func (properties *CProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result CPropertiesARM
+	result := &CPropertiesARM{}
 
 	// Set property ‘IntField’:
 	if properties.IntField != nil {
@@ -1850,7 +1850,7 @@ func (resource *BResource) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if resource == nil {
 		return nil, nil
 	}
-	var result BResourceARM
+	result := &BResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {
@@ -1933,7 +1933,7 @@ func (resource *CResource) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if resource == nil {
 		return nil, nil
 	}
-	var result CResourceARM
+	result := &CResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
@@ -281,12 +281,12 @@ func (a A_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (a A_SpecARM) GetName() string {
+func (a *A_SpecARM) GetName() string {
 	return a.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/A"
-func (a A_SpecARM) GetType() string {
+func (a *A_SpecARM) GetType() string {
 	return "Microsoft.Azure/A"
 }
 
@@ -321,7 +321,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if a == nil {
 		return nil, nil
 	}
-	var result A_SpecARM
+	result := &A_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -332,7 +332,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(APropertiesARM)
+		properties := *propertiesARM.(*APropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -516,7 +516,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result APropertiesARM
+	result := &APropertiesARM{}
 
 	// Set property ‘Left’:
 	if properties.Left != nil {
@@ -524,7 +524,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		left := leftARM.(Left_SubResourceEmbeddedARM)
+		left := *leftARM.(*Left_SubResourceEmbeddedARM)
 		result.Left = &left
 	}
 
@@ -534,7 +534,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		right := rightARM.(Right_SubResourceEmbedded_1ARM)
+		right := *rightARM.(*Right_SubResourceEmbedded_1ARM)
 		result.Right = &right
 	}
 	return result, nil
@@ -694,7 +694,7 @@ func (embedded *Left_SubResourceEmbedded) ConvertToARM(resolved genruntime.Conve
 	if embedded == nil {
 		return nil, nil
 	}
-	var result Left_SubResourceEmbeddedARM
+	result := &Left_SubResourceEmbeddedARM{}
 
 	// Set property ‘Name’:
 	if embedded.Name != nil {
@@ -708,7 +708,7 @@ func (embedded *Left_SubResourceEmbedded) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(LeftPropertiesARM)
+		properties := *propertiesARM.(*LeftPropertiesARM)
 		result.Properties = &properties
 	}
 
@@ -718,7 +718,7 @@ func (embedded *Left_SubResourceEmbedded) ConvertToARM(resolved genruntime.Conve
 		if err != nil {
 			return nil, err
 		}
-		refField := refFieldARM.(FakeResource_SubResourceEmbeddedARM)
+		refField := *refFieldARM.(*FakeResource_SubResourceEmbeddedARM)
 		result.RefField = &refField
 	}
 	return result, nil
@@ -864,7 +864,7 @@ func (embedded1 *Right_SubResourceEmbedded_1) ConvertToARM(resolved genruntime.C
 	if embedded1 == nil {
 		return nil, nil
 	}
-	var result Right_SubResourceEmbedded_1ARM
+	result := &Right_SubResourceEmbedded_1ARM{}
 
 	// Set property ‘Name’:
 	if embedded1.Name != nil {
@@ -878,7 +878,7 @@ func (embedded1 *Right_SubResourceEmbedded_1) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(RightPropertiesARM)
+		properties := *propertiesARM.(*RightPropertiesARM)
 		result.Properties = &properties
 	}
 
@@ -888,7 +888,7 @@ func (embedded1 *Right_SubResourceEmbedded_1) ConvertToARM(resolved genruntime.C
 		if err != nil {
 			return nil, err
 		}
-		refField := refFieldARM.(FakeResource_SubResourceEmbedded_1ARM)
+		refField := *refFieldARM.(*FakeResource_SubResourceEmbedded_1ARM)
 		result.RefField = &refField
 	}
 	return result, nil
@@ -1038,7 +1038,7 @@ func (embedded *FakeResource_SubResourceEmbedded) ConvertToARM(resolved genrunti
 	if embedded == nil {
 		return nil, nil
 	}
-	var result FakeResource_SubResourceEmbeddedARM
+	result := &FakeResource_SubResourceEmbeddedARM{}
 
 	// Set property ‘Name’:
 	if embedded.Name != nil {
@@ -1052,7 +1052,7 @@ func (embedded *FakeResource_SubResourceEmbedded) ConvertToARM(resolved genrunti
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(FakeResourceProperties_SubResourceEmbeddedARM)
+		properties := *propertiesARM.(*FakeResourceProperties_SubResourceEmbeddedARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1157,7 +1157,7 @@ func (embedded1 *FakeResource_SubResourceEmbedded_1) ConvertToARM(resolved genru
 	if embedded1 == nil {
 		return nil, nil
 	}
-	var result FakeResource_SubResourceEmbedded_1ARM
+	result := &FakeResource_SubResourceEmbedded_1ARM{}
 
 	// Set property ‘Name’:
 	if embedded1.Name != nil {
@@ -1171,7 +1171,7 @@ func (embedded1 *FakeResource_SubResourceEmbedded_1) ConvertToARM(resolved genru
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(FakeResourceProperties_SubResourceEmbedded_1ARM)
+		properties := *propertiesARM.(*FakeResourceProperties_SubResourceEmbedded_1ARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1275,7 +1275,7 @@ func (properties *LeftProperties) ConvertToARM(resolved genruntime.ConvertToARMR
 	if properties == nil {
 		return nil, nil
 	}
-	var result LeftPropertiesARM
+	result := &LeftPropertiesARM{}
 
 	// Set property ‘StrField’:
 	if properties.StrField != nil {
@@ -1348,7 +1348,7 @@ func (properties *RightProperties) ConvertToARM(resolved genruntime.ConvertToARM
 	if properties == nil {
 		return nil, nil
 	}
-	var result RightPropertiesARM
+	result := &RightPropertiesARM{}
 
 	// Set property ‘StrField’:
 	if properties.StrField != nil {
@@ -1421,7 +1421,7 @@ func (embedded *FakeResourceProperties_SubResourceEmbedded) ConvertToARM(resolve
 	if embedded == nil {
 		return nil, nil
 	}
-	var result FakeResourceProperties_SubResourceEmbeddedARM
+	result := &FakeResourceProperties_SubResourceEmbeddedARM{}
 
 	// Set property ‘Loop2’:
 	if embedded.Loop2 != nil {
@@ -1429,7 +1429,7 @@ func (embedded *FakeResourceProperties_SubResourceEmbedded) ConvertToARM(resolve
 		if err != nil {
 			return nil, err
 		}
-		loop2 := loop2ARM.(Right_SubResourceEmbeddedARM)
+		loop2 := *loop2ARM.(*Right_SubResourceEmbeddedARM)
 		result.Loop2 = &loop2
 	}
 	return result, nil
@@ -1521,7 +1521,7 @@ func (embedded1 *FakeResourceProperties_SubResourceEmbedded_1) ConvertToARM(reso
 	if embedded1 == nil {
 		return nil, nil
 	}
-	var result FakeResourceProperties_SubResourceEmbedded_1ARM
+	result := &FakeResourceProperties_SubResourceEmbedded_1ARM{}
 
 	// Set property ‘Loop1’:
 	if embedded1.Loop1 != nil {
@@ -1529,7 +1529,7 @@ func (embedded1 *FakeResourceProperties_SubResourceEmbedded_1) ConvertToARM(reso
 		if err != nil {
 			return nil, err
 		}
-		loop1 := loop1ARM.(Left_SubResourceEmbedded_1ARM)
+		loop1 := *loop1ARM.(*Left_SubResourceEmbedded_1ARM)
 		result.Loop1 = &loop1
 	}
 	return result, nil
@@ -1634,7 +1634,7 @@ func (embedded1 *Left_SubResourceEmbedded_1) ConvertToARM(resolved genruntime.Co
 	if embedded1 == nil {
 		return nil, nil
 	}
-	var result Left_SubResourceEmbedded_1ARM
+	result := &Left_SubResourceEmbedded_1ARM{}
 
 	// Set property ‘Name’:
 	if embedded1.Name != nil {
@@ -1648,7 +1648,7 @@ func (embedded1 *Left_SubResourceEmbedded_1) ConvertToARM(resolved genruntime.Co
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(LeftPropertiesARM)
+		properties := *propertiesARM.(*LeftPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -1753,7 +1753,7 @@ func (embedded *Right_SubResourceEmbedded) ConvertToARM(resolved genruntime.Conv
 	if embedded == nil {
 		return nil, nil
 	}
-	var result Right_SubResourceEmbeddedARM
+	result := &Right_SubResourceEmbeddedARM{}
 
 	// Set property ‘Name’:
 	if embedded.Name != nil {
@@ -1767,7 +1767,7 @@ func (embedded *Right_SubResourceEmbedded) ConvertToARM(resolved genruntime.Conv
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(RightPropertiesARM)
+		properties := *propertiesARM.(*RightPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
@@ -281,12 +281,12 @@ func (a A_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (a A_SpecARM) GetName() string {
+func (a *A_SpecARM) GetName() string {
 	return a.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/A"
-func (a A_SpecARM) GetType() string {
+func (a *A_SpecARM) GetType() string {
 	return "Microsoft.Azure/A"
 }
 
@@ -553,12 +553,12 @@ func (b B_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (b B_SpecARM) GetName() string {
+func (b *B_SpecARM) GetName() string {
 	return b.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/B"
-func (b B_SpecARM) GetType() string {
+func (b *B_SpecARM) GetType() string {
 	return "Microsoft.Azure/B"
 }
 
@@ -594,7 +594,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if a == nil {
 		return nil, nil
 	}
-	var result A_SpecARM
+	result := &A_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -605,7 +605,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(APropertiesARM)
+		properties := *propertiesARM.(*APropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -801,7 +801,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if b == nil {
 		return nil, nil
 	}
-	var result B_SpecARM
+	result := &B_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -812,7 +812,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(BPropertiesARM)
+		properties := *propertiesARM.(*BPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -997,7 +997,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result APropertiesARM
+	result := &APropertiesARM{}
 
 	// Set property ‘IntField’:
 	if properties.IntField != nil {
@@ -1011,7 +1011,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 		if err != nil {
 			return nil, err
 		}
-		refField := refFieldARM.(BResourceARM)
+		refField := *refFieldARM.(*BResourceARM)
 		result.RefField = &refField
 	}
 
@@ -1133,7 +1133,7 @@ func (properties *BProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result BPropertiesARM
+	result := &BPropertiesARM{}
 
 	// Set property ‘EnumField’:
 	if properties.EnumField != nil {
@@ -1226,7 +1226,7 @@ func (resource *BResource) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	if resource == nil {
 		return nil, nil
 	}
-	var result BResourceARM
+	result := &BResourceARM{}
 
 	// Set property ‘Id’:
 	if resource.Reference != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
@@ -281,12 +281,12 @@ func (a A_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (a A_SpecARM) GetName() string {
+func (a *A_SpecARM) GetName() string {
 	return a.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/A"
-func (a A_SpecARM) GetType() string {
+func (a *A_SpecARM) GetType() string {
 	return "Microsoft.Azure/A"
 }
 
@@ -553,12 +553,12 @@ func (b B_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (b B_SpecARM) GetName() string {
+func (b *B_SpecARM) GetName() string {
 	return b.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/B"
-func (b B_SpecARM) GetType() string {
+func (b *B_SpecARM) GetType() string {
 	return "Microsoft.Azure/B"
 }
 
@@ -593,7 +593,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if a == nil {
 		return nil, nil
 	}
-	var result A_SpecARM
+	result := &A_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -604,7 +604,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(APropertiesARM)
+		properties := *propertiesARM.(*APropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -800,7 +800,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if b == nil {
 		return nil, nil
 	}
-	var result B_SpecARM
+	result := &B_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -811,7 +811,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(BPropertiesARM)
+		properties := *propertiesARM.(*BPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -995,7 +995,7 @@ func (properties *AProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result APropertiesARM
+	result := &APropertiesARM{}
 
 	// Set property ‘IntField’:
 	if properties.IntField != nil {
@@ -1086,7 +1086,7 @@ func (properties *BProperties) ConvertToARM(resolved genruntime.ConvertToARMReso
 	if properties == nil {
 		return nil, nil
 	}
-	var result BPropertiesARM
+	result := &BPropertiesARM{}
 
 	// Set property ‘EnumField’:
 	if properties.EnumField != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
@@ -281,12 +281,12 @@ func (a A_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (a A_SpecARM) GetName() string {
+func (a *A_SpecARM) GetName() string {
 	return a.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/A"
-func (a A_SpecARM) GetType() string {
+func (a *A_SpecARM) GetType() string {
 	return "Microsoft.Azure/A"
 }
 
@@ -553,12 +553,12 @@ func (b B_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (b B_SpecARM) GetName() string {
+func (b *B_SpecARM) GetName() string {
 	return b.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/B"
-func (b B_SpecARM) GetType() string {
+func (b *B_SpecARM) GetType() string {
 	return "Microsoft.Azure/B"
 }
 
@@ -587,7 +587,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if a == nil {
 		return nil, nil
 	}
-	var result A_SpecARM
+	result := &A_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -598,7 +598,7 @@ func (a *A_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(CommonPropertiesARM)
+		properties := *propertiesARM.(*CommonPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -789,7 +789,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 	if b == nil {
 		return nil, nil
 	}
-	var result B_SpecARM
+	result := &B_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -800,7 +800,7 @@ func (b *B_Spec) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(CommonPropertiesARM)
+		properties := *propertiesARM.(*CommonPropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -990,7 +990,7 @@ func (properties *CommonProperties) ConvertToARM(resolved genruntime.ConvertToAR
 	if properties == nil {
 		return nil, nil
 	}
-	var result CommonPropertiesARM
+	result := &CommonPropertiesARM{}
 
 	// Set property ‘IntField’:
 	if properties.IntField != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
@@ -283,12 +283,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -323,7 +323,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -334,7 +334,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(FakeResourcePropertiesARM)
+		properties := *propertiesARM.(*FakeResourcePropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -523,7 +523,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 	if properties == nil {
 		return nil, nil
 	}
-	var result FakeResourcePropertiesARM
+	result := &FakeResourcePropertiesARM{}
 
 	// Set property ‘Id’:
 	if properties.Reference != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
@@ -283,12 +283,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -323,7 +323,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name
@@ -334,7 +334,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		properties := propertiesARM.(FakeResourcePropertiesARM)
+		properties := *propertiesARM.(*FakeResourcePropertiesARM)
 		result.Properties = &properties
 	}
 	return result, nil
@@ -524,7 +524,7 @@ func (properties *FakeResourceProperties) ConvertToARM(resolved genruntime.Conve
 	if properties == nil {
 		return nil, nil
 	}
-	var result FakeResourcePropertiesARM
+	result := &FakeResourcePropertiesARM{}
 
 	// Set property ‘OptionalVNet’:
 	if properties.OptionalVNetReference != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
@@ -287,12 +287,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -337,7 +337,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘ArrayFoo’:
 	for _, item := range resource.ArrayFoo {
@@ -345,7 +345,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		result.ArrayFoo = append(result.ArrayFoo, itemARM.(FooARM))
+		result.ArrayFoo = append(result.ArrayFoo, *itemARM.(*FooARM))
 	}
 
 	// Set property ‘ArrayOfArrays’:
@@ -356,7 +356,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 			if err != nil {
 				return nil, err
 			}
-			itemTemp = append(itemTemp, item1ARM.(FooARM))
+			itemTemp = append(itemTemp, *item1ARM.(*FooARM))
 		}
 		result.ArrayOfArrays = append(result.ArrayOfArrays, itemTemp)
 	}
@@ -371,7 +371,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 				if err != nil {
 					return nil, err
 				}
-				item1Temp = append(item1Temp, item2ARM.(FooARM))
+				item1Temp = append(item1Temp, *item2ARM.(*FooARM))
 			}
 			itemTemp = append(itemTemp, item1Temp)
 		}
@@ -392,7 +392,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 				if err != nil {
 					return nil, err
 				}
-				itemTemp[key] = valueARM.(FooARM)
+				itemTemp[key] = *valueARM.(*FooARM)
 			}
 			result.ArrayOfMaps = append(result.ArrayOfMaps, itemTemp)
 		}
@@ -863,7 +863,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if foo == nil {
 		return nil, nil
 	}
-	var result FooARM
+	result := &FooARM{}
 
 	// Set property ‘Name’:
 	if foo.Name != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
@@ -285,12 +285,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -332,7 +332,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘Color’:
 	if resource.Color != nil {
@@ -346,7 +346,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		foo := fooARM.(FooARM)
+		foo := *fooARM.(*FooARM)
 		result.Foo = &foo
 	}
 
@@ -359,7 +359,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		optionalFoo := optionalFooARM.(FooARM)
+		optionalFoo := *optionalFooARM.(*FooARM)
 		result.OptionalFoo = &optionalFoo
 	}
 	return result, nil
@@ -604,7 +604,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if foo == nil {
 		return nil, nil
 	}
-	var result FooARM
+	result := &FooARM{}
 
 	// Set property ‘Name’:
 	if foo.Name != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
@@ -286,12 +286,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -326,7 +326,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘JsonObject’:
 	if resource.JsonObject != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
@@ -289,12 +289,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -341,7 +341,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘MapFoo’:
 	if resource.MapFoo != nil {
@@ -351,7 +351,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 			if err != nil {
 				return nil, err
 			}
-			result.MapFoo[key] = valueARM.(FooARM)
+			result.MapFoo[key] = *valueARM.(*FooARM)
 		}
 	}
 
@@ -365,7 +365,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 				if err != nil {
 					return nil, err
 				}
-				valueTemp = append(valueTemp, itemARM.(FooARM))
+				valueTemp = append(valueTemp, *itemARM.(*FooARM))
 			}
 			result.MapOfArrays[key] = valueTemp
 		}
@@ -390,7 +390,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 					if err != nil {
 						return nil, err
 					}
-					valueTemp[valueKey] = value1ARM.(FooARM)
+					valueTemp[valueKey] = *value1ARM.(*FooARM)
 				}
 				result.MapOfMaps[key] = valueTemp
 			}
@@ -411,7 +411,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 							if err != nil {
 								return nil, err
 							}
-							value1Temp[valueKey1] = value2ARM.(FooARM)
+							value1Temp[valueKey1] = *value2ARM.(*FooARM)
 						}
 						valueTemp[valueKey] = value1Temp
 					}
@@ -1013,7 +1013,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if foo == nil {
 		return nil, nil
 	}
-	var result FooARM
+	result := &FooARM{}
 
 	// Set property ‘FooName’:
 	if foo.FooName != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
@@ -282,12 +282,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -315,7 +315,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name

--- a/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -286,12 +286,12 @@ func (resource FakeResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource FakeResource_SpecARM) GetName() string {
+func (resource *FakeResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/FakeResource"
-func (resource FakeResource_SpecARM) GetType() string {
+func (resource *FakeResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/FakeResource"
 }
 
@@ -339,7 +339,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 	if resource == nil {
 		return nil, nil
 	}
-	var result FakeResource_SpecARM
+	result := &FakeResource_SpecARM{}
 
 	// Set property ‘Color’:
 	if resource.Color != nil {
@@ -353,7 +353,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		foo := fooARM.(FooARM)
+		foo := *fooARM.(*FooARM)
 		result.Foo = &foo
 	}
 
@@ -366,7 +366,7 @@ func (resource *FakeResource_Spec) ConvertToARM(resolved genruntime.ConvertToARM
 		if err != nil {
 			return nil, err
 		}
-		optionalFoo := optionalFooARM.(FooARM)
+		optionalFoo := *optionalFooARM.(*FooARM)
 		result.OptionalFoo = &optionalFoo
 	}
 	return result, nil
@@ -611,7 +611,7 @@ func (testType *EmbeddedTestType) ConvertToARM(resolved genruntime.ConvertToARMR
 	if testType == nil {
 		return nil, nil
 	}
-	var result EmbeddedTestTypeARM
+	result := &EmbeddedTestTypeARM{}
 
 	// Set property ‘FancyProp’:
 	result.FancyProp = testType.FancyProp
@@ -680,7 +680,7 @@ func (foo *Foo) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	if foo == nil {
 		return nil, nil
 	}
-	var result FooARM
+	result := &FooARM{}
 
 	// Set property ‘Name’:
 	if foo.Name != nil {

--- a/v2/tools/generator/internal/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
@@ -282,12 +282,12 @@ func (resource AResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource AResource_SpecARM) GetName() string {
+func (resource *AResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/AResource"
-func (resource AResource_SpecARM) GetType() string {
+func (resource *AResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/AResource"
 }
 
@@ -315,7 +315,7 @@ func (resource *AResource_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if resource == nil {
 		return nil, nil
 	}
-	var result AResource_SpecARM
+	result := &AResource_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name

--- a/v2/tools/generator/internal/codegen/testdata/EnumNames/Single_valued_enum_name.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EnumNames/Single_valued_enum_name.golden
@@ -275,12 +275,12 @@ func (resource AResource_SpecARM) GetAPIVersion() string {
 }
 
 // GetName returns the Name of the resource
-func (resource AResource_SpecARM) GetName() string {
+func (resource *AResource_SpecARM) GetName() string {
 	return resource.Name
 }
 
 // GetType returns the ARM Type of the resource. This is always "Microsoft.Azure/AResource"
-func (resource AResource_SpecARM) GetType() string {
+func (resource *AResource_SpecARM) GetType() string {
 	return "Microsoft.Azure/AResource"
 }
 
@@ -304,7 +304,7 @@ func (resource *AResource_Spec) ConvertToARM(resolved genruntime.ConvertToARMRes
 	if resource == nil {
 		return nil, nil
 	}
-	var result AResource_SpecARM
+	result := &AResource_SpecARM{}
 
 	// Set property ‘Name’:
 	result.Name = resolved.Name


### PR DESCRIPTION
`ConvertToARM` returning a struct rather than a ptr to a struct originally came about because the contract in the ARM conversion code generation is that handlers should return value types. This contract makes sense for primitive types. It also makes sense when assigning to slices or maps, as usually there the type is `map[string]Foo` rather than `map[string]*Foo`.

The unfortunate result of this pattern though is that the final type returned by `ConvertToARM` is a struct rather than a ptr. Until now that hasn't been a problem, but for `RouteTable` we need the ability to modify that struct by assigning a new `Properties` field to it, if one doesn't already exist. That isn't possible if a struct is returned and wrapped in an interface like we do.

This change rectifies the issue by having `ConvertToARM` return a pointer. This impacts both the top level result but also the "inner" results as we walk the type graph and convert everything. This has a few consequences:
- The `ConvertToARM` code generation now must dereference the returned pointer in order to continue meeting the contract of always returning value types. This sometimes results in unnatural code that looks like:
    ```
    identity := *identityARM.(*BatchAccountIdentityARM)
    result.Identity = &identity
    ```
- The callers of `ConvertToARM` can now easily modify the returned types.

In an effort to avoid the unnatural `*` + `&` combo above, I put a timeboxed effort towards doing a better job. It turns out that while the contract of the inner handler returning a struct is awkward in this case, it's NOT awkward in other cases such as map and slice handling. There's no trivial way to avoid this as the conversion generation exists now, and given the complexity of that code I'm worried about making it _more_ complicated to solve this "problem", so for now I'm going to leave this as is.