### PR TITLE
Fix makeUniqueIndexMethodName to be unique always

### DIFF
--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -75,7 +75,6 @@ func handleSecretPropertyChains(
 	idFactory astmodel.IdentifierFactory,
 	def astmodel.TypeDefinition,
 ) ([]*functions.IndexRegistrationFunction, []string) {
-
 	indexFunctions := make([]*functions.IndexRegistrationFunction, 0, len(chains))
 	secretPropertyKeys := make([]string, 0, len(chains))
 


### PR DESCRIPTION

Closes #2332 

**What this PR does / why we need it**:

This PR adds some counter index logic to make sure that `IndexMethods` always have a unique name by appending counter index to the method names.
