### PR TITLE
Ensure parallel tests don't race for names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - tparallel
     - paralleltest
     - prealloc
+    - unparam  # This was added while we used go1.18 which means it's always been disabled. It may eventually be re-enabled and we'll need to fix what it finds
   presets:
     - bugs
     - unused

--- a/v2/internal/controllers/crd_aks_managedcluster_test.go
+++ b/v2/internal/controllers/crd_aks_managedcluster_test.go
@@ -85,8 +85,8 @@ func Test_AKS_ManagedCluster_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "AKS AgentPool CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				AKS_ManagedCluster_AgentPool_CRUD(testContext, cluster)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				AKS_ManagedCluster_AgentPool_CRUD(tc, cluster)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_cache_redis_test.go
+++ b/v2/internal/controllers/crd_cache_redis_test.go
@@ -53,14 +53,14 @@ func Test_Cache_Redis_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Redis linked server CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				Redis_LinkedServer_CRUD(testContext, rg, redis1, redis2)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				Redis_LinkedServer_CRUD(tc, rg, redis1, redis2)
 			},
 		},
 		testcommon.Subtest{
 			Name: "Redis patch schedule CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				Redis_PatchSchedule_CRUD(testContext, redis1)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				Redis_PatchSchedule_CRUD(tc, redis1)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_cdn_test.go
+++ b/v2/internal/controllers/crd_cdn_test.go
@@ -41,8 +41,8 @@ func Test_CDN_Profile_CRUD(t *testing.T) {
 
 	tc.RunParallelSubtests(testcommon.Subtest{
 		Name: "CDN Endpoint CRUD",
-		Test: func(testContext *testcommon.KubePerTestContext) {
-			Endpoint_CRUD(testContext, profile)
+		Test: func(tc *testcommon.KubePerTestContext) {
+			Endpoint_CRUD(tc, profile)
 		},
 	})
 

--- a/v2/internal/controllers/crd_cosmosdb_mongodb_test.go
+++ b/v2/internal/controllers/crd_cosmosdb_mongodb_test.go
@@ -83,14 +83,14 @@ func Test_CosmosDB_MongoDatabase_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "CosmosDB MongoDB Collection CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				CosmosDB_MongoDB_Collection_CRUD(testContext, &db)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				CosmosDB_MongoDB_Collection_CRUD(tc, &db)
 			},
 		},
 		testcommon.Subtest{
 			Name: "CosmosDB MongoDB Database throughput settings CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				CosmosDB_MongoDB_Database_ThroughputSettings_CRUD(testContext, &db)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				CosmosDB_MongoDB_Database_ThroughputSettings_CRUD(tc, &db)
 			},
 		})
 }
@@ -147,8 +147,8 @@ func CosmosDB_MongoDB_Collection_CRUD(tc *testcommon.KubePerTestContext, db clie
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "CosmosDB MongoDB Database Collection throughput settings CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				CosmosDB_MongoDB_Database_Collections_ThroughputSettings_CRUD(testContext, &collection)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				CosmosDB_MongoDB_Database_Collections_ThroughputSettings_CRUD(tc, &collection)
 			},
 		})
 

--- a/v2/internal/controllers/crd_dbformysql_flexibleserver_test.go
+++ b/v2/internal/controllers/crd_dbformysql_flexibleserver_test.go
@@ -22,6 +22,9 @@ func Test_DBForMySQL_FlexibleServer_CRUD(t *testing.T) {
 	t.Parallel()
 	tc := globalTestContext.ForTest(t)
 
+	//location := tc.AzureRegion Capacity crunch in West US 2 makes this not work when live
+	location := "eastus"
+
 	rg := tc.CreateTestResourceGroupAndWait()
 
 	adminPasswordKey := "adminPassword"
@@ -44,7 +47,7 @@ func Test_DBForMySQL_FlexibleServer_CRUD(t *testing.T) {
 	flexibleServer := &mysql.FlexibleServer{
 		ObjectMeta: tc.MakeObjectMeta("mysql"),
 		Spec: mysql.FlexibleServers_Spec{
-			Location: tc.AzureRegion,
+			Location: &location,
 			Owner:    testcommon.AsOwner(rg),
 			Version:  &version,
 			Sku: &mysql.Sku{
@@ -88,14 +91,14 @@ func Test_DBForMySQL_FlexibleServer_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "MySQL Flexible servers database CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				MySQLFlexibleServer_Database_CRUD(testContext, flexibleServer)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				MySQLFlexibleServer_Database_CRUD(tc, flexibleServer)
 			},
 		},
 		testcommon.Subtest{
 			Name: "MySQL Flexible servers firewall CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				MySQLFlexibleServer_FirewallRule_CRUD(testContext, flexibleServer)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				MySQLFlexibleServer_FirewallRule_CRUD(tc, flexibleServer)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_dbforpostgresql_flexibleserver_test.go
+++ b/v2/internal/controllers/crd_dbforpostgresql_flexibleserver_test.go
@@ -90,20 +90,20 @@ func Test_DBForPostgreSQL_FlexibleServer_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Flexible servers database CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				FlexibleServer_Database_CRUD(testContext, flexibleServer)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				FlexibleServer_Database_CRUD(tc, flexibleServer)
 			},
 		},
 		testcommon.Subtest{
 			Name: "Flexible servers firewall CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				FlexibleServer_FirewallRule_CRUD(testContext, flexibleServer)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				FlexibleServer_FirewallRule_CRUD(tc, flexibleServer)
 			},
 		},
 		testcommon.Subtest{
 			Name: "Flexible servers configuration CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				FlexibleServer_Configuration_CRUD(testContext, flexibleServer)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				FlexibleServer_Configuration_CRUD(tc, flexibleServer)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_eventgrid_domain_test.go
+++ b/v2/internal/controllers/crd_eventgrid_domain_test.go
@@ -13,6 +13,7 @@ import (
 	eventgrid "github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601"
 	storage "github.com/Azure/azure-service-operator/v2/api/storage/v1beta20210401"
 	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
 func Test_EventGrid_Domain(t *testing.T) {
@@ -79,59 +80,13 @@ func Test_EventGrid_Domain(t *testing.T) {
 		testcommon.Subtest{
 			Name: "CreateDomainTopicAndSubscription",
 			Test: func(tc *testcommon.KubePerTestContext) {
-				topic := &eventgrid.DomainsTopic{
-					ObjectMeta: tc.MakeObjectMeta("topic"),
-					Spec: eventgrid.DomainsTopics_Spec{
-						Owner: testcommon.AsOwner(domain),
-					},
-				}
-
-				tc.CreateResourceAndWait(topic)
-				// don’t bother deleting; deleting domain will clean up
-
-				endpointType := eventgrid.StorageQueueEventSubscriptionDestinationEndpointTypeStorageQueue
-				subscription := &eventgrid.EventSubscription{
-					ObjectMeta: tc.MakeObjectMeta("sub"),
-					Spec: eventgrid.EventSubscriptions_Spec{
-						Owner: tc.AsExtensionOwner(topic),
-						Destination: &eventgrid.EventSubscriptionDestination{
-							StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
-								EndpointType: &endpointType,
-								Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{
-									ResourceReference: acctReference,
-									QueueName:         &queue.Name,
-								},
-							},
-						},
-					},
-				}
-
-				tc.CreateResourceAndWait(subscription)
-				// don’t bother deleting
+				DomainTopicAndSubscription_CRUD(tc, queue, domain, acctReference)
 			},
 		},
 		testcommon.Subtest{
 			Name: "CreateDomainSubscription",
 			Test: func(tc *testcommon.KubePerTestContext) {
-				endpointType := eventgrid.StorageQueueEventSubscriptionDestinationEndpointTypeStorageQueue
-				subscription := &eventgrid.EventSubscription{
-					ObjectMeta: tc.MakeObjectMeta("sub"),
-					Spec: eventgrid.EventSubscriptions_Spec{
-						Owner: tc.AsExtensionOwner(domain),
-						Destination: &eventgrid.EventSubscriptionDestination{
-							StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
-								EndpointType: &endpointType,
-								Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{
-									ResourceReference: acctReference,
-									QueueName:         &queue.Name,
-								},
-							},
-						},
-					},
-				}
-
-				tc.CreateResourceAndWait(subscription)
-				// don’t bother deleting
+				DomainSubscription_CRUD(tc, queue, domain, acctReference)
 			},
 		},
 	)
@@ -145,4 +100,58 @@ func Test_EventGrid_Domain(t *testing.T) {
 		string(eventgrid.APIVersionValue))
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
+}
+
+func DomainTopicAndSubscription_CRUD(tc *testcommon.KubePerTestContext, queue *storage.StorageAccountsQueueServicesQueue, domain *eventgrid.Domain, acctReference *genruntime.ResourceReference) {
+	topic := &eventgrid.DomainsTopic{
+		ObjectMeta: tc.MakeObjectMeta("topic"),
+		Spec: eventgrid.DomainsTopics_Spec{
+			Owner: testcommon.AsOwner(domain),
+		},
+	}
+
+	tc.CreateResourceAndWait(topic)
+	// don’t bother deleting; deleting domain will clean up
+
+	endpointType := eventgrid.StorageQueueEventSubscriptionDestinationEndpointTypeStorageQueue
+	subscription := &eventgrid.EventSubscription{
+		ObjectMeta: tc.MakeObjectMeta("sub"),
+		Spec: eventgrid.EventSubscriptions_Spec{
+			Owner: tc.AsExtensionOwner(topic),
+			Destination: &eventgrid.EventSubscriptionDestination{
+				StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
+					EndpointType: &endpointType,
+					Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{
+						ResourceReference: acctReference,
+						QueueName:         &queue.Name,
+					},
+				},
+			},
+		},
+	}
+
+	tc.CreateResourceAndWait(subscription)
+	// don’t bother deleting
+}
+
+func DomainSubscription_CRUD(tc *testcommon.KubePerTestContext, queue *storage.StorageAccountsQueueServicesQueue, domain *eventgrid.Domain, acctReference *genruntime.ResourceReference) {
+	endpointType := eventgrid.StorageQueueEventSubscriptionDestinationEndpointTypeStorageQueue
+	subscription := &eventgrid.EventSubscription{
+		ObjectMeta: tc.MakeObjectMeta("sub"),
+		Spec: eventgrid.EventSubscriptions_Spec{
+			Owner: tc.AsExtensionOwner(domain),
+			Destination: &eventgrid.EventSubscriptionDestination{
+				StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
+					EndpointType: &endpointType,
+					Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{
+						ResourceReference: acctReference,
+						QueueName:         &queue.Name,
+					},
+				},
+			},
+		},
+	}
+
+	tc.CreateResourceAndWait(subscription)
+	// don’t bother deleting
 }

--- a/v2/internal/controllers/crd_eventgrid_topic_test.go
+++ b/v2/internal/controllers/crd_eventgrid_topic_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	eventgrid "github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601"
+	resources "github.com/Azure/azure-service-operator/v2/api/resources/v1beta20200601"
 	storage "github.com/Azure/azure-service-operator/v2/api/storage/v1beta20210401"
 	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
 )
@@ -46,63 +47,7 @@ func Test_EventGrid_Topic(t *testing.T) {
 		testcommon.Subtest{
 			Name: "CreateTopicSubscription",
 			Test: func(tc *testcommon.KubePerTestContext) {
-				// First create a queue to use as destination
-
-				kind := storage.StorageAccountsSpecKindStorageV2
-				sku := storage.SkuNameStandardLRS
-				acctName := tc.NoSpaceNamer.GenerateName("stor")
-				tier := storage.StorageAccountPropertiesCreateParametersAccessTierHot
-				acct := &storage.StorageAccount{
-					ObjectMeta: tc.MakeObjectMetaWithName(acctName),
-					Spec: storage.StorageAccounts_Spec{
-						Owner:      testcommon.AsOwner(rg),
-						Location:   tc.AzureRegion,
-						Kind:       &kind,
-						AccessTier: &tier,
-						Sku:        &storage.Sku{Name: &sku},
-					},
-				}
-
-				tc.CreateResourceAndWait(acct)
-
-				queueService := &storage.StorageAccountsQueueService{
-					ObjectMeta: tc.MakeObjectMeta("qservice"),
-					Spec: storage.StorageAccountsQueueServices_Spec{
-						Owner: testcommon.AsOwner(acct),
-					},
-				}
-
-				tc.CreateResourceAndWait(queueService)
-
-				queue := &storage.StorageAccountsQueueServicesQueue{
-					ObjectMeta: tc.MakeObjectMeta("queue"),
-					Spec: storage.StorageAccountsQueueServicesQueues_Spec{
-						Owner: testcommon.AsOwner(queueService),
-					},
-				}
-
-				tc.CreateResourceAndWait(queue)
-
-				acctReference := tc.MakeReferenceFromResource(acct)
-
-				endpointType := eventgrid.StorageQueueEventSubscriptionDestinationEndpointTypeStorageQueue
-				subscription := &eventgrid.EventSubscription{
-					ObjectMeta: tc.MakeObjectMeta("sub"),
-					Spec: eventgrid.EventSubscriptions_Spec{
-						Owner: tc.AsExtensionOwner(topic),
-						Destination: &eventgrid.EventSubscriptionDestination{
-							StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
-								EndpointType: &endpointType,
-								Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{
-									ResourceReference: acctReference,
-									QueueName:         &queue.Name,
-								},
-							},
-						},
-					},
-				}
-
-				tc.CreateResourceAndWait(subscription)
+				Topic_Subscription_CRUD(tc, rg, topic)
 			},
 		},
 	)
