### PR TITLE
Fix Git configuration in CI

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -220,9 +220,15 @@ if [ "$VERBOSE" == true ]; then
 fi
 
 if [ "$DEVCONTAINER" == true ]; then 
+
+    # Webhook Certs
     write-info "Setting up k8s webhook certificates"
     mkdir -p /tmp/k8s-webhook-server/serving-certs
     openssl genrsa 2048 > tls.key
     openssl req -new -x509 -nodes -sha256 -days 3650 -key tls.key -subj '/' -out tls.crt
     mv tls.key tls.crt /tmp/k8s-webhook-server/serving-certs
+
+    # Git Permissions
+    # Workaround for issue where /workspace has different owner because checkout happens outside the container
+    git config --global --add safe.directory /workspace
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Our CI builds are failing because our workflows (correctly!) check out the repo outside the dev container, but we run the build within, as a different user.

From the [release notes for Git 2.36](https://github.blog/2022-04-18-highlights-from-git-2-36/):

> Beginning in Git 2.35.2, Git changed its default behavior to prevent you from executing git commands in a repository owned by a different user than the current one. This is designed to prevent git invocations from unintentionally executing commands which the repository owner configured.

Since our CI runs in a controlled environment, disabling the check should be safe.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/l3q2HS9FG81YSdkB2/giphy.gif)
