### PR TITLE
Fix issue with Flect pluralization

### DIFF
--- a/v2/tools/generator/internal/astmodel/type_name.go
+++ b/v2/tools/generator/internal/astmodel/type_name.go
@@ -161,7 +161,7 @@ var typeNamePluralToSingularOverrides = map[string]string{
 var typeNameSingularToPluralOverrides map[string]string
 
 // Singular returns a TypeName with the name singularized.
-func (typeName TypeName) Singular() TypeName {
+func (typeName TypeName) Singular(idFactory IdentifierFactory) TypeName {
 	// work around bug in flect: https://github.com/Azure/azure-service-operator/issues/1454
 	name := typeName.name
 	for plural, single := range typeNamePluralToSingularOverrides {
@@ -171,7 +171,10 @@ func (typeName TypeName) Singular() TypeName {
 		}
 	}
 
-	return MakeTypeName(typeName.PackageReference, flect.Singularize(typeName.name))
+	// Flect isn't consistent about what case it returns. If it's just removing an 's', it will maintain
+	// case, but if it's performing a more complicated transformation the result will be all lower case.
+	singular := idFactory.CreateIdentifier(flect.Singularize(typeName.name), Exported)
+	return MakeTypeName(typeName.PackageReference, singular)
 }
 
 // Plural returns a TypeName with the name pluralized.

--- a/v2/tools/generator/internal/astmodel/type_name_test.go
+++ b/v2/tools/generator/internal/astmodel/type_name_test.go
@@ -27,10 +27,12 @@ func TestSingular_GivesExpectedResults(t *testing.T) {
 		{"ImportServices", "ImportService"},
 		{"Exportservices", "Exportservice"},
 		{"AzureRedis", "AzureRedis"},
+		{"Aliases", "Alias"},
 	}
 
 	ref := makeTestLocalPackageReference("Demo", "v2010")
 
+	idFactory := NewIdentifierFactory()
 	for _, c := range cases {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
@@ -38,7 +40,7 @@ func TestSingular_GivesExpectedResults(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			name := MakeTypeName(ref, c.name)
-			result := name.Singular()
+			result := name.Singular(idFactory)
 			g.Expect(result.name).To(Equal(c.expected))
 		})
 	}

--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -124,7 +124,7 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 
 		// De-pluralize resource types
 		// (Must come after type aliases are resolved)
-		pipeline.ImproveResourcePluralization(),
+		pipeline.ImproveResourcePluralization(idFactory),
 
 		pipeline.StripUnreferencedTypeDefinitions(),
 

--- a/v2/tools/generator/internal/codegen/pipeline/improve_resource_pluralization.go
+++ b/v2/tools/generator/internal/codegen/pipeline/improve_resource_pluralization.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ImproveResourcePluralization improves pluralization for resources
-func ImproveResourcePluralization() *Stage {
+func ImproveResourcePluralization(idFactory astmodel.IdentifierFactory) *Stage {
 	stage := NewLegacyStage(
 		"pluralizeNames",
 		"Improve resource pluralization",
@@ -23,7 +23,7 @@ func ImproveResourcePluralization() *Stage {
 
 			for _, typeDef := range definitions {
 				if resourceType, ok := typeDef.Type().(*astmodel.ResourceType); ok {
-					newTypeName := typeDef.Name().Singular()
+					newTypeName := typeDef.Name().Singular(idFactory)
 					// check if there is already a resource with this name
 					if _, ok := definitions[newTypeName]; !ok {
 						// not found: rename the resource
@@ -33,7 +33,7 @@ func ImproveResourcePluralization() *Stage {
 
 					// Need to update owner ref too if applicable
 					if resourceType.Owner() != nil {
-						owner := resourceType.Owner().Singular()
+						owner := resourceType.Owner().Singular(idFactory)
 						resourceType = resourceType.WithOwner(&owner)
 						typeDef = typeDef.WithType(resourceType)
 					}


### PR DESCRIPTION
It doesn't return strings in the same case you passed them in. This can
result in types being named with all lowercase names, which causes build
errors since those types aren't exported.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