@@ -116,4 +61,62 @@ func Test_EventGrid_Topic(t *testing.T) {
 		string(eventgrid.APIVersionValue))
 	tc.Expect(err).ToNot(HaveOccurred())
 	tc.Expect(exists).To(BeFalse())
+}
+
+func Topic_Subscription_CRUD(tc *testcommon.KubePerTestContext, rg *resources.ResourceGroup, topic *eventgrid.Topic) {
+	kind := storage.StorageAccountsSpecKindStorageV2
+	sku := storage.SkuNameStandardLRS
+	acctName := tc.NoSpaceNamer.GenerateName("stor")
+	tier := storage.StorageAccountPropertiesCreateParametersAccessTierHot
+	acct := &storage.StorageAccount{
+		ObjectMeta: tc.MakeObjectMetaWithName(acctName),
+		Spec: storage.StorageAccounts_Spec{
+			Owner:      testcommon.AsOwner(rg),
+			Location:   tc.AzureRegion,
+			Kind:       &kind,
+			AccessTier: &tier,
+			Sku:        &storage.Sku{Name: &sku},
+		},
+	}
+
+	tc.CreateResourceAndWait(acct)
+
+	queueService := &storage.StorageAccountsQueueService{
+		ObjectMeta: tc.MakeObjectMeta("qservice"),
+		Spec: storage.StorageAccountsQueueServices_Spec{
+			Owner: testcommon.AsOwner(acct),
+		},
+	}
+
+	tc.CreateResourceAndWait(queueService)
+
+	queue := &storage.StorageAccountsQueueServicesQueue{
+		ObjectMeta: tc.MakeObjectMeta("queue"),
+		Spec: storage.StorageAccountsQueueServicesQueues_Spec{
+			Owner: testcommon.AsOwner(queueService),
+		},
+	}
+
+	tc.CreateResourceAndWait(queue)
+
+	acctReference := tc.MakeReferenceFromResource(acct)
+
+	endpointType := eventgrid.StorageQueueEventSubscriptionDestinationEndpointTypeStorageQueue
+	subscription := &eventgrid.EventSubscription{
+		ObjectMeta: tc.MakeObjectMeta("sub"),
+		Spec: eventgrid.EventSubscriptions_Spec{
+			Owner: tc.AsExtensionOwner(topic),
+			Destination: &eventgrid.EventSubscriptionDestination{
+				StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
+					EndpointType: &endpointType,
+					Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{
+						ResourceReference: acctReference,
+						QueueName:         &queue.Name,
+					},
+				},
+			},
+		},
+	}
+
+	tc.CreateResourceAndWait(subscription)
 }

--- a/v2/internal/controllers/crd_eventhub_namespace_test.go
+++ b/v2/internal/controllers/crd_eventhub_namespace_test.go
@@ -55,14 +55,14 @@ func Test_EventHub_Namespace_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "EventHub CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				EventHub_CRUD(testContext, namespace)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				EventHub_CRUD(tc, namespace)
 			},
 		},
 		testcommon.Subtest{
 			Name: "EventHub namespace auth rule CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				Namespace_AuthorizationRules_CRUD(testContext, namespace)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				Namespace_AuthorizationRules_CRUD(tc, namespace)
 			},
 		},
 	)
@@ -99,14 +99,14 @@ func EventHub_CRUD(tc *testcommon.KubePerTestContext, namespace client.Object) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "EventHub auth rule CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				EventHub_AuthorizationRules_CRUD(testContext, eh)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				EventHub_AuthorizationRules_CRUD(tc, eh)
 			},
 		},
 		testcommon.Subtest{
 			Name: "EventHub consumer group CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				EventHub_ConsumerGroup_CRUD(testContext, eh)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				EventHub_ConsumerGroup_CRUD(tc, eh)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_networking_nsg_test.go
+++ b/v2/internal/controllers/crd_networking_nsg_test.go
@@ -49,8 +49,8 @@ func Test_Networking_NetworkSecurityGroup_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "SecurityRules CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				NetworkSecurityGroup_SecurityRules_CRUD(testContext, nsg)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				NetworkSecurityGroup_SecurityRules_CRUD(tc, nsg)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_networking_routetable_test.go
+++ b/v2/internal/controllers/crd_networking_routetable_test.go
@@ -41,8 +41,8 @@ func Test_Networking_RouteTable_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Routes CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				Routes_CRUD(testContext, routeTable)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				Routes_CRUD(tc, routeTable)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_networking_virtualnetwork_test.go
+++ b/v2/internal/controllers/crd_networking_virtualnetwork_test.go
@@ -41,8 +41,8 @@ func Test_Networking_VirtualNetwork_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Subnet CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				Subnet_CRUD(testContext, vnet)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				Subnet_CRUD(tc, vnet)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_servicebus_namespace_basic_test.go
+++ b/v2/internal/controllers/crd_servicebus_namespace_basic_test.go
@@ -44,8 +44,8 @@ func Test_ServiceBus_Namespace_Basic_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Queue CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				ServiceBus_Queue_CRUD(testContext, namespace)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				ServiceBus_Queue_CRUD(tc, namespace)
 			},
 		},
 	)

--- a/v2/internal/controllers/crd_servicebus_namespace_standard_test.go
+++ b/v2/internal/controllers/crd_servicebus_namespace_standard_test.go
@@ -44,11 +44,11 @@ func Test_ServiceBus_Namespace_Standard_CRUD(t *testing.T) {
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Queue CRUD",
-			Test: func(t *testcommon.KubePerTestContext) { ServiceBus_Queue_CRUD(tc, namespace) },
+			Test: func(tc *testcommon.KubePerTestContext) { ServiceBus_Queue_CRUD(tc, namespace) },
 		},
 		testcommon.Subtest{
 			Name: "Topic CRUD",
-			Test: func(t *testcommon.KubePerTestContext) { ServiceBus_Topic_CRUD(tc, namespace) },
+			Test: func(tc *testcommon.KubePerTestContext) { ServiceBus_Topic_CRUD(tc, namespace) },
 		},
 	)
 

--- a/v2/internal/controllers/crd_storage_storageaccount_test.go
+++ b/v2/internal/controllers/crd_storage_storageaccount_test.go
@@ -47,13 +47,13 @@ func Test_Storage_StorageAccount_CRUD(t *testing.T) {
 		},
 		testcommon.Subtest{
 			Name: "Queue Services CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
+			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_QueueServices_CRUD(tc, acct)
 			},
 		},
 		testcommon.Subtest{
 			Name: "Management Policies CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
+			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_ManagementPolicy_CRUD(tc, acct)
 			},
 		},
@@ -84,8 +84,8 @@ func StorageAccount_BlobServices_CRUD(tc *testcommon.KubePerTestContext, storage
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Container CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
-				StorageAccount_BlobServices_Container_CRUD(testContext, blobService)
+			Test: func(tc *testcommon.KubePerTestContext) {
+				StorageAccount_BlobServices_Container_CRUD(tc, blobService)
 			},
 		})
 }
