### PR TITLE
Update resource registration to support ConfigMaps

### DIFF
--- a/v2/api/appconfiguration/v1beta20220501/configuration_store_types_gen.go
+++ b/v2/api/appconfiguration/v1beta20220501/configuration_store_types_gen.go
@@ -578,9 +578,7 @@ func (store *ConfigurationStore_Spec) PopulateFromARM(owner genruntime.Arbitrary
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	store.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	store.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/batch/v1alpha1api20210101/batch_account_types_gen.go
+++ b/v2/api/batch/v1alpha1api20210101/batch_account_types_gen.go
@@ -515,9 +515,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 	}
 
 	// Set property ‘Owner’:
-	account.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PoolAllocationMode’:
 	// copying flattened property:

--- a/v2/api/batch/v1beta20210101/batch_account_types_gen.go
+++ b/v2/api/batch/v1beta20210101/batch_account_types_gen.go
@@ -519,9 +519,7 @@ func (account *BatchAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 	}
 
 	// Set property ‘Owner’:
-	account.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PoolAllocationMode’:
 	// copying flattened property:

--- a/v2/api/cache/v1alpha1api20201201/redis_firewall_rule_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_firewall_rule_types_gen.go
@@ -423,9 +423,7 @@ func (rule *Redis_FirewallRule_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘StartIP’:
 	// copying flattened property:

--- a/v2/api/cache/v1alpha1api20201201/redis_linked_server_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_linked_server_types_gen.go
@@ -438,9 +438,7 @@ func (server *Redis_LinkedServer_Spec) PopulateFromARM(owner genruntime.Arbitrar
 	}
 
 	// Set property ‘Owner’:
-	server.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ServerRole’:
 	// copying flattened property:

--- a/v2/api/cache/v1alpha1api20201201/redis_patch_schedule_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_patch_schedule_types_gen.go
@@ -397,9 +397,7 @@ func (schedule *Redis_PatchSchedule_Spec) PopulateFromARM(owner genruntime.Arbit
 	}
 
 	// Set property ‘Owner’:
-	schedule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	schedule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ScheduleEntries’:
 	// copying flattened property:

--- a/v2/api/cache/v1alpha1api20201201/redis_types_gen.go
+++ b/v2/api/cache/v1alpha1api20201201/redis_types_gen.go
@@ -545,9 +545,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	redis.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	redis.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise_database_types_gen.go
@@ -862,9 +862,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Persistence’:
 	// copying flattened property:

--- a/v2/api/cache/v1alpha1api20210301/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1alpha1api20210301/redis_enterprise_types_gen.go
@@ -819,9 +819,7 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Owner’:
-	enterprise.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	enterprise.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Sku’:
 	if typedInput.Sku != nil {

--- a/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_firewall_rule_types_gen.go
@@ -415,9 +415,7 @@ func (rule *Redis_FirewallRule_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘StartIP’:
 	// copying flattened property:

--- a/v2/api/cache/v1beta20201201/redis_linked_server_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_linked_server_types_gen.go
@@ -431,9 +431,7 @@ func (server *Redis_LinkedServer_Spec) PopulateFromARM(owner genruntime.Arbitrar
 	}
 
 	// Set property ‘Owner’:
-	server.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ServerRole’:
 	// copying flattened property:

--- a/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_patch_schedule_types_gen.go
@@ -387,9 +387,7 @@ func (schedule *Redis_PatchSchedule_Spec) PopulateFromARM(owner genruntime.Arbit
 	}
 
 	// Set property ‘Owner’:
-	schedule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	schedule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ScheduleEntries’:
 	// copying flattened property:

--- a/v2/api/cache/v1beta20201201/redis_types_gen.go
+++ b/v2/api/cache/v1beta20201201/redis_types_gen.go
@@ -567,9 +567,7 @@ func (redis *Redis_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	redis.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	redis.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_database_types_gen.go
@@ -887,9 +887,7 @@ func (database *RedisEnterprise_Database_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Persistence’:
 	// copying flattened property:

--- a/v2/api/cache/v1beta20210301/redis_enterprise_types_gen.go
+++ b/v2/api/cache/v1beta20210301/redis_enterprise_types_gen.go
@@ -839,9 +839,7 @@ func (enterprise *RedisEnterprise_Spec) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Owner’:
-	enterprise.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	enterprise.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Sku’:
 	if typedInput.Sku != nil {

--- a/v2/api/cdn/v1beta20210601/profile_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profile_types_gen.go
@@ -444,9 +444,7 @@ func (profile *Profile_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 	}
 
 	// Set property ‘Owner’:
-	profile.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	profile.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Sku’:
 	if typedInput.Sku != nil {

--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_spec_arm_types_gen_test.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_spec_arm_types_gen_test.go
@@ -1020,9 +1020,7 @@ func DeliveryRuleAction1_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction1_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction1_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	deliveryRuleAction1_ARMGenerator = gen.OneGenOf(gens...)
 
@@ -1115,9 +1113,7 @@ func DeliveryRuleCondition_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	deliveryRuleCondition_ARMGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
@@ -1583,9 +1583,7 @@ func (endpoint *Profiles_Endpoint_Spec) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Owner’:
-	endpoint.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	endpoint.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ProbePath’:
 	// copying flattened property:

--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen_test.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen_test.go
@@ -3116,9 +3116,7 @@ func DeliveryRuleAction1Generator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction1{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction1{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	deliveryRuleAction1Generator = gen.OneGenOf(gens...)
 
@@ -3365,9 +3363,7 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/cdn/v1beta20210601storage/profiles_endpoint_types_gen_test.go
+++ b/v2/api/cdn/v1beta20210601storage/profiles_endpoint_types_gen_test.go
@@ -1905,9 +1905,7 @@ func DeliveryRuleAction1Generator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction1{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleAction1{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	deliveryRuleAction1Generator = gen.OneGenOf(gens...)
 
@@ -2061,9 +2059,7 @@ func DeliveryRuleConditionGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(DeliveryRuleCondition{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	deliveryRuleConditionGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/compute/v1alpha1api20200930/disk_types_gen.go
+++ b/v2/api/compute/v1alpha1api20200930/disk_types_gen.go
@@ -696,9 +696,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 	}
 
 	// Set property ‘Owner’:
-	disk.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	disk.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PurchasePlan’:
 	// copying flattened property:

--- a/v2/api/compute/v1alpha1api20200930/snapshot_types_gen.go
+++ b/v2/api/compute/v1alpha1api20200930/snapshot_types_gen.go
@@ -618,9 +618,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 	}
 
 	// Set property ‘Owner’:
-	snapshot.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	snapshot.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PurchasePlan’:
 	// copying flattened property:

--- a/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machine_scale_set_types_gen.go
@@ -648,9 +648,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 	}
 
 	// Set property ‘Owner’:
-	scaleSet.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	scaleSet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Plan’:
 	if typedInput.Plan != nil {

--- a/v2/api/compute/v1alpha1api20201201/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1alpha1api20201201/virtual_machine_types_gen.go
@@ -781,9 +781,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	machine.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	machine.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Plan’:
 	if typedInput.Plan != nil {

--- a/v2/api/compute/v1alpha1api20210701/image_types_gen.go
+++ b/v2/api/compute/v1alpha1api20210701/image_types_gen.go
@@ -462,9 +462,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	}
 
 	// Set property ‘Owner’:
-	image.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	image.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘SourceVirtualMachine’:
 	// copying flattened property:

--- a/v2/api/compute/v1beta20200930/disk_types_gen.go
+++ b/v2/api/compute/v1beta20200930/disk_types_gen.go
@@ -729,9 +729,7 @@ func (disk *Disk_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 	}
 
 	// Set property ‘Owner’:
-	disk.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	disk.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PurchasePlan’:
 	// copying flattened property:

--- a/v2/api/compute/v1beta20200930/snapshot_types_gen.go
+++ b/v2/api/compute/v1beta20200930/snapshot_types_gen.go
@@ -635,9 +635,7 @@ func (snapshot *Snapshot_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 	}
 
 	// Set property ‘Owner’:
-	snapshot.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	snapshot.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PurchasePlan’:
 	// copying flattened property:

--- a/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_scale_set_types_gen.go
@@ -691,9 +691,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 	}
 
 	// Set property ‘Owner’:
-	scaleSet.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	scaleSet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Plan’:
 	if typedInput.Plan != nil {

--- a/v2/api/compute/v1beta20201201/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1beta20201201/virtual_machine_types_gen.go
@@ -847,9 +847,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	machine.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	machine.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Plan’:
 	if typedInput.Plan != nil {

--- a/v2/api/compute/v1beta20210701/image_types_gen.go
+++ b/v2/api/compute/v1beta20210701/image_types_gen.go
@@ -474,9 +474,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	}
 
 	// Set property ‘Owner’:
-	image.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	image.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘SourceVirtualMachine’:
 	// copying flattened property:

--- a/v2/api/compute/v1beta20220301/image_types_gen.go
+++ b/v2/api/compute/v1beta20220301/image_types_gen.go
@@ -460,9 +460,7 @@ func (image *Image_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	}
 
 	// Set property ‘Owner’:
-	image.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	image.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘SourceVirtualMachine’:
 	// copying flattened property:

--- a/v2/api/compute/v1beta20220301/virtual_machine_scale_set_types_gen.go
+++ b/v2/api/compute/v1beta20220301/virtual_machine_scale_set_types_gen.go
@@ -693,9 +693,7 @@ func (scaleSet *VirtualMachineScaleSet_Spec) PopulateFromARM(owner genruntime.Ar
 	}
 
 	// Set property ‘Owner’:
-	scaleSet.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	scaleSet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Plan’:
 	if typedInput.Plan != nil {

--- a/v2/api/compute/v1beta20220301/virtual_machine_types_gen.go
+++ b/v2/api/compute/v1beta20220301/virtual_machine_types_gen.go
@@ -899,9 +899,7 @@ func (machine *VirtualMachine_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	machine.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	machine.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Plan’:
 	if typedInput.Plan != nil {

--- a/v2/api/containerinstance/v1beta20211001/container_group_types_gen.go
+++ b/v2/api/containerinstance/v1beta20211001/container_group_types_gen.go
@@ -664,9 +664,7 @@ func (group *ContainerGroup_Spec) PopulateFromARM(owner genruntime.ArbitraryOwne
 	}
 
 	// Set property ‘Owner’:
-	group.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RestartPolicy’:
 	// copying flattened property:

--- a/v2/api/containerregistry/v1alpha1api20210901/registry_types_gen.go
+++ b/v2/api/containerregistry/v1alpha1api20210901/registry_types_gen.go
@@ -559,9 +559,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 	}
 
 	// Set property ‘Owner’:
-	registry.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	registry.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Policies’:
 	// copying flattened property:

--- a/v2/api/containerregistry/v1beta20210901/registry_types_gen.go
+++ b/v2/api/containerregistry/v1beta20210901/registry_types_gen.go
@@ -564,9 +564,7 @@ func (registry *Registry_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 	}
 
 	// Set property ‘Owner’:
-	registry.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	registry.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Policies’:
 	// copying flattened property:

--- a/v2/api/containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_cluster_types_gen.go
@@ -892,9 +892,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	cluster.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	cluster.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PodIdentityProfile’:
 	// copying flattened property:

--- a/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1alpha1api20210501/managed_clusters_agent_pool_types_gen.go
@@ -1793,9 +1793,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘Owner’:
-	pool.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// no assignment for property ‘PodSubnetIDReference’
 

--- a/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_cluster_types_gen.go
@@ -939,9 +939,7 @@ func (cluster *ManagedCluster_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	cluster.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	cluster.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PodIdentityProfile’:
 	// copying flattened property:

--- a/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen.go
+++ b/v2/api/containerservice/v1beta20210501/managed_clusters_agent_pool_types_gen.go
@@ -1944,9 +1944,7 @@ func (pool *ManagedClusters_AgentPool_Spec) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘Owner’:
-	pool.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	pool.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// no assignment for property ‘PodSubnetIDReference’
 

--- a/v2/api/dbformariadb/v1beta20180601/configuration_types_gen.go
+++ b/v2/api/dbformariadb/v1beta20180601/configuration_types_gen.go
@@ -667,9 +667,7 @@ func (configuration *Servers_Configuration_Spec) PopulateFromARM(owner genruntim
 	}
 
 	// Set property ‘Owner’:
-	configuration.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Source’:
 	// copying flattened property:

--- a/v2/api/dbformariadb/v1beta20180601/database_types_gen.go
+++ b/v2/api/dbformariadb/v1beta20180601/database_types_gen.go
@@ -608,9 +608,7 @@ func (database *Servers_Database_Spec) PopulateFromARM(owner genruntime.Arbitrar
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/dbformariadb/v1beta20180601/server_spec_arm_types_gen_test.go
+++ b/v2/api/dbformariadb/v1beta20180601/server_spec_arm_types_gen_test.go
@@ -149,9 +149,7 @@ func ServerPropertiesForCreate_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	serverPropertiesForCreate_ARMGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dbformariadb/v1beta20180601/server_types_gen.go
+++ b/v2/api/dbformariadb/v1beta20180601/server_types_gen.go
@@ -436,9 +436,7 @@ func (server *Server_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	server.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/api/dbformariadb/v1beta20180601/server_types_gen_test.go
+++ b/v2/api/dbformariadb/v1beta20180601/server_types_gen_test.go
@@ -737,9 +737,7 @@ func ServerPropertiesForCreateGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	serverPropertiesForCreateGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dbformariadb/v1beta20180601storage/server_types_gen_test.go
+++ b/v2/api/dbformariadb/v1beta20180601storage/server_types_gen_test.go
@@ -438,9 +438,7 @@ func ServerPropertiesForCreateGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(ServerPropertiesForCreate{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	serverPropertiesForCreateGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_server_types_gen.go
@@ -675,9 +675,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	server.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ReplicationRole’:
 	// copying flattened property:

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_database_types_gen.go
@@ -641,9 +641,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1alpha1api20210501/flexible_servers_firewall_rule_types_gen.go
@@ -637,9 +637,7 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘StartIpAddress’:
 	// copying flattened property:

--- a/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_server_types_gen.go
@@ -696,9 +696,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	server.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ReplicationRole’:
 	// copying flattened property:

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_database_types_gen.go
@@ -646,9 +646,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbformysql/v1beta20210501/flexible_servers_firewall_rule_types_gen.go
@@ -641,9 +641,7 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘StartIpAddress’:
 	// copying flattened property:

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_server_types_gen.go
@@ -626,9 +626,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	server.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PointInTimeUTC’:
 	// copying flattened property:

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_configuration_types_gen.go
@@ -807,9 +807,7 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Owner’:
-	configuration.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Source’:
 	// copying flattened property:

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_database_types_gen.go
@@ -641,9 +641,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1alpha1api20210601/flexible_servers_firewall_rule_types_gen.go
@@ -637,9 +637,7 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘StartIpAddress’:
 	// copying flattened property:

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_server_types_gen.go
@@ -643,9 +643,7 @@ func (server *FlexibleServer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	server.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	server.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PointInTimeUTC’:
 	// copying flattened property:

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_configuration_types_gen.go
@@ -830,9 +830,7 @@ func (configuration *FlexibleServers_Configuration_Spec) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Owner’:
-	configuration.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	configuration.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Source’:
 	// copying flattened property:

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_database_types_gen.go
@@ -646,9 +646,7 @@ func (database *FlexibleServers_Database_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen.go
+++ b/v2/api/dbforpostgresql/v1beta20210601/flexible_servers_firewall_rule_types_gen.go
@@ -641,9 +641,7 @@ func (rule *FlexibleServers_FirewallRule_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘StartIpAddress’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/database_account_spec_arm_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_account_spec_arm_types_gen_test.go
@@ -432,9 +432,7 @@ func BackupPolicy_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	backupPolicy_ARMGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen.go
@@ -868,9 +868,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	account.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen_test.go
@@ -967,9 +967,7 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -398,9 +398,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_collection_types_gen.go
@@ -434,9 +434,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 	}
 
 	// Set property ‘Owner’:
-	collection.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	collection.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_throughput_setting_types_gen.go
@@ -398,9 +398,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Populat
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/mongodb_database_types_gen.go
@@ -434,9 +434,7 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_stored_procedure_types_gen.go
@@ -434,9 +434,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 	}
 
 	// Set property ‘Owner’:
-	procedure.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	procedure.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_throughput_setting_types_gen.go
@@ -398,9 +398,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_trigger_types_gen.go
@@ -434,9 +434,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 	}
 
 	// Set property ‘Owner’:
-	trigger.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	trigger.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_types_gen.go
@@ -434,9 +434,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 	}
 
 	// Set property ‘Owner’:
-	container.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_container_user_defined_function_types_gen.go
@@ -434,9 +434,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 	}
 
 	// Set property ‘Owner’:
-	function.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	function.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_throughput_setting_types_gen.go
@@ -398,9 +398,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) PopulateFro
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/sql_database_types_gen.go
@@ -434,9 +434,7 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1alpha1api20210515storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515storage/database_account_types_gen_test.go
@@ -967,9 +967,7 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1beta20210515/database_account_spec_arm_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_spec_arm_types_gen_test.go
@@ -432,9 +432,7 @@ func BackupPolicy_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	backupPolicy_ARMGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
@@ -910,9 +910,7 @@ func (account *DatabaseAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	account.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_types_gen_test.go
@@ -966,9 +966,7 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_throughput_setting_types_gen.go
@@ -393,9 +393,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_Collections_ThroughputSetting_S
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_collection_types_gen.go
@@ -432,9 +432,7 @@ func (collection *DatabaseAccounts_MongodbDatabases_Collection_Spec) PopulateFro
 	}
 
 	// Set property ‘Owner’:
-	collection.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	collection.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_throughput_setting_types_gen.go
@@ -393,9 +393,7 @@ func (setting *DatabaseAccounts_MongodbDatabases_ThroughputSetting_Spec) Populat
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/mongodb_database_types_gen.go
@@ -432,9 +432,7 @@ func (database *DatabaseAccounts_MongodbDatabase_Spec) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_stored_procedure_types_gen.go
@@ -432,9 +432,7 @@ func (procedure *DatabaseAccounts_SqlDatabases_Containers_StoredProcedure_Spec) 
 	}
 
 	// Set property ‘Owner’:
-	procedure.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	procedure.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_throughput_setting_types_gen.go
@@ -393,9 +393,7 @@ func (setting *DatabaseAccounts_SqlDatabases_Containers_ThroughputSetting_Spec) 
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_trigger_types_gen.go
@@ -432,9 +432,7 @@ func (trigger *DatabaseAccounts_SqlDatabases_Containers_Trigger_Spec) PopulateFr
 	}
 
 	// Set property ‘Owner’:
-	trigger.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	trigger.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_types_gen.go
@@ -432,9 +432,7 @@ func (container *DatabaseAccounts_SqlDatabases_Container_Spec) PopulateFromARM(o
 	}
 
 	// Set property ‘Owner’:
-	container.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_container_user_defined_function_types_gen.go
@@ -432,9 +432,7 @@ func (function *DatabaseAccounts_SqlDatabases_Containers_UserDefinedFunction_Spe
 	}
 
 	// Set property ‘Owner’:
-	function.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	function.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_throughput_setting_types_gen.go
@@ -393,9 +393,7 @@ func (setting *DatabaseAccounts_SqlDatabases_ThroughputSetting_Spec) PopulateFro
 	}
 
 	// Set property ‘Owner’:
-	setting.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	setting.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_database_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_database_types_gen.go
@@ -432,9 +432,7 @@ func (database *DatabaseAccounts_SqlDatabase_Spec) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘Owner’:
-	database.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	database.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Resource’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515/sql_role_assignment_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/sql_role_assignment_types_gen.go
@@ -388,9 +388,7 @@ func (assignment *DatabaseAccounts_SqlRoleAssignment_Spec) PopulateFromARM(owner
 	assignment.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	assignment.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	assignment.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PrincipalId’:
 	// copying flattened property:

--- a/v2/api/documentdb/v1beta20210515storage/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515storage/database_account_types_gen_test.go
@@ -587,9 +587,7 @@ func BackupPolicyGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(BackupPolicy{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	backupPolicyGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen.go
@@ -472,9 +472,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 	}
 
 	// Set property ‘Owner’:
-	domain.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	domain.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/eventgrid/v1alpha1api20200601/domains_topic_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domains_topic_types_gen.go
@@ -395,9 +395,7 @@ func (topic *Domains_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	topic.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601/event_subscription_spec_arm_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/event_subscription_spec_arm_types_gen_test.go
@@ -229,9 +229,7 @@ func EventSubscriptionDestination_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	eventSubscriptionDestination_ARMGenerator = gen.OneGenOf(gens...)
 
@@ -531,9 +529,7 @@ func AdvancedFilter_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	advancedFilter_ARMGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen_test.go
@@ -625,9 +625,7 @@ func EventSubscriptionDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	eventSubscriptionDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -1428,9 +1426,7 @@ func AdvancedFilterGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	advancedFilterGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1alpha1api20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/topic_types_gen.go
@@ -395,9 +395,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	}
 
 	// Set property ‘Owner’:
-	topic.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601storage/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601storage/event_subscription_types_gen_test.go
@@ -618,9 +618,7 @@ func EventSubscriptionDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	eventSubscriptionDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -1414,9 +1412,7 @@ func AdvancedFilterGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	advancedFilterGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
@@ -474,9 +474,7 @@ func (domain *Domain_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 	}
 
 	// Set property ‘Owner’:
-	domain.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	domain.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domains_topic_types_gen.go
@@ -385,9 +385,7 @@ func (topic *Domains_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	topic.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/eventgrid/v1beta20200601/event_subscription_spec_arm_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscription_spec_arm_types_gen_test.go
@@ -229,9 +229,7 @@ func EventSubscriptionDestination_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	eventSubscriptionDestination_ARMGenerator = gen.OneGenOf(gens...)
 
@@ -531,9 +529,7 @@ func AdvancedFilter_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	advancedFilter_ARMGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen_test.go
@@ -624,9 +624,7 @@ func EventSubscriptionDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	eventSubscriptionDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -1427,9 +1425,7 @@ func AdvancedFilterGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	advancedFilterGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventgrid/v1beta20200601/topic_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/topic_types_gen.go
@@ -385,9 +385,7 @@ func (topic *Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	}
 
 	// Set property ‘Owner’:
-	topic.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/eventgrid/v1beta20200601storage/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601storage/event_subscription_types_gen_test.go
@@ -364,9 +364,7 @@ func EventSubscriptionDestinationGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(EventSubscriptionDestination{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	eventSubscriptionDestinationGenerator = gen.OneGenOf(gens...)
 
@@ -866,9 +864,7 @@ func AdvancedFilterGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(AdvancedFilter{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	advancedFilterGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/eventhub/v1alpha1api20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespace_types_gen.go
@@ -1185,9 +1185,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	namespace.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PrivateEndpointConnections’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_authorization_rule_types_gen.go
@@ -635,9 +635,7 @@ func (rule *Namespaces_AuthorizationRule_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Rights’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhub_types_gen.go
@@ -788,9 +788,7 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 	}
 
 	// Set property ‘Owner’:
-	eventhub.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	eventhub.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PartitionCount’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -407,9 +407,7 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_Spec) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Rights’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/eventhub/v1alpha1api20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -648,9 +648,7 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_Spec) PopulateFromARM(ow
 	}
 
 	// Set property ‘Owner’:
-	consumergroup.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	consumergroup.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/eventhub/v1beta20211101/namespace_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespace_types_gen.go
@@ -1242,9 +1242,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	namespace.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PrivateEndpointConnections’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_authorization_rule_types_gen.go
@@ -638,9 +638,7 @@ func (rule *Namespaces_AuthorizationRule_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Rights’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhub_types_gen.go
@@ -805,9 +805,7 @@ func (eventhub *Namespaces_Eventhub_Spec) PopulateFromARM(owner genruntime.Arbit
 	}
 
 	// Set property ‘Owner’:
-	eventhub.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	eventhub.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PartitionCount’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_authorization_rule_types_gen.go
@@ -398,9 +398,7 @@ func (rule *Namespaces_Eventhubs_AuthorizationRule_Spec) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Rights’:
 	// copying flattened property:

--- a/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen.go
+++ b/v2/api/eventhub/v1beta20211101/namespaces_eventhubs_consumer_group_types_gen.go
@@ -660,9 +660,7 @@ func (consumergroup *Namespaces_Eventhubs_Consumergroup_Spec) PopulateFromARM(ow
 	}
 
 	// Set property ‘Owner’:
-	consumergroup.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	consumergroup.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/insights/v1alpha1api20180501preview/webtest_types_gen.go
+++ b/v2/api/insights/v1alpha1api20180501preview/webtest_types_gen.go
@@ -573,9 +573,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 	}
 
 	// Set property ‘Owner’:
-	webtest.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	webtest.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Request’:
 	// copying flattened property:

--- a/v2/api/insights/v1alpha1api20200202/component_types_gen.go
+++ b/v2/api/insights/v1alpha1api20200202/component_types_gen.go
@@ -1347,9 +1347,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	component.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	component.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccessForIngestion’:
 	// copying flattened property:

--- a/v2/api/insights/v1beta20180501preview/webtest_types_gen.go
+++ b/v2/api/insights/v1beta20180501preview/webtest_types_gen.go
@@ -583,9 +583,7 @@ func (webtest *Webtest_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 	}
 
 	// Set property ‘Owner’:
-	webtest.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	webtest.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Request’:
 	// copying flattened property:

--- a/v2/api/insights/v1beta20200202/component_types_gen.go
+++ b/v2/api/insights/v1beta20200202/component_types_gen.go
@@ -1444,9 +1444,7 @@ func (component *Component_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	component.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	component.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccessForIngestion’:
 	// copying flattened property:

--- a/v2/api/keyvault/v1beta20210401preview/vault_types_gen.go
+++ b/v2/api/keyvault/v1beta20210401preview/vault_types_gen.go
@@ -405,9 +405,7 @@ func (vault *Vault_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReferenc
 	}
 
 	// Set property ‘Owner’:
-	vault.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	vault.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/api/machinelearningservices/v1beta20210701/workspace_types_gen.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspace_types_gen.go
@@ -700,9 +700,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	workspace.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// no assignment for property ‘PrimaryUserAssignedIdentityReference’
 

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_spec_arm_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_spec_arm_types_gen_test.go
@@ -151,9 +151,7 @@ func Compute_ARMGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_ARM{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute_ARM{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	compute_ARMGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen.go
@@ -784,9 +784,7 @@ func (compute *Workspaces_Compute_Spec) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Owner’:
-	compute.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	compute.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen_test.go
@@ -506,9 +506,7 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_connection_types_gen.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_connection_types_gen.go
@@ -696,9 +696,7 @@ func (connection *Workspaces_Connection_Spec) PopulateFromARM(owner genruntime.A
 	}
 
 	// Set property ‘Owner’:
-	connection.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	connection.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/machinelearningservices/v1beta20210701storage/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1beta20210701storage/workspaces_compute_types_gen_test.go
@@ -295,9 +295,7 @@ func ComputeGenerator() gopter.Gen {
 	// handle OneOf by choosing only one field to instantiate
 	var gens []gopter.Gen
 	for propName, propGen := range generators {
-		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{
-			propName: propGen,
-		}))
+		gens = append(gens, gen.Struct(reflect.TypeOf(Compute{}), map[string]gopter.Gen{propName: propGen}))
 	}
 	computeGenerator = gen.OneGenOf(gens...)
 

--- a/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1alpha1api20181130/user_assigned_identity_types_gen.go
@@ -674,9 +674,7 @@ func (identity *UserAssignedIdentity_Spec) PopulateFromARM(owner genruntime.Arbi
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	identity.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	identity.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen.go
+++ b/v2/api/managedidentity/v1beta20181130/user_assigned_identity_types_gen.go
@@ -678,9 +678,7 @@ func (identity *UserAssignedIdentity_Spec) PopulateFromARM(owner genruntime.Arbi
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	identity.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	identity.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/managedidentity/v1beta20220131preview/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1beta20220131preview/federated_identity_credential_types_gen.go
@@ -614,9 +614,7 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 	}
 
 	// Set property ‘Owner’:
-	credential.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	credential.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Subject’:
 	// copying flattened property:

--- a/v2/api/network/v1alpha1api20201101/load_balancer_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/load_balancer_types_gen.go
@@ -557,9 +557,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘Owner’:
-	balancer.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	balancer.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Probes’:
 	// copying flattened property:

--- a/v2/api/network/v1alpha1api20201101/network_interface_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_interface_types_gen.go
@@ -523,9 +523,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	networkInterface.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	networkInterface.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1alpha1api20201101/network_security_group_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_group_types_gen.go
@@ -395,9 +395,7 @@ func (group *NetworkSecurityGroup_Spec) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Owner’:
-	group.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/network_security_groups_security_rule_types_gen.go
@@ -573,9 +573,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Priority’:
 	// copying flattened property:

--- a/v2/api/network/v1alpha1api20201101/public_ip_address_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/public_ip_address_types_gen.go
@@ -1228,9 +1228,7 @@ func (addresses *PublicIPAddresses_Spec) PopulateFromARM(owner genruntime.Arbitr
 	}
 
 	// Set property ‘Owner’:
-	addresses.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	addresses.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicIPAddressVersion’:
 	// copying flattened property:

--- a/v2/api/network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_network_gateway_types_gen.go
@@ -621,9 +621,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 	}
 
 	// Set property ‘Owner’:
-	gateway.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	gateway.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Sku’:
 	// copying flattened property:

--- a/v2/api/network/v1alpha1api20201101/virtual_network_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_network_types_gen.go
@@ -571,9 +571,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	network.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	network.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_subnet_types_gen.go
@@ -1439,9 +1439,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 	}
 
 	// Set property ‘Owner’:
-	subnet.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	subnet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PrivateEndpointNetworkPolicies’:
 	// copying flattened property:

--- a/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1alpha1api20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -962,9 +962,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 	}
 
 	// Set property ‘Owner’:
-	peering.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	peering.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PeeringState’:
 	// copying flattened property:

--- a/v2/api/network/v1beta20180901/private_dns_zone_types_gen.go
+++ b/v2/api/network/v1beta20180901/private_dns_zone_types_gen.go
@@ -405,9 +405,7 @@ func (zone *PrivateDnsZone_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	zone.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	zone.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1beta20201101/load_balancer_types_gen.go
+++ b/v2/api/network/v1beta20201101/load_balancer_types_gen.go
@@ -566,9 +566,7 @@ func (balancer *LoadBalancer_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘Owner’:
-	balancer.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	balancer.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Probes’:
 	// copying flattened property:

--- a/v2/api/network/v1beta20201101/network_interface_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_interface_types_gen.go
@@ -524,9 +524,7 @@ func (networkInterface *NetworkInterface_Spec) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Owner’:
-	networkInterface.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	networkInterface.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1beta20201101/network_security_group_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_group_types_gen.go
@@ -385,9 +385,7 @@ func (group *NetworkSecurityGroup_Spec) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Owner’:
-	group.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	group.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen.go
+++ b/v2/api/network/v1beta20201101/network_security_groups_security_rule_types_gen.go
@@ -595,9 +595,7 @@ func (rule *NetworkSecurityGroups_SecurityRule_Spec) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Priority’:
 	// copying flattened property:

--- a/v2/api/network/v1beta20201101/public_ip_address_types_gen.go
+++ b/v2/api/network/v1beta20201101/public_ip_address_types_gen.go
@@ -1282,9 +1282,7 @@ func (addresses *PublicIPAddresses_Spec) PopulateFromARM(owner genruntime.Arbitr
 	}
 
 	// Set property ‘Owner’:
-	addresses.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	addresses.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicIPAddressVersion’:
 	// copying flattened property:

--- a/v2/api/network/v1beta20201101/route_table_types_gen.go
+++ b/v2/api/network/v1beta20201101/route_table_types_gen.go
@@ -406,9 +406,7 @@ func (table *RouteTable_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 	}
 
 	// Set property ‘Owner’:
-	table.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	table.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1beta20201101/route_tables_route_types_gen.go
+++ b/v2/api/network/v1beta20201101/route_tables_route_types_gen.go
@@ -719,9 +719,7 @@ func (route *RouteTables_Route_Spec) PopulateFromARM(owner genruntime.ArbitraryO
 	}
 
 	// Set property ‘Owner’:
-	route.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	route.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_network_gateway_types_gen.go
@@ -645,9 +645,7 @@ func (gateway *VirtualNetworkGateway_Spec) PopulateFromARM(owner genruntime.Arbi
 	}
 
 	// Set property ‘Owner’:
-	gateway.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	gateway.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Sku’:
 	// copying flattened property:

--- a/v2/api/network/v1beta20201101/virtual_network_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_network_types_gen.go
@@ -577,9 +577,7 @@ func (network *VirtualNetwork_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	network.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	network.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_subnet_types_gen.go
@@ -1491,9 +1491,7 @@ func (subnet *VirtualNetworks_Subnet_Spec) PopulateFromARM(owner genruntime.Arbi
 	}
 
 	// Set property ‘Owner’:
-	subnet.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	subnet.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PrivateEndpointNetworkPolicies’:
 	// copying flattened property:

--- a/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen.go
+++ b/v2/api/network/v1beta20201101/virtual_networks_virtual_network_peering_types_gen.go
@@ -1008,9 +1008,7 @@ func (peering *VirtualNetworks_VirtualNetworkPeering_Spec) PopulateFromARM(owner
 	}
 
 	// Set property ‘Owner’:
-	peering.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	peering.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PeeringState’:
 	// copying flattened property:

--- a/v2/api/operationalinsights/v1alpha1api20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1alpha1api20210601/workspace_types_gen.go
@@ -505,9 +505,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	workspace.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ProvisioningState’:
 	// copying flattened property:

--- a/v2/api/operationalinsights/v1beta20210601/workspace_types_gen.go
+++ b/v2/api/operationalinsights/v1beta20210601/workspace_types_gen.go
@@ -513,9 +513,7 @@ func (workspace *Workspace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Owner’:
-	workspace.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	workspace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘ProvisioningState’:
 	// copying flattened property:

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespace_types_gen.go
@@ -491,9 +491,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	namespace.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Sku’:
 	if typedInput.Sku != nil {

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_queue_types_gen.go
@@ -593,9 +593,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	queue.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RequiresDuplicateDetection’:
 	// copying flattened property:

--- a/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/servicebus/v1alpha1api20210101preview/namespaces_topic_types_gen.go
@@ -518,9 +518,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	topic.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RequiresDuplicateDetection’:
 	// copying flattened property:

--- a/v2/api/servicebus/v1beta20210101preview/namespace_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespace_types_gen.go
@@ -488,9 +488,7 @@ func (namespace *Namespace_Spec) PopulateFromARM(owner genruntime.ArbitraryOwner
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	namespace.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	namespace.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Sku’:
 	if typedInput.Sku != nil {

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_queue_types_gen.go
@@ -619,9 +619,7 @@ func (queue *Namespaces_Queue_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	queue.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RequiresDuplicateDetection’:
 	// copying flattened property:

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topic_types_gen.go
@@ -531,9 +531,7 @@ func (topic *Namespaces_Topic_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘Owner’:
-	topic.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	topic.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RequiresDuplicateDetection’:
 	// copying flattened property:

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscription_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscription_types_gen.go
@@ -575,9 +575,7 @@ func (subscription *Namespaces_Topics_Subscription_Spec) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Owner’:
-	subscription.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	subscription.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RequiresSession’:
 	// copying flattened property:

--- a/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
+++ b/v2/api/servicebus/v1beta20210101preview/namespaces_topics_subscriptions_rule_types_gen.go
@@ -474,9 +474,7 @@ func (rule *Namespaces_Topics_Subscriptions_Rule_Spec) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Owner’:
-	rule.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	rule.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘SqlFilter’:
 	// copying flattened property:

--- a/v2/api/signalrservice/v1alpha1api20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1alpha1api20211001/signal_r_types_gen.go
@@ -588,9 +588,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 	}
 
 	// Set property ‘Owner’:
-	signalR.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	signalR.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/signalrservice/v1beta20211001/signal_r_types_gen.go
+++ b/v2/api/signalrservice/v1beta20211001/signal_r_types_gen.go
@@ -609,9 +609,7 @@ func (signalR *SignalR_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerRefe
 	}
 
 	// Set property ‘Owner’:
-	signalR.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	signalR.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/api/storage/v1alpha1api20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_account_types_gen.go
@@ -777,9 +777,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	account.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RoutingPreference’:
 	// copying flattened property:

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_service_types_gen.go
@@ -1044,9 +1044,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 	}
 
 	// Set property ‘Owner’:
-	service.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RestorePolicy’:
 	// copying flattened property:

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_blob_services_container_types_gen.go
@@ -1060,9 +1060,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 	}
 
 	// Set property ‘Owner’:
-	container.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicAccess’:
 	// copying flattened property:

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_management_policy_types_gen.go
@@ -583,9 +583,7 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Owner’:
-	policy.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Policy’:
 	// copying flattened property:

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_service_types_gen.go
@@ -593,9 +593,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 	}
 
 	// Set property ‘Owner’:
-	service.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queue_types_gen.go
+++ b/v2/api/storage/v1alpha1api20210401/storage_accounts_queue_services_queue_types_gen.go
@@ -420,9 +420,7 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Owner’:
-	queue.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/storage/v1beta20210401/storage_account_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_account_types_gen.go
@@ -814,9 +814,7 @@ func (account *StorageAccount_Spec) PopulateFromARM(owner genruntime.ArbitraryOw
 	// no assignment for property ‘OperatorSpec’
 
 	// Set property ‘Owner’:
-	account.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	account.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RoutingPreference’:
 	// copying flattened property:

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_service_types_gen.go
@@ -1080,9 +1080,7 @@ func (service *StorageAccounts_BlobService_Spec) PopulateFromARM(owner genruntim
 	}
 
 	// Set property ‘Owner’:
-	service.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘RestorePolicy’:
 	// copying flattened property:

--- a/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_blob_services_container_types_gen.go
@@ -1108,9 +1108,7 @@ func (container *StorageAccounts_BlobServices_Container_Spec) PopulateFromARM(ow
 	}
 
 	// Set property ‘Owner’:
-	container.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	container.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicAccess’:
 	// copying flattened property:

--- a/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_management_policy_types_gen.go
@@ -584,9 +584,7 @@ func (policy *StorageAccounts_ManagementPolicy_Spec) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Owner’:
-	policy.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	policy.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Policy’:
 	// copying flattened property:

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_service_types_gen.go
@@ -594,9 +594,7 @@ func (service *StorageAccounts_QueueService_Spec) PopulateFromARM(owner genrunti
 	}
 
 	// Set property ‘Owner’:
-	service.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	service.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen.go
+++ b/v2/api/storage/v1beta20210401/storage_accounts_queue_services_queue_types_gen.go
@@ -412,9 +412,7 @@ func (queue *StorageAccounts_QueueServices_Queue_Spec) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Owner’:
-	queue.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	queue.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Tags’:
 	if typedInput.Tags != nil {

--- a/v2/api/web/v1beta20220301/server_farm_types_gen.go
+++ b/v2/api/web/v1beta20220301/server_farm_types_gen.go
@@ -1480,9 +1480,7 @@ func (serverfarm *Serverfarm_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘Owner’:
-	serverfarm.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	serverfarm.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PerSiteScaling’:
 	// copying flattened property:

--- a/v2/api/web/v1beta20220301/site_types_gen.go
+++ b/v2/api/web/v1beta20220301/site_types_gen.go
@@ -866,9 +866,7 @@ func (site *Site_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 	}
 
 	// Set property ‘Owner’:
-	site.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	site.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘PublicNetworkAccess’:
 	// copying flattened property:

--- a/v2/internal/controllers/controller_resources_gen.go
+++ b/v2/internal/controllers/controller_resources_gen.go
@@ -1148,7 +1148,7 @@ func indexComputeVirtualMachineAdminPassword(rawObj client.Object) []string {
 	if obj.Spec.OsProfile.AdminPassword == nil {
 		return nil
 	}
-	return []string{obj.Spec.OsProfile.AdminPassword.Name}
+	return obj.Spec.OsProfile.AdminPassword.Index()
 }
 
 // indexComputeVirtualMachineScaleSetAdminPassword an index function for compute_v20220301s.VirtualMachineScaleSet .spec.virtualMachineProfile.osProfile.adminPassword
@@ -1166,7 +1166,7 @@ func indexComputeVirtualMachineScaleSetAdminPassword(rawObj client.Object) []str
 	if obj.Spec.VirtualMachineProfile.OsProfile.AdminPassword == nil {
 		return nil
 	}
-	return []string{obj.Spec.VirtualMachineProfile.OsProfile.AdminPassword.Name}
+	return obj.Spec.VirtualMachineProfile.OsProfile.AdminPassword.Index()
 }
 
 // indexContainerinstanceContainerGroupContainersSecureValue an index function for containerinstance_v20211001s.ContainerGroup .spec.containers.environmentVariables.secureValue
@@ -1181,7 +1181,7 @@ func indexContainerinstanceContainerGroupContainersSecureValue(rawObj client.Obj
 			if environmentVariableItem.SecureValue == nil {
 				continue
 			}
-			result = append(result, environmentVariableItem.SecureValue.Name)
+			result = append(result, environmentVariableItem.SecureValue.Index()...)
 		}
 	}
 	return result
@@ -1199,7 +1199,7 @@ func indexContainerinstanceContainerGroupInitContainersSecureValue(rawObj client
 			if environmentVariableItem.SecureValue == nil {
 				continue
 			}
-			result = append(result, environmentVariableItem.SecureValue.Name)
+			result = append(result, environmentVariableItem.SecureValue.Index()...)
 		}
 	}
 	return result
@@ -1216,7 +1216,7 @@ func indexContainerinstanceContainerGroupPassword(rawObj client.Object) []string
 		if imageRegistryCredentialItem.Password == nil {
 			continue
 		}
-		result = append(result, imageRegistryCredentialItem.Password.Name)
+		result = append(result, imageRegistryCredentialItem.Password.Index()...)
 	}
 	return result
 }
@@ -1236,7 +1236,7 @@ func indexContainerinstanceContainerGroupWorkspaceKey(rawObj client.Object) []st
 	if obj.Spec.Diagnostics.LogAnalytics.WorkspaceKey == nil {
 		return nil
 	}
-	return []string{obj.Spec.Diagnostics.LogAnalytics.WorkspaceKey.Name}
+	return obj.Spec.Diagnostics.LogAnalytics.WorkspaceKey.Index()
 }
 
 // indexDbformariadbServerAdministratorLoginPassword an index function for dbformariadb_v20180601s.Server .spec.properties.serverPropertiesForDefaultCreate.administratorLoginPassword
@@ -1254,7 +1254,7 @@ func indexDbformariadbServerAdministratorLoginPassword(rawObj client.Object) []s
 	if obj.Spec.Properties.ServerPropertiesForDefaultCreate.AdministratorLoginPassword == nil {
 		return nil
 	}
-	return []string{obj.Spec.Properties.ServerPropertiesForDefaultCreate.AdministratorLoginPassword.Name}
+	return obj.Spec.Properties.ServerPropertiesForDefaultCreate.AdministratorLoginPassword.Index()
 }
 
 // indexDbformysqlFlexibleServerAdministratorLoginPassword an index function for dbformysql_v20210501s.FlexibleServer .spec.administratorLoginPassword
@@ -1266,7 +1266,7 @@ func indexDbformysqlFlexibleServerAdministratorLoginPassword(rawObj client.Objec
 	if obj.Spec.AdministratorLoginPassword == nil {
 		return nil
 	}
-	return []string{obj.Spec.AdministratorLoginPassword.Name}
+	return obj.Spec.AdministratorLoginPassword.Index()
 }
 
 // indexDbforpostgresqlFlexibleServerAdministratorLoginPassword an index function for dbforpostgresql_v20210601s.FlexibleServer .spec.administratorLoginPassword
@@ -1278,7 +1278,7 @@ func indexDbforpostgresqlFlexibleServerAdministratorLoginPassword(rawObj client.
 	if obj.Spec.AdministratorLoginPassword == nil {
 		return nil
 	}
-	return []string{obj.Spec.AdministratorLoginPassword.Name}
+	return obj.Spec.AdministratorLoginPassword.Index()
 }
 
 // indexMachinelearningservicesWorkspacesComputeAdminUserPassword an index function for machinelearningservices_v20210701s.WorkspacesCompute .spec.properties.amlCompute.properties.userAccountCredentials.adminUserPassword
@@ -1302,7 +1302,7 @@ func indexMachinelearningservicesWorkspacesComputeAdminUserPassword(rawObj clien
 	if obj.Spec.Properties.AmlCompute.Properties.UserAccountCredentials.AdminUserPassword == nil {
 		return nil
 	}
-	return []string{obj.Spec.Properties.AmlCompute.Properties.UserAccountCredentials.AdminUserPassword.Name}
+	return obj.Spec.Properties.AmlCompute.Properties.UserAccountCredentials.AdminUserPassword.Index()
 }
 
 // indexMachinelearningservicesWorkspacesComputeAdminUserSshPublicKey an index function for machinelearningservices_v20210701s.WorkspacesCompute .spec.properties.amlCompute.properties.userAccountCredentials.adminUserSshPublicKey
@@ -1326,7 +1326,7 @@ func indexMachinelearningservicesWorkspacesComputeAdminUserSshPublicKey(rawObj c
 	if obj.Spec.Properties.AmlCompute.Properties.UserAccountCredentials.AdminUserSshPublicKey == nil {
 		return nil
 	}
-	return []string{obj.Spec.Properties.AmlCompute.Properties.UserAccountCredentials.AdminUserSshPublicKey.Name}
+	return obj.Spec.Properties.AmlCompute.Properties.UserAccountCredentials.AdminUserSshPublicKey.Index()
 }
 
 // indexMachinelearningservicesWorkspacesComputeHDInsightPassword an index function for machinelearningservices_v20210701s.WorkspacesCompute .spec.properties.hdInsight.properties.administratorAccount.password
@@ -1350,7 +1350,7 @@ func indexMachinelearningservicesWorkspacesComputeHDInsightPassword(rawObj clien
 	if obj.Spec.Properties.HDInsight.Properties.AdministratorAccount.Password == nil {
 		return nil
 	}
-	return []string{obj.Spec.Properties.HDInsight.Properties.AdministratorAccount.Password.Name}
+	return obj.Spec.Properties.HDInsight.Properties.AdministratorAccount.Password.Index()
 }
 
 // indexMachinelearningservicesWorkspacesComputeVirtualMachinePassword an index function for machinelearningservices_v20210701s.WorkspacesCompute .spec.properties.virtualMachine.properties.administratorAccount.password
@@ -1374,7 +1374,7 @@ func indexMachinelearningservicesWorkspacesComputeVirtualMachinePassword(rawObj 
 	if obj.Spec.Properties.VirtualMachine.Properties.AdministratorAccount.Password == nil {
 		return nil
 	}
-	return []string{obj.Spec.Properties.VirtualMachine.Properties.AdministratorAccount.Password.Name}
+	return obj.Spec.Properties.VirtualMachine.Properties.AdministratorAccount.Password.Index()
 }
 
 // indexWebSiteAccessKey an index function for web_v20220301s.Site .spec.siteConfig.azureStorageAccounts.accessKey
@@ -1391,7 +1391,7 @@ func indexWebSiteAccessKey(rawObj client.Object) []string {
 		if value.AccessKey == nil {
 			continue
 		}
-		result = append(result, value.AccessKey.Name)
+		result = append(result, value.AccessKey.Index()...)
 	}
 	return result
 }

--- a/v2/internal/controllers/controller_resources_gen.go
+++ b/v2/internal/controllers/controller_resources_gen.go
@@ -152,48 +152,20 @@ import (
 // getKnownStorageTypes returns the list of storage types which can be reconciled.
 func getKnownStorageTypes() []*registration.StorageType {
 	var result []*registration.StorageType
-	result = append(result, &registration.StorageType{
-		Obj: new(appconfiguration_v20220501s.ConfigurationStore),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(authorization_v20200801ps.RoleAssignment),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(batch_v20210101s.BatchAccount),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cache_v20201201s.Redis),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cache_v20201201s.RedisFirewallRule),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cache_v20201201s.RedisLinkedServer),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cache_v20201201s.RedisPatchSchedule),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cache_v20210301s.RedisEnterprise),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cache_v20210301s.RedisEnterpriseDatabase),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cdn_v20210601s.Profile),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(cdn_v20210601s.ProfilesEndpoint),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(compute_v20200930s.Disk),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(compute_v20200930s.Snapshot),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(compute_v20220301s.Image),
-	})
+	result = append(result, &registration.StorageType{Obj: new(appconfiguration_v20220501s.ConfigurationStore)})
+	result = append(result, &registration.StorageType{Obj: new(authorization_v20200801ps.RoleAssignment)})
+	result = append(result, &registration.StorageType{Obj: new(batch_v20210101s.BatchAccount)})
+	result = append(result, &registration.StorageType{Obj: new(cache_v20201201s.Redis)})
+	result = append(result, &registration.StorageType{Obj: new(cache_v20201201s.RedisFirewallRule)})
+	result = append(result, &registration.StorageType{Obj: new(cache_v20201201s.RedisLinkedServer)})
+	result = append(result, &registration.StorageType{Obj: new(cache_v20201201s.RedisPatchSchedule)})
+	result = append(result, &registration.StorageType{Obj: new(cache_v20210301s.RedisEnterprise)})
+	result = append(result, &registration.StorageType{Obj: new(cache_v20210301s.RedisEnterpriseDatabase)})
+	result = append(result, &registration.StorageType{Obj: new(cdn_v20210601s.Profile)})
+	result = append(result, &registration.StorageType{Obj: new(cdn_v20210601s.ProfilesEndpoint)})
+	result = append(result, &registration.StorageType{Obj: new(compute_v20200930s.Disk)})
+	result = append(result, &registration.StorageType{Obj: new(compute_v20200930s.Snapshot)})
+	result = append(result, &registration.StorageType{Obj: new(compute_v20220301s.Image)})
 	result = append(result, &registration.StorageType{
 		Obj: new(compute_v20220301s.VirtualMachine),
 		Indexes: []registration.Index{
@@ -251,21 +223,11 @@ func getKnownStorageTypes() []*registration.StorageType {
 			},
 		},
 	})
-	result = append(result, &registration.StorageType{
-		Obj: new(containerregistry_v20210901s.Registry),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(containerservice_v20210501s.ManagedCluster),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(containerservice_v20210501s.ManagedClustersAgentPool),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(dbformariadb_v20180601s.Configuration),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(dbformariadb_v20180601s.Database),
-	})
+	result = append(result, &registration.StorageType{Obj: new(containerregistry_v20210901s.Registry)})
+	result = append(result, &registration.StorageType{Obj: new(containerservice_v20210501s.ManagedCluster)})
+	result = append(result, &registration.StorageType{Obj: new(containerservice_v20210501s.ManagedClustersAgentPool)})
+	result = append(result, &registration.StorageType{Obj: new(dbformariadb_v20180601s.Configuration)})
+	result = append(result, &registration.StorageType{Obj: new(dbformariadb_v20180601s.Database)})
 	result = append(result, &registration.StorageType{
 		Obj: new(dbformariadb_v20180601s.Server),
 		Indexes: []registration.Index{
@@ -296,12 +258,8 @@ func getKnownStorageTypes() []*registration.StorageType {
 			},
 		},
 	})
-	result = append(result, &registration.StorageType{
-		Obj: new(dbformysql_v20210501s.FlexibleServersDatabase),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(dbformysql_v20210501s.FlexibleServersFirewallRule),
-	})
+	result = append(result, &registration.StorageType{Obj: new(dbformysql_v20210501s.FlexibleServersDatabase)})
+	result = append(result, &registration.StorageType{Obj: new(dbformysql_v20210501s.FlexibleServersFirewallRule)})
 	result = append(result, &registration.StorageType{
 		Obj: new(dbforpostgresql_v20210601s.FlexibleServer),
 		Indexes: []registration.Index{
@@ -317,93 +275,35 @@ func getKnownStorageTypes() []*registration.StorageType {
 			},
 		},
 	})
-	result = append(result, &registration.StorageType{
-		Obj: new(dbforpostgresql_v20210601s.FlexibleServersConfiguration),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(dbforpostgresql_v20210601s.FlexibleServersDatabase),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(dbforpostgresql_v20210601s.FlexibleServersFirewallRule),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.DatabaseAccount),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.MongodbDatabase),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.MongodbDatabaseCollection),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.MongodbDatabaseCollectionThroughputSetting),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.MongodbDatabaseThroughputSetting),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlDatabase),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlDatabaseContainer),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlDatabaseContainerStoredProcedure),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlDatabaseContainerThroughputSetting),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlDatabaseContainerTrigger),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlDatabaseContainerUserDefinedFunction),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlDatabaseThroughputSetting),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(documentdb_v20210515s.SqlRoleAssignment),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventgrid_v20200601s.Domain),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventgrid_v20200601s.DomainsTopic),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventgrid_v20200601s.EventSubscription),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventgrid_v20200601s.Topic),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventhub_v20211101s.Namespace),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventhub_v20211101s.NamespacesAuthorizationRule),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventhub_v20211101s.NamespacesEventhub),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventhub_v20211101s.NamespacesEventhubsAuthorizationRule),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(eventhub_v20211101s.NamespacesEventhubsConsumerGroup),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(insights_v20180501ps.Webtest),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(insights_v20200202s.Component),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(keyvault_v20210401ps.Vault),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(machinelearningservices_v20210701s.Workspace),
-	})
+	result = append(result, &registration.StorageType{Obj: new(dbforpostgresql_v20210601s.FlexibleServersConfiguration)})
+	result = append(result, &registration.StorageType{Obj: new(dbforpostgresql_v20210601s.FlexibleServersDatabase)})
+	result = append(result, &registration.StorageType{Obj: new(dbforpostgresql_v20210601s.FlexibleServersFirewallRule)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.DatabaseAccount)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.MongodbDatabase)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.MongodbDatabaseCollection)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.MongodbDatabaseCollectionThroughputSetting)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.MongodbDatabaseThroughputSetting)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlDatabase)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlDatabaseContainer)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlDatabaseContainerStoredProcedure)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlDatabaseContainerThroughputSetting)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlDatabaseContainerTrigger)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlDatabaseContainerUserDefinedFunction)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlDatabaseThroughputSetting)})
+	result = append(result, &registration.StorageType{Obj: new(documentdb_v20210515s.SqlRoleAssignment)})
+	result = append(result, &registration.StorageType{Obj: new(eventgrid_v20200601s.Domain)})
+	result = append(result, &registration.StorageType{Obj: new(eventgrid_v20200601s.DomainsTopic)})
+	result = append(result, &registration.StorageType{Obj: new(eventgrid_v20200601s.EventSubscription)})
+	result = append(result, &registration.StorageType{Obj: new(eventgrid_v20200601s.Topic)})
+	result = append(result, &registration.StorageType{Obj: new(eventhub_v20211101s.Namespace)})
+	result = append(result, &registration.StorageType{Obj: new(eventhub_v20211101s.NamespacesAuthorizationRule)})
+	result = append(result, &registration.StorageType{Obj: new(eventhub_v20211101s.NamespacesEventhub)})
+	result = append(result, &registration.StorageType{Obj: new(eventhub_v20211101s.NamespacesEventhubsAuthorizationRule)})
+	result = append(result, &registration.StorageType{Obj: new(eventhub_v20211101s.NamespacesEventhubsConsumerGroup)})
+	result = append(result, &registration.StorageType{Obj: new(insights_v20180501ps.Webtest)})
+	result = append(result, &registration.StorageType{Obj: new(insights_v20200202s.Component)})
+	result = append(result, &registration.StorageType{Obj: new(keyvault_v20210401ps.Vault)})
+	result = append(result, &registration.StorageType{Obj: new(machinelearningservices_v20210701s.Workspace)})
 	result = append(result, &registration.StorageType{
 		Obj: new(machinelearningservices_v20210701s.WorkspacesCompute),
 		Indexes: []registration.Index{
@@ -431,96 +331,36 @@ func getKnownStorageTypes() []*registration.StorageType {
 			},
 		},
 	})
