### PR TITLE
Use a unique branch name each time we generate CRD docs

### DIFF
--- a/.github/workflows/api-docs-repo.yaml
+++ b/.github/workflows/api-docs-repo.yaml
@@ -17,12 +17,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         with:
-          branch: 'bot/update-api-docs'
+          branch: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
 
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: bot/update-api-docs
+          ref: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
           fetch-depth: 0 # required to access tags
           submodules: 'true'
 
@@ -75,7 +75,7 @@ jobs:
         uses: devops-infra/action-pull-request@v0.4.2
         with:
           github_token: ${{ secrets.GH_PAT }}
-          source_branch: bot/update-api-docs
+          source_branch: ${{ format('bot/update-api-docs-{0}', github.run_number) }}
           target_branch: main
           title: "[Automated] Add API Docs"
           body: "Add new API Docs for latest release"


### PR DESCRIPTION
**What this PR does / why we need it**:

We were having failures generating CRD documentation because the same branch name was being reused.

This wasn't a problem after successful runs of the workflow, as the follow-up PR merge would delete the branch. But when the workflow fails, the old branch was left around to cause mayhem for the next run.

Fix is to use the `run_number` to make the branch name unique each time.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3BMtVrNUsfFhpb7FUW/giphy.gif)