@@ -116,7 +116,7 @@ func StorageAccount_QueueServices_CRUD(tc *testcommon.KubePerTestContext, storag
 	tc.RunParallelSubtests(
 		testcommon.Subtest{
 			Name: "Queue CRUD",
-			Test: func(testContext *testcommon.KubePerTestContext) {
+			Test: func(tc *testcommon.KubePerTestContext) {
 				StorageAccount_QueueServices_Queue_CRUD(tc, queueService)
 			},
 		},

--- a/v2/internal/controllers/recordings/Test_Cache_Redis_CRUD.yaml
+++ b/v2/internal/controllers/recordings/Test_Cache_Redis_CRUD.yaml
@@ -81,12 +81,12 @@ interactions:
     method: PUT
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":{"primaryKey":"{KEY}","secondaryKey":"{KEY}"},"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":{"primaryKey":"{KEY}","secondaryKey":"{KEY}"},"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "973"
+      - "975"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -102,7 +102,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 201 Created
     code: 201
     duration: ""
@@ -122,12 +122,12 @@ interactions:
     method: PUT
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":{"primaryKey":"{KEY}","secondaryKey":"{KEY}"},"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":{"primaryKey":"{KEY}","secondaryKey":"{KEY}"},"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "973"
+      - "975"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -143,7 +143,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 201 Created
     code: 201
     duration: ""
@@ -157,7 +157,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -176,7 +176,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -190,7 +190,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -209,7 +209,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -223,7 +223,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -242,7 +242,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -256,7 +256,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -275,7 +275,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -289,7 +289,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -308,7 +308,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -322,7 +322,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -341,7 +341,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -355,7 +355,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -374,7 +374,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -388,7 +388,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -407,7 +407,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -421,7 +421,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -440,7 +440,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -454,7 +454,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -473,7 +473,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -487,7 +487,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -506,7 +506,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -520,7 +520,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -539,7 +539,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -553,7 +553,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -572,7 +572,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -586,7 +586,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -605,7 +605,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -619,7 +619,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -638,7 +638,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -652,7 +652,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -671,7 +671,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -685,7 +685,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -704,7 +704,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -718,7 +718,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -737,7 +737,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -751,7 +751,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -770,7 +770,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -784,7 +784,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -803,7 +803,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -817,7 +817,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -836,7 +836,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -850,7 +850,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -869,7 +869,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -883,7 +883,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -902,7 +902,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -916,7 +916,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -935,7 +935,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -949,7 +949,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -968,7 +968,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -982,7 +982,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":false,"isPrimary":false},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1001,40 +1001,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Test-Request-Attempt:
-      - "13"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1048,7 +1015,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1067,7 +1034,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,12 +1043,12 @@ interactions:
     form: {}
     headers:
       Test-Request-Attempt:
-      - "14"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv?api-version=2020-12-01
+      - "13"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1100,7 +1067,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 1a441737-ce91-4795-bf61-fb4fb2ed4f2a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,12 +1078,12 @@ interactions:
       Accept:
       - application/json
       Test-Request-Attempt:
-      - "15"
+      - "14"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv?api-version=2020-12-01
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1135,73 +1102,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Test-Request-Attempt:
-      - "14"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Creating","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Test-Request-Attempt:
-      - "15"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1212,12 +1113,12 @@ interactions:
       Accept:
       - application/json
       Test-Request-Attempt:
-      - "16"
+      - "14"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1236,7 +1137,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1256,7 +1157,7 @@ interactions:
     method: PUT
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":{"primaryKey":"{KEY}","secondaryKey":"{KEY}"},"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":{"primaryKey":"{KEY}","secondaryKey":"{KEY}"},"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1275,7 +1176,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1286,12 +1187,12 @@ interactions:
       Accept:
       - application/json
       Test-Request-Attempt:
-      - "16"
+      - "15"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv?api-version=2020-12-01
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Succeeded","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1310,12 +1211,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"asotestfwrulegkvdow","properties":{"endIP":"1.2.3.4","startIP":"1.2.3.4"}}'
+    body: '{"name":"asotestfwrulexxtytm","properties":{"endIP":"1.2.3.4","startIP":"1.2.3.4"}}'
     form: {}
     headers:
       Accept:
@@ -1326,10 +1227,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
     method: PUT
   response:
-    body: '{"properties":{"startIP":"1.2.3.4","endIP":"1.2.3.4"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow","name":"asotest-redis1-zbvfwv/asotestfwrulegkvdow","type":"Microsoft.Cache/redis/firewallRules"}'
+    body: '{"properties":{"startIP":"1.2.3.4","endIP":"1.2.3.4"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm","name":"asotest-redis1-zbvfwv/asotestfwrulexxtytm","type":"Microsoft.Cache/redis/firewallRules"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1340,7 +1241,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
       Pragma:
       - no-cache
       Server:
@@ -1350,7 +1251,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 201 Created
     code: 201
     duration: ""
@@ -1360,10 +1261,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow","name":"asotest-redis1-zbvfwv/asotestfwrulegkvdow","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"1.2.3.4","endIP":"1.2.3.4"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm","name":"asotest-redis1-zbvfwv/asotestfwrulexxtytm","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"1.2.3.4","endIP":"1.2.3.4"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1382,7 +1283,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1394,10 +1295,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow","name":"asotest-redis1-zbvfwv/asotestfwrulegkvdow","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"1.2.3.4","endIP":"1.2.3.4"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm","name":"asotest-redis1-zbvfwv/asotestfwrulexxtytm","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"1.2.3.4","endIP":"1.2.3.4"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1416,12 +1317,12 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"asotestfwrulegkvdow","properties":{"endIP":"1.2.3.5","startIP":"1.2.3.4"}}'
+    body: '{"name":"asotestfwrulexxtytm","properties":{"endIP":"1.2.3.5","startIP":"1.2.3.4"}}'
     form: {}
     headers:
       Accept:
@@ -1432,10 +1333,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
     method: PUT
   response:
-    body: '{"properties":{"startIP":"1.2.3.4","endIP":"1.2.3.5"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow","name":"asotest-redis1-zbvfwv/asotestfwrulegkvdow","type":"Microsoft.Cache/redis/firewallRules"}'
+    body: '{"properties":{"startIP":"1.2.3.4","endIP":"1.2.3.5"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm","name":"asotest-redis1-zbvfwv/asotestfwrulexxtytm","type":"Microsoft.Cache/redis/firewallRules"}'
     headers:
       Cache-Control:
       - no-cache
@@ -1454,7 +1355,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1466,10 +1367,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "2"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow","name":"asotest-redis1-zbvfwv/asotestfwrulegkvdow","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"1.2.3.4","endIP":"1.2.3.5"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm","name":"asotest-redis1-zbvfwv/asotestfwrulexxtytm","type":"Microsoft.Cache/Redis/firewallRules","properties":{"startIP":"1.2.3.4","endIP":"1.2.3.5"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1488,7 +1389,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,7 +1401,7 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
     method: DELETE
   response:
     body: ""
@@ -1520,7 +1421,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1532,11 +1433,11 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "3"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulegkvdow?api-version=2020-12-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/firewallRules/asotestfwrulexxtytm?api-version=2020-12-01
     method: GET
   response:
     body: '{"error":{"code":"ResourceNotFound","message":"A requested resource could
-      not be found. It may already have been deleted.\r\nRequestID=2c74f785-bda4-48c1-ae90-49d4c3795bbb","target":null}}'
+      not be found. It may already have been deleted.\r\nRequestID=c460e353-1111-4e8d-9dd6-fe74bc6b1bea","target":null}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1555,7 +1456,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1594,42 +1495,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/patchSchedules/default?api-version=2020-12-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/patchSchedules/default","location":"West
-      US 2","name":"asotest-redis1-zbvfwv/default","type":"Microsoft.Cache/Redis/PatchSchedules","properties":{"scheduleEntries":[{"dayOfWeek":"Monday","startHourUtc":6,"maintenanceWindow":"PT6H"}]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1671,9 +1537,44 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 201 Created
     code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/patchSchedules/default?api-version=2020-12-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/patchSchedules/default","location":"West
+      US 2","name":"asotest-redis1-zbvfwv/default","type":"Microsoft.Cache/Redis/PatchSchedules","properties":{"scheduleEntries":[{"dayOfWeek":"Monday","startHourUtc":6,"maintenanceWindow":"PT6H"}]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Rp-Server-Mvid:
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: '{"name":"default","properties":{"scheduleEntries":[{"dayOfWeek":"Monday","maintenanceWindow":"PT6H","startHourUtc":6},{"dayOfWeek":"Wednesday","maintenanceWindow":"PT6H30S","startHourUtc":7}]}}'
@@ -1710,7 +1611,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1745,7 +1646,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1778,7 +1679,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1811,7 +1712,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1844,7 +1745,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1877,7 +1778,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1910,7 +1811,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1943,7 +1844,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1957,7 +1858,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","linkedRedisCacheLocation":"West
-      US 2","serverRole":"Secondary","provisioningState":"Succeeded"}}'
+      US 2","serverRole":"Secondary","provisioningState":"Syncing"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -1976,7 +1877,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -1984,8 +1885,6 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       Test-Request-Attempt:
       - "7"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq?api-version=2020-12-01
@@ -2011,39 +1910,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Cache-Control:
-      - no-cache
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 204 No Content
-    code: 204
     duration: ""
 - request:
     body: ""
@@ -2076,9 +1945,39 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq?api-version=2020-12-01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Rp-Server-Mvid:
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 204 No Content
+    code: 204
     duration: ""
 - request:
     body: ""
@@ -2111,7 +2010,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -2146,7 +2045,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -2161,8 +2060,78 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq?api-version=2020-12-01
     method: GET
   response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","linkedRedisCacheLocation":"West
+      US 2","serverRole":"Secondary","provisioningState":"Succeeded"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Rp-Server-Mvid:
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "12"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq?api-version=2020-12-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis/linkedServers","properties":{"linkedRedisCacheId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","linkedRedisCacheLocation":"West
+      US 2","serverRole":"Secondary","provisioningState":"Succeeded"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Rp-Server-Mvid:
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "13"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv/linkedServers/asotest-redis2-gzcvdq?api-version=2020-12-01
+    method: GET
+  response:
     body: '{"error":{"code":"ResourceNotFound","message":"A requested resource could
-      not be found. It may already have been deleted.\r\nRequestID=81d2d0dd-3adf-435a-9d74-b9551f6b1e13","target":null}}'
+      not be found. It may already have been deleted.\r\nRequestID=9e0e42d9-77b0-4f3d-b256-b9d5806c89e3","target":null}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2181,45 +2150,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 404 Not Found
     code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: DELETE
-  response:
-    body: '{"error":{"code":"BadRequest","message":"Cannot delete ''asotest-redis2-gzcvdq''
-      since it has linked servers associated with it. Please remove the linked server(s)
-      and then try deleting the cache.\r\nRequestID=30825e40-02af-44a6-975b-d92a4e505c2f","target":null}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "261"
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 400 Bad Request
-    code: 400
     duration: ""
 - request:
     body: ""
@@ -2241,7 +2174,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/bc3488d2-a318-4d8a-930c-42abe95f71b7?api-version=2020-12-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/d74818de-395e-40c7-b0d0-5da1701a8a8f?api-version=2020-12-01
       Pragma:
       - no-cache
       Server:
@@ -2251,9 +2184,80 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 202 Accepted
     code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
+    method: DELETE
+  response:
+    body: '{"error":{"code":"BadRequest","message":"Cannot delete ''asotest-redis2-gzcvdq''
+      since it has linked servers associated with it. Please remove the linked server(s)
+      and then try deleting the cache.\r\nRequestID=f058bb4b-fdaa-4464-8d1b-b5cb0436f3f1","target":null}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "261"
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Rp-Server-Mvid:
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 400 Bad Request
+    code: 400
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "16"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv?api-version=2020-12-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Rp-Server-Mvid:
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -2268,7 +2272,7 @@ interactions:
   response:
     body: '{"error":{"code":"BadRequest","message":"Cannot delete ''asotest-redis2-gzcvdq''
       since it has linked servers associated with it. Please remove the linked server(s)
-      and then try deleting the cache.\r\nRequestID=a00c5251-ff2b-447b-8b1f-b5735e744b6e","target":null}}'
+      and then try deleting the cache.\r\nRequestID=928dc089-4a7f-4bd6-9c6b-71282b8456b4","target":null}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2287,7 +2291,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -2303,7 +2307,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2322,7 +2326,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -2337,18 +2341,16 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
     method: DELETE
   response:
-    body: '{"error":{"code":"BadRequest","message":"Cannot delete ''asotest-redis2-gzcvdq''
-      since it has linked servers associated with it. Please remove the linked server(s)
-      and then try deleting the cache.\r\nRequestID=191918a8-656c-494c-88e4-cbaecc7be110","target":null}}'
+    body: ""
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "261"
-      Content-Type:
-      - application/json; charset=utf-8
+      - "0"
       Expires:
       - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/93be166e-d281-47d8-a0c6-9000baf1ca05?api-version=2020-12-01
       Pragma:
       - no-cache
       Server:
@@ -2358,9 +2360,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 400 Bad Request
-    code: 400
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 202 Accepted
+    code: 202
     duration: ""
 - request:
     body: ""
@@ -2374,7 +2376,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2393,7 +2395,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -2404,18 +2406,15 @@ interactions:
       Accept:
       - application/json
       Test-Request-Attempt:
-      - "3"
+      - "15"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: DELETE
+    method: GET
   response:
-    body: '{"error":{"code":"BadRequest","message":"Cannot delete ''asotest-redis2-gzcvdq''
-      since it has linked servers associated with it. Please remove the linked server(s)
-      and then try deleting the cache.\r\nRequestID=2556a1a7-35bd-4c2f-b1b8-ae3b64682187","target":null}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
-      Content-Length:
-      - "261"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -2426,12 +2425,14 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 400 Bad Request
-    code: 400
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -2445,7 +2446,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2464,7 +2465,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -2475,32 +2476,33 @@ interactions:
       Accept:
       - application/json
       Test-Request-Attempt:
-      - "4"
+      - "16"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: DELETE
+    method: GET
   response:
-    body: ""
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
-      Content-Length:
-      - "0"
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Cache/locations/West%20US%202/operationresults/e7dc9250-47a2-441b-844a-2136b77bf84a?api-version=2020-12-01
       Pragma:
       - no-cache
       Server:
       - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 202 Accepted
-    code: 202
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -2514,7 +2516,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2533,7 +2535,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -2549,7 +2551,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2568,7 +2570,7 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
     duration: ""
@@ -2583,11 +2585,13 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv?api-version=2020-12-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+    body: '{"error":{"code":"ResourceNotFound","message":"A requested resource could
+      not be found. It may already have been deleted.\r\nRequestID=ad7fb34c-1ebc-4b27-9dbc-666769414add","target":null}}'
     headers:
       Cache-Control:
       - no-cache
+      Content-Length:
+      - "188"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -2598,14 +2602,12 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 200 OK
-    code: 200
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: ""
@@ -2619,7 +2621,7 @@ interactions:
     method: GET
   response:
     body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
+      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"642","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"642"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -2638,78 +2640,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
+      - 4da883f8-5df9-4855-a10f-ab06bed1009e
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "22"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv?api-version=2020-12-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis1-zbvfwv","location":"West
-      US 2","name":"asotest-redis1-zbvfwv","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis1-zbvfwv.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "23"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis1-zbvfwv?api-version=2020-12-01
-    method: GET
-  response:
-    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Cache/Redis/asotest-redis1-zbvfwv''
-      under resource group ''asotest-rg-hyymvm'' was not found. For more details please
-      go to https://aka.ms/ARMResourceNotFoundFix"}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "232"
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Failure-Cause:
-      - gateway
-    status: 404 Not Found
-    code: 404
     duration: ""
 - request:
     body: ""
@@ -2719,41 +2652,6 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "19"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/Redis/asotest-redis2-gzcvdq","location":"West
-      US 2","name":"asotest-redis2-gzcvdq","type":"Microsoft.Cache/Redis","tags":{},"properties":{"provisioningState":"Deleting","redisVersion":"6.0.14","sku":{"name":"Premium","family":"P","capacity":1},"enableNonSslPort":false,"instances":[{"sslPort":15000,"isMaster":true,"isPrimary":true},{"sslPort":15001,"isMaster":false,"isPrimary":false}],"minimumTlsVersion":"1.2","publicNetworkAccess":"Enabled","redisConfiguration":{"maxmemory-policy":"allkeys-lru","maxmemory-reserved":"10","maxclients":"7500","maxfragmentationmemory-reserved":"642","maxmemory-delta":"10"},"accessKeys":null,"hostName":"asotest-redis2-gzcvdq.redis.cache.windows.net","port":6379,"sslPort":6380,"linkedServers":[]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Rp-Server-Mvid:
-      - 9a05af01-0d10-4d27-8bb8-124a3141d01a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "20"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-hyymvm/providers/Microsoft.Cache/redis/asotest-redis2-gzcvdq?api-version=2020-12-01
     method: GET
   response:

--- a/v2/internal/controllers/recordings/Test_DBForMySQL_FlexibleServer_CRUD.yaml
+++ b/v2/internal/controllers/recordings/Test_DBForMySQL_FlexibleServer_CRUD.yaml
@@ -66,13 +66,13 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"location":"westus2","name":"asotest-mysql-ycpsgb","properties":{"administratorLogin":"myadmin","administratorLoginPassword":"{PASSWORD}","storage":{"storageSizeGB":128},"version":"8.0.21"},"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"}}'
+    body: '{"location":"eastus","name":"asotest-mysql-ycpsgb","properties":{"administratorLogin":"myadmin","administratorLoginPassword":"{PASSWORD}","storage":{"storageSizeGB":128},"version":"8.0.21"},"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"}}'
     form: {}
     headers:
       Accept:
       - application/json
       Content-Length:
-      - "253"
+      - "252"
       Content-Type:
       - application/json
       Test-Request-Attempt:
@@ -83,17 +83,17 @@ interactions:
     body: '{"operation":"UpsertServerManagementOperationV2","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/62816908-aa4a-43c1-87b7-0e740850d4a9?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/afb9f089-4a32-4ba1-b8d0-eb7ee6915427?api-version=2021-05-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "88"
