### PR TITLE
Improve test performance

### DIFF
--- a/v2/api/authorization/v1alpha1api20200801preview/role_assignment_types_gen_test.go
+++ b/v2/api/authorization/v1alpha1api20200801preview/role_assignment_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_RoleAssignment_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RoleAssignment to hub returns original",

--- a/v2/api/authorization/v1alpha1api20200801previewstorage/role_assignment_types_gen_test.go
+++ b/v2/api/authorization/v1alpha1api20200801previewstorage/role_assignment_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RoleAssignment_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RoleAssignment to hub returns original",

--- a/v2/api/authorization/v1beta20200801preview/role_assignment_types_gen_test.go
+++ b/v2/api/authorization/v1beta20200801preview/role_assignment_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RoleAssignment_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RoleAssignment to hub returns original",

--- a/v2/api/batch/v1alpha1api20210101/batch_account_types_gen_test.go
+++ b/v2/api/batch/v1alpha1api20210101/batch_account_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_BatchAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from BatchAccount to hub returns original",

--- a/v2/api/batch/v1alpha1api20210101storage/batch_account_types_gen_test.go
+++ b/v2/api/batch/v1alpha1api20210101storage/batch_account_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_BatchAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from BatchAccount to hub returns original",

--- a/v2/api/batch/v1beta20210101/batch_account_types_gen_test.go
+++ b/v2/api/batch/v1beta20210101/batch_account_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_BatchAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from BatchAccount to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201/redis_firewall_rule_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_firewall_rule_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_RedisFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisFirewallRule to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201/redis_linked_server_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_linked_server_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_RedisLinkedServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisLinkedServer to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201/redis_patch_schedule_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_patch_schedule_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_RedisPatchSchedule_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisPatchSchedule to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201/redis_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Redis_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Redis to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201storage/redis_firewall_rule_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201storage/redis_firewall_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisFirewallRule to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201storage/redis_linked_server_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201storage/redis_linked_server_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisLinkedServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisLinkedServer to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201storage/redis_patch_schedule_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201storage/redis_patch_schedule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisPatchSchedule_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisPatchSchedule to hub returns original",

--- a/v2/api/cache/v1alpha1api20201201storage/redis_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20201201storage/redis_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Redis_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Redis to hub returns original",

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise_database_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise_database_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_RedisEnterpriseDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisEnterpriseDatabase to hub returns original",

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_RedisEnterprise_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisEnterprise to hub returns original",

--- a/v2/api/cache/v1alpha1api20210301storage/redis_enterprise_database_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20210301storage/redis_enterprise_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisEnterpriseDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisEnterpriseDatabase to hub returns original",

--- a/v2/api/cache/v1alpha1api20210301storage/redis_enterprise_types_gen_test.go
+++ b/v2/api/cache/v1alpha1api20210301storage/redis_enterprise_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_RedisEnterprise_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisEnterprise to hub returns original",

--- a/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen_test.go
+++ b/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisFirewallRule to hub returns original",

--- a/v2/api/cache/v1beta20201201/redis_linked_server_types_gen_test.go
+++ b/v2/api/cache/v1beta20201201/redis_linked_server_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisLinkedServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisLinkedServer to hub returns original",

--- a/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen_test.go
+++ b/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisPatchSchedule_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisPatchSchedule to hub returns original",

--- a/v2/api/cache/v1beta20201201/redis_types_gen_test.go
+++ b/v2/api/cache/v1beta20201201/redis_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Redis_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Redis to hub returns original",

--- a/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen_test.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisEnterpriseDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisEnterpriseDatabase to hub returns original",

--- a/v2/api/cache/v1beta20210301/redis_enterprise_types_gen_test.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RedisEnterprise_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RedisEnterprise to hub returns original",

--- a/v2/api/cdn/v1beta20210601/profile_types_gen_test.go
+++ b/v2/api/cdn/v1beta20210601/profile_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Profile_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Profile to hub returns original",

--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen_test.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_ProfilesEndpoint_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ProfilesEndpoint to hub returns original",

--- a/v2/api/compute/v1alpha1api20200930/disk_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20200930/disk_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Disk_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Disk to hub returns original",

--- a/v2/api/compute/v1alpha1api20200930/snapshot_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20200930/snapshot_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Snapshot_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Snapshot to hub returns original",

