### PR TITLE
Fix property bag use for maps and slices

### DIFF
--- a/v2/api/cache/v1alpha1api20201201storage/redis_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201storage/redis_types_gen.go
@@ -1226,6 +1226,8 @@ func (sku *Sku) AssignPropertiesToSku(destination *alpha20210301s.Sku) error {
 	// Family
 	if sku.Family != nil {
 		propertyBag.Add("Family", *sku.Family)
+	} else {
+		propertyBag.Remove("Family")
 	}
 
 	// Name
@@ -1297,6 +1299,8 @@ func (sku *Sku_Status) AssignPropertiesToSkuStatus(destination *alpha20210301s.S
 	// Family
 	if sku.Family != nil {
 		propertyBag.Add("Family", *sku.Family)
+	} else {
+		propertyBag.Remove("Family")
 	}
 
 	// Name

--- a/v2/api/cache/v1alpha1api20210301storage/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1alpha1api20210301storage/redis_enterprise_types_gen.go
@@ -713,6 +713,8 @@ func (sku *Sku) AssignPropertiesFromSku(source *v20201201s.Sku) error {
 	// Family
 	if source.Family != nil {
 		propertyBag.Add("Family", *source.Family)
+	} else {
+		propertyBag.Remove("Family")
 	}
 
 	// Name
@@ -783,6 +785,8 @@ func (sku *Sku_Status) AssignPropertiesFromSkuStatus(source *v20201201s.Sku_Stat
 	// Family
 	if source.Family != nil {
 		propertyBag.Add("Family", *source.Family)
+	} else {
+		propertyBag.Remove("Family")
 	}
 
 	// Name

--- a/v2/api/cache/v1beta20201201storage/redis_types_gen.go
+++ b/v2/api/cache/v1beta20201201storage/redis_types_gen.go
@@ -364,6 +364,8 @@ func (sku *Sku) AssignPropertiesToSku(destination *v20210301s.Sku) error {
 	// Family
 	if sku.Family != nil {
 		propertyBag.Add("Family", *sku.Family)
+	} else {
+		propertyBag.Remove("Family")
 	}
 
 	// Name
@@ -434,6 +436,8 @@ func (sku *Sku_Status) AssignPropertiesToSkuStatus(destination *v20210301s.Sku_S
 	// Family
 	if sku.Family != nil {
 		propertyBag.Add("Family", *sku.Family)
+	} else {
+		propertyBag.Remove("Family")
 	}
 
 	// Name

--- a/v2/pkg/genruntime/property_bag.go
+++ b/v2/pkg/genruntime/property_bag.go
@@ -92,3 +92,10 @@ func (bag PropertyBag) Pull(property string, destination interface{}) error {
 
 	return nil
 }
+
+// Remove ensures the property bag doesn't contain a value for the specified name
+// property is the name of the item to remove
+// It is not an error to try and remove an item that's not present
+func (bag PropertyBag) Remove(property string) {
+	delete(bag, property)
+}

--- a/v2/tools/generator/internal/astbuilder/builder.go
+++ b/v2/tools/generator/internal/astbuilder/builder.go
@@ -400,7 +400,7 @@ func NotExpr(expr dst.Expr) *dst.UnaryExpr {
 	}
 }
 
-// NotNil generates an `x != nil` comparison
+// NotNil generates an `x != nil` condition
 func NotNil(x dst.Expr) *dst.BinaryExpr {
 	return AreNotEqual(x, Nil())
 }
@@ -414,6 +414,15 @@ func Nil() *dst.Ident {
 func Continue() dst.Stmt {
 	return &dst.BranchStmt{
 		Tok: token.CONTINUE,
+	}
+}
+
+// NotEmpty generates an `len(x) > 0` condition
+func NotEmpty(x dst.Expr) *dst.BinaryExpr {
+	return &dst.BinaryExpr{
+		X:  CallFunc("len", x),
+		Op: token.GTR,
+		Y:  dst.NewIdent("0"),
 	}
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectJsonSerializationTests/person-v20200101storage.golden
@@ -105,11 +105,15 @@ func (person *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231s.Per
 	// PostalAddress
 	if source.PostalAddress != nil {
 		propertyBag.Add("PostalAddress", *source.PostalAddress)
+	} else {
+		propertyBag.Remove("PostalAddress")
 	}
 
 	// ResidentialAddress
 	if source.ResidentialAddress != nil {
 		propertyBag.Add("ResidentialAddress", *source.ResidentialAddress)
+	} else {
+		propertyBag.Remove("ResidentialAddress")
 	}
 
 	// Update the property bag

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentFunctions/person-v20200101storage.golden
@@ -105,11 +105,15 @@ func (person *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231s.Per
 	// PostalAddress
 	if source.PostalAddress != nil {
 		propertyBag.Add("PostalAddress", *source.PostalAddress)
+	} else {
+		propertyBag.Remove("PostalAddress")
 	}
 
 	// ResidentialAddress
 	if source.ResidentialAddress != nil {
 		propertyBag.Add("ResidentialAddress", *source.ResidentialAddress)
+	} else {
+		propertyBag.Remove("ResidentialAddress")
 	}
 
 	// Update the property bag

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectPropertyAssignmentTests/person-v20200101storage.golden
@@ -105,11 +105,15 @@ func (person *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231s.Per
 	// PostalAddress
 	if source.PostalAddress != nil {
 		propertyBag.Add("PostalAddress", *source.PostalAddress)
+	} else {
+		propertyBag.Remove("PostalAddress")
 	}
 
 	// ResidentialAddress
 	if source.ResidentialAddress != nil {
 		propertyBag.Add("ResidentialAddress", *source.ResidentialAddress)
+	} else {
+		propertyBag.Remove("ResidentialAddress")
 	}
 
 	// Update the property bag

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20200101storage.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20200101storage.golden
@@ -129,11 +129,15 @@ func (person *Person_Spec) AssignPropertiesFromPersonSpec(source *v20211231s.Per
 	// PostalAddress
 	if source.PostalAddress != nil {
 		propertyBag.Add("PostalAddress", *source.PostalAddress)
+	} else {
+		propertyBag.Remove("PostalAddress")
 	}
 
 	// ResidentialAddress
 	if source.ResidentialAddress != nil {
 		propertyBag.Add("ResidentialAddress", *source.ResidentialAddress)
+	} else {
+		propertyBag.Remove("ResidentialAddress")
 	}
 
 	// Update the property bag

--- a/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyMapToPropertyBag.golden
+++ b/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyMapToPropertyBag.golden
@@ -41,7 +41,11 @@ func (person *Person) AssignPropertiesToPerson(destination *vnext.Person) error 
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Ratings
-	propertyBag.Add("Ratings", person.Ratings)
+	if len(person.Ratings) > 0 {
+		propertyBag.Add("Ratings", person.Ratings)
+	} else {
+		propertyBag.Remove("Ratings")
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalIntToPropertyBag.golden
+++ b/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalIntToPropertyBag.golden
@@ -43,6 +43,8 @@ func (person *Person) AssignPropertiesToPerson(destination *vnext.Person) error 
 	// Age
 	if person.Age != nil {
 		propertyBag.Add("Age", *person.Age)
+	} else {
+		propertyBag.Remove("Age")
 	}
 
 	// Update the property bag

--- a/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalObjectToPropertyBag.golden
+++ b/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalObjectToPropertyBag.golden
@@ -43,6 +43,8 @@ func (person *Person) AssignPropertiesToPerson(destination *vnext.Person) error 
 	// Role
 	if person.Role != nil {
 		propertyBag.Add("Role", *person.Role)
+	} else {
+		propertyBag.Remove("Role")
 	}
 
 	// Update the property bag

--- a/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalStringToPropertyBag.golden
+++ b/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopyOptionalStringToPropertyBag.golden
@@ -43,6 +43,8 @@ func (person *Person) AssignPropertiesToPerson(destination *vnext.Person) error 
 	// Name
 	if person.Name != nil {
 		propertyBag.Add("Name", *person.Name)
+	} else {
+		propertyBag.Remove("Name")
 	}
 
 	// Update the property bag

--- a/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopySliceToPropertyBag.golden
+++ b/v2/tools/generator/internal/functions/testdata/TestGolden_PropertyAssignmentFunction_AsFunc/CopySliceToPropertyBag.golden
@@ -41,7 +41,11 @@ func (person *Person) AssignPropertiesToPerson(destination *vnext.Person) error 
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Scores
-	propertyBag.Add("Scores", person.Scores)
+	if len(person.Scores) > 0 {
+		propertyBag.Add("Scores", person.Scores)
+	} else {
+		propertyBag.Remove("Scores")
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

We already had checks to ensure we don't store explicit **nil** values in a `PropertyBag` when converting versions of a resource (we represent missing values by omitting them from the bag).

This PR extends this practice to empty maps and slices.

Also fixes a bug where an existing value would be left in the bag if our value was nil; now we explicitly remove it.

Closes #2388

**Special notes for your reviewer**

The updates to the golden tests show all the new cases.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/fLykvG2g4Pr487kbAF/giphy.gif)

**If applicable**:
- [x] this PR contains tests