+      - "86"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/operationResults/62816908-aa4a-43c1-87b7-0e740850d4a9?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/operationResults/afb9f089-4a32-4ba1-b8d0-eb7ee6915427?api-version=2021-05-01
       Pragma:
       - no-cache
       Retry-After:
@@ -113,10 +113,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/62816908-aa4a-43c1-87b7-0e740850d4a9?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/afb9f089-4a32-4ba1-b8d0-eb7ee6915427?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"62816908-aa4a-43c1-87b7-0e740850d4a9","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"afb9f089-4a32-4ba1-b8d0-eb7ee6915427","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -145,10 +145,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/62816908-aa4a-43c1-87b7-0e740850d4a9?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/afb9f089-4a32-4ba1-b8d0-eb7ee6915427?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"62816908-aa4a-43c1-87b7-0e740850d4a9","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"afb9f089-4a32-4ba1-b8d0-eb7ee6915427","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -177,10 +177,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "2"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/62816908-aa4a-43c1-87b7-0e740850d4a9?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/afb9f089-4a32-4ba1-b8d0-eb7ee6915427?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"62816908-aa4a-43c1-87b7-0e740850d4a9","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"afb9f089-4a32-4ba1-b8d0-eb7ee6915427","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -209,10 +209,42 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "3"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/62816908-aa4a-43c1-87b7-0e740850d4a9?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/afb9f089-4a32-4ba1-b8d0-eb7ee6915427?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"62816908-aa4a-43c1-87b7-0e740850d4a9","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"afb9f089-4a32-4ba1-b8d0-eb7ee6915427","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "60"
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Test-Request-Attempt:
+      - "4"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/afb9f089-4a32-4ba1-b8d0-eb7ee6915427?api-version=2021-05-01
+    method: GET
+  response:
+    body: '{"name":"afb9f089-4a32-4ba1-b8d0-eb7ee6915427","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -246,8 +278,8 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb?api-version=2021-05-01
     method: GET
   response:
