### PR TITLE
Use prefix match for Go version

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -163,7 +163,7 @@ if [ "$DEVCONTAINER" != true ]; then
         write-info "Installing golangci-lint"
         # golangci-lint is provided by base image if in devcontainer
         # this command copied from there
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$TOOL_DEST" v1.45.2 2>&1
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$TOOL_DEST" v1.46.2 2>&1
     fi
 fi
 

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -85,9 +85,12 @@ if ! command -v go > /dev/null 2>&1; then
     exit 1
 fi
 
+GOVER=$(go version)
+write-info "Go version: ${GOVER[*]}"
+
 GOVERREQUIRED="go1.18"
 GOVERACTUAL=$(go version | { read _ _ ver _; echo $ver; })
-if [ "$GOVERREQUIRED" != "$GOVERACTUAL" ]; then
+if ! [[ "$GOVERACTUAL" =~ $GOVERREQUIRED.* ]]; then
     write-error "Go must be version $GOVERREQUIRED, not $GOVERACTUAL; see : https://golang.org/doc/install"
     exit 1
 fi

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -88,9 +88,9 @@ fi
 GOVER=$(go version)
 write-info "Go version: ${GOVER[*]}"
 
-GOVERREQUIRED="go1.18"
+GOVERREQUIRED="go1.18.*"
 GOVERACTUAL=$(go version | { read _ _ ver _; echo $ver; })
-if ! [[ "$GOVERACTUAL" =~ $GOVERREQUIRED.* ]]; then
+if ! [[ "$GOVERACTUAL" =~ $GOVERREQUIRED ]]; then
     write-error "Go must be version $GOVERREQUIRED, not $GOVERACTUAL; see : https://golang.org/doc/install"
     exit 1
 fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,11 @@ linters:
     - unused
   disable: 
     - scopelint # obsoleted by exportloopref
-
+    # The below rules are disabled due to bug with go1.18 and generics: https://github.com/golangci/golangci-lint/issues/2859
+    - staticcheck
+    - gosimple
+    - stylecheck
+    - unused
 linters-settings:
   govet:
     check-shadowing: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Change our Go version check in `install-dependencies.sh` to allow minor versions to match.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/4BWByhavc3Hr2/giphy.gif)
