### PR TITLE
Fix generation of CRD documentation

### DIFF
--- a/v2/api/dbformysql/v1beta1/doc.go
+++ b/v2/api/dbformysql/v1beta1/doc.go
@@ -3,6 +3,6 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-// Package v1beta20210501 contains hand crafted API Schema definitions for the dbformysql v1beta API group
+// Package v1beta contains hand crafted API Schema definitions for the dbformysql v1beta API group
 // +groupName=dbformysql.azure.com
-package v1beta
+package v1beta1

--- a/v2/api/dbformysql/v1beta1/doc.go
+++ b/v2/api/dbformysql/v1beta1/doc.go
@@ -1,0 +1,8 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+// Package v1beta20210501 contains hand crafted API Schema definitions for the dbformysql v1beta API group
+// +groupName=dbformysql.azure.com
+package v1beta


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds in the missing `doc.go` the lack of which was causing `controller-gen` to crash.

**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/xT0GqtpF1NWd9VbstO/giphy.gif)