-    body: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"properties":{"administratorLogin":"myadmin","storage":{"storageSizeGB":128,"iops":684,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"8.0.21","state":"Ready","fullyQualifiedDomainName":"asotest-mysql-ycpsgb.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-02-28T18:39:14.3478178+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"West
-      US 2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb","name":"asotest-mysql-ycpsgb","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    body: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"administratorLogin":"myadmin","storage":{"storageSizeGB":128,"iops":684,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"8.0.21","state":"Ready","fullyQualifiedDomainName":"asotest-mysql-ycpsgb.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-06-07T20:26:30.1203231+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"East
+      US","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb","name":"asotest-mysql-ycpsgb","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       Cache-Control:
       - no-cache
@@ -269,13 +301,13 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"location":"westus2","name":"asotest-mysql-ycpsgb","properties":{"administratorLogin":"myadmin","administratorLoginPassword":"{PASSWORD}","backup":{"backupRetentionDays":5,"geoRedundantBackup":"Disabled"},"storage":{"storageSizeGB":128},"version":"8.0.21"},"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"}}'
+    body: '{"location":"eastus","name":"asotest-mysql-ycpsgb","properties":{"administratorLogin":"myadmin","administratorLoginPassword":"{PASSWORD}","backup":{"backupRetentionDays":5,"geoRedundantBackup":"Disabled"},"storage":{"storageSizeGB":128},"version":"8.0.21"},"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"}}'
     form: {}
     headers:
       Accept:
       - application/json
       Content-Length:
-      - "320"
+      - "319"
       Content-Type:
       - application/json
       Test-Request-Attempt:
@@ -286,7 +318,7 @@ interactions:
     body: '{"operation":"UpsertServerManagementOperationV2","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/e90ab02e-048a-4e62-8033-b9aedba02fd4?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/51ca9b8b-e81a-4ba7-bafc-67a476e3bff9?api-version=2021-05-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -296,7 +328,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/operationResults/e90ab02e-048a-4e62-8033-b9aedba02fd4?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/operationResults/51ca9b8b-e81a-4ba7-bafc-67a476e3bff9?api-version=2021-05-01
       Pragma:
       - no-cache
       Retry-After:
@@ -316,10 +348,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/e90ab02e-048a-4e62-8033-b9aedba02fd4?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/51ca9b8b-e81a-4ba7-bafc-67a476e3bff9?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"e90ab02e-048a-4e62-8033-b9aedba02fd4","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"51ca9b8b-e81a-4ba7-bafc-67a476e3bff9","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -348,10 +380,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/e90ab02e-048a-4e62-8033-b9aedba02fd4?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/51ca9b8b-e81a-4ba7-bafc-67a476e3bff9?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"e90ab02e-048a-4e62-8033-b9aedba02fd4","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"51ca9b8b-e81a-4ba7-bafc-67a476e3bff9","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -385,8 +417,8 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb?api-version=2021-05-01
     method: GET
   response:
-    body: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"properties":{"administratorLogin":"myadmin","storage":{"storageSizeGB":128,"iops":684,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"8.0.21","state":"Ready","fullyQualifiedDomainName":"asotest-mysql-ycpsgb.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":5,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-02-28T18:39:14.3478178+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"West
-      US 2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb","name":"asotest-mysql-ycpsgb","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    body: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2001-02-03T04:05:06Z"},"properties":{"administratorLogin":"myadmin","storage":{"storageSizeGB":128,"iops":684,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"8.0.21","state":"Ready","fullyQualifiedDomainName":"asotest-mysql-ycpsgb.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":5,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-06-07T20:26:30.1203231+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"East
+      US","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb","name":"asotest-mysql-ycpsgb","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       Cache-Control:
       - no-cache
@@ -406,6 +438,48 @@ interactions:
       - nosniff
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: '{"name":"asotestdbsikgaz","properties":{"charset":"utf8mb4"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - "61"
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbsikgaz?api-version=2021-05-01
+    method: PUT
+  response:
+    body: '{"operation":"UpsertServerDatabaseManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
+    headers:
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/3acf3a39-2236-47ec-a8d7-70fab9d80955?api-version=2021-05-01
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "94"
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/operationResults/3acf3a39-2236-47ec-a8d7-70fab9d80955?api-version=2021-05-01
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+    status: 202 Accepted
+    code: 202
     duration: ""
 - request:
     body: '{"name":"asotest-fwrule-ulqjby","properties":{"endIpAddress":"1.2.3.4","startIpAddress":"1.2.3.4"}}'
@@ -425,7 +499,7 @@ interactions:
     body: '{"operation":"UpsertServerFirewallRulesManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/d90fdf34-86bd-4772-af03-927cfd7b7fcb?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/90cd3f21-d1b6-4244-a969-cfa146c48bb9?api-version=2021-05-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -435,53 +509,11 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/operationResults/d90fdf34-86bd-4772-af03-927cfd7b7fcb?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/operationResults/90cd3f21-d1b6-4244-a969-cfa146c48bb9?api-version=2021-05-01
       Pragma:
       - no-cache
       Retry-After:
       - "60"
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-    status: 202 Accepted
-    code: 202
-    duration: ""
-- request:
-    body: '{"name":"asotestdbadtero","properties":{"charset":"utf8mb4"}}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - "61"
-      Content-Type:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbadtero?api-version=2021-05-01
-    method: PUT
-  response:
-    body: '{"operation":"UpsertServerDatabaseManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
-    headers:
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/29c83803-6d0f-4307-8822-fa5314d29340?api-version=2021-05-01
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "94"
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/operationResults/29c83803-6d0f-4307-8822-fa5314d29340?api-version=2021-05-01
-      Pragma:
-      - no-cache
-      Retry-After:
-      - "15"
       Server:
       - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
@@ -497,10 +529,42 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/29c83803-6d0f-4307-8822-fa5314d29340?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/90cd3f21-d1b6-4244-a969-cfa146c48bb9?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"29c83803-6d0f-4307-8822-fa5314d29340","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"90cd3f21-d1b6-4244-a969-cfa146c48bb9","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "60"
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/3acf3a39-2236-47ec-a8d7-70fab9d80955?api-version=2021-05-01
+    method: GET
+  response:
+    body: '{"name":"3acf3a39-2236-47ec-a8d7-70fab9d80955","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -527,12 +591,116 @@ interactions:
     body: ""
     form: {}
     headers:
+      Accept:
+      - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/d90fdf34-86bd-4772-af03-927cfd7b7fcb?api-version=2021-05-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbsikgaz?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"d90fdf34-86bd-4772-af03-927cfd7b7fcb","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"properties":{"charset":"utf8mb4","collation":"utf8mb4_0900_ai_ci"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbsikgaz","name":"asotestdbsikgaz","type":"Microsoft.DBforMySQL/flexibleServers/databases"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbsikgaz?api-version=2021-05-01
+    method: DELETE
+  response:
+    body: '{"operation":"DropServerDatabaseManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
+    headers:
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/9f699ec9-d222-43c0-ab06-23924987fe1f?api-version=2021-05-01
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "91"
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/operationResults/9f699ec9-d222-43c0-ab06-23924987fe1f?api-version=2021-05-01
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "15"
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "1"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbsikgaz?api-version=2021-05-01
+    method: GET
+  response:
+    body: '{"error":{"code":"ResourceNotFound","message":"The requested resource of
+      type ''Microsoft.DBforMySQL/flexibleServers/databases'' with name ''asotestdbsikgaz''
+      was not found."}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "172"
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Test-Request-Attempt:
+      - "1"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/90cd3f21-d1b6-4244-a969-cfa146c48bb9?api-version=2021-05-01
+    method: GET
+  response:
+    body: '{"name":"90cd3f21-d1b6-4244-a969-cfa146c48bb9","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -588,38 +756,6 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbadtero?api-version=2021-05-01
-    method: GET
-  response:
-    body: '{"properties":{"charset":"utf8mb4","collation":"utf8mb4_0900_ai_ci"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbadtero","name":"asotestdbadtero","type":"Microsoft.DBforMySQL/flexibleServers/databases"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: '{"name":"asotest-fwrule-ulqjby","properties":{"endIpAddress":"1.2.3.5","startIpAddress":"1.2.3.4"}}'
     form: {}
     headers:
@@ -637,7 +773,7 @@ interactions:
     body: '{"operation":"UpsertServerFirewallRulesManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/f645b189-3a46-4cde-87de-5ddeac89fe5f?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/9e9e6436-8910-4b51-b63d-0cff15c3f73d?api-version=2021-05-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -647,7 +783,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/operationResults/f645b189-3a46-4cde-87de-5ddeac89fe5f?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/operationResults/9e9e6436-8910-4b51-b63d-0cff15c3f73d?api-version=2021-05-01
       Pragma:
       - no-cache
       Retry-After:
@@ -665,50 +801,44 @@ interactions:
     body: ""
     form: {}
     headers:
-      Accept:
-      - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbadtero?api-version=2021-05-01
-    method: DELETE
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/9e9e6436-8910-4b51-b63d-0cff15c3f73d?api-version=2021-05-01
+    method: GET
   response:
-    body: '{"operation":"DropServerDatabaseManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"9e9e6436-8910-4b51-b63d-0cff15c3f73d","status":"InProgress","startTime":"2001-02-03T04:05:06Z"}'
     headers:
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/3d3c66d0-1959-4a88-994d-2fade535f6c2?api-version=2021-05-01
       Cache-Control:
       - no-cache
-      Content-Length:
-      - "92"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/operationResults/3d3c66d0-1959-4a88-994d-2fade535f6c2?api-version=2021-05-01
       Pragma:
       - no-cache
       Retry-After:
-      - "15"
+      - "60"
       Server:
       - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
-    status: 202 Accepted
-    code: 202
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/f645b189-3a46-4cde-87de-5ddeac89fe5f?api-version=2021-05-01
+      - "1"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/9e9e6436-8910-4b51-b63d-0cff15c3f73d?api-version=2021-05-01
     method: GET
   response:
-    body: '{"name":"f645b189-3a46-4cde-87de-5ddeac89fe5f","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
+    body: '{"name":"9e9e6436-8910-4b51-b63d-0cff15c3f73d","status":"Succeeded","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Cache-Control:
       - no-cache
@@ -777,17 +907,17 @@ interactions:
     body: '{"operation":"DropServerFirewallRulesManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/azureAsyncOperation/b802f635-e926-4ab8-88ec-c7766bb97b5f?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/azureAsyncOperation/a5eb352b-da08-4288-bc72-abef04e59049?api-version=2021-05-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "96"
+      - "95"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/westus2/operationResults/b802f635-e926-4ab8-88ec-c7766bb97b5f?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/eastus/operationResults/a5eb352b-da08-4288-bc72-abef04e59049?api-version=2021-05-01
       Pragma:
       - no-cache
       Retry-After:
@@ -800,40 +930,6 @@ interactions:
       - nosniff
     status: 202 Accepted
     code: 202
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb/databases/asotestdbadtero?api-version=2021-05-01
-    method: GET
-  response:
-    body: '{"error":{"code":"ResourceNotFound","message":"The requested resource of
-      type ''Microsoft.DBforMySQL/flexibleServers/databases'' with name ''asotestdbadtero''
-      was not found."}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "172"
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-    status: 404 Not Found
-    code: 404
     duration: ""
 - request:
     body: ""
@@ -882,7 +978,7 @@ interactions:
     body: '{"operation":"DropServerManagementOperation","startTime":"2001-02-03T04:05:06Z"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/West%20US%202/azureAsyncOperation/b7084eaa-b48e-4ef7-b2f5-d9f40ebc2706?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/East%20US/azureAsyncOperation/217185d1-81f2-4474-8beb-7c6f0c560b43?api-version=2021-05-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -892,7 +988,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/West%20US%202/operationResults/b7084eaa-b48e-4ef7-b2f5-d9f40ebc2706?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/East%20US/operationResults/217185d1-81f2-4474-8beb-7c6f0c560b43?api-version=2021-05-01
       Pragma:
       - no-cache
       Retry-After:
@@ -917,125 +1013,26 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb?api-version=2021-05-01
     method: GET
   response:
-    body: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"properties":{"administratorLogin":"myadmin","storage":{"storageSizeGB":128,"iops":684,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"8.0.21","state":"Ready","fullyQualifiedDomainName":"asotest-mysql-ycpsgb.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":5,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-02-28T18:39:14.3478178+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"West
-      US 2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb","name":"asotest-mysql-ycpsgb","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "3"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb?api-version=2021-05-01
-    method: GET
-  response:
-    body: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"properties":{"administratorLogin":"myadmin","storage":{"storageSizeGB":128,"iops":684,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"8.0.21","state":"Ready","fullyQualifiedDomainName":"asotest-mysql-ycpsgb.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":5,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-02-28T18:39:14.3478178+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"West
-      US 2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb","name":"asotest-mysql-ycpsgb","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "4"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb?api-version=2021-05-01
-    method: GET
-  response:
-    body: '{"sku":{"name":"Standard_D4ds_v4","tier":"GeneralPurpose"},"properties":{"administratorLogin":"myadmin","storage":{"storageSizeGB":128,"iops":684,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"8.0.21","state":"Ready","fullyQualifiedDomainName":"asotest-mysql-ycpsgb.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":5,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-02-28T18:39:14.3478178+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"West
-      US 2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb","name":"asotest-mysql-ycpsgb","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "5"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb?api-version=2021-05-01
-    method: GET
-  response:
-    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb''
-      under resource group ''asotest-rg-mvhpcy'' was not found. For more details please
-      go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    body: '{"error":{"code":"ResourceNotFound","message":"The requested resource of
+      type ''Microsoft.DBforMySQL/flexibleServers'' with name ''asotest-mysql-ycpsgb''
+      was not found."}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "246"
+      - "167"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Pragma:
       - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
-      X-Ms-Failure-Cause:
-      - gateway
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1046,7 +1043,7 @@ interactions:
       Accept:
       - application/json
       Test-Request-Attempt:
-      - "6"
+      - "3"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-mvhpcy/providers/Microsoft.DBforMySQL/flexibleServers/asotest-mysql-ycpsgb?api-version=2021-05-01
     method: GET
   response:

--- a/v2/internal/controllers/recordings/Test_EventGrid_Topic.yaml
+++ b/v2/internal/controllers/recordings/Test_EventGrid_Topic.yaml
@@ -20,8 +20,6 @@ interactions:
     headers:
       Cache-Control:
       - no-cache
-      Content-Length:
-      - "276"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -30,10 +28,12 @@ interactions:
       - no-cache
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
-    status: 201 Created
-    code: 201
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -80,14 +80,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr?api-version=2020-06-01
     method: PUT
   response:
-    body: '{"properties":{"provisioningState":"Creating","endpoint":null},"location":"westus2","tags":{"cheese":"blue"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
+    body: '{"properties":{"provisioningState":"Updating","endpoint":null},"systemData":null,"location":"westus2","tags":{"cheese":"blue"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/74F7E1AF-CBCA-4F7B-8748-9E3E41DCC570?api-version=2020-06-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/35FB2BE2-E710-4D24-B978-66DCF22C872D?api-version=2020-06-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "325"
+      - "343"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -111,10 +111,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/74F7E1AF-CBCA-4F7B-8748-9E3E41DCC570?api-version=2020-06-01
+    url: https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/35FB2BE2-E710-4D24-B978-66DCF22C872D?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/74F7E1AF-CBCA-4F7B-8748-9E3E41DCC570?api-version=2020-06-01","name":"74f7e1af-cbca-4f7b-8748-9e3e41dcc570","status":"Succeeded"}'
+    body: '{"id":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/35FB2BE2-E710-4D24-B978-66DCF22C872D?api-version=2020-06-01","name":"35fb2be2-e710-4d24-b978-66dcf22c872d","status":"Succeeded"}'
     headers:
       Cache-Control:
       - no-cache
@@ -146,7 +146,7 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr?api-version=2020-06-01
     method: GET
   response:
-    body: '{"properties":{"provisioningState":"Succeeded","endpoint":"https://asotest-topic-fnrbdr.westus2-1.eventgrid.azure.net/api/events","inputSchema":"EventGridSchema","metricResourceId":"650230b0-aa5c-4bae-9e7e-a63ae7f5be9b","publicNetworkAccess":"Enabled"},"location":"westus2","tags":{"cheese":"blue"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
+    body: '{"properties":{"provisioningState":"Succeeded","endpoint":"https://asotest-topic-fnrbdr.westus2-1.eventgrid.azure.net/api/events","inputSchema":"EventGridSchema","metricResourceId":"e1391dba-0f9a-4f7d-b0cc-56eff58ed6de","publicNetworkAccess":"Enabled"},"systemData":null,"location":"westus2","tags":{"cheese":"blue"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
     headers:
       Cache-Control:
       - no-cache
@@ -182,14 +182,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr?api-version=2020-06-01
     method: PUT
   response:
-    body: '{"properties":{"provisioningState":"Updating","endpoint":null},"location":"westus2","tags":{"cheese":"époisses"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
+    body: '{"properties":{"provisioningState":"Updating","endpoint":null},"systemData":null,"location":"westus2","tags":{"cheese":"époisses"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/AECD1EB8-37E0-46EE-AEDD-BE170F0F7CF6?api-version=2020-06-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/76BBDE0B-6754-4DEC-82A0-411021E05C1B?api-version=2020-06-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "330"
+      - "348"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -213,10 +213,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/AECD1EB8-37E0-46EE-AEDD-BE170F0F7CF6?api-version=2020-06-01
+    url: https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/76BBDE0B-6754-4DEC-82A0-411021E05C1B?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/AECD1EB8-37E0-46EE-AEDD-BE170F0F7CF6?api-version=2020-06-01","name":"aecd1eb8-37e0-46ee-aedd-be170f0f7cf6","status":"Succeeded"}'
+    body: '{"id":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/76BBDE0B-6754-4DEC-82A0-411021E05C1B?api-version=2020-06-01","name":"76bbde0b-6754-4dec-82a0-411021e05c1b","status":"Succeeded"}'
     headers:
       Cache-Control:
       - no-cache
@@ -248,7 +248,7 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr?api-version=2020-06-01
     method: GET
   response:
-    body: '{"properties":{"provisioningState":"Succeeded","endpoint":"https://asotest-topic-fnrbdr.westus2-1.eventgrid.azure.net/api/events","inputSchema":"EventGridSchema","metricResourceId":"650230b0-aa5c-4bae-9e7e-a63ae7f5be9b","publicNetworkAccess":"Enabled"},"location":"westus2","tags":{"cheese":"époisses"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
+    body: '{"properties":{"provisioningState":"Succeeded","endpoint":"https://asotest-topic-fnrbdr.westus2-1.eventgrid.azure.net/api/events","inputSchema":"EventGridSchema","metricResourceId":"e1391dba-0f9a-4f7d-b0cc-56eff58ed6de","publicNetworkAccess":"Enabled"},"systemData":null,"location":"westus2","tags":{"cheese":"époisses"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr","name":"asotest-topic-fnrbdr","type":"Microsoft.EventGrid/topics"}'
     headers:
       Cache-Control:
       - no-cache
@@ -270,7 +270,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"kind":"StorageV2","location":"westus2","name":"asoteststoryiramq","properties":{"accessTier":"Hot"},"sku":{"name":"Standard_LRS"}}'
+    body: '{"kind":"StorageV2","location":"westus2","name":"asoteststorhycqcd","properties":{"accessTier":"Hot"},"sku":{"name":"Standard_LRS"}}'
     form: {}
     headers:
       Accept:
@@ -281,7 +281,7 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd?api-version=2021-04-01
     method: PUT
   response:
     body: ""
@@ -295,7 +295,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/b2932941-6c52-4d18-a175-c8e3b7324e33?monitor=true&api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/341a71b2-c561-41a1-9177-a4957aa6b878?monitor=true&api-version=2021-04-01
       Pragma:
       - no-cache
       Retry-After:
@@ -315,7 +315,7 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/b2932941-6c52-4d18-a175-c8e3b7324e33?monitor=true&api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/341a71b2-c561-41a1-9177-a4957aa6b878?monitor=true&api-version=2021-04-01
     method: GET
   response:
     body: ""
@@ -329,7 +329,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/b2932941-6c52-4d18-a175-c8e3b7324e33?monitor=true&api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/341a71b2-c561-41a1-9177-a4957aa6b878?monitor=true&api-version=2021-04-01
       Pragma:
       - no-cache
       Retry-After:
@@ -349,10 +349,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/b2932941-6c52-4d18-a175-c8e3b7324e33?monitor=true&api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/341a71b2-c561-41a1-9177-a4957aa6b878?monitor=true&api-version=2021-04-01
     method: GET
   response:
-    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq","name":"asoteststoryiramq","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2001-02-03T04:05:06Z","key2":"2001-02-03T04:05:06Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2001-02-03T04:05:06Z","primaryEndpoints":{"dfs":"https://asoteststoryiramq.dfs.core.windows.net/","web":"https://asoteststoryiramq.z5.web.core.windows.net/","blob":"https://asoteststoryiramq.blob.core.windows.net/","queue":"https://asoteststoryiramq.queue.core.windows.net/","table":"https://asoteststoryiramq.table.core.windows.net/","file":"https://asoteststoryiramq.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd","name":"asoteststorhycqcd","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2001-02-03T04:05:06Z","key2":"2001-02-03T04:05:06Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2001-02-03T04:05:06Z","primaryEndpoints":{"dfs":"https://asoteststorhycqcd.dfs.core.windows.net/","web":"https://asoteststorhycqcd.z5.web.core.windows.net/","blob":"https://asoteststorhycqcd.blob.core.windows.net/","queue":"https://asoteststorhycqcd.queue.core.windows.net/","table":"https://asoteststorhycqcd.table.core.windows.net/","file":"https://asoteststorhycqcd.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -381,10 +381,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd?api-version=2021-04-01
     method: GET
   response:
-    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq","name":"asoteststoryiramq","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2001-02-03T04:05:06Z","key2":"2001-02-03T04:05:06Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2001-02-03T04:05:06Z","primaryEndpoints":{"dfs":"https://asoteststoryiramq.dfs.core.windows.net/","web":"https://asoteststoryiramq.z5.web.core.windows.net/","blob":"https://asoteststoryiramq.blob.core.windows.net/","queue":"https://asoteststoryiramq.queue.core.windows.net/","table":"https://asoteststoryiramq.table.core.windows.net/","file":"https://asoteststoryiramq.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
+    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd","name":"asoteststorhycqcd","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2001-02-03T04:05:06Z","key2":"2001-02-03T04:05:06Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2001-02-03T04:05:06Z","primaryEndpoints":{"dfs":"https://asoteststorhycqcd.dfs.core.windows.net/","web":"https://asoteststorhycqcd.z5.web.core.windows.net/","blob":"https://asoteststorhycqcd.blob.core.windows.net/","queue":"https://asoteststorhycqcd.queue.core.windows.net/","table":"https://asoteststorhycqcd.table.core.windows.net/","file":"https://asoteststorhycqcd.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -417,7 +417,7 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default?api-version=2021-04-01
     method: PUT
   response:
     body: '{"name":"default"}'
@@ -449,10 +449,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default?api-version=2021-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/queueServices","properties":{"cors":{"corsRules":[]}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/queueServices","properties":{"cors":{"corsRules":[]}}}'
     headers:
       Cache-Control:
       - no-cache
@@ -474,7 +474,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"name":"asotest-queue-vzixbs"}'
+    body: '{"name":"asotest-queue-ffibbc"}'
     form: {}
     headers:
       Accept:
@@ -485,10 +485,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default/queues/asotest-queue-vzixbs?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default/queues/asotest-queue-ffibbc?api-version=2021-04-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default/queues/asotest-queue-vzixbs","name":"asotest-queue-vzixbs","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default/queues/asotest-queue-ffibbc","name":"asotest-queue-ffibbc","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{}}}'
     headers:
       Cache-Control:
       - no-cache
@@ -517,10 +517,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default/queues/asotest-queue-vzixbs?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default/queues/asotest-queue-ffibbc?api-version=2021-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default/queues/asotest-queue-vzixbs","name":"asotest-queue-vzixbs","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{},"approximateMessageCount":0}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default/queues/asotest-queue-ffibbc","name":"asotest-queue-ffibbc","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{},"approximateMessageCount":0}}'
     headers:
       Cache-Control:
       - no-cache
