### PR TITLE
Use KubernetesExporter interface rather than AzureSecrets extension

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -327,7 +327,10 @@ tasks:
     deps: [controller:run-kustomize-for-envtest]
     cmds:
     # -race fails at the moment in controller-runtime
+    # We run these in sequence right now because it doesn't gain us much speed to go in parallel
     - go test -timeout {{.TIMEOUT}} -run '{{default ".*" .TEST_FILTER}}' {{.VERBOSE}} ./internal/controllers
+    - go test -timeout {{.TIMEOUT}} -run '{{default ".*" .TEST_FILTER}}' {{.VERBOSE}} ./pkg/genruntime/test
+    - go test -timeout {{.TIMEOUT}} -run '{{default ".*" .TEST_FILTER}}' {{.VERBOSE}} ./internal/genericarmclient
     vars:
       VERBOSE:
         sh: if [ $TEST_FILTER ];  then echo "-v"; fi
@@ -350,8 +353,20 @@ tasks:
         vars:
           INPUT_FILE: '{{.TEST_OUT}}/controller-integration-tests.json'
           OUTPUT_FILE: '{{.TEST_OUT}}/controller-integration-tests.md'
+    - defer: # want to run even on failure
+        task: produce-markdown-summary
+        vars:
+          INPUT_FILE: '{{.TEST_OUT}}/controller-integration-genruntime-tests.json'
+          OUTPUT_FILE: '{{.TEST_OUT}}/controller-integration-genruntime-tests.md'
+    - defer: # want to run even on failure
+        task: produce-markdown-summary
+        vars:
+          INPUT_FILE: '{{.TEST_OUT}}/controller-integration-genericarmclient-tests.json'
+          OUTPUT_FILE: '{{.TEST_OUT}}/controller-integration-genericarmclient-tests.md'
     # -race fails at the moment in controller-runtime
     - go test -covermode atomic -coverprofile=coverage-integration-envtest.out -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./internal/controllers > '{{.TEST_OUT}}/controller-integration-tests.json'
+    - go test -covermode atomic -coverprofile=coverage-integration-genruntime-envtest.out -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./pkg/genruntime/test > '{{.TEST_OUT}}/controller-integration-genruntime-tests.json'
+    - go test -covermode atomic -coverprofile=coverage-integration-genericarmclient-envtest.out -coverpkg="./..." -json -timeout 15m -run '{{default ".*" .TEST_FILTER}}' ./internal/genericarmclient > '{{.TEST_OUT}}/controller-integration-genericarmclient-tests.json'
 
   controller:test-integration-envtest-live:
     desc: Run integration tests with envtest against live data and output coverage.

--- a/v2/api/containerservice/customizations/managed_cluster_extensions.go
+++ b/v2/api/containerservice/customizations/managed_cluster_extensions.go
@@ -12,23 +12,23 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	containerservice "github.com/Azure/azure-service-operator/v2/api/containerservice/v1beta20210501storage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
-var _ extensions.SecretsRetriever = &ManagedClusterExtension{}
+var _ genruntime.KubernetesExporter = &ManagedClusterExtension{}
 
