### PR TITLE
Fix: Add non-default serviceAccount to multi-tenant file creation

### DIFF
--- a/scripts/make-multitenant-cluster.sh
+++ b/scripts/make-multitenant-cluster.sh
@@ -17,10 +17,10 @@ deployment='(.kind == "Deployment" and .metadata.name == "azureserviceoperator-c
 certificate='.kind == "Certificate"'
 issuer='.kind == "Issuer"'
 webhooks='(.kind == "MutatingWebhookConfiguration" or .kind == "ValidatingWebhookConfiguration")'
-query="select($crd or $namespace or $cluster_role or $leader_election_role or $leader_election_binding or $service or $deployment or $certificate or $issuer or $webhooks or $proxy_binding)"
+serviceaccount='.kind == "ServiceAccount"'
+query="select($crd or $namespace or $cluster_role or $leader_election_role or $leader_election_binding or $service or $deployment or $certificate or $issuer or $webhooks or $proxy_binding or $serviceaccount)"
 
 yq eval "$query" "$source" > "$target"
-
 
 # Edit the deployment to run the ASO binary in webhooks-only mode.
 # Remove the aadpodidbinding label - this is only needed for communicating to ARM

--- a/scripts/make-multitenant-tenant.sh
+++ b/scripts/make-multitenant-tenant.sh
@@ -15,7 +15,8 @@ leader_election_role='(.kind == "Role" and .metadata.name == "azureserviceoperat
 leader_election_binding='(.kind == "RoleBinding" and .metadata.name == "azureserviceoperator-leader-election-rolebinding")'
 manager_role_binding='(.kind == "ClusterRoleBinding" and .metadata.name == "azureserviceoperator-manager-rolebinding")'
 deployment='(.kind == "Deployment" and .metadata.name == "azureserviceoperator-controller-manager")'
-query="select($namespace or $leader_election_role or $leader_election_binding or $manager_role_binding or $deployment)"
+serviceaccount='.kind == "ServiceAccount"'
+query="select($namespace or $leader_election_role or $leader_election_binding or $manager_role_binding or $deployment or $serviceaccount)"
 
 yq eval "$query" "$source" > "$target"
 
@@ -34,6 +35,7 @@ inplace_edit "(select($leader_election_role or $leader_election_binding or $depl
 # Update the subject namespaces for the bindings so they refer to the
 # service account in the tenant namespace
 inplace_edit "(select($leader_election_binding or $manager_role_binding).subjects[0].namespace) = \"$tenant_namespace\""
+inplace_edit "(select($serviceaccount).metadata.namespace) = \"$tenant_namespace\""
 
 # Rename the cluster role binding so bindings for different tenants
 # can coexist.


### PR DESCRIPTION

**What this PR does / why we need it**:

Multi-tenant deployment was failing due to `serviceAccountName` and non default `ServiceAccount` added in #2464. This PR includes fix to include the new service account added in the multi-tenant files creation. 

**Special notes for your reviewer**:

Integration tests should pass now. Mainly figured this out when `controller:kind-create-multitenant-cluster` target failed on the other PR after merging main. 
