### PR TITLE
Skip generating tests using gopter for large structs

### DIFF
--- a/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
@@ -8,6 +8,7 @@ package pipeline
 import (
 	"context"
 	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/testcases"
@@ -98,6 +99,14 @@ func (s *objectSerializationTestCaseFactory) AddTestTo(def astmodel.TypeDefiniti
 	container, ok := astmodel.AsPropertyContainer(def.Type())
 	if !ok {
 		return astmodel.TypeDefinition{}, errors.Errorf("expected %s to be a property container", def.Name())
+	}
+
+	// Skip creating a test case for any object with more than 50 properties
+	// Gopter can't test these due to a Go Runtime limitation
+	// See https://github.com/golang/go/issues/54669 for more information
+	if props := container.Properties(); props.Len() > 50 {
+		klog.V(3).Infof("Skipping resource conversion test case for %s as it has %d properties", def.Name(), props.Len())
+		return def, nil
 	}
 
 	isOneOf := astmodel.OneOfFlag.IsOn(def.Type()) // this is ugly but can’t do much better right now

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/testcases"
@@ -70,6 +71,14 @@ func makeResourceConversionTestCaseFactory(idFactory astmodel.IdentifierFactory)
 func (_ *resourceConversionTestCaseFactory) NeedsTest(def astmodel.TypeDefinition) bool {
 	resourceType, ok := astmodel.AsResourceType(def.Type())
 	if !ok {
+		return false
+	}
+
+	// Skip creating a test case for any resource with more than 50 properties
+	// Gopter can't test these due to a Go Runtime limitation
+	// See https://github.com/golang/go/issues/54669 for more information
+	if props := resourceType.Properties(); props.Len() > 50 {
+		klog.V(3).Infof("Skipping resource conversion test case for %s as it has %d properties", def.Name(), props.Len())
 		return false
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Property tests using [gopter](https://github.com/leanovate/gopter) have a limitation where they panic if a struct his more than 50 fields. This is due to [a limitation of the GO runtime](https://github.com/golang/go/issues/54669). 

This PR specifically excludes these large objects from our testing, giving us a workaround for the problem.

A log line is generated for each. Exclusion so that we know that it's happening.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/fqst7AVqF6AVLlYklE/giphy.gif)