-func (ext *ManagedClusterExtension) RetrieveSecrets(
+func (ext *ManagedClusterExtension) ExportKubernetesResources(
 	ctx context.Context,
-	obj genruntime.ARMMetaObject,
+	obj genruntime.MetaObject,
 	armClient *genericarmclient.GenericClient,
-	log logr.Logger) ([]*v1.Secret, error) {
+	log logr.Logger) ([]client.Object, error) {
 
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -47,7 +47,7 @@ func (ext *ManagedClusterExtension) RetrieveSecrets(
 		return nil, nil
 	}
 
-	id, err := genruntime.GetAndParseResourceID(obj)
+	id, err := genruntime.GetAndParseResourceID(typedObj)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (ext *ManagedClusterExtension) RetrieveSecrets(
 	var adminCredentials string
 	if hasAdminCreds {
 		var resp armcontainerservice.ManagedClustersClientListClusterAdminCredentialsResponse
-		resp, err = mcClient.ListClusterAdminCredentials(ctx, id.ResourceGroupName, obj.AzureName(), nil)
+		resp, err = mcClient.ListClusterAdminCredentials(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed listing admin credentials")
 		}
@@ -80,7 +80,7 @@ func (ext *ManagedClusterExtension) RetrieveSecrets(
 	var userCredentials string
 	if hasUserCreds {
 		var resp armcontainerservice.ManagedClustersClientListClusterUserCredentialsResponse
-		resp, err = mcClient.ListClusterUserCredentials(ctx, id.ResourceGroupName, obj.AzureName(), nil)
+		resp, err = mcClient.ListClusterUserCredentials(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed listing admin credentials")
 		}
@@ -96,7 +96,7 @@ func (ext *ManagedClusterExtension) RetrieveSecrets(
 		return nil, err
 	}
 
-	return secretSlice, nil
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
 }
 
 func secretsSpecified(obj *containerservice.ManagedCluster) (bool, bool) {

--- a/v2/api/dbformariadb/customizations/server_extensions.go
+++ b/v2/api/dbformariadb/customizations/server_extensions.go
@@ -12,24 +12,23 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	mariadb "github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1beta20180601storage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
-var _ extensions.SecretsRetriever = &ServerExtension{}
+var _ genruntime.KubernetesExporter = &ServerExtension{}
 
-// RetrieveSecrets implements extensions.SecretsRetriever
-func (ext *ServerExtension) RetrieveSecrets(
+func (ext *ServerExtension) ExportKubernetesResources(
 	ctx context.Context,
-	obj genruntime.ARMMetaObject,
+	obj genruntime.MetaObject,
 	armClient *genericarmclient.GenericClient,
-	log logr.Logger) ([]*v1.Secret, error) {
+	log logr.Logger) ([]client.Object, error) {
 
 	// This has to be the current storage version. It will need to be updated
 	// if the storage version changes.
@@ -53,7 +52,7 @@ func (ext *ServerExtension) RetrieveSecrets(
 		return nil, err
 	}
 
-	return secretSlice, nil
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
 }
 
 func secretsSpecified(obj *mariadb.Server) bool {

--- a/v2/api/dbformysql/customizations/flexible_server_extensions.go
+++ b/v2/api/dbformysql/customizations/flexible_server_extensions.go
@@ -11,24 +11,24 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	mysql "github.com/Azure/azure-service-operator/v2/api/dbformysql/v1beta20210501storage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
-var _ extensions.SecretsRetriever = &FlexibleServerExtension{}
+var _ genruntime.KubernetesExporter = &FlexibleServerExtension{}
 
-func (ext *FlexibleServerExtension) RetrieveSecrets(
+func (ext *FlexibleServerExtension) ExportKubernetesResources(
 	ctx context.Context,
-	obj genruntime.ARMMetaObject,
+	obj genruntime.MetaObject,
 	armClient *genericarmclient.GenericClient,
-	log logr.Logger) ([]*v1.Secret, error) {
+	log logr.Logger) ([]client.Object, error) {
 
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -52,7 +52,7 @@ func (ext *FlexibleServerExtension) RetrieveSecrets(
 		return nil, err
 	}
 
-	return secretSlice, nil
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
 }
 
 func secretsSpecified(obj *mysql.FlexibleServer) bool {

--- a/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
+++ b/v2/api/dbforpostgresql/customizations/flexible_server_extensions.go
@@ -12,23 +12,23 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	postgresql "github.com/Azure/azure-service-operator/v2/api/dbforpostgresql/v1beta20210601storage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
-var _ extensions.SecretsRetriever = &FlexibleServerExtension{}
+var _ genruntime.KubernetesExporter = &FlexibleServerExtension{}
 
-func (ext *FlexibleServerExtension) RetrieveSecrets(
+func (ext *FlexibleServerExtension) ExportKubernetesResources(
 	ctx context.Context,
-	obj genruntime.ARMMetaObject,
+	obj genruntime.MetaObject,
 	armClient *genericarmclient.GenericClient,
-	log logr.Logger) ([]*v1.Secret, error) {
+	log logr.Logger) ([]client.Object, error) {
 
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -52,7 +52,7 @@ func (ext *FlexibleServerExtension) RetrieveSecrets(
 		return nil, err
 	}
 
-	return secretSlice, nil
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
 }
 
 func secretsSpecified(obj *postgresql.FlexibleServer) bool {

--- a/v2/api/documentdb/customizations/database_account_extensions.go
+++ b/v2/api/documentdb/customizations/database_account_extensions.go
@@ -13,23 +13,23 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	documentdb "github.com/Azure/azure-service-operator/v2/api/documentdb/v1beta20210515storage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
-var _ extensions.SecretsRetriever = &DatabaseAccountExtension{}
+var _ genruntime.KubernetesExporter = &DatabaseAccountExtension{}
 
-func (ext *DatabaseAccountExtension) RetrieveSecrets(
+func (ext *DatabaseAccountExtension) ExportKubernetesResources(
 	ctx context.Context,
-	obj genruntime.ARMMetaObject,
+	obj genruntime.MetaObject,
 	armClient *genericarmclient.GenericClient,
-	log logr.Logger) ([]*v1.Secret, error) {
+	log logr.Logger) ([]client.Object, error) {
 
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -48,7 +48,7 @@ func (ext *DatabaseAccountExtension) RetrieveSecrets(
 		return nil, nil
 	}
 
-	id, err := genruntime.GetAndParseResourceID(obj)
+	id, err := genruntime.GetAndParseResourceID(typedObj)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (ext *DatabaseAccountExtension) RetrieveSecrets(
 		// TODO: There is a ListReadOnlyKeys API that requires less permissions. We should consider determining
 		// TODO: that we don't need to call the ListKeys API and install call the listReadOnlyKeys API.
 		var resp armcosmos.DatabaseAccountsClientListKeysResponse
-		resp, err = acctClient.ListKeys(ctx, id.ResourceGroupName, obj.AzureName(), nil)
+		resp, err = acctClient.ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed listing keys")
 		}
@@ -81,7 +81,7 @@ func (ext *DatabaseAccountExtension) RetrieveSecrets(
 		return nil, err
 	}
 
-	return secretSlice, nil
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
 }
 
 func secretsSpecified(obj *documentdb.DatabaseAccount) (bool, bool) {

--- a/v2/api/servicebus/customizations/namespace_extensions.go
+++ b/v2/api/servicebus/customizations/namespace_extensions.go
@@ -12,23 +12,23 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	servicebus "github.com/Azure/azure-service-operator/v2/api/servicebus/v1beta20210101previewstorage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
-var _ extensions.SecretsRetriever = &NamespaceExtension{}
+var _ genruntime.KubernetesExporter = &NamespaceExtension{}
 
-func (ext *NamespaceExtension) RetrieveSecrets(
+func (ext *NamespaceExtension) ExportKubernetesResources(
 	ctx context.Context,
-	obj genruntime.ARMMetaObject,
+	obj genruntime.MetaObject,
 	armClient *genericarmclient.GenericClient,
-	log logr.Logger) ([]*v1.Secret, error) {
+	log logr.Logger) ([]client.Object, error) {
 
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -55,7 +55,7 @@ func (ext *NamespaceExtension) RetrieveSecrets(
 		return nil, err
 	}
 
-	return secretSlice, nil
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
 }
 
 func secretsSpecified(obj *servicebus.Namespace) bool {

--- a/v2/api/storage/customizations/storage_account_extensions.go
+++ b/v2/api/storage/customizations/storage_account_extensions.go
@@ -13,23 +13,23 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	storage "github.com/Azure/azure-service-operator/v2/api/storage/v1beta20210401storage"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/secrets"
 )
 
-var _ extensions.SecretsRetriever = &StorageAccountExtension{}
+var _ genruntime.KubernetesExporter = &StorageAccountExtension{}
 
-func (ext *StorageAccountExtension) RetrieveSecrets(
+func (ext *StorageAccountExtension) ExportKubernetesResources(
 	ctx context.Context,
-	obj genruntime.ARMMetaObject,
+	obj genruntime.MetaObject,
 	armClient *genericarmclient.GenericClient,
-	log logr.Logger) ([]*v1.Secret, error) {
+	log logr.Logger) ([]client.Object, error) {
 
 	// This has to be the current hub storage version. It will need to be updated
 	// if the hub storage version changes.
@@ -48,7 +48,7 @@ func (ext *StorageAccountExtension) RetrieveSecrets(
 		return nil, nil
 	}
 
-	id, err := genruntime.GetAndParseResourceID(obj)
+	id, err := genruntime.GetAndParseResourceID(typedObj)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (ext *StorageAccountExtension) RetrieveSecrets(
 		}
 
 		var resp armstorage.AccountsClientListKeysResponse
-		resp, err = acctClient.ListKeys(ctx, id.ResourceGroupName, obj.AzureName(), nil)
+		resp, err = acctClient.ListKeys(ctx, id.ResourceGroupName, typedObj.AzureName(), nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed listing keys")
 		}
@@ -79,7 +79,7 @@ func (ext *StorageAccountExtension) RetrieveSecrets(
 		return nil, err
 	}
 
-	return secretSlice, nil
+	return secrets.SliceToClientObjectSlice(secretSlice), nil
 }
 
 func secretsSpecified(obj *storage.StorageAccount) (bool, bool) {

--- a/v2/internal/testcommon/kube_per_test_context.go
+++ b/v2/internal/testcommon/kube_per_test_context.go
@@ -648,6 +648,12 @@ func (tc *KubePerTestContext) AsExtensionOwner(obj client.Object) *genruntime.Ar
 	}
 }
 
+// KubeClient returns the KubeClient for the test context. The existing TestContext helpers (tc.Resource(), etc) should
+// be used unless you need a raw KubeClient.
+func (tc *KubePerTestContext) KubeClient() client.Client {
+	return tc.kubeClient
+}
+
 func (tc *KubePerTestContext) ExportAsSample(resource client.Object) {
 	tc.T.Helper()
 

--- a/v2/pkg/genruntime/extensions/kubernetes_exporter.go
+++ b/v2/pkg/genruntime/extensions/kubernetes_exporter.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package extensions
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+)
+
+// This file contains helpers for exporting Kubernetes resources via extensions
+
+type KubernetesExportFunc = func(obj genruntime.MetaObject) ([]client.Object, error)
+
+// CreateKubernetesExporter creates a function to create Kubernetes resources. If the resource
+// in question has not been configured with the genruntime.KubernetesExporter interface, the returned function
+// is a no-op.
+func CreateKubernetesExporter(
+	ctx context.Context,
+	host genruntime.ResourceExtension,
+	armClient *genericarmclient.GenericClient,
+	log logr.Logger) KubernetesExportFunc {
+
+	impl, ok := host.(genruntime.KubernetesExporter)
+	if !ok {
+		return func(obj genruntime.MetaObject) ([]client.Object, error) {
+			return nil, nil
+		}
+	}
+
+	return func(obj genruntime.MetaObject) ([]client.Object, error) {
+		log.V(Info).Info("Getting Kubernetes resources for export")
+		resources, err := impl.ExportKubernetesResources(ctx, obj, armClient, log)
+		if err != nil {
+			return resources, err
+		}
+
+		log.V(Info).Info(
+			"Successfully retrieved Kubernetes resources for export",
+			"ResourcesToWrite", len(resources))
+
+		return resources, nil
+	}
+}

--- a/v2/pkg/genruntime/kubernetes_exporter.go
+++ b/v2/pkg/genruntime/kubernetes_exporter.go
@@ -14,16 +14,14 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 )
 
-// TODO: ConfigMap stuff
-// TODO: how is the handling going to work... I guess we need an optional interface in genruntime?
-// TODO: can we use that same interface for secrets?
-// TODO: ExportsKubernetesResources or something like that... yea I like this
-// TODO: Problem is that secrets calls need to actually go to Azure, whereas other exports may not
-
+// KubernetesExporter defines a resource which can create other resources in Kubernetes.
 type KubernetesExporter interface {
+	// ExportKubernetesResources provides a list of Kubernetes resource for the operator to create once the resource which
+	// implements this interface is successfully provisioned. This method is invoked once a resource has been
+	// successfully created in Azure, but before the Ready condition has been marked successful.
 	ExportKubernetesResources(
 		ctx context.Context,
-		obj MetaObject, // TODO: The metaObject parameter is pointless unless we're reusing this as an extension too, since the type implementing this should be the storage type...
+		obj MetaObject,
 		armClient *genericarmclient.GenericClient,
 		log logr.Logger) ([]client.Object, error)
 }

--- a/v2/pkg/genruntime/kubernetes_exporter.go
+++ b/v2/pkg/genruntime/kubernetes_exporter.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package genruntime
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+)
+
+// TODO: ConfigMap stuff
+// TODO: how is the handling going to work... I guess we need an optional interface in genruntime?
+// TODO: can we use that same interface for secrets?
+// TODO: ExportsKubernetesResources or something like that... yea I like this
+// TODO: Problem is that secrets calls need to actually go to Azure, whereas other exports may not
+
+type KubernetesExporter interface {
+	ExportKubernetesResources(
+		ctx context.Context,
+		obj MetaObject, // TODO: The metaObject parameter is pointless unless we're reusing this as an extension too, since the type implementing this should be the storage type...
+		armClient *genericarmclient.GenericClient,
+		log logr.Logger) ([]client.Object, error)
+}

--- a/v2/pkg/genruntime/owner.go
+++ b/v2/pkg/genruntime/owner.go
@@ -6,8 +6,16 @@
 package genruntime
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"context"
+	"reflect"
 
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/Azure/azure-service-operator/v2/internal/ownerutil"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
 )
 
@@ -32,4 +40,63 @@ func CheckTargetOwnedByObj(obj client.Object, target client.Object) error {
 	}
 
 	return nil
+}
+
+// ApplyObjAndEnsureOwner applies the object (similar to kubectl apply). If the object does not exist
+// it is created. If it exists, it is updated.
+func ApplyObjAndEnsureOwner(ctx context.Context, c client.Client, owner client.Object, obj client.Object) (controllerutil.OperationResult, error) {
+	updatedObj := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(client.Object) // TODO: How risky is this from a panic perspective?
+	updatedObj.SetNamespace(obj.GetNamespace())
+	updatedObj.SetName(obj.GetName())
+
+	objProps, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return controllerutil.OperationResultNone, errors.Wrapf(err, "failed to convert obj to unstructured")
+	}
+
+	result, err := controllerutil.CreateOrUpdate(ctx, c, updatedObj, func() error {
+		// If the secret exists but isn't owned by our resource then it must have been created
+		// by the user. We want to avoid overwriting or otherwise modifying secrets of theirs.
+		if updatedObj.GetResourceVersion() != "" {
+			if err = CheckTargetOwnedByObj(owner, updatedObj); err != nil {
+				return err
+			}
+		}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(objProps, updatedObj)
+		if err != nil {
+			return errors.Wrap(err, "failed to convert unstructured to obj")
+		}
+
+		ownerRef := ownerutil.MakeOwnerReference(owner)
+		updatedObj.SetOwnerReferences(ownerutil.EnsureOwnerRef(updatedObj.GetOwnerReferences(), ownerRef))
+		return nil
+	})
+	if err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+
+	return result, nil
+}
+
+// ApplyObjsAndEnsureOwner applies the specified collection of objects (similar to kubectl apply). If the objects do not exist
+// they are created. If they exist, they are updated. An attempt is made to apply each object before returning an error.
+func ApplyObjsAndEnsureOwner(ctx context.Context, client client.Client, owner client.Object, objs []client.Object) ([]controllerutil.OperationResult, error) {
+	var errs []error
+	results := make([]controllerutil.OperationResult, 0, len(objs))
+
+	for _, secret := range objs {
+		result, err := ApplyObjAndEnsureOwner(ctx, client, owner, secret)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		results = append(results, result)
+	}
+
+	err := kerrors.NewAggregate(errs)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
 }

--- a/v2/pkg/genruntime/owner_test.go
+++ b/v2/pkg/genruntime/owner_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package genruntime_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+)
+
+func Test_ApplyObjAndEnsureOwner(t *testing.T) {
+	t.Parallel()
+
+	tc := globalTestContext.ForTest(t)
+
+	owner := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myconfigmap",
+			Namespace: tc.Namespace,
+		},
+	}
+	tc.CreateResource(owner)
+
+	// Manually set TypeMeta stuff
+	owner.Kind = "ConfigMap"
+	owner.APIVersion = "v1"
+
+	obj := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mysecret",
+			Namespace: tc.Namespace,
+		},
+		StringData: map[string]string{
+			"a": "b",
+		},
+	}
+	result, err := genruntime.ApplyObjAndEnsureOwner(tc.Ctx, tc.KubeClient(), owner, obj)
+	tc.Expect(err).ToNot(HaveOccurred())
+	tc.Expect(result).To(Equal(controllerutil.OperationResultCreated))
+
+	var storedObj v1.Secret
+	tc.GetResource(types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, &storedObj)
+	tc.Expect(storedObj.Data).ToNot(BeNil())
+	tc.Expect(storedObj.Data).To(HaveLen(1)) // Only 1 key should be here
+	tc.Expect(storedObj.Data).To(HaveKey("a"))
+	tc.Expect(storedObj.Data["a"]).To(Equal([]byte("b")))
+
+	// Update Obj
+	obj.StringData = map[string]string{
+		"c": "d",
+	}
+	result, err = genruntime.ApplyObjAndEnsureOwner(tc.Ctx, tc.KubeClient(), owner, obj)
+	tc.Expect(err).ToNot(HaveOccurred())
+	tc.Expect(result).To(Equal(controllerutil.OperationResultUpdated))
+
+	tc.GetResource(client.ObjectKey{Namespace: obj.Namespace, Name: obj.Name}, &storedObj)
+	tc.Expect(storedObj.Data).ToNot(BeNil())
+	tc.Expect(storedObj.Data).To(HaveLen(1)) // Only 1 key should be here
+	tc.Expect(storedObj.Data).To(HaveKey("c"))
+	tc.Expect(storedObj.Data["c"]).To(Equal([]byte("d")))
+}

--- a/v2/pkg/genruntime/secrets/secrets.go
+++ b/v2/pkg/genruntime/secrets/secrets.go
@@ -6,109 +6,15 @@
 package secrets
 
 import (
-	"context"
-
 	v1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/Azure/azure-service-operator/v2/internal/ownerutil"
-	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
 
-// ApplySecret applies the secret in a way similar to kubectl apply. If the secret doesn't exist
-// it is created. If it exists, it is updated.
-func ApplySecret(ctx context.Context, client client.Client, secret *v1.Secret) (controllerutil.OperationResult, error) {
-	updatedSecret := &v1.Secret{
-		ObjectMeta: secret.ObjectMeta,
-	}
-	result, err := controllerutil.CreateOrUpdate(ctx, client, updatedSecret, func() error {
-		// Blow away everything that was there (if anything). We expect total ownership of this secret
-		updatedSecret.Data = nil
-		updatedSecret.StringData = secret.StringData
-		return nil
-	})
-	if err != nil {
-		return controllerutil.OperationResultNone, err
+func SliceToClientObjectSlice(s []*v1.Secret) []client.Object {
+	result := make([]client.Object, 0, len(s))
+	for _, s := range s {
+		result = append(result, s)
 	}
 
-	return result, nil
-}
-
-// ApplySecrets applies the specified collection of secrets (similar to kubectl apply). If the secrets do not exist
-// they are created. If they exist, they are updated. An attempt is made to apply each secret before returning an error.
-func ApplySecrets(ctx context.Context, client client.Client, secrets []*v1.Secret) ([]controllerutil.OperationResult, error) {
-	var errs []error
-	results := make([]controllerutil.OperationResult, 0, len(secrets))
-
-	for _, secret := range secrets {
-		result, err := ApplySecret(ctx, client, secret)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		results = append(results, result)
-	}
-
-	err := kerrors.NewAggregate(errs)
-	if err != nil {
-		return nil, err
-	}
-
-	return results, nil
-}
-
-// ApplySecretAndEnsureOwner applies the secret in a way similar to kubectl apply. If the secret doesn't exist
-// it is created and an owner reference is added. If it exists, it is updated as long as the existing secret
-// has a matching owner reference. If a secret exists that does not have the matching owner reference an error is returned
-func ApplySecretAndEnsureOwner(ctx context.Context, client client.Client, obj client.Object, secret *v1.Secret) (controllerutil.OperationResult, error) {
-	updatedSecret := &v1.Secret{
-		ObjectMeta: secret.ObjectMeta,
-	}
-	result, err := controllerutil.CreateOrUpdate(ctx, client, updatedSecret, func() error {
-		// If the secret exists but isn't owned by our resource then it must have been created
-		// by the user. We want to avoid overwriting or otherwise modifying secrets of theirs.
-		if updatedSecret.GetResourceVersion() != "" {
-			if err := genruntime.CheckTargetOwnedByObj(obj, updatedSecret); err != nil {
-				return err
-			}
-		}
-
-		ownerRef := ownerutil.MakeOwnerReference(obj)
-		updatedSecret.SetOwnerReferences(ownerutil.EnsureOwnerRef(updatedSecret.OwnerReferences, ownerRef))
-
-		// Blow away everything that was there (if anything). We expect total ownership of this secret as enforced above.
-		updatedSecret.Data = nil
-		updatedSecret.StringData = secret.StringData
-		return nil
-	})
-	if err != nil {
-		return controllerutil.OperationResultNone, err
-	}
-
-	return result, nil
-}
-
-// ApplySecretsAndEnsureOwner applies the specified collection of secrets (similar to kubectl apply). If the secrets do not exist
-// they are created. If they exist, they are updated. An attempt is made to apply each secret before returning an error.
-func ApplySecretsAndEnsureOwner(ctx context.Context, client client.Client, obj client.Object, secrets []*v1.Secret) ([]controllerutil.OperationResult, error) {
-	var errs []error
-	results := make([]controllerutil.OperationResult, 0, len(secrets))
-
-	for _, secret := range secrets {
-		result, err := ApplySecretAndEnsureOwner(ctx, client, obj, secret)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		results = append(results, result)
-	}
-
-	err := kerrors.NewAggregate(errs)
-	if err != nil {
-		return nil, err
-	}
-
-	return results, nil
+	return result
 }

--- a/v2/pkg/genruntime/suite_test.go
+++ b/v2/pkg/genruntime/suite_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package genruntime_test
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+
+	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
+)
+
+// Note: This is following the pattern set up in v2/internal/controllers/suite_test.go and should be kept mostly
+// in sync with that
+
+const (
+	DefaultResourceTimeout = 10 * time.Minute
+)
+
+var globalTestContext testcommon.KubeGlobalContext
+
+func setup() error {
+	options := getOptions()
+	log.Println("Running test setup")
+
+	// Note: These are set just so we have somewhat reasonable defaults. Almost all
+	// usage of Eventually is done through the testContext wrapper which understands
+	// replay vs record modes and passes a different timeout and polling interval for each,
+	// meaning that there are very few instances where these timeouts are actually used.
+	gomega.SetDefaultEventuallyTimeout(DefaultResourceTimeout)
+	gomega.SetDefaultEventuallyPollingInterval(5 * time.Second)
+
+	// If you need to debug envtest setup/teardown,
+	// set a global logger for controller-runtime:
+	// import (ctrl "sigs.k8s.io/controller-runtime")
+	// ctrl.SetLogger(klogr.New())
+
+	nameConfig := testcommon.NewResourceNameConfig(
+		testcommon.ResourcePrefix,
+		"-",
+		6,
+		testcommon.ResourceNamerModeRandomBasedOnTestName)
+
+	// set global context var
+	newGlobalTestContext, err := testcommon.NewKubeContext(
+		options.useEnvTest,
+		options.recordReplay,
+		testcommon.DefaultTestRegion,
+		nameConfig)
+	if err != nil {
+		return err
+	}
+
+	log.Print("Done with test setup")
+	globalTestContext = newGlobalTestContext
+	return nil
+}
+
+func teardown() error {
+	return globalTestContext.Cleanup()
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(testcommon.SetupTeardownTestMain(m, setup, teardown))
+}
+
+type Options struct {
+	useEnvTest   bool
+	recordReplay bool
+}
+
+func getOptions() Options {
+	return Options{
+		useEnvTest:   os.Getenv("ENVTEST") != "0",
+		recordReplay: os.Getenv("RECORD_REPLAY") != "0",
+	}
+}

--- a/v2/pkg/genruntime/test/owner_test.go
+++ b/v2/pkg/genruntime/test/owner_test.go
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-package genruntime_test
+package test_test
 
 import (
 	"testing"

--- a/v2/pkg/genruntime/test/suite_test.go
+++ b/v2/pkg/genruntime/test/suite_test.go
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-package genruntime_test
+package test_test
 
 import (
 	"log"


### PR DESCRIPTION
KubernetesExporter is more generic so scales better to ConfigMaps and possibly other Kubernetes resource types in the future

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/d3mlE7uhX8KFgEmY/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
