### PR TITLE
Fix CRD naming to maintain uniqueness

### DIFF
--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -109,7 +109,7 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 		pipeline.NameTypesForCRD(idFactory),
 
 		// Apply property type rewrites from the config file
-		// Must come after NameTypesForCRD ('nameTypes)' and ConvertAllOfAndOneOfToObjects ('allof-anyof-objects') so
+		// Must come after NameTypesForCRD ('nameTypes') and ConvertAllOfAndOneOfToObjects ('allof-anyof-objects') so
 		// that objects are all expanded
 		pipeline.ApplyPropertyRewrites(configuration),
 

--- a/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
+++ b/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
@@ -161,14 +161,14 @@ func nameInnerTypes(
 	builder.VisitResourceType = func(this *astmodel.TypeVisitor, it *astmodel.ResourceType, ctx interface{}) (astmodel.Type, error) {
 		hint := ctx.(nameHint)
 
-		spec, err := this.Visit(it.SpecType(), hint.WithSuffix(astmodel.SpecSuffix))
+		spec, err := this.Visit(it.SpecType(), hint.WithSuffixPart(astmodel.SpecSuffix))
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to name spec type %s", it.SpecType())
 		}
 
 		var status astmodel.Type
 		if it.StatusType() != nil {
-			status, err = this.Visit(it.StatusType(), hint.WithSuffix(astmodel.StatusSuffix))
+			status, err = this.Visit(it.StatusType(), hint.WithSuffixPart(astmodel.StatusSuffix))
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to name status type %s", it.StatusType())
 			}
@@ -238,10 +238,16 @@ func (n nameHint) WithBasePart(part string) nameHint {
 	}
 }
 
-func (n nameHint) WithSuffix(suffix string) nameHint {
+func (n nameHint) WithSuffixPart(suffix string) nameHint {
+
+	newSuffix := strings.TrimPrefix(suffix, "_")
+	if n.suffix != "" {
+		newSuffix = n.suffix + "_" + newSuffix
+	}
+
 	return nameHint{
 		baseName: n.baseName,
-		suffix:   strings.TrimPrefix(suffix, "_"),
+		suffix:   newSuffix,
 	}
 }
 

--- a/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
+++ b/v2/tools/generator/internal/codegen/pipeline/name_types_for_crd.go
@@ -39,9 +39,8 @@ func NameTypesForCRD(idFactory astmodel.IdentifierFactory) *Stage {
 					return nil, errors.Wrapf(err, "failed to name inner definitions")
 				}
 
-				err = result.AddAllAllowDuplicates(newDefs)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to add new definitions")
+				for _, def := range newDefs {
+					result.Add(def)
 				}
 
 				if _, ok := result[typeName]; !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered by @super-harsh while adding support for Azure Functions in PR #2465, floating the suffix to the end of each TypeName introduced duplicates, aborting the generator mid flow.

The specific problem occurs because of the way some resources in the `web` group embed other resources:

Without suffix floating, the behaviour was this. We start with the resource `Sites_Config`:
```
├── Sites_Config: Resource
│   ├── Spec: Sites_Config_Spec
│   └── Status: Error[<missing>]Ignore the Error, it's a red herring.
```

where `Sites_Config_Spec` is an object type with just one property:
```
├── Sites_Config_Spec: Object[Flag:oneof]
│   └── ResourceBase: *Sites_Config_Spec_ResourceBase
```

In turn, the `ResourceBase` property is itself a resource:
```
├── Sites_Config_Spec_ResourceBase: Resource
│   ├── Spec: Sites_Config_Spec_ResourceBase_Spec
│   └── Status: Error[<missing>]
```

Notice how the old behaviour of naming led to two occurrences of `_Spec` in the name of that spec type.

By floating the suffix to the end (and eliminating duplicates), we ended up with multiple types named `Sites_Config_ResourceBase_Spec`.

The fix is simple. Given we already have a later pipeline stage to remove oddly embedded resources like this, the only problem we have here is around name duplication. Modifying `nameHint` to allow duplicates results in this type temporarily being named `Sites_Config_ResourceBase_Spec_Spec`, until it's removed from our object graph.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/1kh3Tjz9EBmU3uwpdP/giphy.gif)