-	result = append(result, &registration.StorageType{
-		Obj: new(machinelearningservices_v20210701s.WorkspacesConnection),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(managedidentity_v20181130s.UserAssignedIdentity),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(managedidentity_v20220131ps.FederatedIdentityCredential),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20180901s.PrivateDnsZone),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.LoadBalancer),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.NetworkInterface),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.NetworkSecurityGroup),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.NetworkSecurityGroupsSecurityRule),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.PublicIPAddress),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.RouteTable),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.RouteTablesRoute),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.VirtualNetwork),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.VirtualNetworkGateway),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.VirtualNetworksSubnet),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(network_v20201101s.VirtualNetworksVirtualNetworkPeering),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(operationalinsights_v20210601s.Workspace),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(servicebus_v20210101ps.Namespace),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(servicebus_v20210101ps.NamespacesQueue),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(servicebus_v20210101ps.NamespacesTopic),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(servicebus_v20210101ps.NamespacesTopicsSubscription),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(servicebus_v20210101ps.NamespacesTopicsSubscriptionsRule),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(signalrservice_v20211001s.SignalR),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(storage_v20210401s.StorageAccount),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(storage_v20210401s.StorageAccountsBlobService),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(storage_v20210401s.StorageAccountsBlobServicesContainer),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(storage_v20210401s.StorageAccountsManagementPolicy),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(storage_v20210401s.StorageAccountsQueueService),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(storage_v20210401s.StorageAccountsQueueServicesQueue),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(subscription_v20211001s.Alias),
-	})
-	result = append(result, &registration.StorageType{
-		Obj: new(web_v20220301s.ServerFarm),
-	})
+	result = append(result, &registration.StorageType{Obj: new(machinelearningservices_v20210701s.WorkspacesConnection)})
+	result = append(result, &registration.StorageType{Obj: new(managedidentity_v20181130s.UserAssignedIdentity)})
+	result = append(result, &registration.StorageType{Obj: new(managedidentity_v20220131ps.FederatedIdentityCredential)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20180901s.PrivateDnsZone)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.LoadBalancer)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.NetworkInterface)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.NetworkSecurityGroup)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.NetworkSecurityGroupsSecurityRule)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.PublicIPAddress)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.RouteTable)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.RouteTablesRoute)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.VirtualNetwork)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.VirtualNetworkGateway)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.VirtualNetworksSubnet)})
+	result = append(result, &registration.StorageType{Obj: new(network_v20201101s.VirtualNetworksVirtualNetworkPeering)})
+	result = append(result, &registration.StorageType{Obj: new(operationalinsights_v20210601s.Workspace)})
+	result = append(result, &registration.StorageType{Obj: new(servicebus_v20210101ps.Namespace)})
+	result = append(result, &registration.StorageType{Obj: new(servicebus_v20210101ps.NamespacesQueue)})
+	result = append(result, &registration.StorageType{Obj: new(servicebus_v20210101ps.NamespacesTopic)})
+	result = append(result, &registration.StorageType{Obj: new(servicebus_v20210101ps.NamespacesTopicsSubscription)})
+	result = append(result, &registration.StorageType{Obj: new(servicebus_v20210101ps.NamespacesTopicsSubscriptionsRule)})
+	result = append(result, &registration.StorageType{Obj: new(signalrservice_v20211001s.SignalR)})
+	result = append(result, &registration.StorageType{Obj: new(storage_v20210401s.StorageAccount)})
+	result = append(result, &registration.StorageType{Obj: new(storage_v20210401s.StorageAccountsBlobService)})
+	result = append(result, &registration.StorageType{Obj: new(storage_v20210401s.StorageAccountsBlobServicesContainer)})
+	result = append(result, &registration.StorageType{Obj: new(storage_v20210401s.StorageAccountsManagementPolicy)})
+	result = append(result, &registration.StorageType{Obj: new(storage_v20210401s.StorageAccountsQueueService)})
+	result = append(result, &registration.StorageType{Obj: new(storage_v20210401s.StorageAccountsQueueServicesQueue)})
+	result = append(result, &registration.StorageType{Obj: new(subscription_v20211001s.Alias)})
+	result = append(result, &registration.StorageType{Obj: new(web_v20220301s.ServerFarm)})
 	result = append(result, &registration.StorageType{
 		Obj: new(web_v20220301s.Site),
 		Indexes: []registration.Index{

--- a/v2/pkg/genruntime/configmaps.go
+++ b/v2/pkg/genruntime/configmaps.go
@@ -27,6 +27,12 @@ type ConfigMapReference struct {
 	Key string `json:"key"`
 }
 
+var _ Indexer = ConfigMapReference{}
+
+func (c ConfigMapReference) Index() []string {
+	return []string{c.Name}
+}
+
 // Copy makes an independent copy of the ConfigMapReference
 func (c ConfigMapReference) Copy() ConfigMapReference {
 	return c

--- a/v2/pkg/genruntime/indexer.go
+++ b/v2/pkg/genruntime/indexer.go
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package genruntime
+
+type Indexer interface {
+	// Index returns the index of the Indexer. The index can be passed to a registration.Index to
+	// build an index for the controller-runtime client. If Index returns nil, there is nothing to index.
+	// See controller-runtime mgr.GetFieldIndexer().IndexField() for more details.
+	Index() []string
+}

--- a/v2/pkg/genruntime/secrets.go
+++ b/v2/pkg/genruntime/secrets.go
@@ -31,6 +31,12 @@ type SecretReference struct {
 	// here and default it to Kubernetes if it's not set. See the secrets design for more details.
 }
 
+var _ Indexer = SecretReference{}
+
+func (c SecretReference) Index() []string {
+	return []string{c.Name}
+}
+
 // Copy makes an independent copy of the SecretReference
 func (s SecretReference) Copy() SecretReference {
 	return s

--- a/v2/tools/generator/internal/astbuilder/composite_literals.go
+++ b/v2/tools/generator/internal/astbuilder/composite_literals.go
@@ -13,6 +13,7 @@ import (
 type CompositeLiteralBuilder struct {
 	structType dst.Expr
 	elts       []dst.Expr
+	newLines   bool
 }
 
 // NewCompositeLiteralBuilder creates a new instance for initialization of the specified struct
@@ -20,7 +21,14 @@ type CompositeLiteralBuilder struct {
 func NewCompositeLiteralBuilder(structType dst.Expr) *CompositeLiteralBuilder {
 	return &CompositeLiteralBuilder{
 		structType: structType,
+		newLines:   true,
 	}
+}
+
+// WithoutNewLines returns the CompositeLiteralBuilder without NewLines enabled
+func (b *CompositeLiteralBuilder) WithoutNewLines() *CompositeLiteralBuilder {
+	b.newLines = false
+	return b
 }
 
 // AddField adds initialization of another field
@@ -30,9 +38,10 @@ func (b *CompositeLiteralBuilder) AddField(name string, value dst.Expr) *Composi
 		Key:   dst.NewIdent(name),
 		Value: dst.Clone(value).(dst.Expr),
 	}
-
-	expr.Decs.Before = dst.NewLine
-	expr.Decs.After = dst.NewLine
+	if b.newLines {
+		expr.Decs.Before = dst.NewLine
+		expr.Decs.After = dst.NewLine
+	}
 
 	b.elts = append(b.elts, expr)
 	return b

--- a/v2/tools/generator/internal/astbuilder/composite_literals.go
+++ b/v2/tools/generator/internal/astbuilder/composite_literals.go
@@ -38,17 +38,26 @@ func (b *CompositeLiteralBuilder) AddField(name string, value dst.Expr) *Composi
 		Key:   dst.NewIdent(name),
 		Value: dst.Clone(value).(dst.Expr),
 	}
-	if b.newLines {
-		expr.Decs.Before = dst.NewLine
-		expr.Decs.After = dst.NewLine
-	}
+	expr.Decs.Before = dst.NewLine
+	expr.Decs.After = dst.NewLine
 
 	b.elts = append(b.elts, expr)
 	return b
 }
 
 // Build constructs the actual dst.CompositeLit that's required
-func (b CompositeLiteralBuilder) Build() *dst.CompositeLit {
+func (b *CompositeLiteralBuilder) Build() *dst.CompositeLit {
+	// If we only have a single element, remove the NewLine directives to force it onto a single line.
+	// While there are places where this doesn't look amazing, on balance it is cleaner than having them
+	// on multiple lines. This is especially true when the CompositeLit is used in a deeply nested context.
+	if len(b.elts) == 1 {
+		for _, elt := range b.elts {
+			kvExpr := elt.(*dst.KeyValueExpr) // This is safe because it's the only type we put into elts
+			kvExpr.Decs.Before = dst.None
+			kvExpr.Decs.After = dst.None
+		}
+	}
+
 	return &dst.CompositeLit{
 		Type: b.structType,
 		Elts: b.elts,

--- a/v2/tools/generator/internal/astbuilder/slices.go
+++ b/v2/tools/generator/internal/astbuilder/slices.go
@@ -51,6 +51,18 @@ func AppendItemsToSlice(lhs dst.Expr, rhs ...dst.Expr) dst.Stmt {
 		CallFunc("append", args...))
 }
 
+// AppendSliceToSlice returns a statement to append a slice to another slice
+//
+// <lhs> = append(<lhs>, <rhs>...)
+//
+func AppendSliceToSlice(lhs dst.Expr, rhs dst.Expr) dst.Stmt {
+	f := CallFunc("append", dst.Clone(lhs).(dst.Expr), dst.Clone(rhs).(dst.Expr))
+	f.Ellipsis = true
+	return SimpleAssignment(
+		dst.Clone(lhs).(dst.Expr),
+		f)
+}
+
 // IterateOverSlice creates a statement to iterate over the content of a list using the specified
 // identifier for each element in the list
 //

--- a/v2/tools/generator/internal/astmodel/std_references.go
+++ b/v2/tools/generator/internal/astmodel/std_references.go
@@ -110,7 +110,8 @@ var (
 	ValidatorInterfaceName          = MakeTypeName(ControllerRuntimeAdmission, "Validator")
 
 	// Type names - Core types
-	SecretType = MakeTypeName(CoreV1Reference, "Secret")
+	SecretType    = MakeTypeName(CoreV1Reference, "Secret")
+	ConfigMapType = MakeTypeName(CoreV1Reference, "ConfigMap")
 
 	// Type names - stdlib types
 	ContextType = MakeTypeName(ContextReference, "Context")

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -48,6 +48,7 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 						if err != nil {
 							return nil, errors.Wrapf(err, "failed to catalog %s secret property chains", def.Name())
 						}
+
 						configMapChains, err := catalogConfigMapPropertyChains(def, definitions)
 						if err != nil {
 							return nil, errors.Wrapf(err, "failed to catalog %s configmap property chains", def.Name())

--- a/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
+++ b/v2/tools/generator/internal/codegen/pipeline/export_controller_type_registrations.go
@@ -35,6 +35,7 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 			var resourceExtensions []astmodel.TypeName
 			indexFunctions := make(map[astmodel.TypeName][]*functions.IndexRegistrationFunction)
 			secretPropertyKeys := make(map[astmodel.TypeName][]string)
+			configMapPropertyKeys := make(map[astmodel.TypeName][]string)
 
 			// We need to register each version
 			for _, def := range definitions {
@@ -43,14 +44,21 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 					if resource.IsStorageVersion() {
 						storageVersionResources = append(storageVersionResources, def.Name())
 
-						chains, err := catalogSecretPropertyChains(def, definitions)
+						secretChains, err := catalogSecretPropertyChains(def, definitions)
 						if err != nil {
-							return nil, errors.Wrapf(err, "failed to catalog %s property chains", def.Name())
+							return nil, errors.Wrapf(err, "failed to catalog %s secret property chains", def.Name())
+						}
+						configMapChains, err := catalogConfigMapPropertyChains(def, definitions)
+						if err != nil {
+							return nil, errors.Wrapf(err, "failed to catalog %s configmap property chains", def.Name())
 						}
 
-						resourceIndexFunctions, resourceSecretPropertyKeys := handleSecretPropertyChains(chains, idFactory, def)
-						indexFunctions[def.Name()] = resourceIndexFunctions
+						resourceSecretIndexFunctions, resourceSecretPropertyKeys := transformChainsToIndexFunctionsAndKeys(secretChains, idFactory, def)
+						resourceConfigMapIndexFunctions, resourceConfigMapPropertyKeys := transformChainsToIndexFunctionsAndKeys(configMapChains, idFactory, def)
+
+						indexFunctions[def.Name()] = append(resourceSecretIndexFunctions, resourceConfigMapIndexFunctions...)
 						secretPropertyKeys[def.Name()] = resourceSecretPropertyKeys
+						configMapPropertyKeys[def.Name()] = resourceConfigMapPropertyKeys
 					}
 
 					resources = append(resources, def.Name())
@@ -60,7 +68,13 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 					}
 				}
 			}
-			file := NewResourceRegistrationFile(resources, storageVersionResources, indexFunctions, secretPropertyKeys, resourceExtensions)
+			file := NewResourceRegistrationFile(
+				resources,
+				storageVersionResources,
+				indexFunctions,
+				secretPropertyKeys,
+				configMapPropertyKeys,
+				resourceExtensions)
 			fileWriter := astmodel.NewGoSourceFileWriter(file)
 
 			err := fileWriter.SaveToFile(outputPath)
@@ -72,29 +86,29 @@ func ExportControllerResourceRegistrations(idFactory astmodel.IdentifierFactory,
 		})
 }
 
-func handleSecretPropertyChains(
+func transformChainsToIndexFunctionsAndKeys(
 	chains []*propertyChain,
 	idFactory astmodel.IdentifierFactory,
 	def astmodel.TypeDefinition,
 ) ([]*functions.IndexRegistrationFunction, []string) {
 	indexFunctions := make([]*functions.IndexRegistrationFunction, 0, len(chains))
-	secretPropertyKeys := make([]string, 0, len(chains))
+	propertyKeys := make([]string, 0, len(chains))
 
 	ensureIndexPropertyPathsUnique(chains)
 
 	for _, chain := range chains {
-		secretPropertyKey := chain.indexPropertyKey()
+		propertyKey := chain.indexPropertyKey()
 		indexFunction := functions.NewIndexRegistrationFunction(
 			idFactory,
 			chain.indexMethodName(idFactory, def.Name()),
 			def.Name(),
-			secretPropertyKey,
+			propertyKey,
 			chain.properties())
 		indexFunctions = append(indexFunctions, indexFunction)
-		secretPropertyKeys = append(secretPropertyKeys, secretPropertyKey)
+		propertyKeys = append(propertyKeys, propertyKey)
 	}
 
-	return indexFunctions, secretPropertyKeys
+	return indexFunctions, propertyKeys
 }
 
 // ensureIndexPropertyPathsUnique looks for conflicting index property paths (which would lead to conflicting index
@@ -174,6 +188,20 @@ func catalogSecretPropertyChains(def astmodel.TypeDefinition, definitions astmod
 		VisitObjectType: indexBuilder.catalogSecretProperties,
 	}.Build()
 
+	return catalogPropertyChains(def, definitions, indexBuilder, visitor)
+}
+
+func catalogConfigMapPropertyChains(def astmodel.TypeDefinition, definitions astmodel.TypeDefinitionSet) ([]*propertyChain, error) {
+	indexBuilder := &indexFunctionBuilder{}
+
+	visitor := astmodel.TypeVisitorBuilder{
+		VisitObjectType: indexBuilder.catalogConfigMapProperties,
+	}.Build()
+
+	return catalogPropertyChains(def, definitions, indexBuilder, visitor)
+}
+
+func catalogPropertyChains(def astmodel.TypeDefinition, definitions astmodel.TypeDefinitionSet, indexBuilder *indexFunctionBuilder, visitor astmodel.TypeVisitor) ([]*propertyChain, error) {
 	walker := astmodel.NewTypeWalker(definitions, visitor)
 	walker.MakeContext = func(it astmodel.TypeName, ctx interface{}) (interface{}, error) {
 		if ctx != nil {
@@ -195,7 +223,41 @@ type indexFunctionBuilder struct {
 	propChains []*propertyChain
 }
 
-// propertyChain represents an chain of properties that can be used to index a secret on a resource. Each chain is made
+func (b *indexFunctionBuilder) catalogSecretProperties(this *astmodel.TypeVisitor, it *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
+	chain := ctx.(*propertyChain)
+
+	it.Properties().ForEach(func(prop *astmodel.PropertyDefinition) {
+		if prop.IsSecret() {
+			b.propChains = append(b.propChains, chain.add(prop))
+		}
+	})
+
+	identityVisit := astmodel.MakeIdentityVisitOfObjectType(preservePropertyChain)
+	return identityVisit(this, it, ctx)
+}
+
+func (b *indexFunctionBuilder) catalogConfigMapProperties(this *astmodel.TypeVisitor, it *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
+	chain := ctx.(*propertyChain)
+
+	it.Properties().ForEach(func(prop *astmodel.PropertyDefinition) {
+		typeName, ok := astmodel.AsTypeName(prop.PropertyType())
+		if !ok {
+			return
+		}
+
+		isConfigMapReference := typeName.Equals(astmodel.ConfigMapReferenceType, astmodel.EqualityOverrides{})
+		if !isConfigMapReference {
+			return
+		}
+
+		b.propChains = append(b.propChains, chain.add(prop))
+	})
+
+	identityVisit := astmodel.MakeIdentityVisitOfObjectType(preservePropertyChain)
+	return identityVisit(this, it, ctx)
+}
+
+// propertyChain represents a chain of properties that can be used to index a property on a resource. Each chain is made
 // up of a leaf property and a reference to a (potentially shared) parent chain. Sharing these parents keeps memory
 // consumption down, while also allowing us to include properties partway along the path to resolve ambiguities when
 // generating method names.
@@ -239,19 +301,6 @@ func preservePropertyChain(_ *astmodel.ObjectType, prop *astmodel.PropertyDefini
 	chain := ctx.(*propertyChain)
 
 	return chain.add(prop), nil
-}
-
-func (b *indexFunctionBuilder) catalogSecretProperties(this *astmodel.TypeVisitor, it *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
-	chain := ctx.(*propertyChain)
-
-	it.Properties().ForEach(func(prop *astmodel.PropertyDefinition) {
-		if prop.IsSecret() {
-			b.propChains = append(b.propChains, chain.add(prop))
-		}
-	})
-
-	identityVisit := astmodel.MakeIdentityVisitOfObjectType(preservePropertyChain)
-	return identityVisit(this, it, ctx)
 }
 
 func (chain *propertyChain) indexMethodName(

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_oneof_resource_conversion_on_arm_type_only_azure.golden
@@ -351,9 +351,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_dependent_resource_and_ownership_azure.golden
@@ -1144,9 +1144,7 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	a.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil
@@ -1305,9 +1303,7 @@ func (b *B_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	b.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	b.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	b.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil
@@ -1461,9 +1457,7 @@ func (c *C_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	c.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	c.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	c.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil
@@ -1617,9 +1611,7 @@ func (d *D_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	d.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	d.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	d.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_empty_objecttype_removed_azure.golden
@@ -615,9 +615,7 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	a.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {
@@ -828,9 +826,7 @@ func (b *B_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	b.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	b.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	b.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_has_embedded_resource_inside_azure.golden
@@ -887,9 +887,7 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	a.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {
@@ -1101,9 +1099,7 @@ func (b *B_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	b.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	b.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	b.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {
@@ -1309,9 +1305,7 @@ func (c *C_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	c.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	c.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	c.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_multiple_contexts_azure.golden
@@ -343,9 +343,7 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	a.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_resource_removed_azure.golden
@@ -615,9 +615,7 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	a.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {
@@ -829,9 +827,7 @@ func (b *B_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	b.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	b.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	b.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_azure.golden
@@ -615,9 +615,7 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	a.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {
@@ -828,9 +826,7 @@ func (b *B_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	b.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	b.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	b.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_embedded_subresource_same_properties_azure.golden
@@ -615,9 +615,7 @@ func (a *A_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	a.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	a.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	a.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {
@@ -822,9 +820,7 @@ func (b *B_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armIn
 	b.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	b.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	b.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_id_resource_reference_azure.golden
@@ -350,9 +350,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_required_and_optional_resource_references_azure.golden
@@ -350,9 +350,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// Set property ‘Properties’:
 	if typedInput.Properties != nil {

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_array_properties_azure.golden
@@ -482,9 +482,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_complex_properties_azure.golden
@@ -409,9 +409,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_json_fields_azure.golden
@@ -389,9 +389,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_map_properties_azure.golden
@@ -580,9 +580,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
+++ b/v2/tools/generator/internal/codegen/testdata/ArmResource/Arm_test_simple_resource_renders_spec_azure.golden
@@ -338,9 +338,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EmbeddedTypes/Embedded_type_simple_resource.golden
@@ -416,9 +416,7 @@ func (resource *FakeResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EnumNames/Multi_valued_enum_name.golden
@@ -338,9 +338,7 @@ func (resource *AResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 	resource.SetAzureName(genruntime.ExtractKubernetesResourceNameFromARMName(typedInput.Name))
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil

--- a/v2/tools/generator/internal/codegen/testdata/EnumNames/Single_valued_enum_name.golden
+++ b/v2/tools/generator/internal/codegen/testdata/EnumNames/Single_valued_enum_name.golden
@@ -324,9 +324,7 @@ func (resource *AResource_Spec) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 	}
 
 	// Set property ‘Owner’:
-	resource.Owner = &genruntime.KnownResourceReference{
-		Name: owner.Name,
-	}
+	resource.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
 	// No error
 	return nil


### PR DESCRIPTION
- Correctly indexes ConfigMaps in the resource registration function if needed.
- Use Indexer interface in controller_resources_gen index functions.

  The indexer interface makes it easier to abstract across various shapes that can be indexed (ConfigMap, Secret, etc). This helps us avoid generating code for each distinct shape, instead we can target the interface.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