--- a/v2/api/compute/v1alpha1api20200930storage/disk_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20200930storage/disk_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Disk_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Disk to hub returns original",

--- a/v2/api/compute/v1alpha1api20200930storage/snapshot_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20200930storage/snapshot_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Snapshot_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Snapshot to hub returns original",

--- a/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_VirtualMachineScaleSet_WhenConvertedToHub_RoundTripsWithoutLoss(t *tes
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualMachineScaleSet to hub returns original",

--- a/v2/api/compute/v1alpha1api20201201/virtual_machine_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machine_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_VirtualMachine_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualMachine to hub returns original",

--- a/v2/api/compute/v1alpha1api20201201storage/virtual_machine_scale_set_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20201201storage/virtual_machine_scale_set_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualMachineScaleSet_WhenConvertedToHub_RoundTripsWithoutLoss(t *tes
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualMachineScaleSet to hub returns original",

--- a/v2/api/compute/v1alpha1api20201201storage/virtual_machine_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20201201storage/virtual_machine_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_VirtualMachine_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualMachine to hub returns original",

--- a/v2/api/compute/v1alpha1api20210701/image_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20210701/image_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Image_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Image to hub returns original",

--- a/v2/api/compute/v1alpha1api20210701storage/image_types_gen_test.go
+++ b/v2/api/compute/v1alpha1api20210701storage/image_types_gen_test.go
@@ -24,6 +24,7 @@ func Test_Image_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Image to hub returns original",

--- a/v2/api/compute/v1beta20200930/disk_types_gen_test.go
+++ b/v2/api/compute/v1beta20200930/disk_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Disk_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Disk to hub returns original",

--- a/v2/api/compute/v1beta20200930/snapshot_types_gen_test.go
+++ b/v2/api/compute/v1beta20200930/snapshot_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Snapshot_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Snapshot to hub returns original",

--- a/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen_test.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualMachineScaleSet_WhenConvertedToHub_RoundTripsWithoutLoss(t *tes
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualMachineScaleSet to hub returns original",

--- a/v2/api/compute/v1beta20201201/virtual_machine_types_gen_test.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualMachine_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualMachine to hub returns original",

--- a/v2/api/compute/v1beta20210701/image_types_gen_test.go
+++ b/v2/api/compute/v1beta20210701/image_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Image_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Image to hub returns original",

--- a/v2/api/containerinstance/v1beta20211001/container_group_types_gen_test.go
+++ b/v2/api/containerinstance/v1beta20211001/container_group_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_ContainerGroup_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ContainerGroup to hub returns original",

--- a/v2/api/containerregistry/v1alpha1api20210901/registry_types_gen_test.go
+++ b/v2/api/containerregistry/v1alpha1api20210901/registry_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Registry_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Registry to hub returns original",

--- a/v2/api/containerregistry/v1alpha1api20210901storage/registry_types_gen_test.go
+++ b/v2/api/containerregistry/v1alpha1api20210901storage/registry_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Registry_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Registry to hub returns original",

--- a/v2/api/containerregistry/v1beta20210901/registry_types_gen_test.go
+++ b/v2/api/containerregistry/v1beta20210901/registry_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Registry_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Registry to hub returns original",

--- a/v2/api/containerservice/v1alpha1api20210501/managed_cluster_types_gen_test.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_cluster_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_ManagedCluster_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ManagedCluster to hub returns original",

--- a/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen_test.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_ManagedClustersAgentPool_WhenConvertedToHub_RoundTripsWithoutLoss(t *t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ManagedClustersAgentPool to hub returns original",

--- a/v2/api/containerservice/v1alpha1api20210501storage/managed_cluster_types_gen_test.go
+++ b/v2/api/containerservice/v1alpha1api20210501storage/managed_cluster_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_ManagedCluster_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ManagedCluster to hub returns original",

--- a/v2/api/containerservice/v1alpha1api20210501storage/managed_clusters_agent_pool_types_gen_test.go
+++ b/v2/api/containerservice/v1alpha1api20210501storage/managed_clusters_agent_pool_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_ManagedClustersAgentPool_WhenConvertedToHub_RoundTripsWithoutLoss(t *t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ManagedClustersAgentPool to hub returns original",

--- a/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen_test.go
+++ b/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_ManagedCluster_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ManagedCluster to hub returns original",

--- a/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen_test.go
+++ b/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_ManagedClustersAgentPool_WhenConvertedToHub_RoundTripsWithoutLoss(t *t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from ManagedClustersAgentPool to hub returns original",

--- a/v2/api/dbformariadb/v1beta20180601/configuration_types_gen_test.go
+++ b/v2/api/dbformariadb/v1beta20180601/configuration_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Configuration_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Configuration to hub returns original",

--- a/v2/api/dbformariadb/v1beta20180601/database_types_gen_test.go
+++ b/v2/api/dbformariadb/v1beta20180601/database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Database_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Database to hub returns original",

--- a/v2/api/dbformariadb/v1beta20180601/server_types_gen_test.go
+++ b/v2/api/dbformariadb/v1beta20180601/server_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Server_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Server to hub returns original",

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_server_types_gen_test.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_server_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_FlexibleServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServer to hub returns original",

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen_test.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_FlexibleServersDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersDatabase to hub returns original",

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_FlexibleServersFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersFirewallRule to hub returns original",

--- a/v2/api/dbformysql/v1alpha1api20210501storage/flexible_server_types_gen_test.go
+++ b/v2/api/dbformysql/v1alpha1api20210501storage/flexible_server_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServer to hub returns original",

--- a/v2/api/dbformysql/v1alpha1api20210501storage/flexible_servers_database_types_gen_test.go
+++ b/v2/api/dbformysql/v1alpha1api20210501storage/flexible_servers_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersDatabase to hub returns original",

--- a/v2/api/dbformysql/v1alpha1api20210501storage/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/dbformysql/v1alpha1api20210501storage/flexible_servers_firewall_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersFirewallRule to hub returns original",

--- a/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen_test.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServer to hub returns original",

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen_test.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersDatabase to hub returns original",

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersFirewallRule to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_FlexibleServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServer to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_FlexibleServersConfiguration_WhenConvertedToHub_RoundTripsWithoutLoss(
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersConfiguration to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_FlexibleServersDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersDatabase to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_FlexibleServersFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersFirewallRule to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_server_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_server_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServer to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_servers_configuration_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_servers_configuration_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersConfiguration_WhenConvertedToHub_RoundTripsWithoutLoss(
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersConfiguration to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_servers_database_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_servers_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersDatabase to hub returns original",

--- a/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601storage/flexible_servers_firewall_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersFirewallRule to hub returns original",

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServer to hub returns original",

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersConfiguration_WhenConvertedToHub_RoundTripsWithoutLoss(
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersConfiguration to hub returns original",

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *te
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersDatabase to hub returns original",

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen_test.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_FlexibleServersFirewallRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from FlexibleServersFirewallRule to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_DatabaseAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from DatabaseAccount to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_MongodbDatabaseCollectionThroughputSetting_WhenConvertedToHub_RoundTri
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseCollectionThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_MongodbDatabaseCollection_WhenConvertedToHub_RoundTripsWithoutLoss(t *
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseCollection to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_MongodbDatabaseThroughputSetting_WhenConvertedToHub_RoundTripsWithoutL
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_MongodbDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabase to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SqlDatabaseContainerStoredProcedure_WhenConvertedToHub_RoundTripsWitho
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerStoredProcedure to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SqlDatabaseContainerThroughputSetting_WhenConvertedToHub_RoundTripsWit
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SqlDatabaseContainerTrigger_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerTrigger to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SqlDatabaseContainer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainer to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SqlDatabaseContainerUserDefinedFunction_WhenConvertedToHub_RoundTripsW
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerUserDefinedFunction to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SqlDatabaseThroughputSetting_WhenConvertedToHub_RoundTripsWithoutLoss(
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SqlDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabase to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/database_account_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_DatabaseAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from DatabaseAccount to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_collection_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_collection_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabaseCollectionThroughputSetting_WhenConvertedToHub_RoundTri
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseCollectionThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_collection_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_collection_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabaseCollection_WhenConvertedToHub_RoundTripsWithoutLoss(t *
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseCollection to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabaseThroughputSetting_WhenConvertedToHub_RoundTripsWithoutL
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/mongodb_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabase to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_stored_procedure_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_stored_procedure_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerStoredProcedure_WhenConvertedToHub_RoundTripsWitho
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerStoredProcedure to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerThroughputSetting_WhenConvertedToHub_RoundTripsWit
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_trigger_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_trigger_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerTrigger_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerTrigger to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainer to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_user_defined_function_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/sql_database_container_user_defined_function_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerUserDefinedFunction_WhenConvertedToHub_RoundTripsW
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerUserDefinedFunction to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/sql_database_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/sql_database_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseThroughputSetting_WhenConvertedToHub_RoundTripsWithoutLoss(
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1alpha1api20210515storage/sql_database_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/sql_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabase to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_DatabaseAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from DatabaseAccount to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabaseCollectionThroughputSetting_WhenConvertedToHub_RoundTri
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseCollectionThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabaseCollection_WhenConvertedToHub_RoundTripsWithoutLoss(t *
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseCollection to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabaseThroughputSetting_WhenConvertedToHub_RoundTripsWithoutL
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabaseThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_MongodbDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from MongodbDatabase to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerStoredProcedure_WhenConvertedToHub_RoundTripsWitho
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerStoredProcedure to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerThroughputSetting_WhenConvertedToHub_RoundTripsWit
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerTrigger_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerTrigger to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainer to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseContainerUserDefinedFunction_WhenConvertedToHub_RoundTripsW
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseContainerUserDefinedFunction to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabaseThroughputSetting_WhenConvertedToHub_RoundTripsWithoutLoss(
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabaseThroughputSetting to hub returns original",

--- a/v2/api/documentdb/v1beta20210515/sql_database_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SqlDatabase_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SqlDatabase to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Domain_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Domain to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601/domains_topic_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domains_topic_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_DomainsTopic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from DomainsTopic to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_EventSubscription_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from EventSubscription to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601/topic_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/topic_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Topic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Topic to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601storage/domain_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601storage/domain_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Domain_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Domain to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601storage/domains_topic_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601storage/domains_topic_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_DomainsTopic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from DomainsTopic to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601storage/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601storage/event_subscription_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_EventSubscription_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from EventSubscription to hub returns original",

--- a/v2/api/eventgrid/v1alpha1api20200601storage/topic_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601storage/topic_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Topic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Topic to hub returns original",

--- a/v2/api/eventgrid/v1beta20200601/domain_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/domain_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Domain_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Domain to hub returns original",

--- a/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_DomainsTopic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from DomainsTopic to hub returns original",

--- a/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_EventSubscription_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from EventSubscription to hub returns original",

--- a/v2/api/eventgrid/v1beta20200601/topic_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/topic_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Topic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Topic to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101/namespace_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespace_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Namespace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Namespace to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NamespacesAuthorizationRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesAuthorizationRule to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NamespacesEventhub_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhub to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NamespacesEventhubsAuthorizationRule_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhubsAuthorizationRule to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NamespacesEventhubsConsumerGroup_WhenConvertedToHub_RoundTripsWithoutL
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhubsConsumerGroup to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101storage/namespace_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101storage/namespace_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Namespace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Namespace to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101storage/namespaces_authorization_rule_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101storage/namespaces_authorization_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesAuthorizationRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesAuthorizationRule to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101storage/namespaces_eventhub_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101storage/namespaces_eventhub_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesEventhub_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhub to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101storage/namespaces_eventhubs_authorization_rule_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101storage/namespaces_eventhubs_authorization_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesEventhubsAuthorizationRule_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhubsAuthorizationRule to hub returns original",

--- a/v2/api/eventhub/v1alpha1api20211101storage/namespaces_eventhubs_consumer_group_types_gen_test.go
+++ b/v2/api/eventhub/v1alpha1api20211101storage/namespaces_eventhubs_consumer_group_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesEventhubsConsumerGroup_WhenConvertedToHub_RoundTripsWithoutL
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhubsConsumerGroup to hub returns original",

--- a/v2/api/eventhub/v1beta20211101/namespace_types_gen_test.go
+++ b/v2/api/eventhub/v1beta20211101/namespace_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Namespace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Namespace to hub returns original",

--- a/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen_test.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesAuthorizationRule_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesAuthorizationRule to hub returns original",

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen_test.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesEventhub_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhub to hub returns original",

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen_test.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesEventhubsAuthorizationRule_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhubsAuthorizationRule to hub returns original",

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen_test.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesEventhubsConsumerGroup_WhenConvertedToHub_RoundTripsWithoutL
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesEventhubsConsumerGroup to hub returns original",

--- a/v2/api/insights/v1alpha1api20180501preview/webtest_types_gen_test.go
+++ b/v2/api/insights/v1alpha1api20180501preview/webtest_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Webtest_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Webtest to hub returns original",

--- a/v2/api/insights/v1alpha1api20180501previewstorage/webtest_types_gen_test.go
+++ b/v2/api/insights/v1alpha1api20180501previewstorage/webtest_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Webtest_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Webtest to hub returns original",

--- a/v2/api/insights/v1alpha1api20200202/component_types_gen_test.go
+++ b/v2/api/insights/v1alpha1api20200202/component_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Component_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Component to hub returns original",

--- a/v2/api/insights/v1alpha1api20200202storage/component_types_gen_test.go
+++ b/v2/api/insights/v1alpha1api20200202storage/component_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Component_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Component to hub returns original",

--- a/v2/api/insights/v1beta20180501preview/webtest_types_gen_test.go
+++ b/v2/api/insights/v1beta20180501preview/webtest_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Webtest_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Webtest to hub returns original",

--- a/v2/api/insights/v1beta20200202/component_types_gen_test.go
+++ b/v2/api/insights/v1beta20200202/component_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Component_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Component to hub returns original",

--- a/v2/api/keyvault/v1beta20210401preview/vault_types_gen_test.go
+++ b/v2/api/keyvault/v1beta20210401preview/vault_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Vault_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Vault to hub returns original",

--- a/v2/api/machinelearningservices/v1beta20210701/workspace_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspace_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Workspace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Workspace to hub returns original",

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_WorkspacesCompute_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from WorkspacesCompute to hub returns original",

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_connection_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_connection_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_WorkspacesConnection_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from WorkspacesConnection to hub returns original",

--- a/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen_test.go
+++ b/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_UserAssignedIdentity_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from UserAssignedIdentity to hub returns original",

--- a/v2/api/managedidentity/v1alpha1api20181130storage/user_assigned_identity_types_gen_test.go
+++ b/v2/api/managedidentity/v1alpha1api20181130storage/user_assigned_identity_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_UserAssignedIdentity_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from UserAssignedIdentity to hub returns original",

--- a/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen_test.go
+++ b/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_UserAssignedIdentity_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from UserAssignedIdentity to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/load_balancer_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/load_balancer_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_LoadBalancer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from LoadBalancer to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/network_interface_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/network_interface_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NetworkInterface_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkInterface to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/network_security_group_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_group_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NetworkSecurityGroup_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkSecurityGroup to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/network_security_groups_security_rule_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_groups_security_rule_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NetworkSecurityGroupsSecurityRule_WhenConvertedToHub_RoundTripsWithout
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkSecurityGroupsSecurityRule to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/public_ip_address_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/public_ip_address_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_PublicIPAddress_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from PublicIPAddress to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/virtual_network_gateway_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_network_gateway_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_VirtualNetworkGateway_WhenConvertedToHub_RoundTripsWithoutLoss(t *test
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworkGateway to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/virtual_network_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_network_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_VirtualNetwork_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetwork to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_subnet_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_subnet_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_VirtualNetworksSubnet_WhenConvertedToHub_RoundTripsWithoutLoss(t *test
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworksSubnet to hub returns original",

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_VirtualNetworksVirtualNetworkPeering_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworksVirtualNetworkPeering to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/load_balancer_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/load_balancer_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_LoadBalancer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from LoadBalancer to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/network_interface_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/network_interface_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NetworkInterface_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkInterface to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/network_security_group_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/network_security_group_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NetworkSecurityGroup_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkSecurityGroup to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/network_security_groups_security_rule_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/network_security_groups_security_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NetworkSecurityGroupsSecurityRule_WhenConvertedToHub_RoundTripsWithout
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkSecurityGroupsSecurityRule to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/public_ip_address_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/public_ip_address_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_PublicIPAddress_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from PublicIPAddress to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/virtual_network_gateway_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/virtual_network_gateway_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetworkGateway_WhenConvertedToHub_RoundTripsWithoutLoss(t *test
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworkGateway to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/virtual_network_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/virtual_network_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetwork_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetwork to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/virtual_networks_subnet_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/virtual_networks_subnet_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetworksSubnet_WhenConvertedToHub_RoundTripsWithoutLoss(t *test
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworksSubnet to hub returns original",

--- a/v2/api/network/v1alpha1api20201101storage/virtual_networks_virtual_network_peering_types_gen_test.go
+++ b/v2/api/network/v1alpha1api20201101storage/virtual_networks_virtual_network_peering_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetworksVirtualNetworkPeering_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworksVirtualNetworkPeering to hub returns original",

--- a/v2/api/network/v1beta20201101/load_balancer_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/load_balancer_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_LoadBalancer_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from LoadBalancer to hub returns original",

--- a/v2/api/network/v1beta20201101/network_interface_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/network_interface_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NetworkInterface_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkInterface to hub returns original",

--- a/v2/api/network/v1beta20201101/network_security_group_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/network_security_group_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NetworkSecurityGroup_WhenConvertedToHub_RoundTripsWithoutLoss(t *testi
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkSecurityGroup to hub returns original",

--- a/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NetworkSecurityGroupsSecurityRule_WhenConvertedToHub_RoundTripsWithout
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NetworkSecurityGroupsSecurityRule to hub returns original",

--- a/v2/api/network/v1beta20201101/public_ip_address_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/public_ip_address_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_PublicIPAddress_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from PublicIPAddress to hub returns original",

--- a/v2/api/network/v1beta20201101/route_table_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/route_table_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RouteTable_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RouteTable to hub returns original",

--- a/v2/api/network/v1beta20201101/route_tables_route_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/route_tables_route_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_RouteTablesRoute_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from RouteTablesRoute to hub returns original",

--- a/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetworkGateway_WhenConvertedToHub_RoundTripsWithoutLoss(t *test
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworkGateway to hub returns original",

--- a/v2/api/network/v1beta20201101/virtual_network_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/virtual_network_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetwork_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetwork to hub returns original",

--- a/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetworksSubnet_WhenConvertedToHub_RoundTripsWithoutLoss(t *test
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworksSubnet to hub returns original",

--- a/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen_test.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_VirtualNetworksVirtualNetworkPeering_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from VirtualNetworksVirtualNetworkPeering to hub returns original",

--- a/v2/api/operationalinsights/v1alpha1api20210601/workspace_types_gen_test.go
+++ b/v2/api/operationalinsights/v1alpha1api20210601/workspace_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Workspace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Workspace to hub returns original",

--- a/v2/api/operationalinsights/v1alpha1api20210601storage/workspace_types_gen_test.go
+++ b/v2/api/operationalinsights/v1alpha1api20210601storage/workspace_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Workspace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Workspace to hub returns original",

--- a/v2/api/operationalinsights/v1beta20210601/workspace_types_gen_test.go
+++ b/v2/api/operationalinsights/v1beta20210601/workspace_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Workspace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Workspace to hub returns original",

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespace_types_gen_test.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespace_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_Namespace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Namespace to hub returns original",

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen_test.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NamespacesQueue_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesQueue to hub returns original",

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen_test.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_NamespacesTopic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesTopic to hub returns original",

--- a/v2/api/servicebus/v1alpha1api20210101previewstorage/namespace_types_gen_test.go
+++ b/v2/api/servicebus/v1alpha1api20210101previewstorage/namespace_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Namespace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Namespace to hub returns original",

--- a/v2/api/servicebus/v1alpha1api20210101previewstorage/namespaces_queue_types_gen_test.go
+++ b/v2/api/servicebus/v1alpha1api20210101previewstorage/namespaces_queue_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesQueue_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesQueue to hub returns original",

--- a/v2/api/servicebus/v1alpha1api20210101previewstorage/namespaces_topic_types_gen_test.go
+++ b/v2/api/servicebus/v1alpha1api20210101previewstorage/namespaces_topic_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesTopic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesTopic to hub returns original",

--- a/v2/api/servicebus/v1beta20210101preview/namespace_types_gen_test.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespace_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_Namespace_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Namespace to hub returns original",

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen_test.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesQueue_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesQueue to hub returns original",

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen_test.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_NamespacesTopic_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T)
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from NamespacesTopic to hub returns original",

--- a/v2/api/signalrservice/v1alpha1api20211001/signal_r_types_gen_test.go
+++ b/v2/api/signalrservice/v1alpha1api20211001/signal_r_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_SignalR_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SignalR to hub returns original",

--- a/v2/api/signalrservice/v1alpha1api20211001storage/signal_r_types_gen_test.go
+++ b/v2/api/signalrservice/v1alpha1api20211001storage/signal_r_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SignalR_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SignalR to hub returns original",

--- a/v2/api/signalrservice/v1beta20211001/signal_r_types_gen_test.go
+++ b/v2/api/signalrservice/v1beta20211001/signal_r_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_SignalR_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from SignalR to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401/storage_account_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_account_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_StorageAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccount to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_StorageAccountsBlobService_WhenConvertedToHub_RoundTripsWithoutLoss(t 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsBlobService to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_StorageAccountsBlobServicesContainer_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsBlobServicesContainer to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_management_policy_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_management_policy_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_StorageAccountsManagementPolicy_WhenConvertedToHub_RoundTripsWithoutLo
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsManagementPolicy to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_service_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_service_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_StorageAccountsQueueService_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsQueueService to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queue_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queue_types_gen_test.go
@@ -23,6 +23,7 @@ func Test_StorageAccountsQueueServicesQueue_WhenConvertedToHub_RoundTripsWithout
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsQueueServicesQueue to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401storage/storage_account_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401storage/storage_account_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccount to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401storage/storage_accounts_blob_service_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401storage/storage_accounts_blob_service_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsBlobService_WhenConvertedToHub_RoundTripsWithoutLoss(t 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsBlobService to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401storage/storage_accounts_blob_services_container_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401storage/storage_accounts_blob_services_container_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsBlobServicesContainer_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsBlobServicesContainer to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401storage/storage_accounts_management_policy_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401storage/storage_accounts_management_policy_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsManagementPolicy_WhenConvertedToHub_RoundTripsWithoutLo
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsManagementPolicy to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401storage/storage_accounts_queue_service_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401storage/storage_accounts_queue_service_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsQueueService_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsQueueService to hub returns original",

--- a/v2/api/storage/v1alpha1api20210401storage/storage_accounts_queue_services_queue_types_gen_test.go
+++ b/v2/api/storage/v1alpha1api20210401storage/storage_accounts_queue_services_queue_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsQueueServicesQueue_WhenConvertedToHub_RoundTripsWithout
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsQueueServicesQueue to hub returns original",

--- a/v2/api/storage/v1beta20210401/storage_account_types_gen_test.go
+++ b/v2/api/storage/v1beta20210401/storage_account_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccount_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccount to hub returns original",

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen_test.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsBlobService_WhenConvertedToHub_RoundTripsWithoutLoss(t 
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsBlobService to hub returns original",

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen_test.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsBlobServicesContainer_WhenConvertedToHub_RoundTripsWith
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsBlobServicesContainer to hub returns original",

--- a/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen_test.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsManagementPolicy_WhenConvertedToHub_RoundTripsWithoutLo
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsManagementPolicy to hub returns original",

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen_test.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsQueueService_WhenConvertedToHub_RoundTripsWithoutLoss(t
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsQueueService to hub returns original",

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen_test.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen_test.go
@@ -22,6 +22,7 @@ func Test_StorageAccountsQueueServicesQueue_WhenConvertedToHub_RoundTripsWithout
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from StorageAccountsQueueServicesQueue to hub returns original",

--- a/v2/tools/generator/internal/astmodel/errored_type_test.go
+++ b/v2/tools/generator/internal/astmodel/errored_type_test.go
@@ -15,7 +15,11 @@ import (
 
 func TestErroredTypeProperties(t *testing.T) {
 	t.Parallel()
-	g := gopter.NewProperties(nil)
+
+	parameters := gopter.DefaultTestParameters()
+	parameters.MaxSize = 10
+
+	g := gopter.NewProperties(parameters)
 
 	g.Property("wrapping an ErroredType with another merges its errors and warnings",
 		prop.ForAll(

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20200101_test.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20200101_test.golden
@@ -23,6 +23,7 @@ func Test_Person_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Person to hub returns original",

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20200101storage_test.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20200101storage_test.golden
@@ -22,6 +22,7 @@ func Test_Person_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Person to hub returns original",

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20211231_test.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/TestGolden_InjectResourceConversionTestCases/person-v20211231_test.golden
@@ -22,6 +22,7 @@ func Test_Person_WhenConvertedToHub_RoundTripsWithoutLoss(t *testing.T) {
 	t.Parallel()
 	parameters := gopter.DefaultTestParameters()
 	parameters.MaxSize = 10
+	parameters.MinSuccessfulTests = 10
 	properties := gopter.NewProperties(parameters)
 	properties.Property(
 		"Round trip from Person to hub returns original",

--- a/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
+++ b/v2/tools/generator/internal/testcases/resource_conversion_test_case.go
@@ -143,6 +143,7 @@ func (tc *ResourceConversionTestCase) Equals(other astmodel.TestCase, override a
 //
 // parameters := gopter.DefaultTestParameters()
 // parameters.MaxSize = 10
+// parameters.MinSuccessfulTests = 10
 // properties := gopter.NewProperties(parameters)
 // properties.Property("...", prop.ForAll(RunTestForX, XGenerator())
 // properties.TestingRun(t, gopter.NewFormatedReporter(true, 240, os.Stdout))
@@ -174,6 +175,13 @@ func (tc *ResourceConversionTestCase) createTestRunner(codegenContext *astmodel.
 	configureMaxSize := astbuilder.QualifiedAssignment(
 		dst.NewIdent(parametersLocal),
 		"MaxSize",
+		token.ASSIGN,
+		astbuilder.IntLiteral(10))
+
+	// parameters.MinSuccessfulTests = 10
+	configureMinSuccessfulTests := astbuilder.QualifiedAssignment(
+		dst.NewIdent(parametersLocal),
+		"MinSuccessfulTests",
 		token.ASSIGN,
 		astbuilder.IntLiteral(10))
 
@@ -217,6 +225,7 @@ func (tc *ResourceConversionTestCase) createTestRunner(codegenContext *astmodel.
 		declareParallel,
 		defineParameters,
 		configureMaxSize,
+		configureMinSuccessfulTests,
 		defineProperties,
 		defineTestCase,
 		runTests)

--- a/v2/tools/generator/internal/testcases/testdata/TestGolden_ResourceConversionTestCase_AsFunc/person_test.golden
+++ b/v2/tools/generator/internal/testcases/testdata/TestGolden_ResourceConversionTestCase_AsFunc/person_test.golden
@@ -19,6 +19,7 @@
 +	t.Parallel()
 +	parameters := gopter.DefaultTestParameters()
 +	parameters.MaxSize = 10
++	parameters.MinSuccessfulTests = 10
 +	properties := gopter.NewProperties(parameters)
 +	properties.Property(
 +		"Round trip from Person to hub returns original",


### PR DESCRIPTION
**What this PR does / why we need it**:

Our tests are taking too long to run, so we need to reduce the time spent.

We have separate tests that check each step of the generated resource conversion graph works in isolation; we also have tests that check they work in concert together, conducting round trip checks to the hub type for each resource.

Given we have good property-testing coverage (via gopter) of the individual steps, it seems safe to reduce the number of tests we run of the entire round trip.

Performance generally looks better (results from a single run only, so take with a grain of salt):

| Package                                |  Before |    After |
| -------------------------------------- | ------: | -------: |
| api/compute/v1alpha1api20200930        | 19.768s |   9.263s |
| api/compute/v1alpha1api20200930storage | 16.145s |  12.331s |
| api/compute/v1alpha1api20201201        | 35.509s |  27.243s |
| api/compute/v1alpha1api20201201storage | 35.017s |  32.165s |
| api/compute/v1alpha1api20210701        | 14.404s |   6.937s |
| api/compute/v1alpha1api20210701storage | 15.339s |   6.718s |
| api/compute/v1beta20200930             | 19.094s |  15.635s |
| api/compute/v1beta20201201             | 26.636s |  26.532s |
| api/compute/v1beta20201201storage      | 28.967s |  29.254s |
| api/compute/v1beta20210701             |  9.147s |  16.722s |
| api/compute/v1beta20210701storage      | 17.605s |  14.032s |
| api/compute/v1beta20220301             | 18.459s |  14.606s |

**Special notes for your reviewer**:

Changes to generated files are the addition of one configuration assignment to each test:

``` golang
parameters.MinSuccessfulTests = 10
```

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/J6VR03Q4GRO12/giphy.gif)

**If applicable**:
- [x] this PR contains tests
