### PR TITLE
Improve EnvTest performance by not launching so many

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
 	k8s.io/api v0.24.0-beta.0
 	k8s.io/apiextensions-apiserver v0.23.5
@@ -32,6 +33,7 @@ require (
 	k8s.io/client-go v0.24.0-beta.0
 	k8s.io/klog/v2 v2.60.1
 	sigs.k8s.io/controller-runtime v0.11.2
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -87,5 +89,4 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -688,6 +688,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/v2/internal/testcommon/kube_test_context_envtest_test.go
+++ b/v2/internal/testcommon/kube_test_context_envtest_test.go
@@ -23,9 +23,8 @@ func Test_CfgToKey_HasAllConfigDotValuesKeys(t *testing.T) {
 	testConfigType := reflect.TypeOf(testConfig{})
 
 	for i, field := range reflect.VisibleFields(testConfigType) {
-		if i == 0 && field.Name == "Values" {
-			// Skip the embedded struct - we'll check for the fields
-			// inside it.
+		// Skip the embedded struct and TerminateWhenDone field
+		if (i == 0 && field.Name == "Values") || field.Name == "CountsTowardsLimit" {
 			continue
 		}
 		g.Expect(key).To(ContainSubstring(field.Name + ":"))

--- a/v2/internal/testcommon/test_context.go
+++ b/v2/internal/testcommon/test_context.go
@@ -7,6 +7,7 @@ package testcommon
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -55,6 +56,10 @@ type PerTestContext struct {
 	NoSpaceNamer        ResourceNamer
 	TestName            string
 	Namespace           string
+	Ctx                 context.Context
+	// CountsTowardsParallelLimits true means that the envtest (if any) started for this test pass counts towards the limit of
+	// concurrent envtests running at once. If this is false, it doesn't count towards the limit.
+	CountsTowardsParallelLimits bool
 }
 
 // There are two prefixes here because each represents a resource kind with a distinct lifecycle.
@@ -133,6 +138,8 @@ func (tc TestContext) ForTest(t *testing.T) (PerTestContext, error) {
 
 	namer := tc.NameConfig.NewResourceNamer(t.Name())
 
+	context := context.Background() // we could consider using context.WithTimeout(OperationTimeout()) here
+
 	return PerTestContext{
 		TestContext:         tc,
 		T:                   t,
@@ -146,6 +153,7 @@ func (tc TestContext) ForTest(t *testing.T) (PerTestContext, error) {
 		AzureClientRecorder: recorder,
 		TestName:            t.Name(),
 		Namespace:           createTestNamespaceName(t),
+		Ctx:                 context,
 	}, nil
 }
 


### PR DESCRIPTION
* Stop envtest (kube-apiserver, etcd) when they are no longer needed.
* Prevent more than `numCores` extra envtests from being run at once. Total running should be 1 + `numCores`.