### PR TITLE
Limit concurrency of CI builds

### DIFF
--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Run integration tests
         run: |
           container_id=${{steps.devcontainer.outputs.id}}
-          docker exec -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID "$container_id" task controller:ci-integration-tests
+          docker exec -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID "$container_id" task controller:ci-integration-tests --concurrency 1 # limit concurrency because build machines are small
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -96,7 +96,7 @@ jobs:
           container_id=${{steps.devcontainer.outputs.id}}
 
           set +e # don't exit instantly on failure, we need to produce Markdown summary
-          docker exec "$container_id" task ci
+          docker exec "$container_id" task ci --concurrency 1 # limit concurrency because build machines are small
           EXIT_CODE=$?
           set -e
 
@@ -114,8 +114,8 @@ jobs:
       - name: Build docker image & build configuration YAML
         run: |
           container_id=${{steps.devcontainer.outputs.id}}
-          docker exec "$container_id" task controller:docker-build-and-save
-          docker exec "$container_id" task controller:run-kustomize-for-envtest
+          docker exec "$container_id" task controller:docker-build-and-save --concurrency 1 # limit concurrency because build machines are small
+          docker exec "$container_id" task controller:run-kustomize-for-envtest --concurrency 1 # limit concurrency because build machines are small
 
       - name: Archive outputs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
**What this PR does / why we need it**:

Limits the concurrency of CI builds because the build machines are small and we suspect we are overloading them.

**Special notes for your reviewer**:

I'm hoping the CI build for this PR will run with the workflow modification included. If it doesn't, we'll need to merge this, and then run some tests.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/kkYbDLFmNvO4E/giphy.gif)
