### PR TITLE
Fix ADO job cluster query

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -292,7 +292,7 @@ jobs:
         scriptType: 'bash'
         scriptLocation: 'inlineScript'
         inlineScript: |
-          az resource list --tag freeforpipeline=true --query "[?type=='Microsoft.ContainerService/managedClusters'].{Name:name}" -o table > clusters.txt
+          az resource list --tag freeforpipeline=true --query "[?(type == 'Microsoft.ContainerService/managedClusters') || (type == 'microsoft.containerservice/managedclusters')].{Name:name}" -o table > clusters.txt
           clustername=$(tail -n 1 clusters.txt)
           if [ "$clustername" == "" ]; then
             echo AKS clusters unavailable


### PR DESCRIPTION
ARM apperantly now can return Type either in the correct case or
lowercase. This feels like a bug but it's not something they're fixing
anytime soon, so for now we need to work around it.
