### PR TITLE
Configure rate limiter to accomodate ARM throttling

### DIFF
--- a/v2/internal/controllers/generic_controller.go
+++ b/v2/internal/controllers/generic_controller.go
@@ -382,8 +382,11 @@ func NewRateLimiter(minBackoff time.Duration, maxBackoff time.Duration) workqueu
 		workqueue.NewItemExponentialFailureRateLimiter(minBackoff, maxBackoff),
 		// TODO: We could have an azure global (or per subscription) bucket rate limiter to prevent running into subscription
 		// TODO: level throttling. For now though just stay with the default that client-go uses.
-		// 10 rps, 100 bucket (spike) size. This is across all requests (not per item)
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		// Setting the limiter to 1 every 3 seconds & a burst of 40
+		// Based on ARM limits of 1200 puts per hour (20 per minute),
+		&workqueue.BucketRateLimiter{
+			Limiter: rate.NewLimiter(rate.Limit(0.2), 20),
+		},
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Our configuration of rate limiting permitted requests at a much higher rate than ARM accommodates; configuring the rate limiter so we play nicely with ARM should improve things overall.

**Special notes for your reviewer**:

This isn't perfect, as noted by @matthchr, because not every request respects this limiter; but this should still help.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/KZh5bJqo97p2ygvCdY/giphy.gif)
