### PR TITLE
Upgrade referenced versions of actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades CodeQL action references to the latest versions as per the [deprecation blog](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/).

Closes #2471.

**Special notes for your reviewer**:

Can't trigger this manually, so I think we just need to merge and try it.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/dvOjCftweY0XejNHBO/giphy.gif)
