### PR TITLE
Change mysql live tests location to Australia East

### DIFF
--- a/v2/test/mysql_test.go
+++ b/v2/test/mysql_test.go
@@ -417,7 +417,7 @@ func newSecret(tc *testcommon.KubePerTestContext, key string, password string) *
 func newMySQLServer(tc *testcommon.KubePerTestContext, rg *resources.ResourceGroup, adminUsername string, adminKey string, adminSecretName string) *mysql.FlexibleServer {
 	// Force this test to run in a region that is not capacity constrained.
 	// location := tc.AzureRegion TODO: Uncomment this line when West US 2 is no longer constrained
-	location := to.StringPtr("Australia East")
+	location := to.StringPtr("australiaeast")
 
 	version := mysql.ServerProperties_Version_8021
 	secretRef := genruntime.SecretReference{

--- a/v2/test/mysql_test.go
+++ b/v2/test/mysql_test.go
@@ -417,7 +417,7 @@ func newSecret(tc *testcommon.KubePerTestContext, key string, password string) *
 func newMySQLServer(tc *testcommon.KubePerTestContext, rg *resources.ResourceGroup, adminUsername string, adminKey string, adminSecretName string) *mysql.FlexibleServer {
 	// Force this test to run in a region that is not capacity constrained.
 	// location := tc.AzureRegion TODO: Uncomment this line when West US 2 is no longer constrained
-	location := to.StringPtr("East US")
+	location := to.StringPtr("Australia East")
 
 	version := mysql.ServerProperties_Version_8021
 	secretRef := genruntime.SecretReference{


### PR DESCRIPTION
RP keeps restricting the US zones for the org subs, so changing it to Australia East. 