### PR TITLE
Update ReflectVisitor to use reflect.Value parameter

### DIFF
--- a/v2/internal/reflecthelpers/reflect_helpers.go
+++ b/v2/internal/reflecthelpers/reflect_helpers.go
@@ -42,11 +42,10 @@ func FindReferences(obj interface{}, t reflect.Type) (map[interface{}]struct{}, 
 	result := make(map[interface{}]struct{})
 
 	visitor := NewReflectVisitor()
-	visitor.VisitStruct = func(this *ReflectVisitor, it interface{}, ctx interface{}) error {
-		if reflect.TypeOf(it) == t {
-			val := reflect.ValueOf(it)
-			if val.CanInterface() {
-				result[val.Interface()] = struct{}{}
+	visitor.VisitStruct = func(this *ReflectVisitor, it reflect.Value, ctx interface{}) error {
+		if it.Type() == t {
+			if it.CanInterface() {
+				result[it.Interface()] = struct{}{}
 			}
 			return nil
 		}

--- a/v2/pkg/genruntime/resource_reference.go
+++ b/v2/pkg/genruntime/resource_reference.go
@@ -72,10 +72,12 @@ type ResourceReference struct {
 	ARMID string `json:"armId,omitempty"`
 }
 
+// IsDirectARMReference returns true if this ResourceReference is referring to an ARMID directly.
 func (ref ResourceReference) IsDirectARMReference() bool {
 	return ref.ARMID != "" && ref.Name == "" && ref.Group == "" && ref.Kind == ""
 }
 
+// IsKubernetesReference returns true if this ResourceReference is referring to a Kubernetes resource.
 func (ref ResourceReference) IsKubernetesReference() bool {
 	return ref.ARMID == "" && ref.Name != "" && ref.Group != "" && ref.Kind != ""
 }


### PR DESCRIPTION
  - This more easily allows ReflectVisitor to be used to modify structures.
  - Added a test that showcases how this can be used (and serves as a regression test to ensure that it continues to work going forward).

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