@@ -542,7 +542,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"name":"asotest-sub-ffibbc","properties":{"destination":{"endpointType":"StorageQueue","properties":{"queueName":"asotest-queue-vzixbs","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq"}}}}'
+    body: '{"name":"asotest-sub-jrvntx","properties":{"destination":{"endpointType":"StorageQueue","properties":{"queueName":"asotest-queue-ffibbc","resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd"}}}}'
     form: {}
     headers:
       Accept:
@@ -553,17 +553,17 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-ffibbc?api-version=2020-06-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-jrvntx?api-version=2020-06-01
     method: PUT
   response:
-    body: '{"properties":{"topic":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/microsoft.eventgrid/topics/asotest-topic-fnrbdr","provisioningState":"Creating","destination":{"properties":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq","queueName":"asotest-queue-vzixbs"},"endpointType":"StorageQueue"},"filter":{"subjectBeginsWith":"","subjectEndsWith":""},"labels":null,"retryPolicy":{"maxDeliveryAttempts":30,"eventTimeToLiveInMinutes":1440}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-ffibbc","name":"asotest-sub-ffibbc","type":"Microsoft.EventGrid/eventSubscriptions"}'
+    body: '{"properties":{"topic":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/microsoft.eventgrid/topics/asotest-topic-fnrbdr","provisioningState":"Creating","destination":{"properties":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd","queueName":"asotest-queue-ffibbc"},"endpointType":"StorageQueue"},"filter":{"subjectBeginsWith":"","subjectEndsWith":""},"labels":null,"retryPolicy":{"maxDeliveryAttempts":30,"eventTimeToLiveInMinutes":1440}},"systemData":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-jrvntx","name":"asotest-sub-jrvntx","type":"Microsoft.EventGrid/eventSubscriptions"}'
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/C477EDF4-E548-40B4-8D41-480E78B08B00?api-version=2020-06-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/FBBF0062-31CC-4A77-9D53-91D9957F28CA?api-version=2020-06-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "894"
+      - "912"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -589,10 +589,10 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/C477EDF4-E548-40B4-8D41-480E78B08B00?api-version=2020-06-01
+    url: https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/FBBF0062-31CC-4A77-9D53-91D9957F28CA?api-version=2020-06-01
     method: GET
   response:
-    body: '{"id":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/C477EDF4-E548-40B4-8D41-480E78B08B00?api-version=2020-06-01","name":"c477edf4-e548-40b4-8d41-480e78b08b00","status":"Succeeded"}'
+    body: '{"id":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/FBBF0062-31CC-4A77-9D53-91D9957F28CA?api-version=2020-06-01","name":"fbbf0062-31cc-4a77-9d53-91d9957f28ca","status":"Succeeded"}'
     headers:
       Cache-Control:
       - no-cache
@@ -621,10 +621,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-ffibbc?api-version=2020-06-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-jrvntx?api-version=2020-06-01
     method: GET
   response:
-    body: '{"properties":{"topic":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/microsoft.eventgrid/topics/asotest-topic-fnrbdr","provisioningState":"Succeeded","destination":{"properties":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq","queueName":"asotest-queue-vzixbs"},"endpointType":"StorageQueue"},"filter":{"subjectBeginsWith":"","subjectEndsWith":""},"labels":null,"eventDeliverySchema":"EventGridSchema","retryPolicy":{"maxDeliveryAttempts":30,"eventTimeToLiveInMinutes":1440}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-ffibbc","name":"asotest-sub-ffibbc","type":"Microsoft.EventGrid/eventSubscriptions"}'
+    body: '{"properties":{"topic":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/microsoft.eventgrid/topics/asotest-topic-fnrbdr","provisioningState":"Succeeded","destination":{"properties":{"resourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd","queueName":"asotest-queue-ffibbc"},"endpointType":"StorageQueue"},"filter":{"subjectBeginsWith":"","subjectEndsWith":""},"labels":null,"eventDeliverySchema":"EventGridSchema","retryPolicy":{"maxDeliveryAttempts":30,"eventTimeToLiveInMinutes":1440}},"systemData":null,"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.EventGrid/topics/asotest-topic-fnrbdr/providers/Microsoft.EventGrid/eventSubscriptions/asotest-sub-jrvntx","name":"asotest-sub-jrvntx","type":"Microsoft.EventGrid/eventSubscriptions"}'
     headers:
       Cache-Control:
       - no-cache
@@ -659,7 +659,7 @@ interactions:
     body: ""
     headers:
       Azure-Asyncoperation:
-      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/BEFC9B0A-ECA2-400E-AE6B-6CABFE8B8AA1?api-version=2020-06-01
+      - https://management.azure.com:443/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationsStatus/305C35AA-23B3-442D-B3E9-D622E66F744D?api-version=2020-06-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -667,7 +667,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationResults/BEFC9B0A-ECA2-400E-AE6B-6CABFE8B8AA1?api-version=2020-06-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.EventGrid/locations/westus2/operationResults/305C35AA-23B3-442D-B3E9-D622E66F744D?api-version=2020-06-01
       Pragma:
       - no-cache
       Retry-After:
@@ -756,10 +756,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default?api-version=2021-04-01
     method: DELETE
   response:
-    body: '{"error":{"code":"HttpResourceNotFound","message":"The request url http://10.0.90.144:30020/011cccb4-baf2-4564-896e-d911f333590c/132834683354622541/76be6d5e-38f3-418d-b226-b1b982f72fd9/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default?api-version=2021-04-01
+    body: '{"error":{"code":"HttpResourceNotFound","message":"The request url http://10.0.90.103:30004/011cccb4-baf2-4564-896e-d911f333590c/132985985615869254/3ff6a4cc-cb12-4c4e-9025-a1f148ed1665/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default?api-version=2021-04-01
       is not found."}}'
     headers:
       Cache-Control:
@@ -789,7 +789,7 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default/queues/asotest-queue-vzixbs?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default/queues/asotest-queue-ffibbc?api-version=2021-04-01
     method: DELETE
   response:
     body: ""
@@ -851,7 +851,7 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd?api-version=2021-04-01
     method: DELETE
   response:
     body: ""
@@ -883,11 +883,11 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default?api-version=2021-04-01
     method: GET
   response:
     body: '{"error":{"code":"ParentResourceNotFound","message":"Can not perform requested
-      operation on nested resource. Parent resource ''asoteststoryiramq'' not found."}}'
+      operation on nested resource. Parent resource ''asoteststorhycqcd'' not found."}}'
     headers:
       Cache-Control:
       - no-cache
@@ -916,11 +916,11 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq/queueServices/default/queues/asotest-queue-vzixbs?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd/queueServices/default/queues/asotest-queue-ffibbc?api-version=2021-04-01
     method: GET
   response:
     body: '{"error":{"code":"ParentResourceNotFound","message":"Can not perform requested
-      operation on nested resource. Parent resource ''asoteststoryiramq'' not found."}}'
+      operation on nested resource. Parent resource ''asoteststorhycqcd'' not found."}}'
     headers:
       Cache-Control:
       - no-cache
@@ -949,16 +949,17 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststoryiramq?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn/providers/Microsoft.Storage/storageAccounts/asoteststorhycqcd?api-version=2021-04-01
     method: GET
   response:
-    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''asotest-rg-cyoshn''
-      could not be found."}}'
+    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Storage/storageAccounts/asoteststorhycqcd''
+      under resource group ''asotest-rg-cyoshn'' was not found. For more details please
+      go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "109"
+      - "240"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -982,6 +983,126 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn?api-version=2020-06-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn","name":"asotest-rg-cyoshn","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "2"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn?api-version=2020-06-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn","name":"asotest-rg-cyoshn","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "3"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn?api-version=2020-06-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn","name":"asotest-rg-cyoshn","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "4"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn?api-version=2020-06-01
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn","name":"asotest-rg-cyoshn","type":"Microsoft.Resources/resourceGroups","location":"westus2","tags":{"CreatedAt":"2001-02-03T04:05:06Z"},"properties":{"provisioningState":"Deleting"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "5"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-cyoshn?api-version=2020-06-01
     method: GET
   response:

--- a/v2/internal/controllers/recordings/Test_ServiceBus_Namespace_Standard_CRUD.yaml
+++ b/v2/internal/controllers/recordings/Test_ServiceBus_Namespace_Standard_CRUD.yaml
@@ -92,10 +92,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -126,10 +126,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -160,10 +160,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -194,10 +194,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -230,10 +230,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -244,97 +244,21 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"location":"westus2","name":"asotest-topic-aouwry"}'
+    body: '{"location":"westus2","name":"asotest-topic-cwiusv"}'
     form: {}
     headers:
       Accept:
       - application/json
       Content-Length:
-      - "68"
+      - "52"
       Content-Type:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-aouwry?api-version=2021-01-01-preview
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-cwiusv?api-version=2021-01-01-preview
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-aouwry","name":"asotest-topic-aouwry","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
-      US 2","properties":{"maxMessageSizeInKilobytes":256,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","accessedAt":"0001-01-01T00:00:00","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Service-Bus-Resource-Provider/CH3
-      - Microsoft-HTTPAPI/2.0
-      Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"location":"westus2","name":"asotest-queue-kxegfh"}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - "68"
-      Content-Type:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-kxegfh?api-version=2021-01-01-preview
-    method: PUT
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-kxegfh","name":"asotest-queue-kxegfh","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
-      US 2","properties":{"maxMessageSizeInKilobytes":256,"lockDuration":"PT1M","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","accessedAt":"0001-01-01T00:00:00"}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Service-Bus-Resource-Provider/CH3
-      - Microsoft-HTTPAPI/2.0
-      Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-aouwry?api-version=2021-01-01-preview
-    method: GET
-  response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-aouwry","name":"asotest-topic-aouwry","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-cwiusv","name":"asotest-topic-cwiusv","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
       US 2","properties":{"maxMessageSizeInKilobytes":256,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","accessedAt":"2001-02-03T04:05:06Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
     headers:
       Cache-Control:
@@ -360,17 +284,21 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"location":"westus2","name":"asotest-queue-qxxgdt"}'
     form: {}
     headers:
       Accept:
       - application/json
+      Content-Length:
+      - "52"
+      Content-Type:
+      - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-kxegfh?api-version=2021-01-01-preview
-    method: GET
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-qxxgdt?api-version=2021-01-01-preview
+    method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-kxegfh","name":"asotest-queue-kxegfh","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-qxxgdt","name":"asotest-queue-qxxgdt","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
       US 2","properties":{"maxMessageSizeInKilobytes":256,"lockDuration":"PT1M","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","accessedAt":"2001-02-03T04:05:06Z"}}'
     headers:
       Cache-Control:
@@ -403,7 +331,79 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-kxegfh?api-version=2021-01-01-preview
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-cwiusv?api-version=2021-01-01-preview
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-cwiusv","name":"asotest-topic-cwiusv","type":"Microsoft.ServiceBus/Namespaces/Topics","location":"West
+      US 2","properties":{"maxMessageSizeInKilobytes":256,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"duplicateDetectionHistoryTimeWindow":"PT10M","enableBatchedOperations":true,"sizeInBytes":0,"status":"Active","supportOrdering":true,"autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","accessedAt":"2001-02-03T04:05:06Z","subscriptionCount":0,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0}}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      Server-Sb:
+      - Service-Bus-Resource-Provider/CH3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-qxxgdt?api-version=2021-01-01-preview
+    method: GET
+  response:
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-qxxgdt","name":"asotest-queue-qxxgdt","type":"Microsoft.ServiceBus/Namespaces/Queues","location":"West
+      US 2","properties":{"maxMessageSizeInKilobytes":256,"lockDuration":"PT1M","maxSizeInMegabytes":1024,"requiresDuplicateDetection":false,"requiresSession":false,"defaultMessageTimeToLive":"P10675199DT2H48M5.4775807S","deadLetteringOnMessageExpiration":false,"enableBatchedOperations":true,"duplicateDetectionHistoryTimeWindow":"PT10M","maxDeliveryCount":10,"sizeInBytes":0,"messageCount":0,"status":"Active","autoDeleteOnIdle":"P10675199DT2H48M5.4775807S","enablePartitioning":false,"enableExpress":false,"countDetails":{"activeMessageCount":0,"deadLetterMessageCount":0,"scheduledMessageCount":0,"transferMessageCount":0,"transferDeadLetterMessageCount":0},"createdAt":"2001-02-03T04:05:06Z","updatedAt":"2001-02-03T04:05:06Z","accessedAt":"2001-02-03T04:05:06Z"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Service-Bus-Resource-Provider/CH3
+      - Microsoft-HTTPAPI/2.0
+      Server-Sb:
+      - Service-Bus-Resource-Provider/CH3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-cwiusv?api-version=2021-01-01-preview
     method: DELETE
   response:
     body: ""
