### PR TITLE
Prevent self-referencing types from crashing the structure report

### DIFF
--- a/v2/tools/generator/internal/astmodel/type_name_set.go
+++ b/v2/tools/generator/internal/astmodel/type_name_set.go
@@ -78,6 +78,15 @@ func (ts TypeNameSet) Single() TypeName {
 	panic(fmt.Sprintf("Single() cannot be called with %d types in the set", len(ts)))
 }
 
+func (ts TypeNameSet) Copy() TypeNameSet {
+	result := make(TypeNameSet, len(ts))
+	for k := range ts {
+		result.Add(k)
+	}
+
+	return result
+}
+
 // SetUnion returns a new set with all of the names in s1 or s2.
 func SetUnion(s1, s2 TypeNameSet) TypeNameSet {
 	result := NewTypeNameSet()

--- a/v2/tools/generator/internal/reporting/testdata/Test_TypeCateaLogReport_GivenDirectlyRecursiveType_WhenInlined_ShowsExpectedDetails.golden
+++ b/v2/tools/generator/internal/reporting/testdata/Test_TypeCateaLogReport_GivenDirectlyRecursiveType_WhenInlined_ShowsExpectedDetails.golden
@@ -1,0 +1,12 @@
+github.com/Azure/azure-service-operator/testing/person/v20200101
+└── Relationship: 
+    ├── FirstParty: 
+    │   ├── FamilyName: string
+    │   ├── FullName: string
+    │   ├── KnownAs: string
+    │   └── Parent: *Person
+    └── SecondParty: 
+        ├── FamilyName: string
+        ├── FullName: string
+        ├── KnownAs: string
+        └── Parent: *Person

--- a/v2/tools/generator/internal/reporting/type_catalog_report_test.go
+++ b/v2/tools/generator/internal/reporting/type_catalog_report_test.go
@@ -48,6 +48,53 @@ func Test_TypeCatalogReport_GivenTypes_WhenInlined_ShowsExpectedDetails(t *testi
 	golden.Assert(t, t.Name(), content.Bytes())
 }
 
+func Test_TypeCateaLogReport_GivenDirectlyRecursiveType_WhenInlined_ShowsExpectedDetails(t *testing.T) {
+	t.Parallel()
+
+	golden := goldie.New(t)
+	g := gomega.NewWithT(t)
+
+	personName := astmodel.MakeTypeName(test.Pkg2020, "Person")
+
+	parentProperty := astmodel.NewPropertyDefinition(
+		"Parent",
+		"parentName",
+		astmodel.NewOptionalType(personName)).
+		WithDescription("Optional reference to our parent")
+
+	personObj := astmodel.NewObjectType().
+		WithProperties(
+			test.FullNameProperty,
+			test.FamilyNameProperty,
+			test.KnownAsProperty,
+			parentProperty)
+
+	person := astmodel.MakeTypeDefinition(personName, personObj)
+
+	relationship := test.CreateObjectDefinition(
+		test.Pkg2020,
+		"Relationship",
+		astmodel.NewPropertyDefinition(
+			"FirstParty",
+			"firstparty",
+			astmodel.NewOptionalType(personName)),
+		astmodel.NewPropertyDefinition(
+			"SecondParty",
+			"secondparty",
+			astmodel.NewOptionalType(personName)))
+
+	defs := make(astmodel.TypeDefinitionSet)
+	defs.Add(person)
+	defs.Add(relationship)
+
+	var content bytes.Buffer
+	rpt := NewTypeCatalogReport(defs)
+	rpt.InlineTypes()
+
+	g.Expect(rpt.WriteTo(&content)).To(gomega.Succeed())
+	golden.Assert(t, t.Name(), content.Bytes())
+}
+
 func createDefinitionSet() astmodel.TypeDefinitionSet {
 	testSpec := test.CreateSpec(
 		test.Pkg2020,


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered while merging `main` into the Swagger WIP branch, the resource structure report crashes with a stack overflow if any of the inlined types are self-referential. 

**Special notes for your reviewer**:

We have no types like this in `main`, and controller-gen doesn't support them - but we have them in the Swagger branch at the moment and don't want things to crash.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/3o6nV3DA88eUyfX9VS/giphy.gif)

**If applicable**:
- [x] this PR contains tests
