### PR TITLE
More customizable retry

### DIFF
--- a/v2/internal/controllers/to_azure_configmaps_test.go
+++ b/v2/internal/controllers/to_azure_configmaps_test.go
@@ -73,7 +73,7 @@ func Test_MissingConfigMap_ReturnsError(t *testing.T) {
 
 	tc.CreateResourceAndWaitForState(roleAssignment, metav1.ConditionFalse, conditions.ConditionSeverityWarning)
 	// We expect the ready condition to include details of the error
-	tc.Expect(roleAssignment.Status.Conditions[0].Reason).To(Equal(conditions.ReasonConfigMapNotFound))
+	tc.Expect(roleAssignment.Status.Conditions[0].Reason).To(Equal(conditions.ReasonConfigMapNotFound.Name))
 	tc.Expect(roleAssignment.Status.Conditions[0].Message).To(
 		ContainSubstring("failed resolving config map references: %s/%s does not exist", tc.Namespace, configMapName))
 }
@@ -184,7 +184,7 @@ func Test_MissingConfigMapKey_ReturnsError(t *testing.T) {
 
 	tc.CreateResourceAndWaitForState(roleAssignment, metav1.ConditionFalse, conditions.ConditionSeverityWarning)
 	// We expect the ready condition to include details of the error
-	tc.Expect(roleAssignment.Status.Conditions[0].Reason).To(Equal(conditions.ReasonConfigMapNotFound))
+	tc.Expect(roleAssignment.Status.Conditions[0].Reason).To(Equal(conditions.ReasonConfigMapNotFound.Name))
 	tc.Expect(roleAssignment.Status.Conditions[0].Message).To(
 		ContainSubstring("ConfigMap \"%s/%s\" does not contain key \"%s\"", tc.Namespace, configMap.Name, principalIdKey))
 
@@ -236,7 +236,7 @@ func Test_ConfigMapInDifferentNamespace_ConfigMapNotFound(t *testing.T) {
 
 	tc.CreateResourceAndWaitForState(roleAssignment, metav1.ConditionFalse, conditions.ConditionSeverityWarning)
 	// We expect the ready condition to include details of the error
-	tc.Expect(roleAssignment.Status.Conditions[0].Reason).To(Equal(conditions.ReasonConfigMapNotFound))
+	tc.Expect(roleAssignment.Status.Conditions[0].Reason).To(Equal(conditions.ReasonConfigMapNotFound.Name))
 	tc.Expect(roleAssignment.Status.Conditions[0].Message).To(
 		ContainSubstring("failed resolving config map references: %s/%s does not exist", tc.Namespace, configMapName))
 

--- a/v2/internal/controllers/to_azure_secrets_test.go
+++ b/v2/internal/controllers/to_azure_secrets_test.go
@@ -47,7 +47,7 @@ func Test_MissingSecret_ReturnsError_ReconcilesSuccessfullyWhenSecretAdded(t *te
 
 	tc.CreateResourceAndWaitForState(vm, metav1.ConditionFalse, conditions.ConditionSeverityWarning)
 	// We expect the ready condition to include details of the error
-	tc.Expect(vm.Status.Conditions[0].Reason).To(Equal(conditions.ReasonSecretNotFound))
+	tc.Expect(vm.Status.Conditions[0].Reason).To(Equal(conditions.ReasonSecretNotFound.Name))
 	tc.Expect(vm.Status.Conditions[0].Message).To(
 		ContainSubstring("failed resolving secret references: %s/%s does not exist", tc.Namespace, secretRef.Name))
 
@@ -86,7 +86,7 @@ func Test_MissingSecretKey_ReturnsError(t *testing.T) {
 
 	tc.CreateResourceAndWaitForState(vm, metav1.ConditionFalse, conditions.ConditionSeverityWarning)
 	// We expect the ready condition to include details of the error
-	tc.Expect(vm.Status.Conditions[0].Reason).To(Equal(conditions.ReasonSecretNotFound))
+	tc.Expect(vm.Status.Conditions[0].Reason).To(Equal(conditions.ReasonSecretNotFound.Name))
 	tc.Expect(vm.Status.Conditions[0].Message).To(
 		ContainSubstring("Secret \"%s/%s\" does not contain key \"%s\"", tc.Namespace, secret.Name, secret.Key))
 
@@ -118,7 +118,7 @@ func Test_UserSecretInDifferentNamespace_SecretNotFound(t *testing.T) {
 
 	tc.CreateResourceAndWaitForState(vm, metav1.ConditionFalse, conditions.ConditionSeverityWarning)
 	// We expect the ready condition to include details of the error
-	tc.Expect(vm.Status.Conditions[0].Reason).To(Equal(conditions.ReasonSecretNotFound))
+	tc.Expect(vm.Status.Conditions[0].Reason).To(Equal(conditions.ReasonSecretNotFound.Name))
 	tc.Expect(vm.Status.Conditions[0].Message).To(
 		ContainSubstring("failed resolving secret references: %s/%s does not exist", tc.Namespace, secretInDiffNamespace.Name))
 

--- a/v2/internal/util/interval/interval_calculator.go
+++ b/v2/internal/util/interval/interval_calculator.go
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package interval
+
+import (
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
+	"github.com/Azure/azure-service-operator/v2/internal/util/randextensions"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+)
+
+// Calculator calculates an interval
+type Calculator interface {
+	NextInterval(req ctrl.Request, result ctrl.Result, err error) (ctrl.Result, error)
+}
+
+type CalculatorParameters struct {
+	Rand                 *rand.Rand
+	ErrorBaseDelay       time.Duration
+	ErrorMaxFastDelay    time.Duration
+	ErrorMaxSlowDelay    time.Duration
+	SyncPeriod           *time.Duration
+	RequeueDelayOverride time.Duration
+}
+
+// NewCalculator creates a new Calculator.
+func NewCalculator(params CalculatorParameters) Calculator {
+	return &calculator{
+		failures:             make(map[ctrl.Request]int),
+		errorBaseDelay:       params.ErrorBaseDelay,
+		errorMaxSlowDelay:    params.ErrorMaxSlowDelay,
+		errorMaxFastDelay:    params.ErrorMaxFastDelay,
+		syncPeriod:           params.SyncPeriod,
+		requeueDelayOverride: params.RequeueDelayOverride,
+		rand:                 params.Rand,
+	}
+}
+
+type calculator struct {
+	failuresLock sync.Mutex
+	failures     map[ctrl.Request]int
+
+	// Used only if there is an error
+	errorBaseDelay    time.Duration
+	errorMaxSlowDelay time.Duration
+	errorMaxFastDelay time.Duration
+
+	// Used only if there is not an error
+	syncPeriod           *time.Duration
+	requeueDelayOverride time.Duration
+	rand                 *rand.Rand
+}
+
+var _ Calculator = &calculator{}
+
+// NextInterval calculates the next interval for a given request, result, and error.
+// Remember: There is also a controller-runtime RateLimiter that also can determine intervals. This implementation
+// takes ownership of specific scenarios while leaving the rest to the standard RateLimiter.
+// The scenarios that this implementation targets are:
+// 1. Errors of type ReadyConditionImpactingError. These have a RetryClassification on them which is honored here.
+// 2. If syncPeriod is set, success results that would normally be terminal are instead configured to try again in syncPeriod.
+// 3. If requeueDelayOverride is set, all happy-path requests have requeueDelayOverride set.
+// The scenarios that this handler doesn't target:
+// 1. Any error other than ReadyConditionImpacting error.
+// 2. Happy-path requests when requeueDelayOverride is not set. These are scenarios where the operator is working
+//    as expected and we're just doing something like polling an async operation.
+func (i *calculator) NextInterval(req ctrl.Request, result ctrl.Result, err error) (ctrl.Result, error) {
+	i.failuresLock.Lock()
+	defer i.failuresLock.Unlock()
+
+	if err != nil {
+		return i.failureResult(req, err)
+	}
+
+	// Happy path
+	if (result == ctrl.Result{}) {
+		// If result is a success, ensure that we requeue for monitoring state in Azure
+		result = i.makeSuccessResult()
+	}
+
+	delete(i.failures, req) // On reconcile without an error, forget any previous failures
+
+	hasRequeueDelayOverride := i.requeueDelayOverride != time.Duration(0)
+	isRequeueing := result.Requeue || result.RequeueAfter > time.Duration(0)
+	if hasRequeueDelayOverride && isRequeueing {
+		result.RequeueAfter = i.requeueDelayOverride
+		result.Requeue = true
+	}
+	return result, nil
+}
+
+func (i *calculator) failureResult(req ctrl.Request, err error) (ctrl.Result, error) {
+	exp := i.failures[req]
+	i.failures[req] = i.failures[req] + 1
+
+	readyErr, ok := conditions.AsReadyConditionImpactingError(err)
+	if !ok {
+		// NotFound is a superfluous error as per https://github.com/kubernetes-sigs/controller-runtime/issues/377
+		// The correct handling is just to ignore it and we will get an event shortly with the updated version to patch
+		// We must also ignore conflict here because updating a resource that
+		// doesn't exist returns conflict unfortunately: https://github.com/kubernetes/kubernetes/issues/89985. This is OK
+		// to ignore because a conflict means either the resource has been deleted (in which case there's nothing to do) or
+		// it has been updated, in which case there's going to be a new event triggered for it and we can count this
+		// round of reconciliation as a success and wait for the next event.
+		return ctrl.Result{}, kubeclient.IgnoreNotFoundAndConflict(err)
+	}
+
+	// Now we have a readyErr
+	if readyErr.Severity == conditions.ConditionSeverityError {
+		// Severity error is fatal, return fast and block requeue
+		// Since this is fatal, stop tracking the req
+		delete(i.failures, req)
+		return ctrl.Result{}, nil
+	} else if readyErr.Severity == conditions.ConditionSeverityWarning {
+		switch readyErr.RetryClassification {
+		case conditions.RetrySlow:
+			delay := i.calculateExponentialDelay(i.errorBaseDelay, exp, i.errorMaxSlowDelay)
+			return ctrl.Result{RequeueAfter: delay}, nil
+		case conditions.RetryFast:
+			delay := i.calculateExponentialDelay(i.errorBaseDelay, exp, i.errorMaxFastDelay)
+			return ctrl.Result{RequeueAfter: delay}, nil
+		case conditions.RetryNone:
+			// This shouldn't happen, return an error
+			return ctrl.Result{}, errors.New("didn't expect RetryNone classification for error")
+		default:
+			// This shouldn't happen, return an error
+			return ctrl.Result{}, errors.Errorf("unknown RetryClassification %q", readyErr.RetryClassification)
+		}
+	}
+
+	// This shouldn't happen, return an error
+	return ctrl.Result{}, errors.Errorf("Error with severity %q is unexpected", readyErr.Severity)
+}
+
+func (i *calculator) makeSuccessResult() ctrl.Result {
+	result := ctrl.Result{}
+	// This has a RequeueAfter because we want to force a re-sync at some point in the future in order to catch
+	// potential drift from the state in Azure. Note that we cannot use mgr.Options.SyncPeriod for this because we filter
+	// our events by predicate.GenerationChangedPredicate and the generation will not have changed.
+	if i.syncPeriod != nil {
+		result.RequeueAfter = randextensions.Jitter(i.rand, *i.syncPeriod, 0.1)
+	}
+
+	return result
+}
+
+func (i *calculator) calculateExponentialDelay(base time.Duration, exp int, max time.Duration) time.Duration {
+	// The backoff is capped such that 'calculated' value never overflows.
+	backoff := float64(base.Nanoseconds()) * math.Pow(2, float64(exp))
+	if backoff > math.MaxInt64 {
+		return max
+	}
+
+	calculated := time.Duration(backoff)
+	if calculated > max {
+		return max
+	}
+
+	return calculated
+}

--- a/v2/internal/util/interval/interval_calculator_test.go
+++ b/v2/internal/util/interval/interval_calculator_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package interval
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/Azure/azure-service-operator/v2/internal/util/lockedrand"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/conditions"
+)
+
+func newCalculator(params CalculatorParameters) Calculator {
+	seed := time.Now().UnixNano()
+	//nolint:gosec // do not want cryptographic randomness here
+	rng := rand.New(lockedrand.NewSource(seed))
+	params.Rand = rng
+
+	calc := NewCalculator(params)
+
+	return calc
+}
+
+func Test_Success_WithoutSyncPeriod_ReturnsEmptyResult(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	result, err := calc.NextInterval(req, ctrl.Result{}, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_Success_WithSyncPeriod_ReturnsSyncPeriod(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	syncPeriod := 10 * time.Second
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+			SyncPeriod:        &syncPeriod,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	result, err := calc.NextInterval(req, ctrl.Result{}, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result.RequeueAfter > 8*time.Second).To(BeTrue())
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_Requeue_ReturnsResultUnmodified(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	syncPeriod := 10 * time.Second
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+			SyncPeriod:        &syncPeriod,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	result, err := calc.NextInterval(req, ctrl.Result{Requeue: true}, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_RequeueWithDelayOverride_ReturnsResultWithDelay(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	syncPeriod := 10 * time.Second
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:       1 * time.Second,
+			ErrorMaxFastDelay:    5 * time.Second,
+			ErrorMaxSlowDelay:    10 * time.Second,
+			SyncPeriod:           &syncPeriod,
+			RequeueDelayOverride: 77 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	result, err := calc.NextInterval(req, ctrl.Result{Requeue: true}, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: 77 * time.Second}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_Error_ReturnedAsIs(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	inputErr := errors.New("An error")
+	result, err := calc.NextInterval(req, ctrl.Result{}, inputErr)
+	g.Expect(err).To(Equal(inputErr))
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(1))
+}
+
+func Test_ErrorFollowedBySuccess_ClearsFailureTracking(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	inputErr := errors.New("An error")
+	result, err := calc.NextInterval(req, ctrl.Result{}, inputErr)
+	g.Expect(err).To(Equal(inputErr))
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	result, err = calc.NextInterval(req, ctrl.Result{}, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_ReadyConditionErrorWithErrorSeverity_ReturnsSuccess(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	inputErr := conditions.NewReadyConditionImpactingError(errors.New("problem"), conditions.ConditionSeverityError, conditions.ReasonFailed)
+	result, err := calc.NextInterval(req, ctrl.Result{}, inputErr)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_ReadyConditionErrorWithSlowBackoff_UsesSlowBackoff(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	inputErr := conditions.NewReadyConditionImpactingError(
+		errors.New("problem"),
+		conditions.ConditionSeverityWarning,
+		conditions.Reason{Name: "Abc", RetryClassification: conditions.RetrySlow})
+
+	expectedDelaySec := []int64{1, 2, 4, 8, 10, 10, 10}
+
+	for _, delay := range expectedDelaySec {
+		result, err := calc.NextInterval(req, ctrl.Result{}, inputErr)
+		g.Expect(err).ToNot(HaveOccurred()) // No error because we're manually controlling backoff here
+		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: time.Duration(delay) * time.Second}))
+	}
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(1))
+
+	// Success should then clear failure tracking
+	result, err := calc.NextInterval(req, ctrl.Result{}, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_ReadyConditionErrorWithFastBackoff_UsesFastBackoff(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	inputErr := conditions.NewReadyConditionImpactingError(
+		errors.New("problem"),
+		conditions.ConditionSeverityWarning,
+		conditions.Reason{Name: "Abc", RetryClassification: conditions.RetryFast})
+
+	expectedDelaySec := []int64{1, 2, 4, 5, 5, 5, 5}
+
+	for _, delay := range expectedDelaySec {
+		result, err := calc.NextInterval(req, ctrl.Result{}, inputErr)
+		g.Expect(err).ToNot(HaveOccurred()) // No error because we're manually controlling backoff here
+		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: time.Duration(delay) * time.Second}))
+	}
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(1))
+
+	// Success should then clear failure tracking
+	result, err := calc.NextInterval(req, ctrl.Result{}, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(0))
+}
+
+func Test_KubeClientConflictError_ReturnsSuccess(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	calc := newCalculator(
+		CalculatorParameters{
+			ErrorBaseDelay:    1 * time.Second,
+			ErrorMaxFastDelay: 5 * time.Second,
+			ErrorMaxSlowDelay: 10 * time.Second,
+		})
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}
+
+	inputErr := &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Reason: metav1.StatusReasonConflict,
+		},
+	}
+
+	result, err := calc.NextInterval(req, ctrl.Result{}, inputErr)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(calc.(*calculator).failures).To(HaveLen(1))
+}

--- a/v2/internal/util/kubeclient/utilities.go
+++ b/v2/internal/util/kubeclient/utilities.go
@@ -7,13 +7,15 @@ package kubeclient
 
 import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func IgnoreNotFoundAndConflict(err error) error {
-	if apierrors.IsConflict(err) {
+	if IsNotFoundOrConflict(err) {
 		return nil
 	}
+	return err
+}
 
-	return client.IgnoreNotFound(err)
+func IsNotFoundOrConflict(err error) bool {
+	return apierrors.IsConflict(err) || apierrors.IsNotFound(err)
 }

--- a/v2/pkg/genruntime/conditions/conditions.go
+++ b/v2/pkg/genruntime/conditions/conditions.go
@@ -219,11 +219,11 @@ func SetCondition(o Conditioner, new Condition) {
 // v2/tools/generator/internal/readonly/readonly_map.go but given
 // Golang generics bugs for now we go with the simpler approach
 var reasonPriority = map[string]int{
-	ReasonReferenceNotFound: -2,
-	ReasonSecretNotFound:    -2,
-	ReasonConfigMapNotFound: -2,
-	ReasonWaitingForOwner:   -2,
-	ReasonReconciling:       -1,
+	ReasonReferenceNotFound.Name: -2,
+	ReasonSecretNotFound.Name:    -2,
+	ReasonConfigMapNotFound.Name: -2,
+	ReasonWaitingForOwner.Name:   -2,
+	ReasonReconciling.Name:       -1,
 }
 
 // SetConditionReasonAware sets the provided Condition on the Conditioner. This is similar to SetCondition

--- a/v2/pkg/genruntime/conditions/conditions_test.go
+++ b/v2/pkg/genruntime/conditions/conditions_test.go
@@ -303,19 +303,19 @@ func Test_SetConditionReasonAware_OverwritesAsExpected(t *testing.T) {
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityInfo,
 		1,
-		conditions.ReasonReconciling,
+		conditions.ReasonReconciling.Name,
 		"a message")
 	referenceNotFoundCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
-		conditions.ReasonReferenceNotFound,
+		conditions.ReasonReferenceNotFound.Name,
 		"a message")
 	secretNotFoundCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
-		conditions.ReasonSecretNotFound,
+		conditions.ReasonSecretNotFound.Name,
 		"a message")
 	arbitraryInfoCondition := builder.MakeFalseCondition(
 		conditions.ConditionTypeReady,
@@ -339,7 +339,7 @@ func Test_SetConditionReasonAware_OverwritesAsExpected(t *testing.T) {
 		conditions.ConditionTypeReady,
 		conditions.ConditionSeverityWarning,
 		1,
-		conditions.ReasonWaitingForOwner,
+		conditions.ReasonWaitingForOwner.Name,
 		"a message")
 	successCondition := builder.MakeTrueCondition(conditions.ConditionTypeReady, 1)
 

--- a/v2/pkg/genruntime/conditions/errors.go
+++ b/v2/pkg/genruntime/conditions/errors.go
@@ -14,17 +14,19 @@ import (
 
 // ReadyConditionImpactingError is an error that requires notification in the Ready condition
 type ReadyConditionImpactingError struct {
-	Severity ConditionSeverity
-	Reason   string
-	cause    error
+	Severity            ConditionSeverity
+	Reason              string
+	cause               error
+	RetryClassification RetryClassification
 }
 
 // NewReadyConditionImpactingError creates a new ReadyConditionImpactingError
-func NewReadyConditionImpactingError(cause error, severity ConditionSeverity, reason string) *ReadyConditionImpactingError {
+func NewReadyConditionImpactingError(cause error, severity ConditionSeverity, reason Reason) *ReadyConditionImpactingError {
 	return &ReadyConditionImpactingError{
-		cause:    cause,
-		Severity: severity,
-		Reason:   reason,
+		cause:               cause,
+		Severity:            severity,
+		Reason:              reason.Name,
+		RetryClassification: reason.RetryClassification,
 	}
 }
 
@@ -37,6 +39,11 @@ func AsReadyConditionImpactingError(err error) (*ReadyConditionImpactingError, b
 	}
 
 	return nil, false
+}
+
+func (e *ReadyConditionImpactingError) WithRetryClassification(classification RetryClassification) *ReadyConditionImpactingError {
+	e.RetryClassification = classification
+	return e
 }
 
 func (e *ReadyConditionImpactingError) Error() string {

--- a/v2/pkg/genruntime/conditions/ready_condition_builder.go
+++ b/v2/pkg/genruntime/conditions/ready_condition_builder.go
@@ -5,28 +5,44 @@ Licensed under the MIT license.
 
 package conditions
 
+type RetryClassification string
+
 const (
-	// Auth reasons
-	ReasonSubscriptionMismatch = "SubscriptionMismatch"
-
-	// Precondition reasons
-	ReasonSecretNotFound    = "SecretNotFound"
-	ReasonConfigMapNotFound = "ConfigMapNotFound"
-	ReasonReferenceNotFound = "ReferenceNotFound"
-	ReasonWaitingForOwner   = "WaitingForOwner"
-
-	// Post-ARM PUT reasons
-	ReasonAzureResourceNotFound               = "AzureResourceNotFound"
-	ReasonAdditionalKubernetesObjWriteFailure = "FailedWritingAdditionalKubernetesObjects"
-
-	// Other reasons
-	ReasonReconciling                     = "Reconciling"
-	ReasonDeleting                        = "Deleting"
-	ReasonReconciliationFailedPermanently = "ReconciliationFailedPermanently"
-
-	// ReasonFailed is a catch-all error code for when we don't have a more specific error classification
-	ReasonFailed = "Failed"
+	// RetryNone means that this classification is not expected to ever retry (it's only ever set on for fatal errors)
+	RetryNone = RetryClassification("None") // TODO: ??
+	RetryFast = RetryClassification("RetryFast")
+	RetrySlow = RetryClassification("RetrySlow")
 )
+
+type Reason struct {
+	Name                string
+	RetryClassification RetryClassification
+}
+
+// Auth reasons
+var ReasonSubscriptionMismatch = Reason{Name: "SubscriptionMismatch", RetryClassification: RetryFast}
+
+// Precondition reasons
+var ReasonSecretNotFound = Reason{Name: "SecretNotFound", RetryClassification: RetryFast}
+var ReasonConfigMapNotFound = Reason{Name: "ConfigMapNotFound", RetryClassification: RetryFast}
+var ReasonReferenceNotFound = Reason{Name: "ReferenceNotFound", RetryClassification: RetryFast}
+var ReasonWaitingForOwner = Reason{Name: "WaitingForOwner", RetryClassification: RetryFast}
+
+// Post-ARM PUT reasons
+var ReasonAzureResourceNotFound = Reason{Name: "AzureResourceNotFound", RetryClassification: RetrySlow}
+var ReasonAdditionalKubernetesObjWriteFailure = Reason{Name: "FailedWritingAdditionalKubernetesObjects", RetryClassification: RetrySlow}
+
+// Other reasons
+var ReasonReconciling = Reason{Name: "Reconciling", RetryClassification: RetryFast}
+var ReasonDeleting = Reason{Name: "Deleting", RetryClassification: RetryFast}
+var ReasonReconciliationFailedPermanently = Reason{Name: "ReconciliationFailedPermanently", RetryClassification: RetryNone}
+
+// ReasonFailed is a catch-all error code for when we don't have a more specific error classification
+var ReasonFailed = Reason{Name: "Failed", RetryClassification: RetrySlow}
+
+func MakeReason(reason string) Reason {
+	return Reason{Name: reason, RetryClassification: RetrySlow} // Always classify custom reasons as Slow retry
+}
 
 func NewReadyConditionBuilder(builder PositiveConditionBuilderInterface) *ReadyConditionBuilder {
 	return &ReadyConditionBuilder{
@@ -52,7 +68,7 @@ func (b *ReadyConditionBuilder) Reconciling(observedGeneration int64) Condition 
 		ConditionTypeReady,
 		ConditionSeverityInfo,
 		observedGeneration,
-		ReasonReconciling,
+		ReasonReconciling.Name,
 		"The resource is in the process of being reconciled by the operator")
 }
 
@@ -61,7 +77,7 @@ func (b *ReadyConditionBuilder) Deleting(observedGeneration int64) Condition {
 		ConditionTypeReady,
 		ConditionSeverityInfo,
 		observedGeneration,
-		ReasonDeleting,
+		ReasonDeleting.Name,
 		"The resource is being deleted")
 }
 


### PR DESCRIPTION
Retry less aggressively for most Azure returned errors. Retry more aggressively for Kube-local errors such as WaitingForOwner.

Closes #2575.
Closes #2556

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