@@ -436,7 +436,7 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-aouwry?api-version=2021-01-01-preview
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-qxxgdt?api-version=2021-01-01-preview
     method: DELETE
   response:
     body: ""
@@ -469,11 +469,11 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-kxegfh?api-version=2021-01-01-preview
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-cwiusv?api-version=2021-01-01-preview
     method: GET
   response:
-    body: '{"error":{"message":"The requested resource asotest-queue-kxegfh does not
-      exist. CorrelationId: 43cd5530-66fb-4661-ad70-ea2aa6ebd803","code":"NotFound"}}'
+    body: '{"error":{"message":"The requested resource asotest-topic-cwiusv does not
+      exist. CorrelationId: 372d053c-3bd1-4ba0-b78e-02323ace7b4e","code":"NotFound"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -505,11 +505,11 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/topics/asotest-topic-aouwry?api-version=2021-01-01-preview
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo/queues/asotest-queue-qxxgdt?api-version=2021-01-01-preview
     method: GET
   response:
-    body: '{"error":{"message":"The requested resource asotest-topic-aouwry does not
-      exist. CorrelationId: 52d6004d-cf34-4117-9b86-39a357bc669a","code":"NotFound"}}'
+    body: '{"error":{"message":"The requested resource asotest-queue-qxxgdt does not
+      exist. CorrelationId: 41cd8dc0-cd23-4c16-87ec-be68b80a963a","code":"NotFound"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -557,10 +557,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -591,10 +591,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -627,10 +627,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Vary:
@@ -651,7 +651,7 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo?api-version=2021-01-01-preview
     method: GET
   response:
-    body: '{"error":{"message":"Namespace does not exist. CorrelationId: 4d3d7946-e8a3-44f0-9c02-ea3245c03825","code":"NotFound"}}'
+    body: '{"error":{"message":"Namespace does not exist. CorrelationId: 17e119c9-0340-4b5d-9cca-96775f8fce57","code":"NotFound"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -664,10 +664,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -686,7 +686,7 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-agwubx/providers/Microsoft.ServiceBus/namespaces/asotest-sbstandard-nrqflo?api-version=2021-01-01-preview
     method: GET
   response:
-    body: '{"error":{"message":"Namespace does not exist. CorrelationId: ba7a5946-9e16-4662-8a18-09e0ed1a6dbd","code":"NotFound"}}'
+    body: '{"error":{"message":"Namespace does not exist. CorrelationId: 8bb6869e-732c-4b14-bf2c-66f9ed2477fb","code":"NotFound"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -699,10 +699,10 @@ interactions:
       Pragma:
       - no-cache
       Server:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       - Microsoft-HTTPAPI/2.0
       Server-Sb:
-      - Service-Bus-Resource-Provider/CH3
+      - Service-Bus-Resource-Provider/SN1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:

--- a/v2/internal/controllers/recordings/Test_Storage_StorageAccount_CRUD.yaml
+++ b/v2/internal/controllers/recordings/Test_Storage_StorageAccount_CRUD.yaml
@@ -91,7 +91,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/3446cbce-b11d-4f65-a8fc-c4360cb3fbe6?monitor=true&api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/54f00fb0-fba5-49f1-82f8-cf7ab7f2035e?monitor=true&api-version=2021-04-01
       Pragma:
       - no-cache
       Retry-After:
@@ -111,7 +111,7 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/3446cbce-b11d-4f65-a8fc-c4360cb3fbe6?monitor=true&api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/54f00fb0-fba5-49f1-82f8-cf7ab7f2035e?monitor=true&api-version=2021-04-01
     method: GET
   response:
     body: ""
@@ -125,7 +125,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/3446cbce-b11d-4f65-a8fc-c4360cb3fbe6?monitor=true&api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/54f00fb0-fba5-49f1-82f8-cf7ab7f2035e?monitor=true&api-version=2021-04-01
       Pragma:
       - no-cache
       Retry-After:
@@ -145,7 +145,7 @@ interactions:
     headers:
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/3446cbce-b11d-4f65-a8fc-c4360cb3fbe6?monitor=true&api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus2/asyncoperations/54f00fb0-fba5-49f1-82f8-cf7ab7f2035e?monitor=true&api-version=2021-04-01
     method: GET
   response:
     body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi","name":"asoteststorhvxypi","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2001-02-03T04:05:06Z","key2":"2001-02-03T04:05:06Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2001-02-03T04:05:06Z","primaryEndpoints":{"dfs":"https://asoteststorhvxypi.dfs.core.windows.net/","web":"https://asoteststorhvxypi.z5.web.core.windows.net/","blob":"https://asoteststorhvxypi.blob.core.windows.net/","queue":"https://asoteststorhvxypi.queue.core.windows.net/","table":"https://asoteststorhvxypi.table.core.windows.net/","file":"https://asoteststorhvxypi.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
@@ -181,78 +181,6 @@ interactions:
     method: GET
   response:
     body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi","name":"asoteststorhvxypi","type":"Microsoft.Storage/storageAccounts","location":"westus2","tags":{},"properties":{"keyCreationTime":{"key1":"2001-02-03T04:05:06Z","key2":"2001-02-03T04:05:06Z"},"privateEndpointConnections":[],"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2001-02-03T04:05:06Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2001-02-03T04:05:06Z","primaryEndpoints":{"dfs":"https://asoteststorhvxypi.dfs.core.windows.net/","web":"https://asoteststorhvxypi.z5.web.core.windows.net/","blob":"https://asoteststorhvxypi.blob.core.windows.net/","queue":"https://asoteststorhvxypi.queue.core.windows.net/","table":"https://asoteststorhvxypi.table.core.windows.net/","file":"https://asoteststorhvxypi.file.core.windows.net/"},"primaryLocation":"westus2","statusOfPrimary":"available"}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"default"}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - "18"
-      Content-Type:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default?api-version=2021-04-01
-    method: PUT
-  response:
-    body: '{"name":"default"}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"default"}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - "18"
-      Content-Type:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default?api-version=2021-04-01
-    method: PUT
-  response:
-    body: '{"name":"default"}'
     headers:
       Cache-Control:
       - no-cache
@@ -317,10 +245,82 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/managementPolicies/default?api-version=2021-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/queueServices","properties":{"cors":{"corsRules":[]}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/managementPolicies/default","name":"DefaultManagementPolicy","type":"Microsoft.Storage/storageAccounts/managementPolicies","properties":{"policy":{"rules":[{"enabled":true,"name":"test-rule","type":"Lifecycle","definition":{"actions":{"version":{"delete":{"daysAfterCreationGreaterThan":30.0}}},"filters":{"blobTypes":["blockBlob"],"prefixMatch":["sample-container/blob1"]}}}]},"lastModifiedTime":"2001-02-03T04:05:06Z"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"default"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - "18"
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default?api-version=2021-04-01
+    method: PUT
+  response:
+    body: '{"name":"default"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"default"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - "18"
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default?api-version=2021-04-01
+    method: PUT
+  response:
+    body: '{"name":"default"}'
     headers:
       Cache-Control:
       - no-cache
@@ -352,7 +352,7 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default?api-version=2021-04-01
     method: GET
   response:
-    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/blobServices","properties":{"cors":{"corsRules":[]},"deleteRetentionPolicy":{"enabled":false}}}'
+    body: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/blobServices","properties":{"cors":{"corsRules":[]},"deleteRetentionPolicy":{"allowPermanentDelete":false,"enabled":false}}}'
     headers:
       Cache-Control:
       - no-cache
@@ -381,10 +381,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/managementPolicies/default?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default?api-version=2021-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/managementPolicies/default","name":"DefaultManagementPolicy","type":"Microsoft.Storage/storageAccounts/managementPolicies","properties":{"policy":{"rules":[{"enabled":true,"name":"test-rule","type":"Lifecycle","definition":{"actions":{"version":{"delete":{"daysAfterCreationGreaterThan":30.0}}},"filters":{"blobTypes":["blockBlob"],"prefixMatch":["sample-container/blob1"]}}}]},"lastModifiedTime":"2001-02-03T04:05:06Z"}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default","name":"default","type":"Microsoft.Storage/storageAccounts/queueServices","properties":{"cors":{"corsRules":[]}}}'
     headers:
       Cache-Control:
       - no-cache
@@ -438,7 +438,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"name":"asotest-queue-hcqdah"}'
+    body: '{"name":"asotest-queue-zspram"}'
     form: {}
     headers:
       Accept:
@@ -449,10 +449,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-hcqdah?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-zspram?api-version=2021-04-01
     method: PUT
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-hcqdah","name":"asotest-queue-hcqdah","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{}}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-zspram","name":"asotest-queue-zspram","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{}}}'
     headers:
       Cache-Control:
       - no-cache
@@ -497,7 +497,7 @@ interactions:
       Content-Type:
       - application/json
       Etag:
-      - '"0x8DA056547E701D1"'
+      - '"0x8DA48AD553FB02C"'
       Expires:
       - "-1"
       Pragma:
@@ -519,10 +519,10 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-hcqdah?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-zspram?api-version=2021-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-hcqdah","name":"asotest-queue-hcqdah","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{},"approximateMessageCount":0}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-zspram","name":"asotest-queue-zspram","type":"Microsoft.Storage/storageAccounts/queueServices/queues","properties":{"metadata":{},"approximateMessageCount":0}}'
     headers:
       Cache-Control:
       - no-cache
@@ -584,7 +584,7 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-hcqdah?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-zspram?api-version=2021-04-01
     method: DELETE
   response:
     body: ""
@@ -614,11 +614,11 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-hcqdah?api-version=2021-04-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/queueServices/default/queues/asotest-queue-zspram?api-version=2021-04-01
     method: GET
   response:
     body: '{"error":{"code":"QueueNotFound","message":"The specified queue does not
-      exist.\nRequestId:5655c315-4003-0024-054e-3773b6000000\nTime:2001-02-03T04:05:06Z"}}'
+      exist.\nRequestId:0d987499-0003-0028-6f96-7a89fa000000\nTime:2001-02-03T04:05:06Z"}}'
     headers:
       Cache-Control:
       - no-cache
