### PR TITLE
Add helper method GetAPIVersion to genruntime

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -542,3 +542,16 @@ func ConvertToARMResourceImpl(
 	result := genruntime.NewARMResource(typedArmSpec, nil, armID)
 	return result, nil
 }
+
+// MustGetAPIVersion returns the ARM API version for the resource we're reconciling
+func (r *azureDeploymentReconcilerInstance) MustGetAPIVersion() string {
+	metaObject := r.Obj
+	scheme := r.ResourceResolver.Scheme()
+
+	apiVersion, err := genruntime.GetAPIVersion(metaObject, scheme)
+	if err != nil {
+		panic(err)
+	}
+
+	return apiVersion
+}

--- a/v2/pkg/genruntime/kubernetes_resource.go
+++ b/v2/pkg/genruntime/kubernetes_resource.go
@@ -81,3 +81,13 @@ func NewEmptyVersionedResourceFromGVK(scheme *runtime.Scheme, gvk schema.GroupVe
 	// Return the empty resource
 	return mo, nil
 }
+
+// GetAPIVersion returns the ARM API version that should be used with the resource
+func GetAPIVersion(metaObject ARMMetaObject, scheme *runtime.Scheme) (string, error) {
+	rsrc, err := NewEmptyVersionedResource(metaObject, scheme)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable return API version for %s", metaObject.GetObjectKind().GroupVersionKind())
+	}
+
+	return rsrc.GetAPIVersion(), nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Closes #[issue number]

**What this PR does / why we need it**:

The API version associated with a resource is the one that should always be used when making ARM REST API calls. This wasn't the case, as documented in #2416

Fixes #2416

**Special notes for your reviewer**:

Thanks to @matthchr for helping to track down the issue.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/vp122eOzO0Hxm/giphy.gif)
