### PR TITLE
Install updated versions of NodeJS and NPM

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,9 +6,14 @@ FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.18
 # APT dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends bash-completion software-properties-common lsb-release npm \
+    && apt-get -y install --no-install-recommends bash-completion software-properties-common lsb-release \
     # install az-cli
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash -
+
+# For Hugo we need a newer version of NodeJS than the v12.22.12 available via the standard sources
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource-setup.sh \
+    && sudo bash /tmp/nodesource-setup.sh \
+    && apt-get -y install nodejs
 
 # install docker
 # - not yet needed?


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates to the Hugo tooling we use for generating our website require a newer version of NodeJS:

```
[build-docs-site] npm WARN EBADENGINE Unsupported engine {
[build-docs-site] npm WARN EBADENGINE   package: 'postcss-cli@10.0.0',
[build-docs-site] npm WARN EBADENGINE   required: { node: '>=14' },
[build-docs-site] npm WARN EBADENGINE   current: { node: 'v12.22.12', npm: '[7](https://github.com/Azure/azure-service-operator/runs/7124675759?check_suite_focus=true#step:6:8).5.2' }
[build-docs-site] npm WARN EBADENGINE }
[build-docs-site] npm WARN EBADENGINE Unsupported engine {
[build-docs-site] npm WARN EBADENGINE   package: 'postcss-load-config@4.0.1',
[build-docs-site] npm WARN EBADENGINE   required: { node: '>= 14' },
[build-docs-site] npm WARN EBADENGINE   current: { node: 'v[12](https://github.com/Azure/azure-service-operator/runs/7124675759?check_suite_focus=true#step:6:13).22.12', npm: '7.5.2' }
[build-docs-site] npm WARN EBADENGINE }
[build-docs-site] npm WARN EBADENGINE Unsupported engine {
[build-docs-site] npm WARN EBADENGINE   package: 'yaml@2.1.1',
[build-docs-site] npm WARN EBADENGINE   required: { node: '>= [14](https://github.com/Azure/azure-service-operator/runs/7124675759?check_suite_focus=true#step:6:15)' },
[build-docs-site] npm WARN EBADENGINE   current: { node: 'v12.22.12', npm: '7.5.2' }
[build-docs-site] npm WARN EBADENGINE } 
```

With this change to our DevContainer, we'll have v18 available.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3o7budMRwZvNGJ3pyE/giphy.gif)
