### PR TITLE
Alternate fix for gopter tests of large objects

### DIFF
--- a/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/json_serialization_test_cases.go
@@ -7,11 +7,9 @@ package pipeline
 
 import (
 	"context"
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
-
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/testcases"
+	"github.com/pkg/errors"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
@@ -99,14 +97,6 @@ func (s *objectSerializationTestCaseFactory) AddTestTo(def astmodel.TypeDefiniti
 	container, ok := astmodel.AsPropertyContainer(def.Type())
 	if !ok {
 		return astmodel.TypeDefinition{}, errors.Errorf("expected %s to be a property container", def.Name())
-	}
-
-	// Skip creating a test case for any object with more than 50 properties
-	// Gopter can't test these due to a Go Runtime limitation
-	// See https://github.com/golang/go/issues/54669 for more information
-	if props := container.Properties(); props.Len() > 50 {
-		klog.V(3).Infof("Skipping resource conversion test case for %s as it has %d properties", def.Name(), props.Len())
-		return def, nil
 	}
 
 	isOneOf := astmodel.OneOfFlag.IsOn(def.Type()) // this is ugly but can’t do much better right now

--- a/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/property_assignment_test_cases.go
@@ -6,14 +6,12 @@
 package pipeline
 
 import (
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
-
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/functions"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/testcases"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // InjectPropertyAssignmentTestsID is the unique identifier for this stage
@@ -65,16 +63,6 @@ func makePropertyAssignmentTestCaseFactory(idFactory astmodel.IdentifierFactory)
 }
 
 func (s *propertyAssignmentTestCaseFactory) NeedsTest(def astmodel.TypeDefinition) bool {
-	// Skip creating a test case for any object with more than 50 properties
-	// Gopter can't test these due to a Go Runtime limitation
-	// See https://github.com/golang/go/issues/54669 for more information
-	if pc, ok := astmodel.AsPropertyContainer(def.Type()); ok {
-		if props := pc.Properties(); props.Len() > 50 {
-			klog.V(3).Infof("Skipping resource conversion test case for %s as it has %d properties", def.Name(), props.Len())
-			return false
-		}
-	}
-
 	container, ok := astmodel.AsFunctionContainer(def.Type())
 	if !ok {
 		return false

--- a/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
+++ b/v2/tools/generator/internal/codegen/pipeline/resource_conversion_test_cases.go
@@ -6,13 +6,11 @@
 package pipeline
 
 import (
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/testcases"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
-
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
-	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/testcases"
 )
 
 // InjectResourceConversionTestsID is the unique identifier for this stage
@@ -71,14 +69,6 @@ func makeResourceConversionTestCaseFactory(idFactory astmodel.IdentifierFactory)
 func (_ *resourceConversionTestCaseFactory) NeedsTest(def astmodel.TypeDefinition) bool {
 	resourceType, ok := astmodel.AsResourceType(def.Type())
 	if !ok {
-		return false
-	}
-
-	// Skip creating a test case for any resource with more than 50 properties
-	// Gopter can't test these due to a Go Runtime limitation
-	// See https://github.com/golang/go/issues/54669 for more information
-	if props := resourceType.Properties(); props.Len() > 50 {
-		klog.V(3).Infof("Skipping resource conversion test case for %s as it has %d properties", def.Name(), props.Len())
 		return false
 	}
 

--- a/v2/tools/generator/internal/testcases/json_serialization_test_case.go
+++ b/v2/tools/generator/internal/testcases/json_serialization_test_case.go
@@ -645,6 +645,7 @@ func (o *JSONSerializationTestCase) createGenerators(
 	return result
 }
 
+// createIndependentGenerator creates an independent generator for a property whose type is
 // is directly supported by a Gopter generator, returning nil if the property type isn't supported.
 func (o *JSONSerializationTestCase) createIndependentGenerator(
 	name string,
@@ -709,6 +710,7 @@ func (o *JSONSerializationTestCase) createIndependentGenerator(
 	return nil
 }
 
+// createIndependentGenerator creates a generator for a property whose type is
 // defined within the current package, returning nil if the property type isn't supported.
 func (o *JSONSerializationTestCase) createRelatedGenerator(
 	name string,

--- a/v2/tools/generator/internal/testcases/json_serialization_test_case.go
+++ b/v2/tools/generator/internal/testcases/json_serialization_test_case.go
@@ -710,7 +710,7 @@ func (o *JSONSerializationTestCase) createIndependentGenerator(
 	return nil
 }
 
-// createIndependentGenerator creates a generator for a property whose type is
+// createRelatedGenerator creates a generator for a property whose type is
 // defined within the current package, returning nil if the property type isn't supported.
 func (o *JSONSerializationTestCase) createRelatedGenerator(
 	name string,


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses the issue of gopter tests for large objects by skipping primitive properties (strings ints, etc).

Tested by merge into @super-harsh's branch `feature/azure-functions`.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/4T7e4DmcrP9du/giphy.gif)