@@ -648,14 +648,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default/containers/asotest-container-nebhqc?api-version=2021-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default/containers/asotest-container-nebhqc","name":"asotest-container-nebhqc","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8DA056547E701D1\"","properties":{"deleted":false,"remainingRetentionDays":0,"defaultEncryptionScope":"$account-encryption-key","denyEncryptionScopeOverride":false,"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2001-02-03T04:05:06Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default/containers/asotest-container-nebhqc","name":"asotest-container-nebhqc","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8DA48AD553FB02C\"","properties":{"deleted":false,"remainingRetentionDays":0,"defaultEncryptionScope":"$account-encryption-key","denyEncryptionScopeOverride":false,"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2001-02-03T04:05:06Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Etag:
-      - '"0x8DA056547E701D1"'
+      - '"0x8DA48AD553FB02C"'
       Expires:
       - "-1"
       Pragma:
@@ -682,14 +682,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default/containers/asotest-container-nebhqc?api-version=2021-04-01
     method: GET
   response:
-    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default/containers/asotest-container-nebhqc","name":"asotest-container-nebhqc","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8DA056547E701D1\"","properties":{"deleted":false,"remainingRetentionDays":0,"defaultEncryptionScope":"$account-encryption-key","denyEncryptionScopeOverride":false,"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2001-02-03T04:05:06Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
+    body: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-ioycvi/providers/Microsoft.Storage/storageAccounts/asoteststorhvxypi/blobServices/default/containers/asotest-container-nebhqc","name":"asotest-container-nebhqc","type":"Microsoft.Storage/storageAccounts/blobServices/containers","etag":"\"0x8DA48AD553FB02C\"","properties":{"deleted":false,"remainingRetentionDays":0,"defaultEncryptionScope":"$account-encryption-key","denyEncryptionScopeOverride":false,"publicAccess":"None","leaseStatus":"Unlocked","leaseState":"Available","lastModifiedTime":"2001-02-03T04:05:06Z","legalHold":{"hasLegalHold":false,"tags":[]},"hasImmutabilityPolicy":false,"hasLegalHold":false}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json
       Etag:
-      - '"0x8DA056547E701D1"'
+      - '"0x8DA48AD553FB02C"'
       Expires:
       - "-1"
       Pragma:
@@ -749,7 +749,7 @@ interactions:
     method: GET
   response:
     body: '{"error":{"code":"ContainerNotFound","message":"The specified container
-      does not exist.\nRequestId:136e4a5b-601e-001c-0c4e-37d776000000\nTime:2001-02-03T04:05:06Z"}}'
+      does not exist.\nRequestId:c24e4a46-801e-0036-0896-7a6522000000\nTime:2001-02-03T04:05:06Z"}}'
     headers:
       Cache-Control:
       - no-cache

--- a/v2/internal/controllers/recordings/Test_Subnet_CreatedBeforeVNET.yaml
+++ b/v2/internal/controllers/recordings/Test_Subnet_CreatedBeforeVNET.yaml
@@ -66,13 +66,13 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"location":"westus2","name":"asotest-vn-rosbkx","properties":{"addressSpace":{"addressPrefixes":["10.0.0.0/16"]},"subnets":[{"name":"asotest-subnet-tvejwg","properties":{"addressPrefix":"10.0.0.0/24"}}]}}'
+    body: '{"location":"westus2","name":"asotest-vn-rosbkx","properties":{"addressSpace":{"addressPrefixes":["10.0.0.0/16"]}}}'
     form: {}
     headers:
       Accept:
       - application/json
       Content-Length:
-      - "205"
+      - "115"
       Content-Type:
       - application/json
       Test-Request-Attempt:
@@ -81,28 +81,21 @@ interactions:
     method: PUT
   response:
     body: "{\r\n  \"name\": \"asotest-vn-rosbkx\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx\",\r\n
-      \ \"etag\": \"W/\\\"a866782f-9b67-4b9c-99b8-83abe5676ea8\\\"\",\r\n  \"type\":
+      \ \"etag\": \"W/\\\"5f7fdd42-e0b2-4038-93b6-61f7c375602c\\\"\",\r\n  \"type\":
       \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus2\",\r\n  \"properties\":
-      {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"9aa27010-5346-4542-b238-1a46b10688f2\",\r\n
+      {\r\n    \"provisioningState\": \"Updating\",\r\n    \"resourceGuid\": \"cecf4566-c731-4d9e-9230-1a51fff1a710\",\r\n
       \   \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n
-      \     ]\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"asotest-subnet-tvejwg\",\r\n
-      \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg\",\r\n
-      \       \"etag\": \"W/\\\"a866782f-9b67-4b9c-99b8-83abe5676ea8\\\"\",\r\n        \"properties\":
-      {\r\n          \"provisioningState\": \"Updating\",\r\n          \"addressPrefix\":
-      \"10.0.0.0/24\",\r\n          \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-      \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-      \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-      \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-      false\r\n  }\r\n}"
+      \     ]\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":
+      [],\r\n    \"enableDdosProtection\": false\r\n  }\r\n}"
     headers:
       Azure-Asyncnotification:
       - Enabled
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/d26a769f-fefd-47b6-a500-88dc6d2fdec8?api-version=2020-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/3ca7ef81-a0b7-4500-9ec7-ab651ec8ab1f?api-version=2020-11-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "1283"
+      - "630"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -122,96 +115,12 @@ interactions:
     code: 201
     duration: ""
 - request:
-    body: '{"name":"asotest-subnet-tvejwg","properties":{"addressPrefix":"10.0.0.0/24"}}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Length:
-      - "77"
-      Content-Type:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
-    method: PUT
-  response:
-    body: "{\r\n  \"name\": \"asotest-subnet-tvejwg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg\",\r\n
-      \ \"etag\": \"W/\\\"73682f23-3bc9-4462-9c4a-1d5ee79f2074\\\"\",\r\n  \"properties\":
-      {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
-      \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
-      \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
-      \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/52ae3f15-3a4f-4558-b20b-8c7d41741642?api-version=2020-11-01
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
-    method: GET
-  response:
-    body: "{\r\n  \"name\": \"asotest-subnet-tvejwg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg\",\r\n
-      \ \"etag\": \"W/\\\"73682f23-3bc9-4462-9c4a-1d5ee79f2074\\\"\",\r\n  \"properties\":
-      {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
-      \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
-      \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
-      \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Etag:
-      - W/"73682f23-3bc9-4462-9c4a-1d5ee79f2074"
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/d26a769f-fefd-47b6-a500-88dc6d2fdec8?api-version=2020-11-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/3ca7ef81-a0b7-4500-9ec7-ab651ec8ab1f?api-version=2020-11-01
     method: GET
   response:
     body: "{\r\n  \"status\": \"Succeeded\"\r\n}"
@@ -248,26 +157,96 @@ interactions:
     method: GET
   response:
     body: "{\r\n  \"name\": \"asotest-vn-rosbkx\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx\",\r\n
-      \ \"etag\": \"W/\\\"73682f23-3bc9-4462-9c4a-1d5ee79f2074\\\"\",\r\n  \"type\":
+      \ \"etag\": \"W/\\\"f0fa92b3-fb1e-4067-bb03-606b44378d3f\\\"\",\r\n  \"type\":
       \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"westus2\",\r\n  \"properties\":
-      {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"9aa27010-5346-4542-b238-1a46b10688f2\",\r\n
+      {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"cecf4566-c731-4d9e-9230-1a51fff1a710\",\r\n
       \   \"addressSpace\": {\r\n      \"addressPrefixes\": [\r\n        \"10.0.0.0/16\"\r\n
-      \     ]\r\n    },\r\n    \"subnets\": [\r\n      {\r\n        \"name\": \"asotest-subnet-tvejwg\",\r\n
-      \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg\",\r\n
-      \       \"etag\": \"W/\\\"73682f23-3bc9-4462-9c4a-1d5ee79f2074\\\"\",\r\n        \"properties\":
-      {\r\n          \"provisioningState\": \"Succeeded\",\r\n          \"addressPrefix\":
-      \"10.0.0.0/24\",\r\n          \"delegations\": [],\r\n          \"privateEndpointNetworkPolicies\":
-      \"Enabled\",\r\n          \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n
-      \       },\r\n        \"type\": \"Microsoft.Network/virtualNetworks/subnets\"\r\n
-      \     }\r\n    ],\r\n    \"virtualNetworkPeerings\": [],\r\n    \"enableDdosProtection\":
-      false\r\n  }\r\n}"
+      \     ]\r\n    },\r\n    \"subnets\": [],\r\n    \"virtualNetworkPeerings\":
+      [],\r\n    \"enableDdosProtection\": false\r\n  }\r\n}"
     headers:
       Cache-Control:
       - no-cache
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"73682f23-3bc9-4462-9c4a-1d5ee79f2074"
+      - W/"f0fa92b3-fb1e-4067-bb03-606b44378d3f"
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"asotest-subnet-tvejwg","properties":{"addressPrefix":"10.0.0.0/24"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Length:
+      - "77"
+      Content-Type:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
+    method: PUT
+  response:
+    body: "{\r\n  \"name\": \"asotest-subnet-tvejwg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg\",\r\n
+      \ \"etag\": \"W/\\\"4ebd1d4d-b26e-4e9b-be35-8a1467f0889d\\\"\",\r\n  \"properties\":
+      {\r\n    \"provisioningState\": \"Updating\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+      \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
+      \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+      \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/729f614a-e1f7-4630-b49a-1d22031fc081?api-version=2020-11-01
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - "567"
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Retry-After:
+      - "3"
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/729f614a-e1f7-4630-b49a-1d22031fc081?api-version=2020-11-01
+    method: GET
+  response:
+    body: "{\r\n  \"status\": \"Succeeded\"\r\n}"
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
       Expires:
       - "-1"
       Pragma:
@@ -292,15 +271,53 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx?api-version=2020-11-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
+    method: GET
+  response:
+    body: "{\r\n  \"name\": \"asotest-subnet-tvejwg\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg\",\r\n
+      \ \"etag\": \"W/\\\"93103a67-8681-464d-8fe2-22fa45a64618\\\"\",\r\n  \"properties\":
+      {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"addressPrefix\": \"10.0.0.0/24\",\r\n
+      \   \"delegations\": [],\r\n    \"privateEndpointNetworkPolicies\": \"Enabled\",\r\n
+      \   \"privateLinkServiceNetworkPolicies\": \"Enabled\"\r\n  },\r\n  \"type\":
+      \"Microsoft.Network/virtualNetworks/subnets\"\r\n}"
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"93103a67-8681-464d-8fe2-22fa45a64618"
+      Expires:
+      - "-1"
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Test-Request-Attempt:
+      - "0"
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
     method: DELETE
   response:
     body: ""
     headers:
-      Azure-Asyncnotification:
-      - Enabled
       Azure-Asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/e6827ae6-b7c9-4bbd-bcd9-19069a1742a5?api-version=2020-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/6f8b664e-f4b7-4591-9d9b-05862a49cbda?api-version=2020-11-01
       Cache-Control:
       - no-cache
       Content-Length:
@@ -308,7 +325,7 @@ interactions:
       Expires:
       - "-1"
       Location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operationResults/e6827ae6-b7c9-4bbd-bcd9-19069a1742a5?api-version=2020-11-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operationResults/6f8b664e-f4b7-4591-9d9b-05862a49cbda?api-version=2020-11-01
       Pragma:
       - no-cache
       Retry-After:
@@ -331,24 +348,27 @@ interactions:
       - application/json
       Test-Request-Attempt:
       - "0"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
+    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx?api-version=2020-11-01
     method: DELETE
   response:
-    body: "{\r\n  \"error\": {\r\n    \"code\": \"AnotherOperationInProgress\",\r\n
-      \   \"message\": \"Another operation on this or dependent resource is in progress.
-      To retrieve status of the operation use uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/e6827ae6-b7c9-4bbd-bcd9-19069a1742a5?api-version=2020-11-01.\",\r\n
-      \   \"details\": []\r\n  }\r\n}"
+    body: ""
     headers:
+      Azure-Asyncnotification:
+      - Enabled
+      Azure-Asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operations/f06359c8-f158-4bee-afb8-b72870e7a1d2?api-version=2020-11-01
       Cache-Control:
       - no-cache
       Content-Length:
-      - "411"
-      Content-Type:
-      - application/json; charset=utf-8
+      - "0"
       Expires:
       - "-1"
+      Location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus2/operationResults/f06359c8-f158-4bee-afb8-b72870e7a1d2?api-version=2020-11-01
       Pragma:
       - no-cache
+      Retry-After:
+      - "10"
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
@@ -356,8 +376,8 @@ interactions:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
-    status: 409 Conflict
-    code: 409
+    status: 202 Accepted
+    code: 202
     duration: ""
 - request:
     body: ""
@@ -400,7 +420,7 @@ interactions:
       Test-Request-Attempt:
       - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
-    method: DELETE
+    method: GET
   response:
     body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/asotest-vn-rosbkx''
       under resource group ''asotest-rg-gfhebn'' was not found. For more details please
@@ -436,13 +456,14 @@ interactions:
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx?api-version=2020-11-01
     method: GET
   response:
-    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''asotest-rg-gfhebn''
-      could not be found."}}'
+    body: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/asotest-vn-rosbkx''
+      under resource group ''asotest-rg-gfhebn'' was not found. For more details please
+      go to https://aka.ms/ARMResourceNotFoundFix"}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - "109"
+      - "240"
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -467,39 +488,6 @@ interactions:
       Test-Request-Attempt:
       - "1"
     url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn?api-version=2020-06-01
-    method: GET
-  response:
-    body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''asotest-rg-gfhebn''
-      could not be found."}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - "109"
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Failure-Cause:
-      - gateway
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Test-Request-Attempt:
-      - "1"
-    url: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/asotest-rg-gfhebn/providers/Microsoft.Network/virtualNetworks/asotest-vn-rosbkx/subnets/asotest-subnet-tvejwg?api-version=2020-11-01
     method: GET
   response:
     body: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group ''asotest-rg-gfhebn''

--- a/v2/internal/genericarmclient/generic_client.go
+++ b/v2/internal/genericarmclient/generic_client.go
@@ -262,12 +262,12 @@ func (client *GenericClient) deleteByID(ctx context.Context, resourceID string, 
 	resourceType := metrics.GetTypeFromResourceID(resourceID)
 
 	client.metrics.RecordAzureRequestsTime(resourceType, time.Since(requestStartTime), metrics.HttpDelete)
-	client.metrics.RecordAzureRequestsTotal(resourceType, resp.StatusCode, metrics.HttpDelete)
 
 	if err != nil {
 		client.metrics.RecordAzureFailedRequestsTotal(resourceType, metrics.HttpDelete)
 		return nil, err
 	}
+	client.metrics.RecordAzureRequestsTotal(resourceType, resp.StatusCode, metrics.HttpDelete)
 
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted, http.StatusNoContent, http.StatusNotFound) {
 		return nil, runtime.NewResponseError(resp)

--- a/v2/internal/testcommon/kube_per_test_context.go
+++ b/v2/internal/testcommon/kube_per_test_context.go
@@ -242,6 +242,7 @@ func (tc *KubePerTestContext) Subtest(t *testing.T) *KubePerTestContext {
 	result.T = t
 	result.G = gomega.NewWithT(t)
 	result.Namer = tc.Namer.WithTestName(t.Name())
+	result.NoSpaceNamer = result.Namer.WithSeparator("") // TODO: better way to avoid this mistake in the future
 	result.TestName = t.Name()
 	result.logger = NewTestLogger(t)
 	return result


### PR DESCRIPTION
Intermittently failing tests are annoying. This fixes a few causes of them.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
