### PR TITLE
Address lint issues

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -174,7 +174,7 @@ fi
 write-verbose "Checking for $TOOL_DEST/go-task"
 if should-install "$TOOL_DEST/task"; then 
     write-info "Installing go-task"
-    curl -sL "https://github.com/go-task/task/releases/download/v3.12.1/task_linux_amd64.tar.gz" | tar xz -C "$TOOL_DEST" task
+    curl -sL "https://github.com/go-task/task/releases/download/v3.14.1/task_linux_amd64.tar.gz" | tar xz -C "$TOOL_DEST" task
 fi
 
 # Install Trivy

--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -210,6 +210,13 @@ if should-install "$TOOL_DEST/cmctl"; then
     curl -L "https://github.com/jetstack/cert-manager/releases/latest/download/cmctl-${os}-${arch}.tar.gz" | tar -xz -C "$TOOL_DEST"
 fi
 
+# Ensure tooling for Hugo is available
+write-verbose "Checking for /usr/bin/postcss"
+if should-install "/usr/bin/postcss"; then 
+    write-info "Installing postcss"
+    sudo npm install -g postcss postcss-cli autoprefixer
+fi
+
 if [ "$VERBOSE" == true ]; then 
     echo "Installed tools: $(ls "$TOOL_DEST")"
 fi

--- a/v2/internal/reconcilers/common.go
+++ b/v2/internal/reconcilers/common.go
@@ -52,6 +52,7 @@ func LogObj(log logr.Logger, level int, note string, obj genruntime.MetaObject) 
 		// Log just what we're interested in. We avoid logging the whole obj
 		// due to possible risk of disclosing secrets or other data that is "private" and users may
 		// not want in logs.
+		// nolint: logrlint // We can see the keys and values, above, but the linter can't
 		log.V(level).Info(note, keysAndValues...)
 	}
 }

--- a/v2/internal/set/set_test.go
+++ b/v2/internal/set/set_test.go
@@ -50,6 +50,7 @@ func (s *S) M() {}
 var _ I = &S{}
 
 type cloningMap[K comparable, V any] struct {
+	//nolint:structcheck // 2022-09 incorrectly flaggging inner as unused
 	inner map[K]V
 }
 

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -329,6 +329,7 @@ func (set *sharedEnvTests) getEnvTestForConfig(ctx context.Context, cfg testConf
 	defer set.envtestLock.Unlock()
 	logger.V(2).Info("Starting envtest")
 	// no envtest exists for this config; make one
+	// nolint: contextcheck // 2022-09 @unrepentantgeek Seems to be a false positive
 	newEnvTest, err := createSharedEnvTest(cfg, set.namespaceResources)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shared envtest environment")

--- a/v2/tools/generator/internal/codegen/debug_reporter.go
+++ b/v2/tools/generator/internal/codegen/debug_reporter.go
@@ -25,7 +25,6 @@ import (
 type debugReporter struct {
 	outputFolder  string
 	groupSelector config.StringMatcher
-	priorText     string
 }
 
 // newDebugReporter creates a new debugReporter.

--- a/v2/tools/generator/internal/readonly/readonly_map.go
+++ b/v2/tools/generator/internal/readonly/readonly_map.go
@@ -8,6 +8,7 @@ package readonly
 import "golang.org/x/exp/maps"
 
 type Map[K comparable, V any] struct {
+	//nolint:structcheck // 2022-09 incorrectly flaggging inner as unused
 	inner map[K]V
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It appears the version of `golangci` in our base image has been updated.

The linter `structcheck` is giving us two new lint messages - one is valid (and fixed in this PR), the other is not (and is suppressed).

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/TYKOdOASPBVjW/giphy.gif)
