### PR TITLE
Fix for discriminator enums being optional

### DIFF
--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen.go
@@ -8598,7 +8598,7 @@ const (
 type DeliveryRuleCacheExpirationAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleCacheExpirationAction_Name `json:"name,omitempty"`
+	Name *DeliveryRuleCacheExpirationAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -8615,7 +8615,9 @@ func (action *DeliveryRuleCacheExpirationAction) ConvertToARM(resolved genruntim
 	result := &DeliveryRuleCacheExpirationAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -8642,7 +8644,7 @@ func (action *DeliveryRuleCacheExpirationAction) PopulateFromARM(owner genruntim
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -8664,9 +8666,10 @@ func (action *DeliveryRuleCacheExpirationAction) AssignProperties_From_DeliveryR
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleCacheExpirationAction_Name(*source.Name)
+		name := DeliveryRuleCacheExpirationAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -8691,8 +8694,12 @@ func (action *DeliveryRuleCacheExpirationAction) AssignProperties_To_DeliveryRul
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -8719,7 +8726,7 @@ func (action *DeliveryRuleCacheExpirationAction) AssignProperties_To_DeliveryRul
 
 type DeliveryRuleCacheExpirationAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleCacheExpirationAction_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleCacheExpirationAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *CacheExpirationActionParameters_STATUS `json:"parameters,omitempty"`
@@ -8740,7 +8747,7 @@ func (action *DeliveryRuleCacheExpirationAction_STATUS) PopulateFromARM(owner ge
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -8762,9 +8769,10 @@ func (action *DeliveryRuleCacheExpirationAction_STATUS) AssignProperties_From_De
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleCacheExpirationAction_Name_STATUS(*source.Name)
+		name := DeliveryRuleCacheExpirationAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -8789,8 +8797,12 @@ func (action *DeliveryRuleCacheExpirationAction_STATUS) AssignProperties_To_Deli
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -8818,7 +8830,7 @@ func (action *DeliveryRuleCacheExpirationAction_STATUS) AssignProperties_To_Deli
 type DeliveryRuleCacheKeyQueryStringAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleCacheKeyQueryStringAction_Name `json:"name,omitempty"`
+	Name *DeliveryRuleCacheKeyQueryStringAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -8835,7 +8847,9 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) ConvertToARM(resolved genru
 	result := &DeliveryRuleCacheKeyQueryStringAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -8862,7 +8876,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -8884,9 +8898,10 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) AssignProperties_From_Deliv
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleCacheKeyQueryStringAction_Name(*source.Name)
+		name := DeliveryRuleCacheKeyQueryStringAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -8911,8 +8926,12 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) AssignProperties_To_Deliver
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -8939,7 +8958,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction) AssignProperties_To_Deliver
 
 type DeliveryRuleCacheKeyQueryStringAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleCacheKeyQueryStringAction_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleCacheKeyQueryStringAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *CacheKeyQueryStringActionParameters_STATUS `json:"parameters,omitempty"`
@@ -8960,7 +8979,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction_STATUS) PopulateFromARM(owne
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -8982,9 +9001,10 @@ func (action *DeliveryRuleCacheKeyQueryStringAction_STATUS) AssignProperties_Fro
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleCacheKeyQueryStringAction_Name_STATUS(*source.Name)
+		name := DeliveryRuleCacheKeyQueryStringAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -9009,8 +9029,12 @@ func (action *DeliveryRuleCacheKeyQueryStringAction_STATUS) AssignProperties_To_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -9038,7 +9062,7 @@ func (action *DeliveryRuleCacheKeyQueryStringAction_STATUS) AssignProperties_To_
 type DeliveryRuleClientPortCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleClientPortCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleClientPortCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -9055,7 +9079,9 @@ func (condition *DeliveryRuleClientPortCondition) ConvertToARM(resolved genrunti
 	result := &DeliveryRuleClientPortCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -9082,7 +9108,7 @@ func (condition *DeliveryRuleClientPortCondition) PopulateFromARM(owner genrunti
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9104,9 +9130,10 @@ func (condition *DeliveryRuleClientPortCondition) AssignProperties_From_Delivery
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleClientPortCondition_Name(*source.Name)
+		name := DeliveryRuleClientPortCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9131,8 +9158,12 @@ func (condition *DeliveryRuleClientPortCondition) AssignProperties_To_DeliveryRu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9159,7 +9190,7 @@ func (condition *DeliveryRuleClientPortCondition) AssignProperties_To_DeliveryRu
 
 type DeliveryRuleClientPortCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleClientPortCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleClientPortCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *ClientPortMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -9180,7 +9211,7 @@ func (condition *DeliveryRuleClientPortCondition_STATUS) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9202,9 +9233,10 @@ func (condition *DeliveryRuleClientPortCondition_STATUS) AssignProperties_From_D
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleClientPortCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleClientPortCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9229,8 +9261,12 @@ func (condition *DeliveryRuleClientPortCondition_STATUS) AssignProperties_To_Del
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9258,7 +9294,7 @@ func (condition *DeliveryRuleClientPortCondition_STATUS) AssignProperties_To_Del
 type DeliveryRuleCookiesCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleCookiesCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleCookiesCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -9275,7 +9311,9 @@ func (condition *DeliveryRuleCookiesCondition) ConvertToARM(resolved genruntime.
 	result := &DeliveryRuleCookiesCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -9302,7 +9340,7 @@ func (condition *DeliveryRuleCookiesCondition) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9324,9 +9362,10 @@ func (condition *DeliveryRuleCookiesCondition) AssignProperties_From_DeliveryRul
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleCookiesCondition_Name(*source.Name)
+		name := DeliveryRuleCookiesCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9351,8 +9390,12 @@ func (condition *DeliveryRuleCookiesCondition) AssignProperties_To_DeliveryRuleC
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9379,7 +9422,7 @@ func (condition *DeliveryRuleCookiesCondition) AssignProperties_To_DeliveryRuleC
 
 type DeliveryRuleCookiesCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleCookiesCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleCookiesCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *CookiesMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -9400,7 +9443,7 @@ func (condition *DeliveryRuleCookiesCondition_STATUS) PopulateFromARM(owner genr
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9422,9 +9465,10 @@ func (condition *DeliveryRuleCookiesCondition_STATUS) AssignProperties_From_Deli
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleCookiesCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleCookiesCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9449,8 +9493,12 @@ func (condition *DeliveryRuleCookiesCondition_STATUS) AssignProperties_To_Delive
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9478,7 +9526,7 @@ func (condition *DeliveryRuleCookiesCondition_STATUS) AssignProperties_To_Delive
 type DeliveryRuleHostNameCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleHostNameCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleHostNameCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -9495,7 +9543,9 @@ func (condition *DeliveryRuleHostNameCondition) ConvertToARM(resolved genruntime
 	result := &DeliveryRuleHostNameCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -9522,7 +9572,7 @@ func (condition *DeliveryRuleHostNameCondition) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9544,9 +9594,10 @@ func (condition *DeliveryRuleHostNameCondition) AssignProperties_From_DeliveryRu
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleHostNameCondition_Name(*source.Name)
+		name := DeliveryRuleHostNameCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9571,8 +9622,12 @@ func (condition *DeliveryRuleHostNameCondition) AssignProperties_To_DeliveryRule
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9599,7 +9654,7 @@ func (condition *DeliveryRuleHostNameCondition) AssignProperties_To_DeliveryRule
 
 type DeliveryRuleHostNameCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleHostNameCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleHostNameCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *HostNameMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -9620,7 +9675,7 @@ func (condition *DeliveryRuleHostNameCondition_STATUS) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9642,9 +9697,10 @@ func (condition *DeliveryRuleHostNameCondition_STATUS) AssignProperties_From_Del
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleHostNameCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleHostNameCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9669,8 +9725,12 @@ func (condition *DeliveryRuleHostNameCondition_STATUS) AssignProperties_To_Deliv
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9698,7 +9758,7 @@ func (condition *DeliveryRuleHostNameCondition_STATUS) AssignProperties_To_Deliv
 type DeliveryRuleHttpVersionCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleHttpVersionCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleHttpVersionCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -9715,7 +9775,9 @@ func (condition *DeliveryRuleHttpVersionCondition) ConvertToARM(resolved genrunt
 	result := &DeliveryRuleHttpVersionCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -9742,7 +9804,7 @@ func (condition *DeliveryRuleHttpVersionCondition) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9764,9 +9826,10 @@ func (condition *DeliveryRuleHttpVersionCondition) AssignProperties_From_Deliver
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleHttpVersionCondition_Name(*source.Name)
+		name := DeliveryRuleHttpVersionCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9791,8 +9854,12 @@ func (condition *DeliveryRuleHttpVersionCondition) AssignProperties_To_DeliveryR
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9819,7 +9886,7 @@ func (condition *DeliveryRuleHttpVersionCondition) AssignProperties_To_DeliveryR
 
 type DeliveryRuleHttpVersionCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleHttpVersionCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleHttpVersionCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *HttpVersionMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -9840,7 +9907,7 @@ func (condition *DeliveryRuleHttpVersionCondition_STATUS) PopulateFromARM(owner 
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9862,9 +9929,10 @@ func (condition *DeliveryRuleHttpVersionCondition_STATUS) AssignProperties_From_
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleHttpVersionCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleHttpVersionCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -9889,8 +9957,12 @@ func (condition *DeliveryRuleHttpVersionCondition_STATUS) AssignProperties_To_De
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -9918,7 +9990,7 @@ func (condition *DeliveryRuleHttpVersionCondition_STATUS) AssignProperties_To_De
 type DeliveryRuleIsDeviceCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleIsDeviceCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleIsDeviceCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -9935,7 +10007,9 @@ func (condition *DeliveryRuleIsDeviceCondition) ConvertToARM(resolved genruntime
 	result := &DeliveryRuleIsDeviceCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -9962,7 +10036,7 @@ func (condition *DeliveryRuleIsDeviceCondition) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -9984,9 +10058,10 @@ func (condition *DeliveryRuleIsDeviceCondition) AssignProperties_From_DeliveryRu
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleIsDeviceCondition_Name(*source.Name)
+		name := DeliveryRuleIsDeviceCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10011,8 +10086,12 @@ func (condition *DeliveryRuleIsDeviceCondition) AssignProperties_To_DeliveryRule
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10039,7 +10118,7 @@ func (condition *DeliveryRuleIsDeviceCondition) AssignProperties_To_DeliveryRule
 
 type DeliveryRuleIsDeviceCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleIsDeviceCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleIsDeviceCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *IsDeviceMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -10060,7 +10139,7 @@ func (condition *DeliveryRuleIsDeviceCondition_STATUS) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10082,9 +10161,10 @@ func (condition *DeliveryRuleIsDeviceCondition_STATUS) AssignProperties_From_Del
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleIsDeviceCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleIsDeviceCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10109,8 +10189,12 @@ func (condition *DeliveryRuleIsDeviceCondition_STATUS) AssignProperties_To_Deliv
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10138,7 +10222,7 @@ func (condition *DeliveryRuleIsDeviceCondition_STATUS) AssignProperties_To_Deliv
 type DeliveryRulePostArgsCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRulePostArgsCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRulePostArgsCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -10155,7 +10239,9 @@ func (condition *DeliveryRulePostArgsCondition) ConvertToARM(resolved genruntime
 	result := &DeliveryRulePostArgsCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -10182,7 +10268,7 @@ func (condition *DeliveryRulePostArgsCondition) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10204,9 +10290,10 @@ func (condition *DeliveryRulePostArgsCondition) AssignProperties_From_DeliveryRu
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRulePostArgsCondition_Name(*source.Name)
+		name := DeliveryRulePostArgsCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10231,8 +10318,12 @@ func (condition *DeliveryRulePostArgsCondition) AssignProperties_To_DeliveryRule
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10259,7 +10350,7 @@ func (condition *DeliveryRulePostArgsCondition) AssignProperties_To_DeliveryRule
 
 type DeliveryRulePostArgsCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRulePostArgsCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRulePostArgsCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *PostArgsMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -10280,7 +10371,7 @@ func (condition *DeliveryRulePostArgsCondition_STATUS) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10302,9 +10393,10 @@ func (condition *DeliveryRulePostArgsCondition_STATUS) AssignProperties_From_Del
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRulePostArgsCondition_Name_STATUS(*source.Name)
+		name := DeliveryRulePostArgsCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10329,8 +10421,12 @@ func (condition *DeliveryRulePostArgsCondition_STATUS) AssignProperties_To_Deliv
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10358,7 +10454,7 @@ func (condition *DeliveryRulePostArgsCondition_STATUS) AssignProperties_To_Deliv
 type DeliveryRuleQueryStringCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleQueryStringCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleQueryStringCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -10375,7 +10471,9 @@ func (condition *DeliveryRuleQueryStringCondition) ConvertToARM(resolved genrunt
 	result := &DeliveryRuleQueryStringCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -10402,7 +10500,7 @@ func (condition *DeliveryRuleQueryStringCondition) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10424,9 +10522,10 @@ func (condition *DeliveryRuleQueryStringCondition) AssignProperties_From_Deliver
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleQueryStringCondition_Name(*source.Name)
+		name := DeliveryRuleQueryStringCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10451,8 +10550,12 @@ func (condition *DeliveryRuleQueryStringCondition) AssignProperties_To_DeliveryR
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10479,7 +10582,7 @@ func (condition *DeliveryRuleQueryStringCondition) AssignProperties_To_DeliveryR
 
 type DeliveryRuleQueryStringCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleQueryStringCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleQueryStringCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *QueryStringMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -10500,7 +10603,7 @@ func (condition *DeliveryRuleQueryStringCondition_STATUS) PopulateFromARM(owner 
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10522,9 +10625,10 @@ func (condition *DeliveryRuleQueryStringCondition_STATUS) AssignProperties_From_
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleQueryStringCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleQueryStringCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10549,8 +10653,12 @@ func (condition *DeliveryRuleQueryStringCondition_STATUS) AssignProperties_To_De
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10578,7 +10686,7 @@ func (condition *DeliveryRuleQueryStringCondition_STATUS) AssignProperties_To_De
 type DeliveryRuleRemoteAddressCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRemoteAddressCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRemoteAddressCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -10595,7 +10703,9 @@ func (condition *DeliveryRuleRemoteAddressCondition) ConvertToARM(resolved genru
 	result := &DeliveryRuleRemoteAddressCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -10622,7 +10732,7 @@ func (condition *DeliveryRuleRemoteAddressCondition) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10644,9 +10754,10 @@ func (condition *DeliveryRuleRemoteAddressCondition) AssignProperties_From_Deliv
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRemoteAddressCondition_Name(*source.Name)
+		name := DeliveryRuleRemoteAddressCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10671,8 +10782,12 @@ func (condition *DeliveryRuleRemoteAddressCondition) AssignProperties_To_Deliver
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10699,7 +10814,7 @@ func (condition *DeliveryRuleRemoteAddressCondition) AssignProperties_To_Deliver
 
 type DeliveryRuleRemoteAddressCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRemoteAddressCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRemoteAddressCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *RemoteAddressMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -10720,7 +10835,7 @@ func (condition *DeliveryRuleRemoteAddressCondition_STATUS) PopulateFromARM(owne
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10742,9 +10857,10 @@ func (condition *DeliveryRuleRemoteAddressCondition_STATUS) AssignProperties_Fro
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRemoteAddressCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleRemoteAddressCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10769,8 +10885,12 @@ func (condition *DeliveryRuleRemoteAddressCondition_STATUS) AssignProperties_To_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10798,7 +10918,7 @@ func (condition *DeliveryRuleRemoteAddressCondition_STATUS) AssignProperties_To_
 type DeliveryRuleRequestBodyCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestBodyCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRequestBodyCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -10815,7 +10935,9 @@ func (condition *DeliveryRuleRequestBodyCondition) ConvertToARM(resolved genrunt
 	result := &DeliveryRuleRequestBodyCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -10842,7 +10964,7 @@ func (condition *DeliveryRuleRequestBodyCondition) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10864,9 +10986,10 @@ func (condition *DeliveryRuleRequestBodyCondition) AssignProperties_From_Deliver
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestBodyCondition_Name(*source.Name)
+		name := DeliveryRuleRequestBodyCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10891,8 +11014,12 @@ func (condition *DeliveryRuleRequestBodyCondition) AssignProperties_To_DeliveryR
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -10919,7 +11046,7 @@ func (condition *DeliveryRuleRequestBodyCondition) AssignProperties_To_DeliveryR
 
 type DeliveryRuleRequestBodyCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestBodyCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRequestBodyCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *RequestBodyMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -10940,7 +11067,7 @@ func (condition *DeliveryRuleRequestBodyCondition_STATUS) PopulateFromARM(owner 
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -10962,9 +11089,10 @@ func (condition *DeliveryRuleRequestBodyCondition_STATUS) AssignProperties_From_
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestBodyCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleRequestBodyCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -10989,8 +11117,12 @@ func (condition *DeliveryRuleRequestBodyCondition_STATUS) AssignProperties_To_De
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -11018,7 +11150,7 @@ func (condition *DeliveryRuleRequestBodyCondition_STATUS) AssignProperties_To_De
 type DeliveryRuleRequestHeaderAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleRequestHeaderAction_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRequestHeaderAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -11035,7 +11167,9 @@ func (action *DeliveryRuleRequestHeaderAction) ConvertToARM(resolved genruntime.
 	result := &DeliveryRuleRequestHeaderAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -11062,7 +11196,7 @@ func (action *DeliveryRuleRequestHeaderAction) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11084,9 +11218,10 @@ func (action *DeliveryRuleRequestHeaderAction) AssignProperties_From_DeliveryRul
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleRequestHeaderAction_Name(*source.Name)
+		name := DeliveryRuleRequestHeaderAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -11111,8 +11246,12 @@ func (action *DeliveryRuleRequestHeaderAction) AssignProperties_To_DeliveryRuleR
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -11139,7 +11278,7 @@ func (action *DeliveryRuleRequestHeaderAction) AssignProperties_To_DeliveryRuleR
 
 type DeliveryRuleRequestHeaderAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleRequestHeaderAction_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRequestHeaderAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *HeaderActionParameters_STATUS `json:"parameters,omitempty"`
@@ -11160,7 +11299,7 @@ func (action *DeliveryRuleRequestHeaderAction_STATUS) PopulateFromARM(owner genr
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11182,9 +11321,10 @@ func (action *DeliveryRuleRequestHeaderAction_STATUS) AssignProperties_From_Deli
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleRequestHeaderAction_Name_STATUS(*source.Name)
+		name := DeliveryRuleRequestHeaderAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -11209,8 +11349,12 @@ func (action *DeliveryRuleRequestHeaderAction_STATUS) AssignProperties_To_Delive
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -11238,7 +11382,7 @@ func (action *DeliveryRuleRequestHeaderAction_STATUS) AssignProperties_To_Delive
 type DeliveryRuleRequestHeaderCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestHeaderCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRequestHeaderCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -11255,7 +11399,9 @@ func (condition *DeliveryRuleRequestHeaderCondition) ConvertToARM(resolved genru
 	result := &DeliveryRuleRequestHeaderCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -11282,7 +11428,7 @@ func (condition *DeliveryRuleRequestHeaderCondition) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11304,9 +11450,10 @@ func (condition *DeliveryRuleRequestHeaderCondition) AssignProperties_From_Deliv
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestHeaderCondition_Name(*source.Name)
+		name := DeliveryRuleRequestHeaderCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -11331,8 +11478,12 @@ func (condition *DeliveryRuleRequestHeaderCondition) AssignProperties_To_Deliver
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -11359,7 +11510,7 @@ func (condition *DeliveryRuleRequestHeaderCondition) AssignProperties_To_Deliver
 
 type DeliveryRuleRequestHeaderCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestHeaderCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRequestHeaderCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *RequestHeaderMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -11380,7 +11531,7 @@ func (condition *DeliveryRuleRequestHeaderCondition_STATUS) PopulateFromARM(owne
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11402,9 +11553,10 @@ func (condition *DeliveryRuleRequestHeaderCondition_STATUS) AssignProperties_Fro
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestHeaderCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleRequestHeaderCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -11429,8 +11581,12 @@ func (condition *DeliveryRuleRequestHeaderCondition_STATUS) AssignProperties_To_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -11458,7 +11614,7 @@ func (condition *DeliveryRuleRequestHeaderCondition_STATUS) AssignProperties_To_
 type DeliveryRuleRequestMethodCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestMethodCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRequestMethodCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -11475,7 +11631,9 @@ func (condition *DeliveryRuleRequestMethodCondition) ConvertToARM(resolved genru
 	result := &DeliveryRuleRequestMethodCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -11502,7 +11660,7 @@ func (condition *DeliveryRuleRequestMethodCondition) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11524,9 +11682,10 @@ func (condition *DeliveryRuleRequestMethodCondition) AssignProperties_From_Deliv
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestMethodCondition_Name(*source.Name)
+		name := DeliveryRuleRequestMethodCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -11551,8 +11710,12 @@ func (condition *DeliveryRuleRequestMethodCondition) AssignProperties_To_Deliver
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -11579,7 +11742,7 @@ func (condition *DeliveryRuleRequestMethodCondition) AssignProperties_To_Deliver
 
 type DeliveryRuleRequestMethodCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestMethodCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRequestMethodCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *RequestMethodMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -11600,7 +11763,7 @@ func (condition *DeliveryRuleRequestMethodCondition_STATUS) PopulateFromARM(owne
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11622,9 +11785,10 @@ func (condition *DeliveryRuleRequestMethodCondition_STATUS) AssignProperties_Fro
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestMethodCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleRequestMethodCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -11649,8 +11813,12 @@ func (condition *DeliveryRuleRequestMethodCondition_STATUS) AssignProperties_To_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -11678,7 +11846,7 @@ func (condition *DeliveryRuleRequestMethodCondition_STATUS) AssignProperties_To_
 type DeliveryRuleRequestSchemeCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestSchemeCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRequestSchemeCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -11695,7 +11863,9 @@ func (condition *DeliveryRuleRequestSchemeCondition) ConvertToARM(resolved genru
 	result := &DeliveryRuleRequestSchemeCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -11722,7 +11892,7 @@ func (condition *DeliveryRuleRequestSchemeCondition) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11744,9 +11914,10 @@ func (condition *DeliveryRuleRequestSchemeCondition) AssignProperties_From_Deliv
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestSchemeCondition_Name(*source.Name)
+		name := DeliveryRuleRequestSchemeCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -11771,8 +11942,12 @@ func (condition *DeliveryRuleRequestSchemeCondition) AssignProperties_To_Deliver
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -11799,7 +11974,7 @@ func (condition *DeliveryRuleRequestSchemeCondition) AssignProperties_To_Deliver
 
 type DeliveryRuleRequestSchemeCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestSchemeCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRequestSchemeCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *RequestSchemeMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -11820,7 +11995,7 @@ func (condition *DeliveryRuleRequestSchemeCondition_STATUS) PopulateFromARM(owne
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11842,9 +12017,10 @@ func (condition *DeliveryRuleRequestSchemeCondition_STATUS) AssignProperties_Fro
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestSchemeCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleRequestSchemeCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -11869,8 +12045,12 @@ func (condition *DeliveryRuleRequestSchemeCondition_STATUS) AssignProperties_To_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -11898,7 +12078,7 @@ func (condition *DeliveryRuleRequestSchemeCondition_STATUS) AssignProperties_To_
 type DeliveryRuleRequestUriCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestUriCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRequestUriCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -11915,7 +12095,9 @@ func (condition *DeliveryRuleRequestUriCondition) ConvertToARM(resolved genrunti
 	result := &DeliveryRuleRequestUriCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -11942,7 +12124,7 @@ func (condition *DeliveryRuleRequestUriCondition) PopulateFromARM(owner genrunti
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -11964,9 +12146,10 @@ func (condition *DeliveryRuleRequestUriCondition) AssignProperties_From_Delivery
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestUriCondition_Name(*source.Name)
+		name := DeliveryRuleRequestUriCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -11991,8 +12174,12 @@ func (condition *DeliveryRuleRequestUriCondition) AssignProperties_To_DeliveryRu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -12019,7 +12206,7 @@ func (condition *DeliveryRuleRequestUriCondition) AssignProperties_To_DeliveryRu
 
 type DeliveryRuleRequestUriCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleRequestUriCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRequestUriCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *RequestUriMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -12040,7 +12227,7 @@ func (condition *DeliveryRuleRequestUriCondition_STATUS) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12062,9 +12249,10 @@ func (condition *DeliveryRuleRequestUriCondition_STATUS) AssignProperties_From_D
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleRequestUriCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleRequestUriCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -12089,8 +12277,12 @@ func (condition *DeliveryRuleRequestUriCondition_STATUS) AssignProperties_To_Del
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -12118,7 +12310,7 @@ func (condition *DeliveryRuleRequestUriCondition_STATUS) AssignProperties_To_Del
 type DeliveryRuleResponseHeaderAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleResponseHeaderAction_Name `json:"name,omitempty"`
+	Name *DeliveryRuleResponseHeaderAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -12135,7 +12327,9 @@ func (action *DeliveryRuleResponseHeaderAction) ConvertToARM(resolved genruntime
 	result := &DeliveryRuleResponseHeaderAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -12162,7 +12356,7 @@ func (action *DeliveryRuleResponseHeaderAction) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12184,9 +12378,10 @@ func (action *DeliveryRuleResponseHeaderAction) AssignProperties_From_DeliveryRu
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleResponseHeaderAction_Name(*source.Name)
+		name := DeliveryRuleResponseHeaderAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -12211,8 +12406,12 @@ func (action *DeliveryRuleResponseHeaderAction) AssignProperties_To_DeliveryRule
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -12239,7 +12438,7 @@ func (action *DeliveryRuleResponseHeaderAction) AssignProperties_To_DeliveryRule
 
 type DeliveryRuleResponseHeaderAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleResponseHeaderAction_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleResponseHeaderAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *HeaderActionParameters_STATUS `json:"parameters,omitempty"`
@@ -12260,7 +12459,7 @@ func (action *DeliveryRuleResponseHeaderAction_STATUS) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12282,9 +12481,10 @@ func (action *DeliveryRuleResponseHeaderAction_STATUS) AssignProperties_From_Del
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleResponseHeaderAction_Name_STATUS(*source.Name)
+		name := DeliveryRuleResponseHeaderAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -12309,8 +12509,12 @@ func (action *DeliveryRuleResponseHeaderAction_STATUS) AssignProperties_To_Deliv
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -12338,7 +12542,7 @@ func (action *DeliveryRuleResponseHeaderAction_STATUS) AssignProperties_To_Deliv
 type DeliveryRuleRouteConfigurationOverrideAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleRouteConfigurationOverrideAction_Name `json:"name,omitempty"`
+	Name *DeliveryRuleRouteConfigurationOverrideAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -12355,7 +12559,9 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) ConvertToARM(resolve
 	result := &DeliveryRuleRouteConfigurationOverrideAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -12382,7 +12588,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) PopulateFromARM(owne
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12404,9 +12610,10 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) AssignProperties_Fro
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleRouteConfigurationOverrideAction_Name(*source.Name)
+		name := DeliveryRuleRouteConfigurationOverrideAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -12431,8 +12638,12 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) AssignProperties_To_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -12459,7 +12670,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction) AssignProperties_To_
 
 type DeliveryRuleRouteConfigurationOverrideAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *RouteConfigurationOverrideActionParameters_STATUS `json:"parameters,omitempty"`
@@ -12480,7 +12691,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction_STATUS) PopulateFromA
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12502,9 +12713,10 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction_STATUS) AssignPropert
 
 	// Name
 	if source.Name != nil {
-		action.Name = DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS(*source.Name)
+		name := DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -12529,8 +12741,12 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction_STATUS) AssignPropert
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -12558,7 +12774,7 @@ func (action *DeliveryRuleRouteConfigurationOverrideAction_STATUS) AssignPropert
 type DeliveryRuleServerPortCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleServerPortCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleServerPortCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -12575,7 +12791,9 @@ func (condition *DeliveryRuleServerPortCondition) ConvertToARM(resolved genrunti
 	result := &DeliveryRuleServerPortCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -12602,7 +12820,7 @@ func (condition *DeliveryRuleServerPortCondition) PopulateFromARM(owner genrunti
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12624,9 +12842,10 @@ func (condition *DeliveryRuleServerPortCondition) AssignProperties_From_Delivery
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleServerPortCondition_Name(*source.Name)
+		name := DeliveryRuleServerPortCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -12651,8 +12870,12 @@ func (condition *DeliveryRuleServerPortCondition) AssignProperties_To_DeliveryRu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -12679,7 +12902,7 @@ func (condition *DeliveryRuleServerPortCondition) AssignProperties_To_DeliveryRu
 
 type DeliveryRuleServerPortCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleServerPortCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleServerPortCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *ServerPortMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -12700,7 +12923,7 @@ func (condition *DeliveryRuleServerPortCondition_STATUS) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12722,9 +12945,10 @@ func (condition *DeliveryRuleServerPortCondition_STATUS) AssignProperties_From_D
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleServerPortCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleServerPortCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -12749,8 +12973,12 @@ func (condition *DeliveryRuleServerPortCondition_STATUS) AssignProperties_To_Del
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -12778,7 +13006,7 @@ func (condition *DeliveryRuleServerPortCondition_STATUS) AssignProperties_To_Del
 type DeliveryRuleSocketAddrCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleSocketAddrCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleSocketAddrCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -12795,7 +13023,9 @@ func (condition *DeliveryRuleSocketAddrCondition) ConvertToARM(resolved genrunti
 	result := &DeliveryRuleSocketAddrCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -12822,7 +13052,7 @@ func (condition *DeliveryRuleSocketAddrCondition) PopulateFromARM(owner genrunti
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12844,9 +13074,10 @@ func (condition *DeliveryRuleSocketAddrCondition) AssignProperties_From_Delivery
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleSocketAddrCondition_Name(*source.Name)
+		name := DeliveryRuleSocketAddrCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -12871,8 +13102,12 @@ func (condition *DeliveryRuleSocketAddrCondition) AssignProperties_To_DeliveryRu
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -12899,7 +13134,7 @@ func (condition *DeliveryRuleSocketAddrCondition) AssignProperties_To_DeliveryRu
 
 type DeliveryRuleSocketAddrCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleSocketAddrCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleSocketAddrCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *SocketAddrMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -12920,7 +13155,7 @@ func (condition *DeliveryRuleSocketAddrCondition_STATUS) PopulateFromARM(owner g
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -12942,9 +13177,10 @@ func (condition *DeliveryRuleSocketAddrCondition_STATUS) AssignProperties_From_D
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleSocketAddrCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleSocketAddrCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -12969,8 +13205,12 @@ func (condition *DeliveryRuleSocketAddrCondition_STATUS) AssignProperties_To_Del
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -12998,7 +13238,7 @@ func (condition *DeliveryRuleSocketAddrCondition_STATUS) AssignProperties_To_Del
 type DeliveryRuleSslProtocolCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleSslProtocolCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleSslProtocolCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -13015,7 +13255,9 @@ func (condition *DeliveryRuleSslProtocolCondition) ConvertToARM(resolved genrunt
 	result := &DeliveryRuleSslProtocolCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -13042,7 +13284,7 @@ func (condition *DeliveryRuleSslProtocolCondition) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13064,9 +13306,10 @@ func (condition *DeliveryRuleSslProtocolCondition) AssignProperties_From_Deliver
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleSslProtocolCondition_Name(*source.Name)
+		name := DeliveryRuleSslProtocolCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13091,8 +13334,12 @@ func (condition *DeliveryRuleSslProtocolCondition) AssignProperties_To_DeliveryR
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13119,7 +13366,7 @@ func (condition *DeliveryRuleSslProtocolCondition) AssignProperties_To_DeliveryR
 
 type DeliveryRuleSslProtocolCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleSslProtocolCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleSslProtocolCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *SslProtocolMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -13140,7 +13387,7 @@ func (condition *DeliveryRuleSslProtocolCondition_STATUS) PopulateFromARM(owner 
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13162,9 +13409,10 @@ func (condition *DeliveryRuleSslProtocolCondition_STATUS) AssignProperties_From_
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleSslProtocolCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleSslProtocolCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13189,8 +13437,12 @@ func (condition *DeliveryRuleSslProtocolCondition_STATUS) AssignProperties_To_De
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13218,7 +13470,7 @@ func (condition *DeliveryRuleSslProtocolCondition_STATUS) AssignProperties_To_De
 type DeliveryRuleUrlFileExtensionCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleUrlFileExtensionCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleUrlFileExtensionCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -13235,7 +13487,9 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) ConvertToARM(resolved ge
 	result := &DeliveryRuleUrlFileExtensionCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -13262,7 +13516,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) PopulateFromARM(owner ge
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13284,9 +13538,10 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) AssignProperties_From_De
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleUrlFileExtensionCondition_Name(*source.Name)
+		name := DeliveryRuleUrlFileExtensionCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13311,8 +13566,12 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) AssignProperties_To_Deli
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13339,7 +13598,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition) AssignProperties_To_Deli
 
 type DeliveryRuleUrlFileExtensionCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleUrlFileExtensionCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleUrlFileExtensionCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *UrlFileExtensionMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -13360,7 +13619,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition_STATUS) PopulateFromARM(o
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13382,9 +13641,10 @@ func (condition *DeliveryRuleUrlFileExtensionCondition_STATUS) AssignProperties_
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleUrlFileExtensionCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleUrlFileExtensionCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13409,8 +13669,12 @@ func (condition *DeliveryRuleUrlFileExtensionCondition_STATUS) AssignProperties_
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13438,7 +13702,7 @@ func (condition *DeliveryRuleUrlFileExtensionCondition_STATUS) AssignProperties_
 type DeliveryRuleUrlFileNameCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleUrlFileNameCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleUrlFileNameCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -13455,7 +13719,9 @@ func (condition *DeliveryRuleUrlFileNameCondition) ConvertToARM(resolved genrunt
 	result := &DeliveryRuleUrlFileNameCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -13482,7 +13748,7 @@ func (condition *DeliveryRuleUrlFileNameCondition) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13504,9 +13770,10 @@ func (condition *DeliveryRuleUrlFileNameCondition) AssignProperties_From_Deliver
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleUrlFileNameCondition_Name(*source.Name)
+		name := DeliveryRuleUrlFileNameCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13531,8 +13798,12 @@ func (condition *DeliveryRuleUrlFileNameCondition) AssignProperties_To_DeliveryR
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13559,7 +13830,7 @@ func (condition *DeliveryRuleUrlFileNameCondition) AssignProperties_To_DeliveryR
 
 type DeliveryRuleUrlFileNameCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleUrlFileNameCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleUrlFileNameCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *UrlFileNameMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -13580,7 +13851,7 @@ func (condition *DeliveryRuleUrlFileNameCondition_STATUS) PopulateFromARM(owner 
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13602,9 +13873,10 @@ func (condition *DeliveryRuleUrlFileNameCondition_STATUS) AssignProperties_From_
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleUrlFileNameCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleUrlFileNameCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13629,8 +13901,12 @@ func (condition *DeliveryRuleUrlFileNameCondition_STATUS) AssignProperties_To_De
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13658,7 +13934,7 @@ func (condition *DeliveryRuleUrlFileNameCondition_STATUS) AssignProperties_To_De
 type DeliveryRuleUrlPathCondition struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleUrlPathCondition_Name `json:"name,omitempty"`
+	Name *DeliveryRuleUrlPathCondition_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the condition.
@@ -13675,7 +13951,9 @@ func (condition *DeliveryRuleUrlPathCondition) ConvertToARM(resolved genruntime.
 	result := &DeliveryRuleUrlPathCondition_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = condition.Name
+	if condition.Name != nil {
+		result.Name = *condition.Name
+	}
 
 	// Set property ‘Parameters’:
 	if condition.Parameters != nil {
@@ -13702,7 +13980,7 @@ func (condition *DeliveryRuleUrlPathCondition) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13724,9 +14002,10 @@ func (condition *DeliveryRuleUrlPathCondition) AssignProperties_From_DeliveryRul
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleUrlPathCondition_Name(*source.Name)
+		name := DeliveryRuleUrlPathCondition_Name(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13751,8 +14030,12 @@ func (condition *DeliveryRuleUrlPathCondition) AssignProperties_To_DeliveryRuleU
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13779,7 +14062,7 @@ func (condition *DeliveryRuleUrlPathCondition) AssignProperties_To_DeliveryRuleU
 
 type DeliveryRuleUrlPathCondition_STATUS struct {
 	// Name: The name of the condition for the delivery rule.
-	Name DeliveryRuleUrlPathCondition_Name_STATUS `json:"name,omitempty"`
+	Name *DeliveryRuleUrlPathCondition_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the condition.
 	Parameters *UrlPathMatchConditionParameters_STATUS `json:"parameters,omitempty"`
@@ -13800,7 +14083,7 @@ func (condition *DeliveryRuleUrlPathCondition_STATUS) PopulateFromARM(owner genr
 	}
 
 	// Set property ‘Name’:
-	condition.Name = typedInput.Name
+	condition.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13822,9 +14105,10 @@ func (condition *DeliveryRuleUrlPathCondition_STATUS) AssignProperties_From_Deli
 
 	// Name
 	if source.Name != nil {
-		condition.Name = DeliveryRuleUrlPathCondition_Name_STATUS(*source.Name)
+		name := DeliveryRuleUrlPathCondition_Name_STATUS(*source.Name)
+		condition.Name = &name
 	} else {
-		condition.Name = ""
+		condition.Name = nil
 	}
 
 	// Parameters
@@ -13849,8 +14133,12 @@ func (condition *DeliveryRuleUrlPathCondition_STATUS) AssignProperties_To_Delive
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(condition.Name)
-	destination.Name = &name
+	if condition.Name != nil {
+		name := string(*condition.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if condition.Parameters != nil {
@@ -13878,7 +14166,7 @@ func (condition *DeliveryRuleUrlPathCondition_STATUS) AssignProperties_To_Delive
 type OriginGroupOverrideAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name OriginGroupOverrideAction_Name `json:"name,omitempty"`
+	Name *OriginGroupOverrideAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -13895,7 +14183,9 @@ func (action *OriginGroupOverrideAction) ConvertToARM(resolved genruntime.Conver
 	result := &OriginGroupOverrideAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -13922,7 +14212,7 @@ func (action *OriginGroupOverrideAction) PopulateFromARM(owner genruntime.Arbitr
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -13944,9 +14234,10 @@ func (action *OriginGroupOverrideAction) AssignProperties_From_OriginGroupOverri
 
 	// Name
 	if source.Name != nil {
-		action.Name = OriginGroupOverrideAction_Name(*source.Name)
+		name := OriginGroupOverrideAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -13971,8 +14262,12 @@ func (action *OriginGroupOverrideAction) AssignProperties_To_OriginGroupOverride
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -13999,7 +14294,7 @@ func (action *OriginGroupOverrideAction) AssignProperties_To_OriginGroupOverride
 
 type OriginGroupOverrideAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name OriginGroupOverrideAction_Name_STATUS `json:"name,omitempty"`
+	Name *OriginGroupOverrideAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *OriginGroupOverrideActionParameters_STATUS `json:"parameters,omitempty"`
@@ -14020,7 +14315,7 @@ func (action *OriginGroupOverrideAction_STATUS) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -14042,9 +14337,10 @@ func (action *OriginGroupOverrideAction_STATUS) AssignProperties_From_OriginGrou
 
 	// Name
 	if source.Name != nil {
-		action.Name = OriginGroupOverrideAction_Name_STATUS(*source.Name)
+		name := OriginGroupOverrideAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -14069,8 +14365,12 @@ func (action *OriginGroupOverrideAction_STATUS) AssignProperties_To_OriginGroupO
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -14098,7 +14398,7 @@ func (action *OriginGroupOverrideAction_STATUS) AssignProperties_To_OriginGroupO
 type UrlRedirectAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name UrlRedirectAction_Name `json:"name,omitempty"`
+	Name *UrlRedirectAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -14115,7 +14415,9 @@ func (action *UrlRedirectAction) ConvertToARM(resolved genruntime.ConvertToARMRe
 	result := &UrlRedirectAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -14142,7 +14444,7 @@ func (action *UrlRedirectAction) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -14164,9 +14466,10 @@ func (action *UrlRedirectAction) AssignProperties_From_UrlRedirectAction(source 
 
 	// Name
 	if source.Name != nil {
-		action.Name = UrlRedirectAction_Name(*source.Name)
+		name := UrlRedirectAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -14191,8 +14494,12 @@ func (action *UrlRedirectAction) AssignProperties_To_UrlRedirectAction(destinati
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -14219,7 +14526,7 @@ func (action *UrlRedirectAction) AssignProperties_To_UrlRedirectAction(destinati
 
 type UrlRedirectAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name UrlRedirectAction_Name_STATUS `json:"name,omitempty"`
+	Name *UrlRedirectAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *UrlRedirectActionParameters_STATUS `json:"parameters,omitempty"`
@@ -14240,7 +14547,7 @@ func (action *UrlRedirectAction_STATUS) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -14262,9 +14569,10 @@ func (action *UrlRedirectAction_STATUS) AssignProperties_From_UrlRedirectAction_
 
 	// Name
 	if source.Name != nil {
-		action.Name = UrlRedirectAction_Name_STATUS(*source.Name)
+		name := UrlRedirectAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -14289,8 +14597,12 @@ func (action *UrlRedirectAction_STATUS) AssignProperties_To_UrlRedirectAction_ST
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -14318,7 +14630,7 @@ func (action *UrlRedirectAction_STATUS) AssignProperties_To_UrlRedirectAction_ST
 type UrlRewriteAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name UrlRewriteAction_Name `json:"name,omitempty"`
+	Name *UrlRewriteAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -14335,7 +14647,9 @@ func (action *UrlRewriteAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	result := &UrlRewriteAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -14362,7 +14676,7 @@ func (action *UrlRewriteAction) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -14384,9 +14698,10 @@ func (action *UrlRewriteAction) AssignProperties_From_UrlRewriteAction(source *v
 
 	// Name
 	if source.Name != nil {
-		action.Name = UrlRewriteAction_Name(*source.Name)
+		name := UrlRewriteAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -14411,8 +14726,12 @@ func (action *UrlRewriteAction) AssignProperties_To_UrlRewriteAction(destination
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -14439,7 +14758,7 @@ func (action *UrlRewriteAction) AssignProperties_To_UrlRewriteAction(destination
 
 type UrlRewriteAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name UrlRewriteAction_Name_STATUS `json:"name,omitempty"`
+	Name *UrlRewriteAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *UrlRewriteActionParameters_STATUS `json:"parameters,omitempty"`
@@ -14460,7 +14779,7 @@ func (action *UrlRewriteAction_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -14482,9 +14801,10 @@ func (action *UrlRewriteAction_STATUS) AssignProperties_From_UrlRewriteAction_ST
 
 	// Name
 	if source.Name != nil {
-		action.Name = UrlRewriteAction_Name_STATUS(*source.Name)
+		name := UrlRewriteAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -14509,8 +14829,12 @@ func (action *UrlRewriteAction_STATUS) AssignProperties_To_UrlRewriteAction_STAT
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -14538,7 +14862,7 @@ func (action *UrlRewriteAction_STATUS) AssignProperties_To_UrlRewriteAction_STAT
 type UrlSigningAction struct {
 	// +kubebuilder:validation:Required
 	// Name: The name of the action for the delivery rule.
-	Name UrlSigningAction_Name `json:"name,omitempty"`
+	Name *UrlSigningAction_Name `json:"name,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Parameters: Defines the parameters for the action.
@@ -14555,7 +14879,9 @@ func (action *UrlSigningAction) ConvertToARM(resolved genruntime.ConvertToARMRes
 	result := &UrlSigningAction_ARM{}
 
 	// Set property ‘Name’:
-	result.Name = action.Name
+	if action.Name != nil {
+		result.Name = *action.Name
+	}
 
 	// Set property ‘Parameters’:
 	if action.Parameters != nil {
@@ -14582,7 +14908,7 @@ func (action *UrlSigningAction) PopulateFromARM(owner genruntime.ArbitraryOwnerR
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -14604,9 +14930,10 @@ func (action *UrlSigningAction) AssignProperties_From_UrlSigningAction(source *v
 
 	// Name
 	if source.Name != nil {
-		action.Name = UrlSigningAction_Name(*source.Name)
+		name := UrlSigningAction_Name(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -14631,8 +14958,12 @@ func (action *UrlSigningAction) AssignProperties_To_UrlSigningAction(destination
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {
@@ -14659,7 +14990,7 @@ func (action *UrlSigningAction) AssignProperties_To_UrlSigningAction(destination
 
 type UrlSigningAction_STATUS struct {
 	// Name: The name of the action for the delivery rule.
-	Name UrlSigningAction_Name_STATUS `json:"name,omitempty"`
+	Name *UrlSigningAction_Name_STATUS `json:"name,omitempty"`
 
 	// Parameters: Defines the parameters for the action.
 	Parameters *UrlSigningActionParameters_STATUS `json:"parameters,omitempty"`
@@ -14680,7 +15011,7 @@ func (action *UrlSigningAction_STATUS) PopulateFromARM(owner genruntime.Arbitrar
 	}
 
 	// Set property ‘Name’:
-	action.Name = typedInput.Name
+	action.Name = &typedInput.Name
 
 	// Set property ‘Parameters’:
 	if typedInput.Parameters != nil {
@@ -14702,9 +15033,10 @@ func (action *UrlSigningAction_STATUS) AssignProperties_From_UrlSigningAction_ST
 
 	// Name
 	if source.Name != nil {
-		action.Name = UrlSigningAction_Name_STATUS(*source.Name)
+		name := UrlSigningAction_Name_STATUS(*source.Name)
+		action.Name = &name
 	} else {
-		action.Name = ""
+		action.Name = nil
 	}
 
 	// Parameters
@@ -14729,8 +15061,12 @@ func (action *UrlSigningAction_STATUS) AssignProperties_To_UrlSigningAction_STAT
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Name
-	name := string(action.Name)
-	destination.Name = &name
+	if action.Name != nil {
+		name := string(*action.Name)
+		destination.Name = &name
+	} else {
+		destination.Name = nil
+	}
 
 	// Parameters
 	if action.Parameters != nil {

--- a/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen_test.go
+++ b/v2/api/cdn/v1beta20210601/profiles_endpoint_types_gen_test.go
@@ -3935,7 +3935,7 @@ func DeliveryRuleCacheExpirationActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleCacheExpirationAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleCacheExpirationAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleCacheExpirationAction_Name_CacheExpiration)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleCacheExpirationAction_Name_CacheExpiration))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleCacheExpirationAction is a factory method for creating gopter generators
@@ -4052,7 +4052,7 @@ func DeliveryRuleCacheExpirationAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleCacheExpirationAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleCacheExpirationAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleCacheExpirationAction_Name_STATUS_CacheExpiration)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleCacheExpirationAction_Name_STATUS_CacheExpiration))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleCacheExpirationAction_STATUS is a factory method for creating gopter generators
@@ -4169,7 +4169,7 @@ func DeliveryRuleCacheKeyQueryStringActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleCacheKeyQueryStringAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleCacheKeyQueryStringAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleCacheKeyQueryStringAction_Name_CacheKeyQueryString)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleCacheKeyQueryStringAction_Name_CacheKeyQueryString))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleCacheKeyQueryStringAction is a factory method for creating gopter generators
@@ -4286,7 +4286,7 @@ func DeliveryRuleCacheKeyQueryStringAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleCacheKeyQueryStringAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleCacheKeyQueryStringAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleCacheKeyQueryStringAction_Name_STATUS_CacheKeyQueryString)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleCacheKeyQueryStringAction_Name_STATUS_CacheKeyQueryString))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleCacheKeyQueryStringAction_STATUS is a factory method for creating gopter generators
@@ -4403,7 +4403,7 @@ func DeliveryRuleClientPortConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleClientPortCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleClientPortCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleClientPortCondition_Name_ClientPort)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleClientPortCondition_Name_ClientPort))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleClientPortCondition is a factory method for creating gopter generators
@@ -4520,7 +4520,7 @@ func DeliveryRuleClientPortCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleClientPortCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleClientPortCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleClientPortCondition_Name_STATUS_ClientPort)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleClientPortCondition_Name_STATUS_ClientPort))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleClientPortCondition_STATUS is a factory method for creating gopter generators
@@ -4637,7 +4637,7 @@ func DeliveryRuleCookiesConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleCookiesCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleCookiesCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleCookiesCondition_Name_Cookies)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleCookiesCondition_Name_Cookies))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleCookiesCondition is a factory method for creating gopter generators
@@ -4754,7 +4754,7 @@ func DeliveryRuleCookiesCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleCookiesCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleCookiesCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleCookiesCondition_Name_STATUS_Cookies)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleCookiesCondition_Name_STATUS_Cookies))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleCookiesCondition_STATUS is a factory method for creating gopter generators
@@ -4871,7 +4871,7 @@ func DeliveryRuleHostNameConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleHostNameCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleHostNameCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleHostNameCondition_Name_HostName)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleHostNameCondition_Name_HostName))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleHostNameCondition is a factory method for creating gopter generators
@@ -4988,7 +4988,7 @@ func DeliveryRuleHostNameCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleHostNameCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleHostNameCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleHostNameCondition_Name_STATUS_HostName)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleHostNameCondition_Name_STATUS_HostName))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleHostNameCondition_STATUS is a factory method for creating gopter generators
@@ -5105,7 +5105,7 @@ func DeliveryRuleHttpVersionConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleHttpVersionCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleHttpVersionCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleHttpVersionCondition_Name_HttpVersion)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleHttpVersionCondition_Name_HttpVersion))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleHttpVersionCondition is a factory method for creating gopter generators
@@ -5222,7 +5222,7 @@ func DeliveryRuleHttpVersionCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleHttpVersionCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleHttpVersionCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleHttpVersionCondition_Name_STATUS_HttpVersion)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleHttpVersionCondition_Name_STATUS_HttpVersion))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleHttpVersionCondition_STATUS is a factory method for creating gopter generators
@@ -5339,7 +5339,7 @@ func DeliveryRuleIsDeviceConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleIsDeviceCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleIsDeviceCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleIsDeviceCondition_Name_IsDevice)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleIsDeviceCondition_Name_IsDevice))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleIsDeviceCondition is a factory method for creating gopter generators
@@ -5456,7 +5456,7 @@ func DeliveryRuleIsDeviceCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleIsDeviceCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleIsDeviceCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleIsDeviceCondition_Name_STATUS_IsDevice)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleIsDeviceCondition_Name_STATUS_IsDevice))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleIsDeviceCondition_STATUS is a factory method for creating gopter generators
@@ -5573,7 +5573,7 @@ func DeliveryRulePostArgsConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRulePostArgsCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRulePostArgsCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRulePostArgsCondition_Name_PostArgs)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRulePostArgsCondition_Name_PostArgs))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRulePostArgsCondition is a factory method for creating gopter generators
@@ -5690,7 +5690,7 @@ func DeliveryRulePostArgsCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRulePostArgsCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRulePostArgsCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRulePostArgsCondition_Name_STATUS_PostArgs)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRulePostArgsCondition_Name_STATUS_PostArgs))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRulePostArgsCondition_STATUS is a factory method for creating gopter generators
@@ -5807,7 +5807,7 @@ func DeliveryRuleQueryStringConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleQueryStringCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleQueryStringCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleQueryStringCondition_Name_QueryString)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleQueryStringCondition_Name_QueryString))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleQueryStringCondition is a factory method for creating gopter generators
@@ -5924,7 +5924,7 @@ func DeliveryRuleQueryStringCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleQueryStringCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleQueryStringCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleQueryStringCondition_Name_STATUS_QueryString)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleQueryStringCondition_Name_STATUS_QueryString))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleQueryStringCondition_STATUS is a factory method for creating gopter generators
@@ -6041,7 +6041,7 @@ func DeliveryRuleRemoteAddressConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRemoteAddressCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRemoteAddressCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRemoteAddressCondition_Name_RemoteAddress)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRemoteAddressCondition_Name_RemoteAddress))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRemoteAddressCondition is a factory method for creating gopter generators
@@ -6158,7 +6158,7 @@ func DeliveryRuleRemoteAddressCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRemoteAddressCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRemoteAddressCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRemoteAddressCondition_Name_STATUS_RemoteAddress)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRemoteAddressCondition_Name_STATUS_RemoteAddress))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRemoteAddressCondition_STATUS is a factory method for creating gopter generators
@@ -6275,7 +6275,7 @@ func DeliveryRuleRequestBodyConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestBodyCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestBodyCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestBodyCondition_Name_RequestBody)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestBodyCondition_Name_RequestBody))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestBodyCondition is a factory method for creating gopter generators
@@ -6392,7 +6392,7 @@ func DeliveryRuleRequestBodyCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestBodyCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestBodyCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestBodyCondition_Name_STATUS_RequestBody)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestBodyCondition_Name_STATUS_RequestBody))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestBodyCondition_STATUS is a factory method for creating gopter generators
@@ -6509,7 +6509,7 @@ func DeliveryRuleRequestHeaderActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestHeaderAction_Name_ModifyRequestHeader)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestHeaderAction_Name_ModifyRequestHeader))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestHeaderAction is a factory method for creating gopter generators
@@ -6626,7 +6626,7 @@ func DeliveryRuleRequestHeaderAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestHeaderAction_Name_STATUS_ModifyRequestHeader)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestHeaderAction_Name_STATUS_ModifyRequestHeader))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestHeaderAction_STATUS is a factory method for creating gopter generators
@@ -6743,7 +6743,7 @@ func DeliveryRuleRequestHeaderConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestHeaderCondition_Name_RequestHeader)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestHeaderCondition_Name_RequestHeader))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestHeaderCondition is a factory method for creating gopter generators
@@ -6860,7 +6860,7 @@ func DeliveryRuleRequestHeaderCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestHeaderCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestHeaderCondition_Name_STATUS_RequestHeader)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestHeaderCondition_Name_STATUS_RequestHeader))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestHeaderCondition_STATUS is a factory method for creating gopter generators
@@ -6977,7 +6977,7 @@ func DeliveryRuleRequestMethodConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestMethodCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestMethodCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestMethodCondition_Name_RequestMethod)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestMethodCondition_Name_RequestMethod))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestMethodCondition is a factory method for creating gopter generators
@@ -7094,7 +7094,7 @@ func DeliveryRuleRequestMethodCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestMethodCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestMethodCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestMethodCondition_Name_STATUS_RequestMethod)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestMethodCondition_Name_STATUS_RequestMethod))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestMethodCondition_STATUS is a factory method for creating gopter generators
@@ -7211,7 +7211,7 @@ func DeliveryRuleRequestSchemeConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestSchemeCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestSchemeCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestSchemeCondition_Name_RequestScheme)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestSchemeCondition_Name_RequestScheme))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestSchemeCondition is a factory method for creating gopter generators
@@ -7328,7 +7328,7 @@ func DeliveryRuleRequestSchemeCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestSchemeCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestSchemeCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestSchemeCondition_Name_STATUS_RequestScheme)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestSchemeCondition_Name_STATUS_RequestScheme))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestSchemeCondition_STATUS is a factory method for creating gopter generators
@@ -7445,7 +7445,7 @@ func DeliveryRuleRequestUriConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestUriCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestUriCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestUriCondition_Name_RequestUri)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestUriCondition_Name_RequestUri))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestUriCondition is a factory method for creating gopter generators
@@ -7562,7 +7562,7 @@ func DeliveryRuleRequestUriCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRequestUriCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRequestUriCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRequestUriCondition_Name_STATUS_RequestUri)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRequestUriCondition_Name_STATUS_RequestUri))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRequestUriCondition_STATUS is a factory method for creating gopter generators
@@ -7679,7 +7679,7 @@ func DeliveryRuleResponseHeaderActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleResponseHeaderAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleResponseHeaderAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleResponseHeaderAction_Name_ModifyResponseHeader)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleResponseHeaderAction_Name_ModifyResponseHeader))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleResponseHeaderAction is a factory method for creating gopter generators
@@ -7796,7 +7796,7 @@ func DeliveryRuleResponseHeaderAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleResponseHeaderAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleResponseHeaderAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleResponseHeaderAction_Name_STATUS_ModifyResponseHeader)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleResponseHeaderAction_Name_STATUS_ModifyResponseHeader))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleResponseHeaderAction_STATUS is a factory method for creating gopter generators
@@ -7913,7 +7913,7 @@ func DeliveryRuleRouteConfigurationOverrideActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRouteConfigurationOverrideAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRouteConfigurationOverrideAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRouteConfigurationOverrideAction_Name_RouteConfigurationOverride)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRouteConfigurationOverrideAction_Name_RouteConfigurationOverride))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRouteConfigurationOverrideAction is a factory method for creating gopter generators
@@ -8030,7 +8030,7 @@ func DeliveryRuleRouteConfigurationOverrideAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleRouteConfigurationOverrideAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleRouteConfigurationOverrideAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS_RouteConfigurationOverride)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleRouteConfigurationOverrideAction_Name_STATUS_RouteConfigurationOverride))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleRouteConfigurationOverrideAction_STATUS is a factory method for creating gopter generators
@@ -8147,7 +8147,7 @@ func DeliveryRuleServerPortConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleServerPortCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleServerPortCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleServerPortCondition_Name_ServerPort)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleServerPortCondition_Name_ServerPort))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleServerPortCondition is a factory method for creating gopter generators
@@ -8264,7 +8264,7 @@ func DeliveryRuleServerPortCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleServerPortCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleServerPortCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleServerPortCondition_Name_STATUS_ServerPort)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleServerPortCondition_Name_STATUS_ServerPort))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleServerPortCondition_STATUS is a factory method for creating gopter generators
@@ -8381,7 +8381,7 @@ func DeliveryRuleSocketAddrConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleSocketAddrCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleSocketAddrCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleSocketAddrCondition_Name_SocketAddr)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleSocketAddrCondition_Name_SocketAddr))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleSocketAddrCondition is a factory method for creating gopter generators
@@ -8498,7 +8498,7 @@ func DeliveryRuleSocketAddrCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleSocketAddrCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleSocketAddrCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleSocketAddrCondition_Name_STATUS_SocketAddr)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleSocketAddrCondition_Name_STATUS_SocketAddr))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleSocketAddrCondition_STATUS is a factory method for creating gopter generators
@@ -8615,7 +8615,7 @@ func DeliveryRuleSslProtocolConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleSslProtocolCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleSslProtocolCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleSslProtocolCondition_Name_SslProtocol)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleSslProtocolCondition_Name_SslProtocol))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleSslProtocolCondition is a factory method for creating gopter generators
@@ -8732,7 +8732,7 @@ func DeliveryRuleSslProtocolCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleSslProtocolCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleSslProtocolCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleSslProtocolCondition_Name_STATUS_SslProtocol)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleSslProtocolCondition_Name_STATUS_SslProtocol))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleSslProtocolCondition_STATUS is a factory method for creating gopter generators
@@ -8849,7 +8849,7 @@ func DeliveryRuleUrlFileExtensionConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileExtensionCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileExtensionCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleUrlFileExtensionCondition_Name_UrlFileExtension)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleUrlFileExtensionCondition_Name_UrlFileExtension))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleUrlFileExtensionCondition is a factory method for creating gopter generators
@@ -8966,7 +8966,7 @@ func DeliveryRuleUrlFileExtensionCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileExtensionCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileExtensionCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleUrlFileExtensionCondition_Name_STATUS_UrlFileExtension)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleUrlFileExtensionCondition_Name_STATUS_UrlFileExtension))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleUrlFileExtensionCondition_STATUS is a factory method for creating gopter generators
@@ -9083,7 +9083,7 @@ func DeliveryRuleUrlFileNameConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileNameCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileNameCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleUrlFileNameCondition_Name_UrlFileName)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleUrlFileNameCondition_Name_UrlFileName))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleUrlFileNameCondition is a factory method for creating gopter generators
@@ -9200,7 +9200,7 @@ func DeliveryRuleUrlFileNameCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileNameCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleUrlFileNameCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleUrlFileNameCondition_Name_STATUS_UrlFileName)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleUrlFileNameCondition_Name_STATUS_UrlFileName))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleUrlFileNameCondition_STATUS is a factory method for creating gopter generators
@@ -9317,7 +9317,7 @@ func DeliveryRuleUrlPathConditionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleUrlPathCondition is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleUrlPathCondition(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleUrlPathCondition_Name_UrlPath)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleUrlPathCondition_Name_UrlPath))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleUrlPathCondition is a factory method for creating gopter generators
@@ -9434,7 +9434,7 @@ func DeliveryRuleUrlPathCondition_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForDeliveryRuleUrlPathCondition_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDeliveryRuleUrlPathCondition_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(DeliveryRuleUrlPathCondition_Name_STATUS_UrlPath)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(DeliveryRuleUrlPathCondition_Name_STATUS_UrlPath))
 }
 
 // AddRelatedPropertyGeneratorsForDeliveryRuleUrlPathCondition_STATUS is a factory method for creating gopter generators
@@ -9551,7 +9551,7 @@ func OriginGroupOverrideActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForOriginGroupOverrideAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForOriginGroupOverrideAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(OriginGroupOverrideAction_Name_OriginGroupOverride)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(OriginGroupOverrideAction_Name_OriginGroupOverride))
 }
 
 // AddRelatedPropertyGeneratorsForOriginGroupOverrideAction is a factory method for creating gopter generators
@@ -9668,7 +9668,7 @@ func OriginGroupOverrideAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForOriginGroupOverrideAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForOriginGroupOverrideAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(OriginGroupOverrideAction_Name_STATUS_OriginGroupOverride)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(OriginGroupOverrideAction_Name_STATUS_OriginGroupOverride))
 }
 
 // AddRelatedPropertyGeneratorsForOriginGroupOverrideAction_STATUS is a factory method for creating gopter generators
@@ -9784,7 +9784,7 @@ func UrlRedirectActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForUrlRedirectAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForUrlRedirectAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(UrlRedirectAction_Name_UrlRedirect)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(UrlRedirectAction_Name_UrlRedirect))
 }
 
 // AddRelatedPropertyGeneratorsForUrlRedirectAction is a factory method for creating gopter generators
@@ -9901,7 +9901,7 @@ func UrlRedirectAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForUrlRedirectAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForUrlRedirectAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(UrlRedirectAction_Name_STATUS_UrlRedirect)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(UrlRedirectAction_Name_STATUS_UrlRedirect))
 }
 
 // AddRelatedPropertyGeneratorsForUrlRedirectAction_STATUS is a factory method for creating gopter generators
@@ -10017,7 +10017,7 @@ func UrlRewriteActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForUrlRewriteAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForUrlRewriteAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(UrlRewriteAction_Name_UrlRewrite)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(UrlRewriteAction_Name_UrlRewrite))
 }
 
 // AddRelatedPropertyGeneratorsForUrlRewriteAction is a factory method for creating gopter generators
@@ -10134,7 +10134,7 @@ func UrlRewriteAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForUrlRewriteAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForUrlRewriteAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(UrlRewriteAction_Name_STATUS_UrlRewrite)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(UrlRewriteAction_Name_STATUS_UrlRewrite))
 }
 
 // AddRelatedPropertyGeneratorsForUrlRewriteAction_STATUS is a factory method for creating gopter generators
@@ -10250,7 +10250,7 @@ func UrlSigningActionGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForUrlSigningAction is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForUrlSigningAction(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(UrlSigningAction_Name_UrlSigning)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(UrlSigningAction_Name_UrlSigning))
 }
 
 // AddRelatedPropertyGeneratorsForUrlSigningAction is a factory method for creating gopter generators
@@ -10367,7 +10367,7 @@ func UrlSigningAction_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForUrlSigningAction_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForUrlSigningAction_STATUS(gens map[string]gopter.Gen) {
-	gens["Name"] = gen.OneConstOf(UrlSigningAction_Name_STATUS_UrlSigning)
+	gens["Name"] = gen.PtrOf(gen.OneConstOf(UrlSigningAction_Name_STATUS_UrlSigning))
 }
 
 // AddRelatedPropertyGeneratorsForUrlSigningAction_STATUS is a factory method for creating gopter generators

--- a/v2/api/cdn/v1beta20210601/structure.txt
+++ b/v2/api/cdn/v1beta20210601/structure.txt
@@ -160,7 +160,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │   └── Rules: Object (4 properties)[]
 │   │   │       ├── Actions: Object (9 properties)[]
 │   │   │       │   ├── CacheExpiration: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "CacheExpiration"
 │   │   │       │   │   └── Parameters: *Object (4 properties)
 │   │   │       │   │       ├── CacheBehavior: *Enum (3 values)
@@ -173,7 +173,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleCacheExpirationActionParameters"
 │   │   │       │   ├── CacheKeyQueryString: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "CacheKeyQueryString"
 │   │   │       │   │   └── Parameters: *Object (3 properties)
 │   │   │       │   │       ├── QueryParameters: *string
@@ -185,7 +185,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters"
 │   │   │       │   ├── ModifyRequestHeader: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "ModifyRequestHeader"
 │   │   │       │   │   └── Parameters: *Object (4 properties)
 │   │   │       │   │       ├── HeaderAction: *Enum (3 values)
@@ -197,7 +197,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       │   └── "DeliveryRuleHeaderActionParameters"
 │   │   │       │   │       └── Value: *string
 │   │   │       │   ├── ModifyResponseHeader: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "ModifyResponseHeader"
 │   │   │       │   │   └── Parameters: *Object (4 properties)
 │   │   │       │   │       ├── HeaderAction: *Enum (3 values)
@@ -209,7 +209,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       │   └── "DeliveryRuleHeaderActionParameters"
 │   │   │       │   │       └── Value: *string
 │   │   │       │   ├── OriginGroupOverride: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "OriginGroupOverride"
 │   │   │       │   │   └── Parameters: *Object (2 properties)
 │   │   │       │   │       ├── OriginGroup: *Object (1 property)
@@ -217,7 +217,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleOriginGroupOverrideActionParameters"
 │   │   │       │   ├── RouteConfigurationOverride: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "RouteConfigurationOverride"
 │   │   │       │   │   └── Parameters: *Object (3 properties)
 │   │   │       │   │       ├── CacheConfiguration: *Object (5 properties)
@@ -245,7 +245,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleRouteConfigurationOverrideActionParameters"
 │   │   │       │   ├── UrlRedirect: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "UrlRedirect"
 │   │   │       │   │   └── Parameters: *Object (7 properties)
 │   │   │       │   │       ├── CustomFragment: *string
@@ -264,7 +264,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleUrlRedirectActionParameters"
 │   │   │       │   ├── UrlRewrite: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "UrlRewrite"
 │   │   │       │   │   └── Parameters: *Object (4 properties)
 │   │   │       │   │       ├── Destination: *string
@@ -273,7 +273,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleUrlRewriteActionParameters"
 │   │   │       │   └── UrlSigning: *Object (2 properties)
-│   │   │       │       ├── Name: Enum (1 value)
+│   │   │       │       ├── Name: *Enum (1 value)
 │   │   │       │       │   └── "UrlSigning"
 │   │   │       │       └── Parameters: *Object (3 properties)
 │   │   │       │           ├── Algorithm: *Enum (1 value)
@@ -288,7 +288,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │               └── "DeliveryRuleUrlSigningActionParameters"
 │   │   │       ├── Conditions: Object (19 properties)[]
 │   │   │       │   ├── ClientPort: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "ClientPort"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -314,7 +314,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleClientPortConditionParameters"
 │   │   │       │   ├── Cookies: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "Cookies"
 │   │   │       │   │   └── Parameters: *Object (6 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -341,7 +341,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleCookiesConditionParameters"
 │   │   │       │   ├── HostName: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "HostName"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -367,7 +367,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleHostNameConditionParameters"
 │   │   │       │   ├── HttpVersion: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "HttpVersion"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -384,7 +384,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleHttpVersionConditionParameters"
 │   │   │       │   ├── IsDevice: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "IsDevice"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: Enum (2 values)[]
@@ -403,7 +403,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleIsDeviceConditionParameters"
 │   │   │       │   ├── PostArgs: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "PostArgs"
 │   │   │       │   │   └── Parameters: *Object (6 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -430,7 +430,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRulePostArgsConditionParameters"
 │   │   │       │   ├── QueryString: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "QueryString"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -456,7 +456,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleQueryStringConditionParameters"
 │   │   │       │   ├── RemoteAddress: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "RemoteAddress"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -475,7 +475,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleRemoteAddressConditionParameters"
 │   │   │       │   ├── RequestBody: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "RequestBody"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -501,7 +501,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleRequestBodyConditionParameters"
 │   │   │       │   ├── RequestHeader: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "RequestHeader"
 │   │   │       │   │   └── Parameters: *Object (6 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -528,7 +528,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleRequestHeaderConditionParameters"
 │   │   │       │   ├── RequestMethod: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "RequestMethod"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: Enum (7 values)[]
@@ -552,7 +552,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleRequestMethodConditionParameters"
 │   │   │       │   ├── RequestScheme: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "RequestScheme"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: Enum (2 values)[]
@@ -571,7 +571,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleRequestSchemeConditionParameters"
 │   │   │       │   ├── RequestUri: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "RequestUri"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -597,7 +597,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleRequestUriConditionParameters"
 │   │   │       │   ├── ServerPort: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "ServerPort"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -623,7 +623,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleServerPortConditionParameters"
 │   │   │       │   ├── SocketAddr: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "SocketAddr"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -641,7 +641,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleSocketAddrConditionParameters"
 │   │   │       │   ├── SslProtocol: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "SslProtocol"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: Enum (3 values)[]
@@ -661,7 +661,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleSslProtocolConditionParameters"
 │   │   │       │   ├── UrlFileExtension: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "UrlFileExtension"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -687,7 +687,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleUrlFileExtensionMatchConditionParameters"
 │   │   │       │   ├── UrlFileName: *Object (2 properties)
-│   │   │       │   │   ├── Name: Enum (1 value)
+│   │   │       │   │   ├── Name: *Enum (1 value)
 │   │   │       │   │   │   └── "UrlFileName"
 │   │   │       │   │   └── Parameters: *Object (5 properties)
 │   │   │       │   │       ├── MatchValues: string[]
@@ -713,7 +713,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │   │   │       │   │       └── TypeName: *Enum (1 value)
 │   │   │       │   │           └── "DeliveryRuleUrlFilenameConditionParameters"
 │   │   │       │   └── UrlPath: *Object (2 properties)
-│   │   │       │       ├── Name: Enum (1 value)
+│   │   │       │       ├── Name: *Enum (1 value)
 │   │   │       │       │   └── "UrlPath"
 │   │   │       │       └── Parameters: *Object (5 properties)
 │   │   │       │           ├── MatchValues: string[]
@@ -849,7 +849,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │   └── Rules: Object (4 properties)[]
 │       │       ├── Actions: Object (9 properties)[]
 │       │       │   ├── CacheExpiration: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "CacheExpiration"
 │       │       │   │   └── Parameters: *Object (4 properties)
 │       │       │   │       ├── CacheBehavior: *Enum (3 values)
@@ -862,7 +862,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleCacheExpirationActionParameters"
 │       │       │   ├── CacheKeyQueryString: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "CacheKeyQueryString"
 │       │       │   │   └── Parameters: *Object (3 properties)
 │       │       │   │       ├── QueryParameters: *string
@@ -874,7 +874,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters"
 │       │       │   ├── ModifyRequestHeader: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "ModifyRequestHeader"
 │       │       │   │   └── Parameters: *Object (4 properties)
 │       │       │   │       ├── HeaderAction: *Enum (3 values)
@@ -886,7 +886,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       │   └── "DeliveryRuleHeaderActionParameters"
 │       │       │   │       └── Value: *string
 │       │       │   ├── ModifyResponseHeader: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "ModifyResponseHeader"
 │       │       │   │   └── Parameters: *Object (4 properties)
 │       │       │   │       ├── HeaderAction: *Enum (3 values)
@@ -898,7 +898,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       │   └── "DeliveryRuleHeaderActionParameters"
 │       │       │   │       └── Value: *string
 │       │       │   ├── OriginGroupOverride: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "OriginGroupOverride"
 │       │       │   │   └── Parameters: *Object (2 properties)
 │       │       │   │       ├── OriginGroup: *Object (1 property)
@@ -906,7 +906,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleOriginGroupOverrideActionParameters"
 │       │       │   ├── RouteConfigurationOverride: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "RouteConfigurationOverride"
 │       │       │   │   └── Parameters: *Object (3 properties)
 │       │       │   │       ├── CacheConfiguration: *Object (5 properties)
@@ -934,7 +934,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleRouteConfigurationOverrideActionParameters"
 │       │       │   ├── UrlRedirect: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "UrlRedirect"
 │       │       │   │   └── Parameters: *Object (7 properties)
 │       │       │   │       ├── CustomFragment: *string
@@ -953,7 +953,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleUrlRedirectActionParameters"
 │       │       │   ├── UrlRewrite: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "UrlRewrite"
 │       │       │   │   └── Parameters: *Object (4 properties)
 │       │       │   │       ├── Destination: *string
@@ -962,7 +962,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleUrlRewriteActionParameters"
 │       │       │   └── UrlSigning: *Object (2 properties)
-│       │       │       ├── Name: Enum (1 value)
+│       │       │       ├── Name: *Enum (1 value)
 │       │       │       │   └── "UrlSigning"
 │       │       │       └── Parameters: *Object (3 properties)
 │       │       │           ├── Algorithm: *Enum (1 value)
@@ -977,7 +977,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │               └── "DeliveryRuleUrlSigningActionParameters"
 │       │       ├── Conditions: Object (19 properties)[]
 │       │       │   ├── ClientPort: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "ClientPort"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1003,7 +1003,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleClientPortConditionParameters"
 │       │       │   ├── Cookies: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "Cookies"
 │       │       │   │   └── Parameters: *Object (6 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1030,7 +1030,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleCookiesConditionParameters"
 │       │       │   ├── HostName: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "HostName"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1056,7 +1056,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleHostNameConditionParameters"
 │       │       │   ├── HttpVersion: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "HttpVersion"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1073,7 +1073,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleHttpVersionConditionParameters"
 │       │       │   ├── IsDevice: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "IsDevice"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: Enum (2 values)[]
@@ -1092,7 +1092,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleIsDeviceConditionParameters"
 │       │       │   ├── PostArgs: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "PostArgs"
 │       │       │   │   └── Parameters: *Object (6 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1119,7 +1119,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRulePostArgsConditionParameters"
 │       │       │   ├── QueryString: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "QueryString"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1145,7 +1145,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleQueryStringConditionParameters"
 │       │       │   ├── RemoteAddress: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "RemoteAddress"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1164,7 +1164,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleRemoteAddressConditionParameters"
 │       │       │   ├── RequestBody: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "RequestBody"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1190,7 +1190,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleRequestBodyConditionParameters"
 │       │       │   ├── RequestHeader: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "RequestHeader"
 │       │       │   │   └── Parameters: *Object (6 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1217,7 +1217,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleRequestHeaderConditionParameters"
 │       │       │   ├── RequestMethod: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "RequestMethod"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: Enum (7 values)[]
@@ -1241,7 +1241,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleRequestMethodConditionParameters"
 │       │       │   ├── RequestScheme: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "RequestScheme"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: Enum (2 values)[]
@@ -1260,7 +1260,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleRequestSchemeConditionParameters"
 │       │       │   ├── RequestUri: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "RequestUri"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1286,7 +1286,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleRequestUriConditionParameters"
 │       │       │   ├── ServerPort: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "ServerPort"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1312,7 +1312,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleServerPortConditionParameters"
 │       │       │   ├── SocketAddr: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "SocketAddr"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1330,7 +1330,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleSocketAddrConditionParameters"
 │       │       │   ├── SslProtocol: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "SslProtocol"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: Enum (3 values)[]
@@ -1350,7 +1350,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleSslProtocolConditionParameters"
 │       │       │   ├── UrlFileExtension: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "UrlFileExtension"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1376,7 +1376,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleUrlFileExtensionMatchConditionParameters"
 │       │       │   ├── UrlFileName: *Object (2 properties)
-│       │       │   │   ├── Name: Enum (1 value)
+│       │       │   │   ├── Name: *Enum (1 value)
 │       │       │   │   │   └── "UrlFileName"
 │       │       │   │   └── Parameters: *Object (5 properties)
 │       │       │   │       ├── MatchValues: string[]
@@ -1402,7 +1402,7 @@ github.com/Azure/azure-service-operator/v2/api/cdn/v1beta20210601
 │       │       │   │       └── TypeName: *Enum (1 value)
 │       │       │   │           └── "DeliveryRuleUrlFilenameConditionParameters"
 │       │       │   └── UrlPath: *Object (2 properties)
-│       │       │       ├── Name: Enum (1 value)
+│       │       │       ├── Name: *Enum (1 value)
 │       │       │       │   └── "UrlPath"
 │       │       │       └── Parameters: *Object (5 properties)
 │       │       │           ├── MatchValues: string[]

--- a/v2/api/dbformariadb/v1beta20180601/server_types_gen.go
+++ b/v2/api/dbformariadb/v1beta20180601/server_types_gen.go
@@ -2292,7 +2292,7 @@ type ServerPropertiesForDefaultCreate struct {
 
 	// +kubebuilder:validation:Required
 	// CreateMode: The mode to create a new server.
-	CreateMode ServerPropertiesForDefaultCreate_CreateMode `json:"createMode,omitempty"`
+	CreateMode *ServerPropertiesForDefaultCreate_CreateMode `json:"createMode,omitempty"`
 
 	// MinimalTlsVersion: Enforce a minimal Tls version for the server.
 	MinimalTlsVersion *MinimalTlsVersion `json:"minimalTlsVersion,omitempty"`
@@ -2334,7 +2334,9 @@ func (create *ServerPropertiesForDefaultCreate) ConvertToARM(resolved genruntime
 	result.AdministratorLoginPassword = administratorLoginPasswordSecret
 
 	// Set property ‘CreateMode’:
-	result.CreateMode = create.CreateMode
+	if create.CreateMode != nil {
+		result.CreateMode = *create.CreateMode
+	}
 
 	// Set property ‘MinimalTlsVersion’:
 	if create.MinimalTlsVersion != nil {
@@ -2393,7 +2395,7 @@ func (create *ServerPropertiesForDefaultCreate) PopulateFromARM(owner genruntime
 	// no assignment for property ‘AdministratorLoginPassword’
 
 	// Set property ‘CreateMode’:
-	create.CreateMode = typedInput.CreateMode
+	create.CreateMode = &typedInput.CreateMode
 
 	// Set property ‘MinimalTlsVersion’:
 	if typedInput.MinimalTlsVersion != nil {
@@ -2449,9 +2451,10 @@ func (create *ServerPropertiesForDefaultCreate) AssignProperties_From_ServerProp
 
 	// CreateMode
 	if source.CreateMode != nil {
-		create.CreateMode = ServerPropertiesForDefaultCreate_CreateMode(*source.CreateMode)
+		createMode := ServerPropertiesForDefaultCreate_CreateMode(*source.CreateMode)
+		create.CreateMode = &createMode
 	} else {
-		create.CreateMode = ""
+		create.CreateMode = nil
 	}
 
 	// MinimalTlsVersion
@@ -2515,8 +2518,12 @@ func (create *ServerPropertiesForDefaultCreate) AssignProperties_To_ServerProper
 	destination.AdministratorLoginPassword = &administratorLoginPassword
 
 	// CreateMode
-	createMode := string(create.CreateMode)
-	destination.CreateMode = &createMode
+	if create.CreateMode != nil {
+		createMode := string(*create.CreateMode)
+		destination.CreateMode = &createMode
+	} else {
+		destination.CreateMode = nil
+	}
 
 	// MinimalTlsVersion
 	if create.MinimalTlsVersion != nil {
@@ -2576,7 +2583,7 @@ func (create *ServerPropertiesForDefaultCreate) AssignProperties_To_ServerProper
 type ServerPropertiesForGeoRestore struct {
 	// +kubebuilder:validation:Required
 	// CreateMode: The mode to create a new server.
-	CreateMode ServerPropertiesForGeoRestore_CreateMode `json:"createMode,omitempty"`
+	CreateMode *ServerPropertiesForGeoRestore_CreateMode `json:"createMode,omitempty"`
 
 	// MinimalTlsVersion: Enforce a minimal Tls version for the server.
 	MinimalTlsVersion *MinimalTlsVersion `json:"minimalTlsVersion,omitempty"`
@@ -2609,7 +2616,9 @@ func (restore *ServerPropertiesForGeoRestore) ConvertToARM(resolved genruntime.C
 	result := &ServerPropertiesForGeoRestore_ARM{}
 
 	// Set property ‘CreateMode’:
-	result.CreateMode = restore.CreateMode
+	if restore.CreateMode != nil {
+		result.CreateMode = *restore.CreateMode
+	}
 
 	// Set property ‘MinimalTlsVersion’:
 	if restore.MinimalTlsVersion != nil {
@@ -2666,7 +2675,7 @@ func (restore *ServerPropertiesForGeoRestore) PopulateFromARM(owner genruntime.A
 	}
 
 	// Set property ‘CreateMode’:
-	restore.CreateMode = typedInput.CreateMode
+	restore.CreateMode = &typedInput.CreateMode
 
 	// Set property ‘MinimalTlsVersion’:
 	if typedInput.MinimalTlsVersion != nil {
@@ -2718,9 +2727,10 @@ func (restore *ServerPropertiesForGeoRestore) AssignProperties_From_ServerProper
 
 	// CreateMode
 	if source.CreateMode != nil {
-		restore.CreateMode = ServerPropertiesForGeoRestore_CreateMode(*source.CreateMode)
+		createMode := ServerPropertiesForGeoRestore_CreateMode(*source.CreateMode)
+		restore.CreateMode = &createMode
 	} else {
-		restore.CreateMode = ""
+		restore.CreateMode = nil
 	}
 
 	// MinimalTlsVersion
@@ -2780,8 +2790,12 @@ func (restore *ServerPropertiesForGeoRestore) AssignProperties_To_ServerProperti
 	propertyBag := genruntime.NewPropertyBag()
 
 	// CreateMode
-	createMode := string(restore.CreateMode)
-	destination.CreateMode = &createMode
+	if restore.CreateMode != nil {
+		createMode := string(*restore.CreateMode)
+		destination.CreateMode = &createMode
+	} else {
+		destination.CreateMode = nil
+	}
 
 	// MinimalTlsVersion
 	if restore.MinimalTlsVersion != nil {
@@ -2844,7 +2858,7 @@ func (restore *ServerPropertiesForGeoRestore) AssignProperties_To_ServerProperti
 type ServerPropertiesForReplica struct {
 	// +kubebuilder:validation:Required
 	// CreateMode: The mode to create a new server.
-	CreateMode ServerPropertiesForReplica_CreateMode `json:"createMode,omitempty"`
+	CreateMode *ServerPropertiesForReplica_CreateMode `json:"createMode,omitempty"`
 
 	// MinimalTlsVersion: Enforce a minimal Tls version for the server.
 	MinimalTlsVersion *MinimalTlsVersion `json:"minimalTlsVersion,omitempty"`
@@ -2877,7 +2891,9 @@ func (replica *ServerPropertiesForReplica) ConvertToARM(resolved genruntime.Conv
 	result := &ServerPropertiesForReplica_ARM{}
 
 	// Set property ‘CreateMode’:
-	result.CreateMode = replica.CreateMode
+	if replica.CreateMode != nil {
+		result.CreateMode = *replica.CreateMode
+	}
 
 	// Set property ‘MinimalTlsVersion’:
 	if replica.MinimalTlsVersion != nil {
@@ -2934,7 +2950,7 @@ func (replica *ServerPropertiesForReplica) PopulateFromARM(owner genruntime.Arbi
 	}
 
 	// Set property ‘CreateMode’:
-	replica.CreateMode = typedInput.CreateMode
+	replica.CreateMode = &typedInput.CreateMode
 
 	// Set property ‘MinimalTlsVersion’:
 	if typedInput.MinimalTlsVersion != nil {
@@ -2986,9 +3002,10 @@ func (replica *ServerPropertiesForReplica) AssignProperties_From_ServerPropertie
 
 	// CreateMode
 	if source.CreateMode != nil {
-		replica.CreateMode = ServerPropertiesForReplica_CreateMode(*source.CreateMode)
+		createMode := ServerPropertiesForReplica_CreateMode(*source.CreateMode)
+		replica.CreateMode = &createMode
 	} else {
-		replica.CreateMode = ""
+		replica.CreateMode = nil
 	}
 
 	// MinimalTlsVersion
@@ -3048,8 +3065,12 @@ func (replica *ServerPropertiesForReplica) AssignProperties_To_ServerPropertiesF
 	propertyBag := genruntime.NewPropertyBag()
 
 	// CreateMode
-	createMode := string(replica.CreateMode)
-	destination.CreateMode = &createMode
+	if replica.CreateMode != nil {
+		createMode := string(*replica.CreateMode)
+		destination.CreateMode = &createMode
+	} else {
+		destination.CreateMode = nil
+	}
 
 	// MinimalTlsVersion
 	if replica.MinimalTlsVersion != nil {
@@ -3112,7 +3133,7 @@ func (replica *ServerPropertiesForReplica) AssignProperties_To_ServerPropertiesF
 type ServerPropertiesForRestore struct {
 	// +kubebuilder:validation:Required
 	// CreateMode: The mode to create a new server.
-	CreateMode ServerPropertiesForRestore_CreateMode `json:"createMode,omitempty"`
+	CreateMode *ServerPropertiesForRestore_CreateMode `json:"createMode,omitempty"`
 
 	// MinimalTlsVersion: Enforce a minimal Tls version for the server.
 	MinimalTlsVersion *MinimalTlsVersion `json:"minimalTlsVersion,omitempty"`
@@ -3149,7 +3170,9 @@ func (restore *ServerPropertiesForRestore) ConvertToARM(resolved genruntime.Conv
 	result := &ServerPropertiesForRestore_ARM{}
 
 	// Set property ‘CreateMode’:
-	result.CreateMode = restore.CreateMode
+	if restore.CreateMode != nil {
+		result.CreateMode = *restore.CreateMode
+	}
 
 	// Set property ‘MinimalTlsVersion’:
 	if restore.MinimalTlsVersion != nil {
@@ -3212,7 +3235,7 @@ func (restore *ServerPropertiesForRestore) PopulateFromARM(owner genruntime.Arbi
 	}
 
 	// Set property ‘CreateMode’:
-	restore.CreateMode = typedInput.CreateMode
+	restore.CreateMode = &typedInput.CreateMode
 
 	// Set property ‘MinimalTlsVersion’:
 	if typedInput.MinimalTlsVersion != nil {
@@ -3270,9 +3293,10 @@ func (restore *ServerPropertiesForRestore) AssignProperties_From_ServerPropertie
 
 	// CreateMode
 	if source.CreateMode != nil {
-		restore.CreateMode = ServerPropertiesForRestore_CreateMode(*source.CreateMode)
+		createMode := ServerPropertiesForRestore_CreateMode(*source.CreateMode)
+		restore.CreateMode = &createMode
 	} else {
-		restore.CreateMode = ""
+		restore.CreateMode = nil
 	}
 
 	// MinimalTlsVersion
@@ -3340,8 +3364,12 @@ func (restore *ServerPropertiesForRestore) AssignProperties_To_ServerPropertiesF
 	propertyBag := genruntime.NewPropertyBag()
 
 	// CreateMode
-	createMode := string(restore.CreateMode)
-	destination.CreateMode = &createMode
+	if restore.CreateMode != nil {
+		createMode := string(*restore.CreateMode)
+		destination.CreateMode = &createMode
+	} else {
+		destination.CreateMode = nil
+	}
 
 	// MinimalTlsVersion
 	if restore.MinimalTlsVersion != nil {

--- a/v2/api/dbformariadb/v1beta20180601/server_types_gen_test.go
+++ b/v2/api/dbformariadb/v1beta20180601/server_types_gen_test.go
@@ -1408,7 +1408,7 @@ func ServerPropertiesForDefaultCreateGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForServerPropertiesForDefaultCreate is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServerPropertiesForDefaultCreate(gens map[string]gopter.Gen) {
 	gens["AdministratorLogin"] = gen.PtrOf(gen.AlphaString())
-	gens["CreateMode"] = gen.OneConstOf(ServerPropertiesForDefaultCreate_CreateMode_Default)
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesForDefaultCreate_CreateMode_Default))
 	gens["MinimalTlsVersion"] = gen.PtrOf(gen.OneConstOf(
 		MinimalTlsVersion_TLS1_0,
 		MinimalTlsVersion_TLS1_1,
@@ -1533,7 +1533,7 @@ func ServerPropertiesForGeoRestoreGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServerPropertiesForGeoRestore is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServerPropertiesForGeoRestore(gens map[string]gopter.Gen) {
-	gens["CreateMode"] = gen.OneConstOf(ServerPropertiesForGeoRestore_CreateMode_GeoRestore)
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesForGeoRestore_CreateMode_GeoRestore))
 	gens["MinimalTlsVersion"] = gen.PtrOf(gen.OneConstOf(
 		MinimalTlsVersion_TLS1_0,
 		MinimalTlsVersion_TLS1_1,
@@ -1659,7 +1659,7 @@ func ServerPropertiesForReplicaGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServerPropertiesForReplica is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServerPropertiesForReplica(gens map[string]gopter.Gen) {
-	gens["CreateMode"] = gen.OneConstOf(ServerPropertiesForReplica_CreateMode_Replica)
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesForReplica_CreateMode_Replica))
 	gens["MinimalTlsVersion"] = gen.PtrOf(gen.OneConstOf(
 		MinimalTlsVersion_TLS1_0,
 		MinimalTlsVersion_TLS1_1,
@@ -1785,7 +1785,7 @@ func ServerPropertiesForRestoreGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServerPropertiesForRestore is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServerPropertiesForRestore(gens map[string]gopter.Gen) {
-	gens["CreateMode"] = gen.OneConstOf(ServerPropertiesForRestore_CreateMode_PointInTimeRestore)
+	gens["CreateMode"] = gen.PtrOf(gen.OneConstOf(ServerPropertiesForRestore_CreateMode_PointInTimeRestore))
 	gens["MinimalTlsVersion"] = gen.PtrOf(gen.OneConstOf(
 		MinimalTlsVersion_TLS1_0,
 		MinimalTlsVersion_TLS1_1,

--- a/v2/api/dbformariadb/v1beta20180601/structure.txt
+++ b/v2/api/dbformariadb/v1beta20180601/structure.txt
@@ -46,7 +46,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1beta20180601
 │   │   │   ├── Default: *Object (8 properties)
 │   │   │   │   ├── AdministratorLogin: *string
 │   │   │   │   ├── AdministratorLoginPassword: genruntime.SecretReference
-│   │   │   │   ├── CreateMode: Enum (1 value)
+│   │   │   │   ├── CreateMode: *Enum (1 value)
 │   │   │   │   │   └── "Default"
 │   │   │   │   ├── MinimalTlsVersion: *Enum (4 values)
 │   │   │   │   │   ├── "TLS1_0"
@@ -72,7 +72,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1beta20180601
 │   │   │   │       ├── "10.2"
 │   │   │   │       └── "10.3"
 │   │   │   ├── GeoRestore: *Object (7 properties)
-│   │   │   │   ├── CreateMode: Enum (1 value)
+│   │   │   │   ├── CreateMode: *Enum (1 value)
 │   │   │   │   │   └── "GeoRestore"
 │   │   │   │   ├── MinimalTlsVersion: *Enum (4 values)
 │   │   │   │   │   ├── "TLS1_0"
@@ -99,7 +99,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1beta20180601
 │   │   │   │       ├── "10.2"
 │   │   │   │       └── "10.3"
 │   │   │   ├── PointInTimeRestore: *Object (8 properties)
-│   │   │   │   ├── CreateMode: Enum (1 value)
+│   │   │   │   ├── CreateMode: *Enum (1 value)
 │   │   │   │   │   └── "PointInTimeRestore"
 │   │   │   │   ├── MinimalTlsVersion: *Enum (4 values)
 │   │   │   │   │   ├── "TLS1_0"
@@ -127,7 +127,7 @@ github.com/Azure/azure-service-operator/v2/api/dbformariadb/v1beta20180601
 │   │   │   │       ├── "10.2"
 │   │   │   │       └── "10.3"
 │   │   │   └── Replica: *Object (7 properties)
-│   │   │       ├── CreateMode: Enum (1 value)
+│   │   │       ├── CreateMode: *Enum (1 value)
 │   │   │       │   └── "Replica"
 │   │   │       ├── MinimalTlsVersion: *Enum (4 values)
 │   │   │       │   ├── "TLS1_0"

--- a/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen.go
@@ -5102,7 +5102,7 @@ const (
 // Deprecated version of ContinuousModeBackupPolicy. Use v1beta20210515.ContinuousModeBackupPolicy instead
 type ContinuousModeBackupPolicy struct {
 	// +kubebuilder:validation:Required
-	Type ContinuousModeBackupPolicy_Type `json:"type,omitempty"`
+	Type *ContinuousModeBackupPolicy_Type `json:"type,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &ContinuousModeBackupPolicy{}
@@ -5115,7 +5115,9 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 	result := &ContinuousModeBackupPolicy_ARM{}
 
 	// Set property ‘Type’:
-	result.Type = policy.Type
+	if policy.Type != nil {
+		result.Type = *policy.Type
+	}
 	return result, nil
 }
 
@@ -5132,7 +5134,7 @@ func (policy *ContinuousModeBackupPolicy) PopulateFromARM(owner genruntime.Arbit
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5143,9 +5145,10 @@ func (policy *ContinuousModeBackupPolicy) AssignProperties_From_ContinuousModeBa
 
 	// Type
 	if source.Type != nil {
-		policy.Type = ContinuousModeBackupPolicy_Type(*source.Type)
+		typeVar := ContinuousModeBackupPolicy_Type(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5158,8 +5161,12 @@ func (policy *ContinuousModeBackupPolicy) AssignProperties_To_ContinuousModeBack
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5174,7 +5181,7 @@ func (policy *ContinuousModeBackupPolicy) AssignProperties_To_ContinuousModeBack
 
 // Deprecated version of ContinuousModeBackupPolicy_STATUS. Use v1beta20210515.ContinuousModeBackupPolicy_STATUS instead
 type ContinuousModeBackupPolicy_STATUS struct {
-	Type ContinuousModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
+	Type *ContinuousModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &ContinuousModeBackupPolicy_STATUS{}
@@ -5192,7 +5199,7 @@ func (policy *ContinuousModeBackupPolicy_STATUS) PopulateFromARM(owner genruntim
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5203,9 +5210,10 @@ func (policy *ContinuousModeBackupPolicy_STATUS) AssignProperties_From_Continuou
 
 	// Type
 	if source.Type != nil {
-		policy.Type = ContinuousModeBackupPolicy_Type_STATUS(*source.Type)
+		typeVar := ContinuousModeBackupPolicy_Type_STATUS(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5218,8 +5226,12 @@ func (policy *ContinuousModeBackupPolicy_STATUS) AssignProperties_To_ContinuousM
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5433,7 +5445,7 @@ type PeriodicModeBackupPolicy struct {
 	PeriodicModeProperties *PeriodicModeProperties `json:"periodicModeProperties,omitempty"`
 
 	// +kubebuilder:validation:Required
-	Type PeriodicModeBackupPolicy_Type `json:"type,omitempty"`
+	Type *PeriodicModeBackupPolicy_Type `json:"type,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &PeriodicModeBackupPolicy{}
@@ -5456,7 +5468,9 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 	}
 
 	// Set property ‘Type’:
-	result.Type = policy.Type
+	if policy.Type != nil {
+		result.Type = *policy.Type
+	}
 	return result, nil
 }
 
@@ -5484,7 +5498,7 @@ func (policy *PeriodicModeBackupPolicy) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5507,9 +5521,10 @@ func (policy *PeriodicModeBackupPolicy) AssignProperties_From_PeriodicModeBackup
 
 	// Type
 	if source.Type != nil {
-		policy.Type = PeriodicModeBackupPolicy_Type(*source.Type)
+		typeVar := PeriodicModeBackupPolicy_Type(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5534,8 +5549,12 @@ func (policy *PeriodicModeBackupPolicy) AssignProperties_To_PeriodicModeBackupPo
 	}
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5550,8 +5569,8 @@ func (policy *PeriodicModeBackupPolicy) AssignProperties_To_PeriodicModeBackupPo
 
 // Deprecated version of PeriodicModeBackupPolicy_STATUS. Use v1beta20210515.PeriodicModeBackupPolicy_STATUS instead
 type PeriodicModeBackupPolicy_STATUS struct {
-	PeriodicModeProperties *PeriodicModeProperties_STATUS       `json:"periodicModeProperties,omitempty"`
-	Type                   PeriodicModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
+	PeriodicModeProperties *PeriodicModeProperties_STATUS        `json:"periodicModeProperties,omitempty"`
+	Type                   *PeriodicModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &PeriodicModeBackupPolicy_STATUS{}
@@ -5580,7 +5599,7 @@ func (policy *PeriodicModeBackupPolicy_STATUS) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5603,9 +5622,10 @@ func (policy *PeriodicModeBackupPolicy_STATUS) AssignProperties_From_PeriodicMod
 
 	// Type
 	if source.Type != nil {
-		policy.Type = PeriodicModeBackupPolicy_Type_STATUS(*source.Type)
+		typeVar := PeriodicModeBackupPolicy_Type_STATUS(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5630,8 +5650,12 @@ func (policy *PeriodicModeBackupPolicy_STATUS) AssignProperties_To_PeriodicModeB
 	}
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1alpha1api20210515/database_account_types_gen_test.go
@@ -2996,7 +2996,7 @@ func ContinuousModeBackupPolicyGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(ContinuousModeBackupPolicy_Type_Continuous)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(ContinuousModeBackupPolicy_Type_Continuous))
 }
 
 func Test_ContinuousModeBackupPolicy_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -3099,7 +3099,7 @@ func ContinuousModeBackupPolicy_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy_STATUS(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(ContinuousModeBackupPolicy_Type_STATUS_Continuous)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(ContinuousModeBackupPolicy_Type_STATUS_Continuous))
 }
 
 func Test_DatabaseAccountOperatorSecrets_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -3412,7 +3412,7 @@ func PeriodicModeBackupPolicyGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(PeriodicModeBackupPolicy_Type_Periodic)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(PeriodicModeBackupPolicy_Type_Periodic))
 }
 
 // AddRelatedPropertyGeneratorsForPeriodicModeBackupPolicy is a factory method for creating gopter generators
@@ -3529,7 +3529,7 @@ func PeriodicModeBackupPolicy_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy_STATUS(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(PeriodicModeBackupPolicy_Type_STATUS_Periodic)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(PeriodicModeBackupPolicy_Type_STATUS_Periodic))
 }
 
 // AddRelatedPropertyGeneratorsForPeriodicModeBackupPolicy_STATUS is a factory method for creating gopter generators

--- a/v2/api/documentdb/v1alpha1api20210515/structure.txt
+++ b/v2/api/documentdb/v1alpha1api20210515/structure.txt
@@ -19,7 +19,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1alpha1api20210515
 │   │   │   └── Rule 2: Pattern: "^[a-z0-9]+(-[a-z0-9]+)*"
 │   │   ├── BackupPolicy: *Object (2 properties)
 │   │   │   ├── Continuous: *Object (1 property)
-│   │   │   │   └── Type: Enum (1 value)
+│   │   │   │   └── Type: *Enum (1 value)
 │   │   │   │       └── "Continuous"
 │   │   │   └── Periodic: *Object (2 properties)
 │   │   │       ├── PeriodicModeProperties: *Object (2 properties)
@@ -27,7 +27,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1alpha1api20210515
 │   │   │       │   │   └── Rule 0: Minimum: 0
 │   │   │       │   └── BackupRetentionIntervalInHours: Validated<*int> (1 rule)
 │   │   │       │       └── Rule 0: Minimum: 0
-│   │   │       └── Type: Enum (1 value)
+│   │   │       └── Type: *Enum (1 value)
 │   │   │           └── "Periodic"
 │   │   ├── Capabilities: Object (1 property)[]
 │   │   │   └── Name: *string
@@ -114,13 +114,13 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1alpha1api20210515
 │       │       └── "4.0"
 │       ├── BackupPolicy: *Object (2 properties)
 │       │   ├── Continuous: *Object (1 property)
-│       │   │   └── Type: Enum (1 value)
+│       │   │   └── Type: *Enum (1 value)
 │       │   │       └── "Continuous"
 │       │   └── Periodic: *Object (2 properties)
 │       │       ├── PeriodicModeProperties: *Object (2 properties)
 │       │       │   ├── BackupIntervalInMinutes: *int
 │       │       │   └── BackupRetentionIntervalInHours: *int
-│       │       └── Type: Enum (1 value)
+│       │       └── Type: *Enum (1 value)
 │       │           └── "Periodic"
 │       ├── Capabilities: Object (1 property)[]
 │       │   └── Name: *string

--- a/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_types_gen.go
@@ -5276,7 +5276,7 @@ const (
 
 type ContinuousModeBackupPolicy struct {
 	// +kubebuilder:validation:Required
-	Type ContinuousModeBackupPolicy_Type `json:"type,omitempty"`
+	Type *ContinuousModeBackupPolicy_Type `json:"type,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &ContinuousModeBackupPolicy{}
@@ -5289,7 +5289,9 @@ func (policy *ContinuousModeBackupPolicy) ConvertToARM(resolved genruntime.Conve
 	result := &ContinuousModeBackupPolicy_ARM{}
 
 	// Set property ‘Type’:
-	result.Type = policy.Type
+	if policy.Type != nil {
+		result.Type = *policy.Type
+	}
 	return result, nil
 }
 
@@ -5306,7 +5308,7 @@ func (policy *ContinuousModeBackupPolicy) PopulateFromARM(owner genruntime.Arbit
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5317,9 +5319,10 @@ func (policy *ContinuousModeBackupPolicy) AssignProperties_From_ContinuousModeBa
 
 	// Type
 	if source.Type != nil {
-		policy.Type = ContinuousModeBackupPolicy_Type(*source.Type)
+		typeVar := ContinuousModeBackupPolicy_Type(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5332,8 +5335,12 @@ func (policy *ContinuousModeBackupPolicy) AssignProperties_To_ContinuousModeBack
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5347,7 +5354,7 @@ func (policy *ContinuousModeBackupPolicy) AssignProperties_To_ContinuousModeBack
 }
 
 type ContinuousModeBackupPolicy_STATUS struct {
-	Type ContinuousModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
+	Type *ContinuousModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &ContinuousModeBackupPolicy_STATUS{}
@@ -5365,7 +5372,7 @@ func (policy *ContinuousModeBackupPolicy_STATUS) PopulateFromARM(owner genruntim
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5376,9 +5383,10 @@ func (policy *ContinuousModeBackupPolicy_STATUS) AssignProperties_From_Continuou
 
 	// Type
 	if source.Type != nil {
-		policy.Type = ContinuousModeBackupPolicy_Type_STATUS(*source.Type)
+		typeVar := ContinuousModeBackupPolicy_Type_STATUS(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5391,8 +5399,12 @@ func (policy *ContinuousModeBackupPolicy_STATUS) AssignProperties_To_ContinuousM
 	propertyBag := genruntime.NewPropertyBag()
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5608,7 +5620,7 @@ type PeriodicModeBackupPolicy struct {
 	PeriodicModeProperties *PeriodicModeProperties `json:"periodicModeProperties,omitempty"`
 
 	// +kubebuilder:validation:Required
-	Type PeriodicModeBackupPolicy_Type `json:"type,omitempty"`
+	Type *PeriodicModeBackupPolicy_Type `json:"type,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &PeriodicModeBackupPolicy{}
@@ -5631,7 +5643,9 @@ func (policy *PeriodicModeBackupPolicy) ConvertToARM(resolved genruntime.Convert
 	}
 
 	// Set property ‘Type’:
-	result.Type = policy.Type
+	if policy.Type != nil {
+		result.Type = *policy.Type
+	}
 	return result, nil
 }
 
@@ -5659,7 +5673,7 @@ func (policy *PeriodicModeBackupPolicy) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5682,9 +5696,10 @@ func (policy *PeriodicModeBackupPolicy) AssignProperties_From_PeriodicModeBackup
 
 	// Type
 	if source.Type != nil {
-		policy.Type = PeriodicModeBackupPolicy_Type(*source.Type)
+		typeVar := PeriodicModeBackupPolicy_Type(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5709,8 +5724,12 @@ func (policy *PeriodicModeBackupPolicy) AssignProperties_To_PeriodicModeBackupPo
 	}
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -5725,8 +5744,8 @@ func (policy *PeriodicModeBackupPolicy) AssignProperties_To_PeriodicModeBackupPo
 
 type PeriodicModeBackupPolicy_STATUS struct {
 	// PeriodicModeProperties: Configuration values for periodic mode backup
-	PeriodicModeProperties *PeriodicModeProperties_STATUS       `json:"periodicModeProperties,omitempty"`
-	Type                   PeriodicModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
+	PeriodicModeProperties *PeriodicModeProperties_STATUS        `json:"periodicModeProperties,omitempty"`
+	Type                   *PeriodicModeBackupPolicy_Type_STATUS `json:"type,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &PeriodicModeBackupPolicy_STATUS{}
@@ -5755,7 +5774,7 @@ func (policy *PeriodicModeBackupPolicy_STATUS) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘Type’:
-	policy.Type = typedInput.Type
+	policy.Type = &typedInput.Type
 
 	// No error
 	return nil
@@ -5778,9 +5797,10 @@ func (policy *PeriodicModeBackupPolicy_STATUS) AssignProperties_From_PeriodicMod
 
 	// Type
 	if source.Type != nil {
-		policy.Type = PeriodicModeBackupPolicy_Type_STATUS(*source.Type)
+		typeVar := PeriodicModeBackupPolicy_Type_STATUS(*source.Type)
+		policy.Type = &typeVar
 	} else {
-		policy.Type = ""
+		policy.Type = nil
 	}
 
 	// No error
@@ -5805,8 +5825,12 @@ func (policy *PeriodicModeBackupPolicy_STATUS) AssignProperties_To_PeriodicModeB
 	}
 
 	// Type
-	typeVar := string(policy.Type)
-	destination.Type = &typeVar
+	if policy.Type != nil {
+		typeVar := string(*policy.Type)
+		destination.Type = &typeVar
+	} else {
+		destination.Type = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/documentdb/v1beta20210515/database_account_types_gen_test.go
+++ b/v2/api/documentdb/v1beta20210515/database_account_types_gen_test.go
@@ -2995,7 +2995,7 @@ func ContinuousModeBackupPolicyGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(ContinuousModeBackupPolicy_Type_Continuous)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(ContinuousModeBackupPolicy_Type_Continuous))
 }
 
 func Test_ContinuousModeBackupPolicy_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -3098,7 +3098,7 @@ func ContinuousModeBackupPolicy_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForContinuousModeBackupPolicy_STATUS(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(ContinuousModeBackupPolicy_Type_STATUS_Continuous)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(ContinuousModeBackupPolicy_Type_STATUS_Continuous))
 }
 
 func Test_DatabaseAccountOperatorSecrets_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -3411,7 +3411,7 @@ func PeriodicModeBackupPolicyGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(PeriodicModeBackupPolicy_Type_Periodic)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(PeriodicModeBackupPolicy_Type_Periodic))
 }
 
 // AddRelatedPropertyGeneratorsForPeriodicModeBackupPolicy is a factory method for creating gopter generators
@@ -3528,7 +3528,7 @@ func PeriodicModeBackupPolicy_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForPeriodicModeBackupPolicy_STATUS(gens map[string]gopter.Gen) {
-	gens["Type"] = gen.OneConstOf(PeriodicModeBackupPolicy_Type_STATUS_Periodic)
+	gens["Type"] = gen.PtrOf(gen.OneConstOf(PeriodicModeBackupPolicy_Type_STATUS_Periodic))
 }
 
 // AddRelatedPropertyGeneratorsForPeriodicModeBackupPolicy_STATUS is a factory method for creating gopter generators

--- a/v2/api/documentdb/v1beta20210515/structure.txt
+++ b/v2/api/documentdb/v1beta20210515/structure.txt
@@ -19,7 +19,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1beta20210515
 │   │   │   └── Rule 2: Pattern: "^[a-z0-9]+(-[a-z0-9]+)*"
 │   │   ├── BackupPolicy: *Object (2 properties)
 │   │   │   ├── Continuous: *Object (1 property)
-│   │   │   │   └── Type: Enum (1 value)
+│   │   │   │   └── Type: *Enum (1 value)
 │   │   │   │       └── "Continuous"
 │   │   │   └── Periodic: *Object (2 properties)
 │   │   │       ├── PeriodicModeProperties: *Object (2 properties)
@@ -27,7 +27,7 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1beta20210515
 │   │   │       │   │   └── Rule 0: Minimum: 0
 │   │   │       │   └── BackupRetentionIntervalInHours: Validated<*int> (1 rule)
 │   │   │       │       └── Rule 0: Minimum: 0
-│   │   │       └── Type: Enum (1 value)
+│   │   │       └── Type: *Enum (1 value)
 │   │   │           └── "Periodic"
 │   │   ├── Capabilities: Object (1 property)[]
 │   │   │   └── Name: *string
@@ -114,13 +114,13 @@ github.com/Azure/azure-service-operator/v2/api/documentdb/v1beta20210515
 │       │       └── "4.0"
 │       ├── BackupPolicy: *Object (2 properties)
 │       │   ├── Continuous: *Object (1 property)
-│       │   │   └── Type: Enum (1 value)
+│       │   │   └── Type: *Enum (1 value)
 │       │   │       └── "Continuous"
 │       │   └── Periodic: *Object (2 properties)
 │       │       ├── PeriodicModeProperties: *Object (2 properties)
 │       │       │   ├── BackupIntervalInMinutes: *int
 │       │       │   └── BackupRetentionIntervalInHours: *int
-│       │       └── Type: Enum (1 value)
+│       │       └── Type: *Enum (1 value)
 │       │           └── "Periodic"
 │       ├── Capabilities: Object (1 property)[]
 │       │   └── Name: *string

--- a/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen.go
@@ -1799,9 +1799,9 @@ type JsonInputSchemaMapping struct {
 	Id          *JsonField            `json:"id,omitempty"`
 
 	// +kubebuilder:validation:Required
-	InputSchemaMappingType JsonInputSchemaMapping_InputSchemaMappingType `json:"inputSchemaMappingType,omitempty"`
-	Subject                *JsonFieldWithDefault                         `json:"subject,omitempty"`
-	Topic                  *JsonField                                    `json:"topic,omitempty"`
+	InputSchemaMappingType *JsonInputSchemaMapping_InputSchemaMappingType `json:"inputSchemaMappingType,omitempty"`
+	Subject                *JsonFieldWithDefault                          `json:"subject,omitempty"`
+	Topic                  *JsonField                                     `json:"topic,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &JsonInputSchemaMapping{}
@@ -1814,7 +1814,9 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 	result := &JsonInputSchemaMapping_ARM{}
 
 	// Set property ‘InputSchemaMappingType’:
-	result.InputSchemaMappingType = mapping.InputSchemaMappingType
+	if mapping.InputSchemaMappingType != nil {
+		result.InputSchemaMappingType = *mapping.InputSchemaMappingType
+	}
 
 	// Set property ‘Properties’:
 	if mapping.DataVersion != nil ||
@@ -1945,7 +1947,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 	}
 
 	// Set property ‘InputSchemaMappingType’:
-	mapping.InputSchemaMappingType = typedInput.InputSchemaMappingType
+	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
 	// Set property ‘Subject’:
 	// copying flattened property:
@@ -2032,9 +2034,10 @@ func (mapping *JsonInputSchemaMapping) AssignProperties_From_JsonInputSchemaMapp
 
 	// InputSchemaMappingType
 	if source.InputSchemaMappingType != nil {
-		mapping.InputSchemaMappingType = JsonInputSchemaMapping_InputSchemaMappingType(*source.InputSchemaMappingType)
+		inputSchemaMappingType := JsonInputSchemaMapping_InputSchemaMappingType(*source.InputSchemaMappingType)
+		mapping.InputSchemaMappingType = &inputSchemaMappingType
 	} else {
-		mapping.InputSchemaMappingType = ""
+		mapping.InputSchemaMappingType = nil
 	}
 
 	// Subject
@@ -2119,8 +2122,12 @@ func (mapping *JsonInputSchemaMapping) AssignProperties_To_JsonInputSchemaMappin
 	}
 
 	// InputSchemaMappingType
-	inputSchemaMappingType := string(mapping.InputSchemaMappingType)
-	destination.InputSchemaMappingType = &inputSchemaMappingType
+	if mapping.InputSchemaMappingType != nil {
+		inputSchemaMappingType := string(*mapping.InputSchemaMappingType)
+		destination.InputSchemaMappingType = &inputSchemaMappingType
+	} else {
+		destination.InputSchemaMappingType = nil
+	}
 
 	// Subject
 	if mapping.Subject != nil {
@@ -2159,13 +2166,13 @@ func (mapping *JsonInputSchemaMapping) AssignProperties_To_JsonInputSchemaMappin
 
 // Deprecated version of JsonInputSchemaMapping_STATUS. Use v1beta20200601.JsonInputSchemaMapping_STATUS instead
 type JsonInputSchemaMapping_STATUS struct {
-	DataVersion            *JsonFieldWithDefault_STATUS                         `json:"dataVersion,omitempty"`
-	EventTime              *JsonField_STATUS                                    `json:"eventTime,omitempty"`
-	EventType              *JsonFieldWithDefault_STATUS                         `json:"eventType,omitempty"`
-	Id                     *JsonField_STATUS                                    `json:"id,omitempty"`
-	InputSchemaMappingType JsonInputSchemaMapping_InputSchemaMappingType_STATUS `json:"inputSchemaMappingType,omitempty"`
-	Subject                *JsonFieldWithDefault_STATUS                         `json:"subject,omitempty"`
-	Topic                  *JsonField_STATUS                                    `json:"topic,omitempty"`
+	DataVersion            *JsonFieldWithDefault_STATUS                          `json:"dataVersion,omitempty"`
+	EventTime              *JsonField_STATUS                                     `json:"eventTime,omitempty"`
+	EventType              *JsonFieldWithDefault_STATUS                          `json:"eventType,omitempty"`
+	Id                     *JsonField_STATUS                                     `json:"id,omitempty"`
+	InputSchemaMappingType *JsonInputSchemaMapping_InputSchemaMappingType_STATUS `json:"inputSchemaMappingType,omitempty"`
+	Subject                *JsonFieldWithDefault_STATUS                          `json:"subject,omitempty"`
+	Topic                  *JsonField_STATUS                                     `json:"topic,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &JsonInputSchemaMapping_STATUS{}
@@ -2239,7 +2246,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 	}
 
 	// Set property ‘InputSchemaMappingType’:
-	mapping.InputSchemaMappingType = typedInput.InputSchemaMappingType
+	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
 	// Set property ‘Subject’:
 	// copying flattened property:
@@ -2326,9 +2333,10 @@ func (mapping *JsonInputSchemaMapping_STATUS) AssignProperties_From_JsonInputSch
 
 	// InputSchemaMappingType
 	if source.InputSchemaMappingType != nil {
-		mapping.InputSchemaMappingType = JsonInputSchemaMapping_InputSchemaMappingType_STATUS(*source.InputSchemaMappingType)
+		inputSchemaMappingType := JsonInputSchemaMapping_InputSchemaMappingType_STATUS(*source.InputSchemaMappingType)
+		mapping.InputSchemaMappingType = &inputSchemaMappingType
 	} else {
-		mapping.InputSchemaMappingType = ""
+		mapping.InputSchemaMappingType = nil
 	}
 
 	// Subject
@@ -2413,8 +2421,12 @@ func (mapping *JsonInputSchemaMapping_STATUS) AssignProperties_To_JsonInputSchem
 	}
 
 	// InputSchemaMappingType
-	inputSchemaMappingType := string(mapping.InputSchemaMappingType)
-	destination.InputSchemaMappingType = &inputSchemaMappingType
+	if mapping.InputSchemaMappingType != nil {
+		inputSchemaMappingType := string(*mapping.InputSchemaMappingType)
+		destination.InputSchemaMappingType = &inputSchemaMappingType
+	} else {
+		destination.InputSchemaMappingType = nil
+	}
 
 	// Subject
 	if mapping.Subject != nil {

--- a/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/domain_types_gen_test.go
@@ -1175,7 +1175,7 @@ func JsonInputSchemaMappingGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForJsonInputSchemaMapping is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForJsonInputSchemaMapping(gens map[string]gopter.Gen) {
-	gens["InputSchemaMappingType"] = gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_Json)
+	gens["InputSchemaMappingType"] = gen.PtrOf(gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_Json))
 }
 
 // AddRelatedPropertyGeneratorsForJsonInputSchemaMapping is a factory method for creating gopter generators
@@ -1297,7 +1297,7 @@ func JsonInputSchemaMapping_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForJsonInputSchemaMapping_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForJsonInputSchemaMapping_STATUS(gens map[string]gopter.Gen) {
-	gens["InputSchemaMappingType"] = gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_STATUS_Json)
+	gens["InputSchemaMappingType"] = gen.PtrOf(gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_STATUS_Json))
 }
 
 // AddRelatedPropertyGeneratorsForJsonInputSchemaMapping_STATUS is a factory method for creating gopter generators

--- a/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen.go
@@ -3683,10 +3683,10 @@ func (filter *AdvancedFilter_STATUS) AssignProperties_To_AdvancedFilter_STATUS(d
 // Deprecated version of AzureFunctionEventSubscriptionDestination. Use v1beta20200601.AzureFunctionEventSubscriptionDestination instead
 type AzureFunctionEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
-	EndpointType                  AzureFunctionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
-	MaxEventsPerBatch             *int                                                   `json:"maxEventsPerBatch,omitempty"`
-	PreferredBatchSizeInKilobytes *int                                                   `json:"preferredBatchSizeInKilobytes,omitempty"`
-	ResourceReference             *genruntime.ResourceReference                          `armReference:"ResourceId" json:"resourceReference,omitempty"`
+	EndpointType                  *AzureFunctionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	MaxEventsPerBatch             *int                                                    `json:"maxEventsPerBatch,omitempty"`
+	PreferredBatchSizeInKilobytes *int                                                    `json:"preferredBatchSizeInKilobytes,omitempty"`
+	ResourceReference             *genruntime.ResourceReference                           `armReference:"ResourceId" json:"resourceReference,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &AzureFunctionEventSubscriptionDestination{}
@@ -3699,7 +3699,9 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 	result := &AzureFunctionEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.MaxEventsPerBatch != nil ||
@@ -3739,7 +3741,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘MaxEventsPerBatch’:
 	// copying flattened property:
@@ -3770,9 +3772,10 @@ func (destination *AzureFunctionEventSubscriptionDestination) AssignProperties_F
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = AzureFunctionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := AzureFunctionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// MaxEventsPerBatch
@@ -3799,8 +3802,12 @@ func (destination *AzureFunctionEventSubscriptionDestination) AssignProperties_T
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// MaxEventsPerBatch
 	target.MaxEventsPerBatch = genruntime.ClonePointerToInt(destination.MaxEventsPerBatch)
@@ -3829,10 +3836,10 @@ func (destination *AzureFunctionEventSubscriptionDestination) AssignProperties_T
 
 // Deprecated version of AzureFunctionEventSubscriptionDestination_STATUS. Use v1beta20200601.AzureFunctionEventSubscriptionDestination_STATUS instead
 type AzureFunctionEventSubscriptionDestination_STATUS struct {
-	EndpointType                  AzureFunctionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	MaxEventsPerBatch             *int                                                          `json:"maxEventsPerBatch,omitempty"`
-	PreferredBatchSizeInKilobytes *int                                                          `json:"preferredBatchSizeInKilobytes,omitempty"`
-	ResourceId                    *string                                                       `json:"resourceId,omitempty"`
+	EndpointType                  *AzureFunctionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	MaxEventsPerBatch             *int                                                           `json:"maxEventsPerBatch,omitempty"`
+	PreferredBatchSizeInKilobytes *int                                                           `json:"preferredBatchSizeInKilobytes,omitempty"`
+	ResourceId                    *string                                                        `json:"resourceId,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &AzureFunctionEventSubscriptionDestination_STATUS{}
@@ -3850,7 +3857,7 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘MaxEventsPerBatch’:
 	// copying flattened property:
@@ -3888,9 +3895,10 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) AssignPrope
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = AzureFunctionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := AzureFunctionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// MaxEventsPerBatch
@@ -3912,8 +3920,12 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) AssignPrope
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// MaxEventsPerBatch
 	target.MaxEventsPerBatch = genruntime.ClonePointerToInt(destination.MaxEventsPerBatch)
@@ -3938,8 +3950,8 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) AssignPrope
 // Deprecated version of EventHubEventSubscriptionDestination. Use v1beta20200601.EventHubEventSubscriptionDestination instead
 type EventHubEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
-	EndpointType      EventHubEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
-	ResourceReference *genruntime.ResourceReference                     `armReference:"ResourceId" json:"resourceReference,omitempty"`
+	EndpointType      *EventHubEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	ResourceReference *genruntime.ResourceReference                      `armReference:"ResourceId" json:"resourceReference,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &EventHubEventSubscriptionDestination{}
@@ -3952,7 +3964,9 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 	result := &EventHubEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -3982,7 +3996,7 @@ func (destination *EventHubEventSubscriptionDestination) PopulateFromARM(owner g
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -3995,9 +4009,10 @@ func (destination *EventHubEventSubscriptionDestination) AssignProperties_From_E
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = EventHubEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := EventHubEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4018,8 +4033,12 @@ func (destination *EventHubEventSubscriptionDestination) AssignProperties_To_Eve
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4042,8 +4061,8 @@ func (destination *EventHubEventSubscriptionDestination) AssignProperties_To_Eve
 
 // Deprecated version of EventHubEventSubscriptionDestination_STATUS. Use v1beta20200601.EventHubEventSubscriptionDestination_STATUS instead
 type EventHubEventSubscriptionDestination_STATUS struct {
-	EndpointType EventHubEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	ResourceId   *string                                                  `json:"resourceId,omitempty"`
+	EndpointType *EventHubEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	ResourceId   *string                                                   `json:"resourceId,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &EventHubEventSubscriptionDestination_STATUS{}
@@ -4061,7 +4080,7 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) PopulateFromARM(
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4081,9 +4100,10 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) AssignProperties
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = EventHubEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := EventHubEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4099,8 +4119,12 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) AssignProperties
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4119,8 +4143,8 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) AssignProperties
 // Deprecated version of HybridConnectionEventSubscriptionDestination. Use v1beta20200601.HybridConnectionEventSubscriptionDestination instead
 type HybridConnectionEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
-	EndpointType      HybridConnectionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
-	ResourceReference *genruntime.ResourceReference                             `armReference:"ResourceId" json:"resourceReference,omitempty"`
+	EndpointType      *HybridConnectionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	ResourceReference *genruntime.ResourceReference                              `armReference:"ResourceId" json:"resourceReference,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &HybridConnectionEventSubscriptionDestination{}
@@ -4133,7 +4157,9 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 	result := &HybridConnectionEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -4163,7 +4189,7 @@ func (destination *HybridConnectionEventSubscriptionDestination) PopulateFromARM
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4176,9 +4202,10 @@ func (destination *HybridConnectionEventSubscriptionDestination) AssignPropertie
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = HybridConnectionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := HybridConnectionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4199,8 +4226,12 @@ func (destination *HybridConnectionEventSubscriptionDestination) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4223,8 +4254,8 @@ func (destination *HybridConnectionEventSubscriptionDestination) AssignPropertie
 
 // Deprecated version of HybridConnectionEventSubscriptionDestination_STATUS. Use v1beta20200601.HybridConnectionEventSubscriptionDestination_STATUS instead
 type HybridConnectionEventSubscriptionDestination_STATUS struct {
-	EndpointType HybridConnectionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	ResourceId   *string                                                          `json:"resourceId,omitempty"`
+	EndpointType *HybridConnectionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	ResourceId   *string                                                           `json:"resourceId,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &HybridConnectionEventSubscriptionDestination_STATUS{}
@@ -4242,7 +4273,7 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) Populate
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4262,9 +4293,10 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) AssignPr
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = HybridConnectionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := HybridConnectionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4280,8 +4312,12 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) AssignPr
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4300,8 +4336,8 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) AssignPr
 // Deprecated version of ServiceBusQueueEventSubscriptionDestination. Use v1beta20200601.ServiceBusQueueEventSubscriptionDestination instead
 type ServiceBusQueueEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
-	EndpointType      ServiceBusQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
-	ResourceReference *genruntime.ResourceReference                            `armReference:"ResourceId" json:"resourceReference,omitempty"`
+	EndpointType      *ServiceBusQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	ResourceReference *genruntime.ResourceReference                             `armReference:"ResourceId" json:"resourceReference,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &ServiceBusQueueEventSubscriptionDestination{}
@@ -4314,7 +4350,9 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 	result := &ServiceBusQueueEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -4344,7 +4382,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) PopulateFromARM(
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4357,9 +4395,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) AssignProperties
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := ServiceBusQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4380,8 +4419,12 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) AssignProperties
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4404,8 +4447,8 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) AssignProperties
 
 // Deprecated version of ServiceBusQueueEventSubscriptionDestination_STATUS. Use v1beta20200601.ServiceBusQueueEventSubscriptionDestination_STATUS instead
 type ServiceBusQueueEventSubscriptionDestination_STATUS struct {
-	EndpointType ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	ResourceId   *string                                                         `json:"resourceId,omitempty"`
+	EndpointType *ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	ResourceId   *string                                                          `json:"resourceId,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &ServiceBusQueueEventSubscriptionDestination_STATUS{}
@@ -4423,7 +4466,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) PopulateF
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4443,9 +4486,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) AssignPro
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4461,8 +4505,12 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) AssignPro
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4481,8 +4529,8 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) AssignPro
 // Deprecated version of ServiceBusTopicEventSubscriptionDestination. Use v1beta20200601.ServiceBusTopicEventSubscriptionDestination instead
 type ServiceBusTopicEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
-	EndpointType      ServiceBusTopicEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
-	ResourceReference *genruntime.ResourceReference                            `armReference:"ResourceId" json:"resourceReference,omitempty"`
+	EndpointType      *ServiceBusTopicEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	ResourceReference *genruntime.ResourceReference                             `armReference:"ResourceId" json:"resourceReference,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &ServiceBusTopicEventSubscriptionDestination{}
@@ -4495,7 +4543,9 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 	result := &ServiceBusTopicEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -4525,7 +4575,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) PopulateFromARM(
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4538,9 +4588,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) AssignProperties
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusTopicEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := ServiceBusTopicEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4561,8 +4612,12 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) AssignProperties
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4585,8 +4640,8 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) AssignProperties
 
 // Deprecated version of ServiceBusTopicEventSubscriptionDestination_STATUS. Use v1beta20200601.ServiceBusTopicEventSubscriptionDestination_STATUS instead
 type ServiceBusTopicEventSubscriptionDestination_STATUS struct {
-	EndpointType ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	ResourceId   *string                                                         `json:"resourceId,omitempty"`
+	EndpointType *ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	ResourceId   *string                                                          `json:"resourceId,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &ServiceBusTopicEventSubscriptionDestination_STATUS{}
@@ -4604,7 +4659,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) PopulateF
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4624,9 +4679,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) AssignPro
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4642,8 +4698,12 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) AssignPro
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4664,8 +4724,8 @@ type StorageBlobDeadLetterDestination struct {
 	BlobContainerName *string `json:"blobContainerName,omitempty"`
 
 	// +kubebuilder:validation:Required
-	EndpointType      StorageBlobDeadLetterDestination_EndpointType `json:"endpointType,omitempty"`
-	ResourceReference *genruntime.ResourceReference                 `armReference:"ResourceId" json:"resourceReference,omitempty"`
+	EndpointType      *StorageBlobDeadLetterDestination_EndpointType `json:"endpointType,omitempty"`
+	ResourceReference *genruntime.ResourceReference                  `armReference:"ResourceId" json:"resourceReference,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &StorageBlobDeadLetterDestination{}
@@ -4678,7 +4738,9 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 	result := &StorageBlobDeadLetterDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.BlobContainerName != nil || destination.ResourceReference != nil {
@@ -4721,7 +4783,7 @@ func (destination *StorageBlobDeadLetterDestination) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4737,9 +4799,10 @@ func (destination *StorageBlobDeadLetterDestination) AssignProperties_From_Stora
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageBlobDeadLetterDestination_EndpointType(*source.EndpointType)
+		endpointType := StorageBlobDeadLetterDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4763,8 +4826,12 @@ func (destination *StorageBlobDeadLetterDestination) AssignProperties_To_Storage
 	target.BlobContainerName = genruntime.ClonePointerToString(destination.BlobContainerName)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4787,9 +4854,9 @@ func (destination *StorageBlobDeadLetterDestination) AssignProperties_To_Storage
 
 // Deprecated version of StorageBlobDeadLetterDestination_STATUS. Use v1beta20200601.StorageBlobDeadLetterDestination_STATUS instead
 type StorageBlobDeadLetterDestination_STATUS struct {
-	BlobContainerName *string                                              `json:"blobContainerName,omitempty"`
-	EndpointType      StorageBlobDeadLetterDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	ResourceId        *string                                              `json:"resourceId,omitempty"`
+	BlobContainerName *string                                               `json:"blobContainerName,omitempty"`
+	EndpointType      *StorageBlobDeadLetterDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	ResourceId        *string                                               `json:"resourceId,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &StorageBlobDeadLetterDestination_STATUS{}
@@ -4816,7 +4883,7 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) PopulateFromARM(owne
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4839,9 +4906,10 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) AssignProperties_Fro
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageBlobDeadLetterDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := StorageBlobDeadLetterDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4860,8 +4928,12 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) AssignProperties_To_
 	target.BlobContainerName = genruntime.ClonePointerToString(destination.BlobContainerName)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4880,9 +4952,9 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) AssignProperties_To_
 // Deprecated version of StorageQueueEventSubscriptionDestination. Use v1beta20200601.StorageQueueEventSubscriptionDestination instead
 type StorageQueueEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
-	EndpointType      StorageQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
-	QueueName         *string                                               `json:"queueName,omitempty"`
-	ResourceReference *genruntime.ResourceReference                         `armReference:"ResourceId" json:"resourceReference,omitempty"`
+	EndpointType      *StorageQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	QueueName         *string                                                `json:"queueName,omitempty"`
+	ResourceReference *genruntime.ResourceReference                          `armReference:"ResourceId" json:"resourceReference,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &StorageQueueEventSubscriptionDestination{}
@@ -4895,7 +4967,9 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 	result := &StorageQueueEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.QueueName != nil || destination.ResourceReference != nil {
@@ -4929,7 +5003,7 @@ func (destination *StorageQueueEventSubscriptionDestination) PopulateFromARM(own
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘QueueName’:
 	// copying flattened property:
@@ -4951,9 +5025,10 @@ func (destination *StorageQueueEventSubscriptionDestination) AssignProperties_Fr
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := StorageQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// QueueName
@@ -4977,8 +5052,12 @@ func (destination *StorageQueueEventSubscriptionDestination) AssignProperties_To
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// QueueName
 	target.QueueName = genruntime.ClonePointerToString(destination.QueueName)
@@ -5004,9 +5083,9 @@ func (destination *StorageQueueEventSubscriptionDestination) AssignProperties_To
 
 // Deprecated version of StorageQueueEventSubscriptionDestination_STATUS. Use v1beta20200601.StorageQueueEventSubscriptionDestination_STATUS instead
 type StorageQueueEventSubscriptionDestination_STATUS struct {
-	EndpointType StorageQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	QueueName    *string                                                      `json:"queueName,omitempty"`
-	ResourceId   *string                                                      `json:"resourceId,omitempty"`
+	EndpointType *StorageQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	QueueName    *string                                                       `json:"queueName,omitempty"`
+	ResourceId   *string                                                       `json:"resourceId,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &StorageQueueEventSubscriptionDestination_STATUS{}
@@ -5024,7 +5103,7 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) PopulateFrom
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘QueueName’:
 	// copying flattened property:
@@ -5053,9 +5132,10 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) AssignProper
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := StorageQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// QueueName
@@ -5074,8 +5154,12 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) AssignProper
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// QueueName
 	target.QueueName = genruntime.ClonePointerToString(destination.QueueName)
@@ -5100,10 +5184,10 @@ type WebHookEventSubscriptionDestination struct {
 	AzureActiveDirectoryTenantId           *string `json:"azureActiveDirectoryTenantId,omitempty"`
 
 	// +kubebuilder:validation:Required
-	EndpointType                  WebHookEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
-	EndpointUrl                   *genruntime.SecretReference                      `json:"endpointUrl,omitempty"`
-	MaxEventsPerBatch             *int                                             `json:"maxEventsPerBatch,omitempty"`
-	PreferredBatchSizeInKilobytes *int                                             `json:"preferredBatchSizeInKilobytes,omitempty"`
+	EndpointType                  *WebHookEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointUrl                   *genruntime.SecretReference                       `json:"endpointUrl,omitempty"`
+	MaxEventsPerBatch             *int                                              `json:"maxEventsPerBatch,omitempty"`
+	PreferredBatchSizeInKilobytes *int                                              `json:"preferredBatchSizeInKilobytes,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &WebHookEventSubscriptionDestination{}
@@ -5116,7 +5200,9 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 	result := &WebHookEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.AzureActiveDirectoryApplicationIdOrUri != nil ||
@@ -5184,7 +5270,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘EndpointUrl’
 
@@ -5221,9 +5307,10 @@ func (destination *WebHookEventSubscriptionDestination) AssignProperties_From_We
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = WebHookEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := WebHookEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// EndpointUrl
@@ -5256,8 +5343,12 @@ func (destination *WebHookEventSubscriptionDestination) AssignProperties_To_WebH
 	target.AzureActiveDirectoryTenantId = genruntime.ClonePointerToString(destination.AzureActiveDirectoryTenantId)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// EndpointUrl
 	if destination.EndpointUrl != nil {
@@ -5286,12 +5377,12 @@ func (destination *WebHookEventSubscriptionDestination) AssignProperties_To_WebH
 
 // Deprecated version of WebHookEventSubscriptionDestination_STATUS. Use v1beta20200601.WebHookEventSubscriptionDestination_STATUS instead
 type WebHookEventSubscriptionDestination_STATUS struct {
-	AzureActiveDirectoryApplicationIdOrUri *string                                                 `json:"azureActiveDirectoryApplicationIdOrUri,omitempty"`
-	AzureActiveDirectoryTenantId           *string                                                 `json:"azureActiveDirectoryTenantId,omitempty"`
-	EndpointBaseUrl                        *string                                                 `json:"endpointBaseUrl,omitempty"`
-	EndpointType                           WebHookEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
-	MaxEventsPerBatch                      *int                                                    `json:"maxEventsPerBatch,omitempty"`
-	PreferredBatchSizeInKilobytes          *int                                                    `json:"preferredBatchSizeInKilobytes,omitempty"`
+	AzureActiveDirectoryApplicationIdOrUri *string                                                  `json:"azureActiveDirectoryApplicationIdOrUri,omitempty"`
+	AzureActiveDirectoryTenantId           *string                                                  `json:"azureActiveDirectoryTenantId,omitempty"`
+	EndpointBaseUrl                        *string                                                  `json:"endpointBaseUrl,omitempty"`
+	EndpointType                           *WebHookEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	MaxEventsPerBatch                      *int                                                     `json:"maxEventsPerBatch,omitempty"`
+	PreferredBatchSizeInKilobytes          *int                                                     `json:"preferredBatchSizeInKilobytes,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &WebHookEventSubscriptionDestination_STATUS{}
@@ -5336,7 +5427,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘MaxEventsPerBatch’:
 	// copying flattened property:
@@ -5374,9 +5465,10 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) AssignProperties_
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = WebHookEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := WebHookEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// MaxEventsPerBatch
@@ -5404,8 +5496,12 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) AssignProperties_
 	target.EndpointBaseUrl = genruntime.ClonePointerToString(destination.EndpointBaseUrl)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// MaxEventsPerBatch
 	target.MaxEventsPerBatch = genruntime.ClonePointerToInt(destination.MaxEventsPerBatch)
@@ -5442,8 +5538,8 @@ type BoolEqualsAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType BoolEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Value        *bool                                 `json:"value,omitempty"`
+	OperatorType *BoolEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Value        *bool                                  `json:"value,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &BoolEqualsAdvancedFilter{}
@@ -5462,7 +5558,9 @@ func (filter *BoolEqualsAdvancedFilter) ConvertToARM(resolved genruntime.Convert
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -5491,7 +5589,7 @@ func (filter *BoolEqualsAdvancedFilter) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5511,9 +5609,10 @@ func (filter *BoolEqualsAdvancedFilter) AssignProperties_From_BoolEqualsAdvanced
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = BoolEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := BoolEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5537,8 +5636,12 @@ func (filter *BoolEqualsAdvancedFilter) AssignProperties_To_BoolEqualsAdvancedFi
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -5561,9 +5664,9 @@ func (filter *BoolEqualsAdvancedFilter) AssignProperties_To_BoolEqualsAdvancedFi
 
 // Deprecated version of BoolEqualsAdvancedFilter_STATUS. Use v1beta20200601.BoolEqualsAdvancedFilter_STATUS instead
 type BoolEqualsAdvancedFilter_STATUS struct {
-	Key          *string                                      `json:"key,omitempty"`
-	OperatorType BoolEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Value        *bool                                        `json:"value,omitempty"`
+	Key          *string                                       `json:"key,omitempty"`
+	OperatorType *BoolEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Value        *bool                                         `json:"value,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &BoolEqualsAdvancedFilter_STATUS{}
@@ -5587,7 +5690,7 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5607,9 +5710,10 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) AssignProperties_From_BoolEqualsA
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = BoolEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := BoolEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5633,8 +5737,12 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) AssignProperties_To_BoolEqualsAdv
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -5686,8 +5794,8 @@ type NumberGreaterThanAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType NumberGreaterThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Value        *float64                                     `json:"value,omitempty"`
+	OperatorType *NumberGreaterThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Value        *float64                                      `json:"value,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &NumberGreaterThanAdvancedFilter{}
@@ -5706,7 +5814,9 @@ func (filter *NumberGreaterThanAdvancedFilter) ConvertToARM(resolved genruntime.
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -5735,7 +5845,7 @@ func (filter *NumberGreaterThanAdvancedFilter) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5755,9 +5865,10 @@ func (filter *NumberGreaterThanAdvancedFilter) AssignProperties_From_NumberGreat
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberGreaterThanAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5781,8 +5892,12 @@ func (filter *NumberGreaterThanAdvancedFilter) AssignProperties_To_NumberGreater
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -5805,9 +5920,9 @@ func (filter *NumberGreaterThanAdvancedFilter) AssignProperties_To_NumberGreater
 
 // Deprecated version of NumberGreaterThanAdvancedFilter_STATUS. Use v1beta20200601.NumberGreaterThanAdvancedFilter_STATUS instead
 type NumberGreaterThanAdvancedFilter_STATUS struct {
-	Key          *string                                             `json:"key,omitempty"`
-	OperatorType NumberGreaterThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Value        *float64                                            `json:"value,omitempty"`
+	Key          *string                                              `json:"key,omitempty"`
+	OperatorType *NumberGreaterThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Value        *float64                                             `json:"value,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &NumberGreaterThanAdvancedFilter_STATUS{}
@@ -5831,7 +5946,7 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) PopulateFromARM(owner genr
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5851,9 +5966,10 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) AssignProperties_From_Numb
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberGreaterThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5877,8 +5993,12 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) AssignProperties_To_Number
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -5904,8 +6024,8 @@ type NumberGreaterThanOrEqualsAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType NumberGreaterThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Value        *float64                                             `json:"value,omitempty"`
+	OperatorType *NumberGreaterThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Value        *float64                                              `json:"value,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &NumberGreaterThanOrEqualsAdvancedFilter{}
@@ -5924,7 +6044,9 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) ConvertToARM(resolved gen
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -5953,7 +6075,7 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5973,9 +6095,10 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) AssignProperties_From_Num
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberGreaterThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5999,8 +6122,12 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) AssignProperties_To_Numbe
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6023,9 +6150,9 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) AssignProperties_To_Numbe
 
 // Deprecated version of NumberGreaterThanOrEqualsAdvancedFilter_STATUS. Use v1beta20200601.NumberGreaterThanOrEqualsAdvancedFilter_STATUS instead
 type NumberGreaterThanOrEqualsAdvancedFilter_STATUS struct {
-	Key          *string                                                     `json:"key,omitempty"`
-	OperatorType NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Value        *float64                                                    `json:"value,omitempty"`
+	Key          *string                                                      `json:"key,omitempty"`
+	OperatorType *NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Value        *float64                                                     `json:"value,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &NumberGreaterThanOrEqualsAdvancedFilter_STATUS{}
@@ -6049,7 +6176,7 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(ow
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6069,9 +6196,10 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) AssignProperties_F
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6095,8 +6223,12 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) AssignProperties_T
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6122,8 +6254,8 @@ type NumberInAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType NumberInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Values       []float64                           `json:"values,omitempty"`
+	OperatorType *NumberInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Values       []float64                            `json:"values,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &NumberInAdvancedFilter{}
@@ -6142,7 +6274,9 @@ func (filter *NumberInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -6170,7 +6304,7 @@ func (filter *NumberInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -6189,9 +6323,10 @@ func (filter *NumberInAdvancedFilter) AssignProperties_From_NumberInAdvancedFilt
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -6220,8 +6355,12 @@ func (filter *NumberInAdvancedFilter) AssignProperties_To_NumberInAdvancedFilter
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -6249,9 +6388,9 @@ func (filter *NumberInAdvancedFilter) AssignProperties_To_NumberInAdvancedFilter
 
 // Deprecated version of NumberInAdvancedFilter_STATUS. Use v1beta20200601.NumberInAdvancedFilter_STATUS instead
 type NumberInAdvancedFilter_STATUS struct {
-	Key          *string                                    `json:"key,omitempty"`
-	OperatorType NumberInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Values       []float64                                  `json:"values,omitempty"`
+	Key          *string                                     `json:"key,omitempty"`
+	OperatorType *NumberInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Values       []float64                                   `json:"values,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &NumberInAdvancedFilter_STATUS{}
@@ -6275,7 +6414,7 @@ func (filter *NumberInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -6294,9 +6433,10 @@ func (filter *NumberInAdvancedFilter_STATUS) AssignProperties_From_NumberInAdvan
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -6325,8 +6465,12 @@ func (filter *NumberInAdvancedFilter_STATUS) AssignProperties_To_NumberInAdvance
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -6357,8 +6501,8 @@ type NumberLessThanAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType NumberLessThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Value        *float64                                  `json:"value,omitempty"`
+	OperatorType *NumberLessThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Value        *float64                                   `json:"value,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &NumberLessThanAdvancedFilter{}
@@ -6377,7 +6521,9 @@ func (filter *NumberLessThanAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -6406,7 +6552,7 @@ func (filter *NumberLessThanAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6426,9 +6572,10 @@ func (filter *NumberLessThanAdvancedFilter) AssignProperties_From_NumberLessThan
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberLessThanAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6452,8 +6599,12 @@ func (filter *NumberLessThanAdvancedFilter) AssignProperties_To_NumberLessThanAd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6476,9 +6627,9 @@ func (filter *NumberLessThanAdvancedFilter) AssignProperties_To_NumberLessThanAd
 
 // Deprecated version of NumberLessThanAdvancedFilter_STATUS. Use v1beta20200601.NumberLessThanAdvancedFilter_STATUS instead
 type NumberLessThanAdvancedFilter_STATUS struct {
-	Key          *string                                          `json:"key,omitempty"`
-	OperatorType NumberLessThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Value        *float64                                         `json:"value,omitempty"`
+	Key          *string                                           `json:"key,omitempty"`
+	OperatorType *NumberLessThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Value        *float64                                          `json:"value,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &NumberLessThanAdvancedFilter_STATUS{}
@@ -6502,7 +6653,7 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6522,9 +6673,10 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) AssignProperties_From_NumberL
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberLessThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6548,8 +6700,12 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) AssignProperties_To_NumberLes
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6575,8 +6731,8 @@ type NumberLessThanOrEqualsAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType NumberLessThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Value        *float64                                          `json:"value,omitempty"`
+	OperatorType *NumberLessThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Value        *float64                                           `json:"value,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &NumberLessThanOrEqualsAdvancedFilter{}
@@ -6595,7 +6751,9 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) ConvertToARM(resolved genrun
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -6624,7 +6782,7 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) PopulateFromARM(owner genrun
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6644,9 +6802,10 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) AssignProperties_From_Number
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberLessThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6670,8 +6829,12 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) AssignProperties_To_NumberLe
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6694,9 +6857,9 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) AssignProperties_To_NumberLe
 
 // Deprecated version of NumberLessThanOrEqualsAdvancedFilter_STATUS. Use v1beta20200601.NumberLessThanOrEqualsAdvancedFilter_STATUS instead
 type NumberLessThanOrEqualsAdvancedFilter_STATUS struct {
-	Key          *string                                                  `json:"key,omitempty"`
-	OperatorType NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Value        *float64                                                 `json:"value,omitempty"`
+	Key          *string                                                   `json:"key,omitempty"`
+	OperatorType *NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Value        *float64                                                  `json:"value,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &NumberLessThanOrEqualsAdvancedFilter_STATUS{}
@@ -6720,7 +6883,7 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(owner
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6740,9 +6903,10 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) AssignProperties_From
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6766,8 +6930,12 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) AssignProperties_To_N
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6793,8 +6961,8 @@ type NumberNotInAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType NumberNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Values       []float64                              `json:"values,omitempty"`
+	OperatorType *NumberNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Values       []float64                               `json:"values,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &NumberNotInAdvancedFilter{}
@@ -6813,7 +6981,9 @@ func (filter *NumberNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -6841,7 +7011,7 @@ func (filter *NumberNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -6860,9 +7030,10 @@ func (filter *NumberNotInAdvancedFilter) AssignProperties_From_NumberNotInAdvanc
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -6891,8 +7062,12 @@ func (filter *NumberNotInAdvancedFilter) AssignProperties_To_NumberNotInAdvanced
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -6920,9 +7095,9 @@ func (filter *NumberNotInAdvancedFilter) AssignProperties_To_NumberNotInAdvanced
 
 // Deprecated version of NumberNotInAdvancedFilter_STATUS. Use v1beta20200601.NumberNotInAdvancedFilter_STATUS instead
 type NumberNotInAdvancedFilter_STATUS struct {
-	Key          *string                                       `json:"key,omitempty"`
-	OperatorType NumberNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Values       []float64                                     `json:"values,omitempty"`
+	Key          *string                                        `json:"key,omitempty"`
+	OperatorType *NumberNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Values       []float64                                      `json:"values,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &NumberNotInAdvancedFilter_STATUS{}
@@ -6946,7 +7121,7 @@ func (filter *NumberNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -6965,9 +7140,10 @@ func (filter *NumberNotInAdvancedFilter_STATUS) AssignProperties_From_NumberNotI
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -6996,8 +7172,12 @@ func (filter *NumberNotInAdvancedFilter_STATUS) AssignProperties_To_NumberNotInA
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -7080,8 +7260,8 @@ type StringBeginsWithAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType StringBeginsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Values       []string                                    `json:"values,omitempty"`
+	OperatorType *StringBeginsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Values       []string                                     `json:"values,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &StringBeginsWithAdvancedFilter{}
@@ -7100,7 +7280,9 @@ func (filter *StringBeginsWithAdvancedFilter) ConvertToARM(resolved genruntime.C
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7128,7 +7310,7 @@ func (filter *StringBeginsWithAdvancedFilter) PopulateFromARM(owner genruntime.A
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7147,9 +7329,10 @@ func (filter *StringBeginsWithAdvancedFilter) AssignProperties_From_StringBegins
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringBeginsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringBeginsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7168,8 +7351,12 @@ func (filter *StringBeginsWithAdvancedFilter) AssignProperties_To_StringBeginsWi
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7187,9 +7374,9 @@ func (filter *StringBeginsWithAdvancedFilter) AssignProperties_To_StringBeginsWi
 
 // Deprecated version of StringBeginsWithAdvancedFilter_STATUS. Use v1beta20200601.StringBeginsWithAdvancedFilter_STATUS instead
 type StringBeginsWithAdvancedFilter_STATUS struct {
-	Key          *string                                            `json:"key,omitempty"`
-	OperatorType StringBeginsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Values       []string                                           `json:"values,omitempty"`
+	Key          *string                                             `json:"key,omitempty"`
+	OperatorType *StringBeginsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Values       []string                                            `json:"values,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &StringBeginsWithAdvancedFilter_STATUS{}
@@ -7213,7 +7400,7 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7232,9 +7419,10 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) AssignProperties_From_Strin
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringBeginsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringBeginsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7253,8 +7441,12 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) AssignProperties_To_StringB
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7275,8 +7467,8 @@ type StringContainsAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType StringContainsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Values       []string                                  `json:"values,omitempty"`
+	OperatorType *StringContainsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Values       []string                                   `json:"values,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &StringContainsAdvancedFilter{}
@@ -7295,7 +7487,9 @@ func (filter *StringContainsAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7323,7 +7517,7 @@ func (filter *StringContainsAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7342,9 +7536,10 @@ func (filter *StringContainsAdvancedFilter) AssignProperties_From_StringContains
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringContainsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringContainsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7363,8 +7558,12 @@ func (filter *StringContainsAdvancedFilter) AssignProperties_To_StringContainsAd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7382,9 +7581,9 @@ func (filter *StringContainsAdvancedFilter) AssignProperties_To_StringContainsAd
 
 // Deprecated version of StringContainsAdvancedFilter_STATUS. Use v1beta20200601.StringContainsAdvancedFilter_STATUS instead
 type StringContainsAdvancedFilter_STATUS struct {
-	Key          *string                                          `json:"key,omitempty"`
-	OperatorType StringContainsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Values       []string                                         `json:"values,omitempty"`
+	Key          *string                                           `json:"key,omitempty"`
+	OperatorType *StringContainsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Values       []string                                          `json:"values,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &StringContainsAdvancedFilter_STATUS{}
@@ -7408,7 +7607,7 @@ func (filter *StringContainsAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7427,9 +7626,10 @@ func (filter *StringContainsAdvancedFilter_STATUS) AssignProperties_From_StringC
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringContainsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringContainsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7448,8 +7648,12 @@ func (filter *StringContainsAdvancedFilter_STATUS) AssignProperties_To_StringCon
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7470,8 +7674,8 @@ type StringEndsWithAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType StringEndsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Values       []string                                  `json:"values,omitempty"`
+	OperatorType *StringEndsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Values       []string                                   `json:"values,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &StringEndsWithAdvancedFilter{}
@@ -7490,7 +7694,9 @@ func (filter *StringEndsWithAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7518,7 +7724,7 @@ func (filter *StringEndsWithAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7537,9 +7743,10 @@ func (filter *StringEndsWithAdvancedFilter) AssignProperties_From_StringEndsWith
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringEndsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringEndsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7558,8 +7765,12 @@ func (filter *StringEndsWithAdvancedFilter) AssignProperties_To_StringEndsWithAd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7577,9 +7788,9 @@ func (filter *StringEndsWithAdvancedFilter) AssignProperties_To_StringEndsWithAd
 
 // Deprecated version of StringEndsWithAdvancedFilter_STATUS. Use v1beta20200601.StringEndsWithAdvancedFilter_STATUS instead
 type StringEndsWithAdvancedFilter_STATUS struct {
-	Key          *string                                          `json:"key,omitempty"`
-	OperatorType StringEndsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Values       []string                                         `json:"values,omitempty"`
+	Key          *string                                           `json:"key,omitempty"`
+	OperatorType *StringEndsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Values       []string                                          `json:"values,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &StringEndsWithAdvancedFilter_STATUS{}
@@ -7603,7 +7814,7 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7622,9 +7833,10 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) AssignProperties_From_StringE
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringEndsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringEndsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7643,8 +7855,12 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) AssignProperties_To_StringEnd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7665,8 +7881,8 @@ type StringInAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType StringInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Values       []string                            `json:"values,omitempty"`
+	OperatorType *StringInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Values       []string                             `json:"values,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &StringInAdvancedFilter{}
@@ -7685,7 +7901,9 @@ func (filter *StringInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7713,7 +7931,7 @@ func (filter *StringInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7732,9 +7950,10 @@ func (filter *StringInAdvancedFilter) AssignProperties_From_StringInAdvancedFilt
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7753,8 +7972,12 @@ func (filter *StringInAdvancedFilter) AssignProperties_To_StringInAdvancedFilter
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7772,9 +7995,9 @@ func (filter *StringInAdvancedFilter) AssignProperties_To_StringInAdvancedFilter
 
 // Deprecated version of StringInAdvancedFilter_STATUS. Use v1beta20200601.StringInAdvancedFilter_STATUS instead
 type StringInAdvancedFilter_STATUS struct {
-	Key          *string                                    `json:"key,omitempty"`
-	OperatorType StringInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Values       []string                                   `json:"values,omitempty"`
+	Key          *string                                     `json:"key,omitempty"`
+	OperatorType *StringInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Values       []string                                    `json:"values,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &StringInAdvancedFilter_STATUS{}
@@ -7798,7 +8021,7 @@ func (filter *StringInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7817,9 +8040,10 @@ func (filter *StringInAdvancedFilter_STATUS) AssignProperties_From_StringInAdvan
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7838,8 +8062,12 @@ func (filter *StringInAdvancedFilter_STATUS) AssignProperties_To_StringInAdvance
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7860,8 +8088,8 @@ type StringNotInAdvancedFilter struct {
 	Key *string `json:"key,omitempty"`
 
 	// +kubebuilder:validation:Required
-	OperatorType StringNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
-	Values       []string                               `json:"values,omitempty"`
+	OperatorType *StringNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	Values       []string                                `json:"values,omitempty"`
 }
 
 var _ genruntime.ARMTransformer = &StringNotInAdvancedFilter{}
@@ -7880,7 +8108,9 @@ func (filter *StringNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7908,7 +8138,7 @@ func (filter *StringNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7927,9 +8157,10 @@ func (filter *StringNotInAdvancedFilter) AssignProperties_From_StringNotInAdvanc
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7948,8 +8179,12 @@ func (filter *StringNotInAdvancedFilter) AssignProperties_To_StringNotInAdvanced
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7967,9 +8202,9 @@ func (filter *StringNotInAdvancedFilter) AssignProperties_To_StringNotInAdvanced
 
 // Deprecated version of StringNotInAdvancedFilter_STATUS. Use v1beta20200601.StringNotInAdvancedFilter_STATUS instead
 type StringNotInAdvancedFilter_STATUS struct {
-	Key          *string                                       `json:"key,omitempty"`
-	OperatorType StringNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
-	Values       []string                                      `json:"values,omitempty"`
+	Key          *string                                        `json:"key,omitempty"`
+	OperatorType *StringNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	Values       []string                                       `json:"values,omitempty"`
 }
 
 var _ genruntime.FromARMConverter = &StringNotInAdvancedFilter_STATUS{}
@@ -7993,7 +8228,7 @@ func (filter *StringNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -8012,9 +8247,10 @@ func (filter *StringNotInAdvancedFilter_STATUS) AssignProperties_From_StringNotI
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -8033,8 +8269,12 @@ func (filter *StringNotInAdvancedFilter_STATUS) AssignProperties_To_StringNotInA
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)

--- a/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1alpha1api20200601/event_subscription_types_gen_test.go
@@ -1736,7 +1736,7 @@ func AzureFunctionEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_AzureFunction)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_AzureFunction))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 }
@@ -1841,7 +1841,7 @@ func AzureFunctionEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_STATUS_AzureFunction)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_STATUS_AzureFunction))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
@@ -1947,7 +1947,7 @@ func EventHubEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_EventHub)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_EventHub))
 }
 
 func Test_EventHubEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2050,7 +2050,7 @@ func EventHubEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_STATUS_EventHub)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_STATUS_EventHub))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2154,7 +2154,7 @@ func HybridConnectionEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_HybridConnection)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_HybridConnection))
 }
 
 func Test_HybridConnectionEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2257,7 +2257,7 @@ func HybridConnectionEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_STATUS_HybridConnection)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_STATUS_HybridConnection))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2361,7 +2361,7 @@ func ServiceBusQueueEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_ServiceBusQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_ServiceBusQueue))
 }
 
 func Test_ServiceBusQueueEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2464,7 +2464,7 @@ func ServiceBusQueueEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS_ServiceBusQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS_ServiceBusQueue))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2568,7 +2568,7 @@ func ServiceBusTopicEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_ServiceBusTopic)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_ServiceBusTopic))
 }
 
 func Test_ServiceBusTopicEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2671,7 +2671,7 @@ func ServiceBusTopicEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS_ServiceBusTopic)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS_ServiceBusTopic))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2776,7 +2776,7 @@ func StorageBlobDeadLetterDestinationGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination(gens map[string]gopter.Gen) {
 	gens["BlobContainerName"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_StorageBlob)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_StorageBlob))
 }
 
 func Test_StorageBlobDeadLetterDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2880,7 +2880,7 @@ func StorageBlobDeadLetterDestination_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination_STATUS(gens map[string]gopter.Gen) {
 	gens["BlobContainerName"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_STATUS_StorageBlob)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_STATUS_StorageBlob))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2984,7 +2984,7 @@ func StorageQueueEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_StorageQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_StorageQueue))
 	gens["QueueName"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -3088,7 +3088,7 @@ func StorageQueueEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_STATUS_StorageQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_STATUS_StorageQueue))
 	gens["QueueName"] = gen.PtrOf(gen.AlphaString())
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
@@ -3195,7 +3195,7 @@ func WebHookEventSubscriptionDestinationGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForWebHookEventSubscriptionDestination(gens map[string]gopter.Gen) {
 	gens["AzureActiveDirectoryApplicationIdOrUri"] = gen.PtrOf(gen.AlphaString())
 	gens["AzureActiveDirectoryTenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_WebHook)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_WebHook))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 }
@@ -3303,7 +3303,7 @@ func AddIndependentPropertyGeneratorsForWebHookEventSubscriptionDestination_STAT
 	gens["AzureActiveDirectoryApplicationIdOrUri"] = gen.PtrOf(gen.AlphaString())
 	gens["AzureActiveDirectoryTenantId"] = gen.PtrOf(gen.AlphaString())
 	gens["EndpointBaseUrl"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_STATUS_WebHook)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_STATUS_WebHook))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 }
@@ -3409,7 +3409,7 @@ func BoolEqualsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_BoolEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_BoolEquals))
 	gens["Value"] = gen.PtrOf(gen.Bool())
 }
 
@@ -3514,7 +3514,7 @@ func BoolEqualsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_STATUS_BoolEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_STATUS_BoolEquals))
 	gens["Value"] = gen.PtrOf(gen.Bool())
 }
 
@@ -3619,7 +3619,7 @@ func NumberGreaterThanAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_NumberGreaterThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_NumberGreaterThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -3724,7 +3724,7 @@ func NumberGreaterThanAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_STATUS_NumberGreaterThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_STATUS_NumberGreaterThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -3829,7 +3829,7 @@ func NumberGreaterThanOrEqualsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_NumberGreaterThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_NumberGreaterThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -3934,7 +3934,7 @@ func NumberGreaterThanOrEqualsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberGreaterThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberGreaterThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4039,7 +4039,7 @@ func NumberInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberInAdvancedFilter_OperatorType_NumberIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberInAdvancedFilter_OperatorType_NumberIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4144,7 +4144,7 @@ func NumberInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberInAdvancedFilter_OperatorType_STATUS_NumberIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberInAdvancedFilter_OperatorType_STATUS_NumberIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4249,7 +4249,7 @@ func NumberLessThanAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_NumberLessThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_NumberLessThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4354,7 +4354,7 @@ func NumberLessThanAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_STATUS_NumberLessThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_STATUS_NumberLessThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4459,7 +4459,7 @@ func NumberLessThanOrEqualsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_NumberLessThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_NumberLessThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4564,7 +4564,7 @@ func NumberLessThanOrEqualsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberLessThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberLessThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4669,7 +4669,7 @@ func NumberNotInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_NumberNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_NumberNotIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4774,7 +4774,7 @@ func NumberNotInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_STATUS_NumberNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_STATUS_NumberNotIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4879,7 +4879,7 @@ func StringBeginsWithAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_StringBeginsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_StringBeginsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -4984,7 +4984,7 @@ func StringBeginsWithAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_STATUS_StringBeginsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_STATUS_StringBeginsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5089,7 +5089,7 @@ func StringContainsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_StringContains)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_StringContains))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5194,7 +5194,7 @@ func StringContainsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_STATUS_StringContains)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_STATUS_StringContains))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5299,7 +5299,7 @@ func StringEndsWithAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_StringEndsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_StringEndsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5404,7 +5404,7 @@ func StringEndsWithAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_STATUS_StringEndsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_STATUS_StringEndsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5509,7 +5509,7 @@ func StringInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringInAdvancedFilter_OperatorType_StringIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringInAdvancedFilter_OperatorType_StringIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5614,7 +5614,7 @@ func StringInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringInAdvancedFilter_OperatorType_STATUS_StringIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringInAdvancedFilter_OperatorType_STATUS_StringIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5719,7 +5719,7 @@ func StringNotInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_StringNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_StringNotIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5824,6 +5824,6 @@ func StringNotInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_STATUS_StringNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_STATUS_StringNotIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }

--- a/v2/api/eventgrid/v1alpha1api20200601/structure.txt
+++ b/v2/api/eventgrid/v1alpha1api20200601/structure.txt
@@ -25,7 +25,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │   │   │       │   └── SourceField: *string
 │   │   │       ├── Id: *Object (1 property)
 │   │   │       │   └── SourceField: *string
-│   │   │       ├── InputSchemaMappingType: Enum (1 value)
+│   │   │       ├── InputSchemaMappingType: *Enum (1 value)
 │   │   │       │   └── "Json"
 │   │   │       ├── Subject: *Object (2 properties)
 │   │   │       │   ├── DefaultValue: *string
@@ -62,7 +62,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │       │       │   └── SourceField: *string
 │       │       ├── Id: *Object (1 property)
 │       │       │   └── SourceField: *string
-│       │       ├── InputSchemaMappingType: Enum (1 value)
+│       │       ├── InputSchemaMappingType: *Enum (1 value)
 │       │       │   └── "Json"
 │       │       ├── Subject: *Object (2 properties)
 │       │       │   ├── DefaultValue: *string
@@ -268,41 +268,41 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │   │   ├── DeadLetterDestination: *Object (1 property)
 │   │   │   └── StorageBlob: *Object (3 properties)
 │   │   │       ├── BlobContainerName: *string
-│   │   │       ├── EndpointType: Enum (1 value)
+│   │   │       ├── EndpointType: *Enum (1 value)
 │   │   │       │   └── "StorageBlob"
 │   │   │       └── ResourceReference: *genruntime.ResourceReference
 │   │   ├── Destination: *Object (7 properties)
 │   │   │   ├── AzureFunction: *Object (4 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "AzureFunction"
 │   │   │   │   ├── MaxEventsPerBatch: *int
 │   │   │   │   ├── PreferredBatchSizeInKilobytes: *int
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── EventHub: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "EventHub"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── HybridConnection: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "HybridConnection"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── ServiceBusQueue: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "ServiceBusQueue"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── ServiceBusTopic: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "ServiceBusTopic"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── StorageQueue: *Object (3 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "StorageQueue"
 │   │   │   │   ├── QueueName: *string
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   └── WebHook: *Object (6 properties)
 │   │   │       ├── AzureActiveDirectoryApplicationIdOrUri: *string
 │   │   │       ├── AzureActiveDirectoryTenantId: *string
-│   │   │       ├── EndpointType: Enum (1 value)
+│   │   │       ├── EndpointType: *Enum (1 value)
 │   │   │       │   └── "WebHook"
 │   │   │       ├── EndpointUrl: *genruntime.SecretReference
 │   │   │       ├── MaxEventsPerBatch: *int
@@ -316,62 +316,62 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │   │   │   ├── AdvancedFilters: Object (12 properties)[]
 │   │   │   │   ├── BoolEquals: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "BoolEquals"
 │   │   │   │   │   └── Value: *bool
 │   │   │   │   ├── NumberGreaterThan: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberGreaterThan"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberGreaterThanOrEquals: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberGreaterThanOrEquals"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberIn: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberIn"
 │   │   │   │   │   └── Values: float64[]
 │   │   │   │   ├── NumberLessThan: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberLessThan"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberLessThanOrEquals: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberLessThanOrEquals"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberNotIn: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberNotIn"
 │   │   │   │   │   └── Values: float64[]
 │   │   │   │   ├── StringBeginsWith: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringBeginsWith"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   ├── StringContains: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringContains"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   ├── StringEndsWith: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringEndsWith"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   ├── StringIn: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringIn"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   └── StringNotIn: *Object (3 properties)
 │   │   │   │       ├── Key: *string
-│   │   │   │       ├── OperatorType: Enum (1 value)
+│   │   │   │       ├── OperatorType: *Enum (1 value)
 │   │   │   │       │   └── "StringNotIn"
 │   │   │   │       └── Values: string[]
 │   │   │   ├── IncludedEventTypes: string[]
@@ -388,34 +388,34 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │       ├── DeadLetterDestination: *Object (1 property)
 │       │   └── StorageBlob: *Object (3 properties)
 │       │       ├── BlobContainerName: *string
-│       │       ├── EndpointType: Enum (1 value)
+│       │       ├── EndpointType: *Enum (1 value)
 │       │       │   └── "StorageBlob"
 │       │       └── ResourceId: *string
 │       ├── Destination: *Object (7 properties)
 │       │   ├── AzureFunction: *Object (4 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "AzureFunction"
 │       │   │   ├── MaxEventsPerBatch: *int
 │       │   │   ├── PreferredBatchSizeInKilobytes: *int
 │       │   │   └── ResourceId: *string
 │       │   ├── EventHub: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "EventHub"
 │       │   │   └── ResourceId: *string
 │       │   ├── HybridConnection: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "HybridConnection"
 │       │   │   └── ResourceId: *string
 │       │   ├── ServiceBusQueue: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "ServiceBusQueue"
 │       │   │   └── ResourceId: *string
 │       │   ├── ServiceBusTopic: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "ServiceBusTopic"
 │       │   │   └── ResourceId: *string
 │       │   ├── StorageQueue: *Object (3 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "StorageQueue"
 │       │   │   ├── QueueName: *string
 │       │   │   └── ResourceId: *string
@@ -423,7 +423,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │       │       ├── AzureActiveDirectoryApplicationIdOrUri: *string
 │       │       ├── AzureActiveDirectoryTenantId: *string
 │       │       ├── EndpointBaseUrl: *string
-│       │       ├── EndpointType: Enum (1 value)
+│       │       ├── EndpointType: *Enum (1 value)
 │       │       │   └── "WebHook"
 │       │       ├── MaxEventsPerBatch: *int
 │       │       └── PreferredBatchSizeInKilobytes: *int
@@ -436,62 +436,62 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │       │   ├── AdvancedFilters: Object (12 properties)[]
 │       │   │   ├── BoolEquals: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "BoolEquals"
 │       │   │   │   └── Value: *bool
 │       │   │   ├── NumberGreaterThan: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberGreaterThan"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberGreaterThanOrEquals: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberGreaterThanOrEquals"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberIn: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberIn"
 │       │   │   │   └── Values: float64[]
 │       │   │   ├── NumberLessThan: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberLessThan"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberLessThanOrEquals: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberLessThanOrEquals"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberNotIn: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberNotIn"
 │       │   │   │   └── Values: float64[]
 │       │   │   ├── StringBeginsWith: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringBeginsWith"
 │       │   │   │   └── Values: string[]
 │       │   │   ├── StringContains: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringContains"
 │       │   │   │   └── Values: string[]
 │       │   │   ├── StringEndsWith: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringEndsWith"
 │       │   │   │   └── Values: string[]
 │       │   │   ├── StringIn: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringIn"
 │       │   │   │   └── Values: string[]
 │       │   │   └── StringNotIn: *Object (3 properties)
 │       │   │       ├── Key: *string
-│       │   │       ├── OperatorType: Enum (1 value)
+│       │   │       ├── OperatorType: *Enum (1 value)
 │       │   │       │   └── "StringNotIn"
 │       │   │       └── Values: string[]
 │       │   ├── IncludedEventTypes: string[]
@@ -835,7 +835,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │   │   │       │   └── SourceField: *string
 │   │   │       ├── Id: *Object (1 property)
 │   │   │       │   └── SourceField: *string
-│   │   │       ├── InputSchemaMappingType: Enum (1 value)
+│   │   │       ├── InputSchemaMappingType: *Enum (1 value)
 │   │   │       │   └── "Json"
 │   │   │       ├── Subject: *Object (2 properties)
 │   │   │       │   ├── DefaultValue: *string
@@ -872,7 +872,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1alpha1api20200601
 │       │       │   └── SourceField: *string
 │       │       ├── Id: *Object (1 property)
 │       │       │   └── SourceField: *string
-│       │       ├── InputSchemaMappingType: Enum (1 value)
+│       │       ├── InputSchemaMappingType: *Enum (1 value)
 │       │       │   └── "Json"
 │       │       ├── Subject: *Object (2 properties)
 │       │       │   ├── DefaultValue: *string

--- a/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/domain_types_gen.go
@@ -1843,7 +1843,7 @@ type JsonInputSchemaMapping struct {
 
 	// +kubebuilder:validation:Required
 	// InputSchemaMappingType: Type of the custom mapping
-	InputSchemaMappingType JsonInputSchemaMapping_InputSchemaMappingType `json:"inputSchemaMappingType,omitempty"`
+	InputSchemaMappingType *JsonInputSchemaMapping_InputSchemaMappingType `json:"inputSchemaMappingType,omitempty"`
 
 	// Subject: The mapping information for the Subject property of the Event Grid Event.
 	Subject *JsonFieldWithDefault `json:"subject,omitempty"`
@@ -1862,7 +1862,9 @@ func (mapping *JsonInputSchemaMapping) ConvertToARM(resolved genruntime.ConvertT
 	result := &JsonInputSchemaMapping_ARM{}
 
 	// Set property ‘InputSchemaMappingType’:
-	result.InputSchemaMappingType = mapping.InputSchemaMappingType
+	if mapping.InputSchemaMappingType != nil {
+		result.InputSchemaMappingType = *mapping.InputSchemaMappingType
+	}
 
 	// Set property ‘Properties’:
 	if mapping.DataVersion != nil ||
@@ -1993,7 +1995,7 @@ func (mapping *JsonInputSchemaMapping) PopulateFromARM(owner genruntime.Arbitrar
 	}
 
 	// Set property ‘InputSchemaMappingType’:
-	mapping.InputSchemaMappingType = typedInput.InputSchemaMappingType
+	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
 	// Set property ‘Subject’:
 	// copying flattened property:
@@ -2080,9 +2082,10 @@ func (mapping *JsonInputSchemaMapping) AssignProperties_From_JsonInputSchemaMapp
 
 	// InputSchemaMappingType
 	if source.InputSchemaMappingType != nil {
-		mapping.InputSchemaMappingType = JsonInputSchemaMapping_InputSchemaMappingType(*source.InputSchemaMappingType)
+		inputSchemaMappingType := JsonInputSchemaMapping_InputSchemaMappingType(*source.InputSchemaMappingType)
+		mapping.InputSchemaMappingType = &inputSchemaMappingType
 	} else {
-		mapping.InputSchemaMappingType = ""
+		mapping.InputSchemaMappingType = nil
 	}
 
 	// Subject
@@ -2167,8 +2170,12 @@ func (mapping *JsonInputSchemaMapping) AssignProperties_To_JsonInputSchemaMappin
 	}
 
 	// InputSchemaMappingType
-	inputSchemaMappingType := string(mapping.InputSchemaMappingType)
-	destination.InputSchemaMappingType = &inputSchemaMappingType
+	if mapping.InputSchemaMappingType != nil {
+		inputSchemaMappingType := string(*mapping.InputSchemaMappingType)
+		destination.InputSchemaMappingType = &inputSchemaMappingType
+	} else {
+		destination.InputSchemaMappingType = nil
+	}
 
 	// Subject
 	if mapping.Subject != nil {
@@ -2219,7 +2226,7 @@ type JsonInputSchemaMapping_STATUS struct {
 	Id *JsonField_STATUS `json:"id,omitempty"`
 
 	// InputSchemaMappingType: Type of the custom mapping
-	InputSchemaMappingType JsonInputSchemaMapping_InputSchemaMappingType_STATUS `json:"inputSchemaMappingType,omitempty"`
+	InputSchemaMappingType *JsonInputSchemaMapping_InputSchemaMappingType_STATUS `json:"inputSchemaMappingType,omitempty"`
 
 	// Subject: The mapping information for the Subject property of the Event Grid Event.
 	Subject *JsonFieldWithDefault_STATUS `json:"subject,omitempty"`
@@ -2299,7 +2306,7 @@ func (mapping *JsonInputSchemaMapping_STATUS) PopulateFromARM(owner genruntime.A
 	}
 
 	// Set property ‘InputSchemaMappingType’:
-	mapping.InputSchemaMappingType = typedInput.InputSchemaMappingType
+	mapping.InputSchemaMappingType = &typedInput.InputSchemaMappingType
 
 	// Set property ‘Subject’:
 	// copying flattened property:
@@ -2386,9 +2393,10 @@ func (mapping *JsonInputSchemaMapping_STATUS) AssignProperties_From_JsonInputSch
 
 	// InputSchemaMappingType
 	if source.InputSchemaMappingType != nil {
-		mapping.InputSchemaMappingType = JsonInputSchemaMapping_InputSchemaMappingType_STATUS(*source.InputSchemaMappingType)
+		inputSchemaMappingType := JsonInputSchemaMapping_InputSchemaMappingType_STATUS(*source.InputSchemaMappingType)
+		mapping.InputSchemaMappingType = &inputSchemaMappingType
 	} else {
-		mapping.InputSchemaMappingType = ""
+		mapping.InputSchemaMappingType = nil
 	}
 
 	// Subject
@@ -2473,8 +2481,12 @@ func (mapping *JsonInputSchemaMapping_STATUS) AssignProperties_To_JsonInputSchem
 	}
 
 	// InputSchemaMappingType
-	inputSchemaMappingType := string(mapping.InputSchemaMappingType)
-	destination.InputSchemaMappingType = &inputSchemaMappingType
+	if mapping.InputSchemaMappingType != nil {
+		inputSchemaMappingType := string(*mapping.InputSchemaMappingType)
+		destination.InputSchemaMappingType = &inputSchemaMappingType
+	} else {
+		destination.InputSchemaMappingType = nil
+	}
 
 	// Subject
 	if mapping.Subject != nil {

--- a/v2/api/eventgrid/v1beta20200601/domain_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/domain_types_gen_test.go
@@ -1174,7 +1174,7 @@ func JsonInputSchemaMappingGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForJsonInputSchemaMapping is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForJsonInputSchemaMapping(gens map[string]gopter.Gen) {
-	gens["InputSchemaMappingType"] = gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_Json)
+	gens["InputSchemaMappingType"] = gen.PtrOf(gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_Json))
 }
 
 // AddRelatedPropertyGeneratorsForJsonInputSchemaMapping is a factory method for creating gopter generators
@@ -1296,7 +1296,7 @@ func JsonInputSchemaMapping_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForJsonInputSchemaMapping_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForJsonInputSchemaMapping_STATUS(gens map[string]gopter.Gen) {
-	gens["InputSchemaMappingType"] = gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_STATUS_Json)
+	gens["InputSchemaMappingType"] = gen.PtrOf(gen.OneConstOf(JsonInputSchemaMapping_InputSchemaMappingType_STATUS_Json))
 }
 
 // AddRelatedPropertyGeneratorsForJsonInputSchemaMapping_STATUS is a factory method for creating gopter generators

--- a/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen.go
@@ -3806,7 +3806,7 @@ func (filter *AdvancedFilter_STATUS) AssignProperties_To_AdvancedFilter_STATUS(d
 type AzureFunctionEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType AzureFunctionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *AzureFunctionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// MaxEventsPerBatch: Maximum number of events per batch.
 	MaxEventsPerBatch *int `json:"maxEventsPerBatch,omitempty"`
@@ -3829,7 +3829,9 @@ func (destination *AzureFunctionEventSubscriptionDestination) ConvertToARM(resol
 	result := &AzureFunctionEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.MaxEventsPerBatch != nil ||
@@ -3869,7 +3871,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) PopulateFromARM(ow
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘MaxEventsPerBatch’:
 	// copying flattened property:
@@ -3900,9 +3902,10 @@ func (destination *AzureFunctionEventSubscriptionDestination) AssignProperties_F
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = AzureFunctionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := AzureFunctionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// MaxEventsPerBatch
@@ -3929,8 +3932,12 @@ func (destination *AzureFunctionEventSubscriptionDestination) AssignProperties_T
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// MaxEventsPerBatch
 	target.MaxEventsPerBatch = genruntime.ClonePointerToInt(destination.MaxEventsPerBatch)
@@ -3959,7 +3966,7 @@ func (destination *AzureFunctionEventSubscriptionDestination) AssignProperties_T
 
 type AzureFunctionEventSubscriptionDestination_STATUS struct {
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType AzureFunctionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *AzureFunctionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// MaxEventsPerBatch: Maximum number of events per batch.
 	MaxEventsPerBatch *int `json:"maxEventsPerBatch,omitempty"`
@@ -3987,7 +3994,7 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) PopulateFro
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘MaxEventsPerBatch’:
 	// copying flattened property:
@@ -4025,9 +4032,10 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) AssignPrope
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = AzureFunctionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := AzureFunctionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// MaxEventsPerBatch
@@ -4049,8 +4057,12 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) AssignPrope
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// MaxEventsPerBatch
 	target.MaxEventsPerBatch = genruntime.ClonePointerToInt(destination.MaxEventsPerBatch)
@@ -4075,7 +4087,7 @@ func (destination *AzureFunctionEventSubscriptionDestination_STATUS) AssignPrope
 type EventHubEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType EventHubEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *EventHubEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// ResourceReference: The Azure Resource Id that represents the endpoint of an Event Hub destination of an event
 	// subscription.
@@ -4092,7 +4104,9 @@ func (destination *EventHubEventSubscriptionDestination) ConvertToARM(resolved g
 	result := &EventHubEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -4122,7 +4136,7 @@ func (destination *EventHubEventSubscriptionDestination) PopulateFromARM(owner g
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4135,9 +4149,10 @@ func (destination *EventHubEventSubscriptionDestination) AssignProperties_From_E
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = EventHubEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := EventHubEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4158,8 +4173,12 @@ func (destination *EventHubEventSubscriptionDestination) AssignProperties_To_Eve
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4182,7 +4201,7 @@ func (destination *EventHubEventSubscriptionDestination) AssignProperties_To_Eve
 
 type EventHubEventSubscriptionDestination_STATUS struct {
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType EventHubEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *EventHubEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// ResourceId: The Azure Resource Id that represents the endpoint of an Event Hub destination of an event subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
@@ -4203,7 +4222,7 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) PopulateFromARM(
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4223,9 +4242,10 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) AssignProperties
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = EventHubEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := EventHubEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4241,8 +4261,12 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) AssignProperties
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4261,7 +4285,7 @@ func (destination *EventHubEventSubscriptionDestination_STATUS) AssignProperties
 type HybridConnectionEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType HybridConnectionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *HybridConnectionEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// ResourceReference: The Azure Resource ID of an hybrid connection that is the destination of an event subscription.
 	ResourceReference *genruntime.ResourceReference `armReference:"ResourceId" json:"resourceReference,omitempty"`
@@ -4277,7 +4301,9 @@ func (destination *HybridConnectionEventSubscriptionDestination) ConvertToARM(re
 	result := &HybridConnectionEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -4307,7 +4333,7 @@ func (destination *HybridConnectionEventSubscriptionDestination) PopulateFromARM
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4320,9 +4346,10 @@ func (destination *HybridConnectionEventSubscriptionDestination) AssignPropertie
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = HybridConnectionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := HybridConnectionEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4343,8 +4370,12 @@ func (destination *HybridConnectionEventSubscriptionDestination) AssignPropertie
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4367,7 +4398,7 @@ func (destination *HybridConnectionEventSubscriptionDestination) AssignPropertie
 
 type HybridConnectionEventSubscriptionDestination_STATUS struct {
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType HybridConnectionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *HybridConnectionEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// ResourceId: The Azure Resource ID of an hybrid connection that is the destination of an event subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
@@ -4388,7 +4419,7 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) Populate
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4408,9 +4439,10 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) AssignPr
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = HybridConnectionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := HybridConnectionEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4426,8 +4458,12 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) AssignPr
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4446,7 +4482,7 @@ func (destination *HybridConnectionEventSubscriptionDestination_STATUS) AssignPr
 type ServiceBusQueueEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType ServiceBusQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *ServiceBusQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// ResourceReference: The Azure Resource Id that represents the endpoint of the Service Bus destination of an event
 	// subscription.
@@ -4463,7 +4499,9 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) ConvertToARM(res
 	result := &ServiceBusQueueEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -4493,7 +4531,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) PopulateFromARM(
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4506,9 +4544,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) AssignProperties
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := ServiceBusQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4529,8 +4568,12 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) AssignProperties
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4553,7 +4596,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination) AssignProperties
 
 type ServiceBusQueueEventSubscriptionDestination_STATUS struct {
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// ResourceId: The Azure Resource Id that represents the endpoint of the Service Bus destination of an event subscription.
 	ResourceId *string `json:"resourceId,omitempty"`
@@ -4574,7 +4617,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) PopulateF
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4594,9 +4637,10 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) AssignPro
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4612,8 +4656,12 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) AssignPro
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4632,7 +4680,7 @@ func (destination *ServiceBusQueueEventSubscriptionDestination_STATUS) AssignPro
 type ServiceBusTopicEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType ServiceBusTopicEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *ServiceBusTopicEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// ResourceReference: The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event
 	// subscription.
@@ -4649,7 +4697,9 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) ConvertToARM(res
 	result := &ServiceBusTopicEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.ResourceReference != nil {
@@ -4679,7 +4729,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) PopulateFromARM(
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4692,9 +4742,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) AssignProperties
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusTopicEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := ServiceBusTopicEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4715,8 +4766,12 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) AssignProperties
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4739,7 +4794,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination) AssignProperties
 
 type ServiceBusTopicEventSubscriptionDestination_STATUS struct {
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// ResourceId: The Azure Resource Id that represents the endpoint of the Service Bus Topic destination of an event
 	// subscription.
@@ -4761,7 +4816,7 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) PopulateF
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -4781,9 +4836,10 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) AssignPro
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -4799,8 +4855,12 @@ func (destination *ServiceBusTopicEventSubscriptionDestination_STATUS) AssignPro
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -4822,7 +4882,7 @@ type StorageBlobDeadLetterDestination struct {
 
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the dead letter destination
-	EndpointType StorageBlobDeadLetterDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *StorageBlobDeadLetterDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// ResourceReference: The Azure Resource ID of the storage account that is the destination of the deadletter events
 	ResourceReference *genruntime.ResourceReference `armReference:"ResourceId" json:"resourceReference,omitempty"`
@@ -4838,7 +4898,9 @@ func (destination *StorageBlobDeadLetterDestination) ConvertToARM(resolved genru
 	result := &StorageBlobDeadLetterDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.BlobContainerName != nil || destination.ResourceReference != nil {
@@ -4881,7 +4943,7 @@ func (destination *StorageBlobDeadLetterDestination) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘ResourceReference’
 
@@ -4897,9 +4959,10 @@ func (destination *StorageBlobDeadLetterDestination) AssignProperties_From_Stora
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageBlobDeadLetterDestination_EndpointType(*source.EndpointType)
+		endpointType := StorageBlobDeadLetterDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceReference
@@ -4923,8 +4986,12 @@ func (destination *StorageBlobDeadLetterDestination) AssignProperties_To_Storage
 	target.BlobContainerName = genruntime.ClonePointerToString(destination.BlobContainerName)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceReference
 	if destination.ResourceReference != nil {
@@ -4950,7 +5017,7 @@ type StorageBlobDeadLetterDestination_STATUS struct {
 	BlobContainerName *string `json:"blobContainerName,omitempty"`
 
 	// EndpointType: Type of the endpoint for the dead letter destination
-	EndpointType StorageBlobDeadLetterDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *StorageBlobDeadLetterDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// ResourceId: The Azure Resource ID of the storage account that is the destination of the deadletter events
 	ResourceId *string `json:"resourceId,omitempty"`
@@ -4980,7 +5047,7 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) PopulateFromARM(owne
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘ResourceId’:
 	// copying flattened property:
@@ -5003,9 +5070,10 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) AssignProperties_Fro
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageBlobDeadLetterDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := StorageBlobDeadLetterDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// ResourceId
@@ -5024,8 +5092,12 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) AssignProperties_To_
 	target.BlobContainerName = genruntime.ClonePointerToString(destination.BlobContainerName)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// ResourceId
 	target.ResourceId = genruntime.ClonePointerToString(destination.ResourceId)
@@ -5044,7 +5116,7 @@ func (destination *StorageBlobDeadLetterDestination_STATUS) AssignProperties_To_
 type StorageQueueEventSubscriptionDestination struct {
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType StorageQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *StorageQueueEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// QueueName: The name of the Storage queue under a storage account that is the destination of an event subscription.
 	QueueName *string `json:"queueName,omitempty"`
@@ -5064,7 +5136,9 @@ func (destination *StorageQueueEventSubscriptionDestination) ConvertToARM(resolv
 	result := &StorageQueueEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.QueueName != nil || destination.ResourceReference != nil {
@@ -5098,7 +5172,7 @@ func (destination *StorageQueueEventSubscriptionDestination) PopulateFromARM(own
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘QueueName’:
 	// copying flattened property:
@@ -5120,9 +5194,10 @@ func (destination *StorageQueueEventSubscriptionDestination) AssignProperties_Fr
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := StorageQueueEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// QueueName
@@ -5146,8 +5221,12 @@ func (destination *StorageQueueEventSubscriptionDestination) AssignProperties_To
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// QueueName
 	target.QueueName = genruntime.ClonePointerToString(destination.QueueName)
@@ -5173,7 +5252,7 @@ func (destination *StorageQueueEventSubscriptionDestination) AssignProperties_To
 
 type StorageQueueEventSubscriptionDestination_STATUS struct {
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType StorageQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *StorageQueueEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// QueueName: The name of the Storage queue under a storage account that is the destination of an event subscription.
 	QueueName *string `json:"queueName,omitempty"`
@@ -5198,7 +5277,7 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) PopulateFrom
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘QueueName’:
 	// copying flattened property:
@@ -5227,9 +5306,10 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) AssignProper
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = StorageQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := StorageQueueEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// QueueName
@@ -5248,8 +5328,12 @@ func (destination *StorageQueueEventSubscriptionDestination_STATUS) AssignProper
 	propertyBag := genruntime.NewPropertyBag()
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// QueueName
 	target.QueueName = genruntime.ClonePointerToString(destination.QueueName)
@@ -5279,7 +5363,7 @@ type WebHookEventSubscriptionDestination struct {
 
 	// +kubebuilder:validation:Required
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType WebHookEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
+	EndpointType *WebHookEventSubscriptionDestination_EndpointType `json:"endpointType,omitempty"`
 
 	// EndpointUrl: The URL that represents the endpoint of the destination of an event subscription.
 	EndpointUrl *genruntime.SecretReference `json:"endpointUrl,omitempty"`
@@ -5301,7 +5385,9 @@ func (destination *WebHookEventSubscriptionDestination) ConvertToARM(resolved ge
 	result := &WebHookEventSubscriptionDestination_ARM{}
 
 	// Set property ‘EndpointType’:
-	result.EndpointType = destination.EndpointType
+	if destination.EndpointType != nil {
+		result.EndpointType = *destination.EndpointType
+	}
 
 	// Set property ‘Properties’:
 	if destination.AzureActiveDirectoryApplicationIdOrUri != nil ||
@@ -5369,7 +5455,7 @@ func (destination *WebHookEventSubscriptionDestination) PopulateFromARM(owner ge
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// no assignment for property ‘EndpointUrl’
 
@@ -5406,9 +5492,10 @@ func (destination *WebHookEventSubscriptionDestination) AssignProperties_From_We
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = WebHookEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		endpointType := WebHookEventSubscriptionDestination_EndpointType(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// EndpointUrl
@@ -5441,8 +5528,12 @@ func (destination *WebHookEventSubscriptionDestination) AssignProperties_To_WebH
 	target.AzureActiveDirectoryTenantId = genruntime.ClonePointerToString(destination.AzureActiveDirectoryTenantId)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// EndpointUrl
 	if destination.EndpointUrl != nil {
@@ -5482,7 +5573,7 @@ type WebHookEventSubscriptionDestination_STATUS struct {
 	EndpointBaseUrl *string `json:"endpointBaseUrl,omitempty"`
 
 	// EndpointType: Type of the endpoint for the event subscription destination.
-	EndpointType WebHookEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
+	EndpointType *WebHookEventSubscriptionDestination_EndpointType_STATUS `json:"endpointType,omitempty"`
 
 	// MaxEventsPerBatch: Maximum number of events per batch.
 	MaxEventsPerBatch *int `json:"maxEventsPerBatch,omitempty"`
@@ -5533,7 +5624,7 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) PopulateFromARM(o
 	}
 
 	// Set property ‘EndpointType’:
-	destination.EndpointType = typedInput.EndpointType
+	destination.EndpointType = &typedInput.EndpointType
 
 	// Set property ‘MaxEventsPerBatch’:
 	// copying flattened property:
@@ -5571,9 +5662,10 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) AssignProperties_
 
 	// EndpointType
 	if source.EndpointType != nil {
-		destination.EndpointType = WebHookEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		endpointType := WebHookEventSubscriptionDestination_EndpointType_STATUS(*source.EndpointType)
+		destination.EndpointType = &endpointType
 	} else {
-		destination.EndpointType = ""
+		destination.EndpointType = nil
 	}
 
 	// MaxEventsPerBatch
@@ -5601,8 +5693,12 @@ func (destination *WebHookEventSubscriptionDestination_STATUS) AssignProperties_
 	target.EndpointBaseUrl = genruntime.ClonePointerToString(destination.EndpointBaseUrl)
 
 	// EndpointType
-	endpointType := string(destination.EndpointType)
-	target.EndpointType = &endpointType
+	if destination.EndpointType != nil {
+		endpointType := string(*destination.EndpointType)
+		target.EndpointType = &endpointType
+	} else {
+		target.EndpointType = nil
+	}
 
 	// MaxEventsPerBatch
 	target.MaxEventsPerBatch = genruntime.ClonePointerToInt(destination.MaxEventsPerBatch)
@@ -5636,7 +5732,7 @@ type BoolEqualsAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType BoolEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *BoolEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Value: The boolean filter value.
 	Value *bool `json:"value,omitempty"`
@@ -5658,7 +5754,9 @@ func (filter *BoolEqualsAdvancedFilter) ConvertToARM(resolved genruntime.Convert
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -5687,7 +5785,7 @@ func (filter *BoolEqualsAdvancedFilter) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5707,9 +5805,10 @@ func (filter *BoolEqualsAdvancedFilter) AssignProperties_From_BoolEqualsAdvanced
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = BoolEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := BoolEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5733,8 +5832,12 @@ func (filter *BoolEqualsAdvancedFilter) AssignProperties_To_BoolEqualsAdvancedFi
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -5760,7 +5863,7 @@ type BoolEqualsAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType BoolEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *BoolEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Value: The boolean filter value.
 	Value *bool `json:"value,omitempty"`
@@ -5787,7 +5890,7 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5807,9 +5910,10 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) AssignProperties_From_BoolEqualsA
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = BoolEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := BoolEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5833,8 +5937,12 @@ func (filter *BoolEqualsAdvancedFilter_STATUS) AssignProperties_To_BoolEqualsAdv
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -5879,7 +5987,7 @@ type NumberGreaterThanAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberGreaterThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *NumberGreaterThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -5901,7 +6009,9 @@ func (filter *NumberGreaterThanAdvancedFilter) ConvertToARM(resolved genruntime.
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -5930,7 +6040,7 @@ func (filter *NumberGreaterThanAdvancedFilter) PopulateFromARM(owner genruntime.
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -5950,9 +6060,10 @@ func (filter *NumberGreaterThanAdvancedFilter) AssignProperties_From_NumberGreat
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberGreaterThanAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -5976,8 +6087,12 @@ func (filter *NumberGreaterThanAdvancedFilter) AssignProperties_To_NumberGreater
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6003,7 +6118,7 @@ type NumberGreaterThanAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberGreaterThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *NumberGreaterThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -6030,7 +6145,7 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) PopulateFromARM(owner genr
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6050,9 +6165,10 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) AssignProperties_From_Numb
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberGreaterThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6076,8 +6192,12 @@ func (filter *NumberGreaterThanAdvancedFilter_STATUS) AssignProperties_To_Number
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6104,7 +6224,7 @@ type NumberGreaterThanOrEqualsAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberGreaterThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *NumberGreaterThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -6126,7 +6246,9 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) ConvertToARM(resolved gen
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -6155,7 +6277,7 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) PopulateFromARM(owner gen
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6175,9 +6297,10 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) AssignProperties_From_Num
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberGreaterThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6201,8 +6324,12 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter) AssignProperties_To_Numbe
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6228,7 +6355,7 @@ type NumberGreaterThanOrEqualsAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -6255,7 +6382,7 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(ow
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6275,9 +6402,10 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) AssignProperties_F
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6301,8 +6429,12 @@ func (filter *NumberGreaterThanOrEqualsAdvancedFilter_STATUS) AssignProperties_T
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6329,7 +6461,7 @@ type NumberInAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *NumberInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []float64 `json:"values,omitempty"`
@@ -6351,7 +6483,9 @@ func (filter *NumberInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -6379,7 +6513,7 @@ func (filter *NumberInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -6398,9 +6532,10 @@ func (filter *NumberInAdvancedFilter) AssignProperties_From_NumberInAdvancedFilt
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -6429,8 +6564,12 @@ func (filter *NumberInAdvancedFilter) AssignProperties_To_NumberInAdvancedFilter
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -6461,7 +6600,7 @@ type NumberInAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *NumberInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []float64 `json:"values,omitempty"`
@@ -6488,7 +6627,7 @@ func (filter *NumberInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -6507,9 +6646,10 @@ func (filter *NumberInAdvancedFilter_STATUS) AssignProperties_From_NumberInAdvan
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -6538,8 +6678,12 @@ func (filter *NumberInAdvancedFilter_STATUS) AssignProperties_To_NumberInAdvance
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -6571,7 +6715,7 @@ type NumberLessThanAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberLessThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *NumberLessThanAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -6593,7 +6737,9 @@ func (filter *NumberLessThanAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -6622,7 +6768,7 @@ func (filter *NumberLessThanAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6642,9 +6788,10 @@ func (filter *NumberLessThanAdvancedFilter) AssignProperties_From_NumberLessThan
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberLessThanAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6668,8 +6815,12 @@ func (filter *NumberLessThanAdvancedFilter) AssignProperties_To_NumberLessThanAd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6695,7 +6846,7 @@ type NumberLessThanAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberLessThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *NumberLessThanAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -6722,7 +6873,7 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6742,9 +6893,10 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) AssignProperties_From_NumberL
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberLessThanAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6768,8 +6920,12 @@ func (filter *NumberLessThanAdvancedFilter_STATUS) AssignProperties_To_NumberLes
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6796,7 +6952,7 @@ type NumberLessThanOrEqualsAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberLessThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *NumberLessThanOrEqualsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -6818,7 +6974,9 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) ConvertToARM(resolved genrun
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Value’:
 	if filter.Value != nil {
@@ -6847,7 +7005,7 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) PopulateFromARM(owner genrun
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6867,9 +7025,10 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) AssignProperties_From_Number
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberLessThanOrEqualsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6893,8 +7052,12 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter) AssignProperties_To_NumberLe
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -6920,7 +7083,7 @@ type NumberLessThanOrEqualsAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Value: The filter value.
 	Value *float64 `json:"value,omitempty"`
@@ -6947,7 +7110,7 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) PopulateFromARM(owner
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Value’:
 	if typedInput.Value != nil {
@@ -6967,9 +7130,10 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) AssignProperties_From
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Value
@@ -6993,8 +7157,12 @@ func (filter *NumberLessThanOrEqualsAdvancedFilter_STATUS) AssignProperties_To_N
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Value
 	if filter.Value != nil {
@@ -7021,7 +7189,7 @@ type NumberNotInAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *NumberNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []float64 `json:"values,omitempty"`
@@ -7043,7 +7211,9 @@ func (filter *NumberNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7071,7 +7241,7 @@ func (filter *NumberNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7090,9 +7260,10 @@ func (filter *NumberNotInAdvancedFilter) AssignProperties_From_NumberNotInAdvanc
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := NumberNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7121,8 +7292,12 @@ func (filter *NumberNotInAdvancedFilter) AssignProperties_To_NumberNotInAdvanced
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -7153,7 +7328,7 @@ type NumberNotInAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType NumberNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *NumberNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []float64 `json:"values,omitempty"`
@@ -7180,7 +7355,7 @@ func (filter *NumberNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7199,9 +7374,10 @@ func (filter *NumberNotInAdvancedFilter_STATUS) AssignProperties_From_NumberNotI
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = NumberNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := NumberNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7230,8 +7406,12 @@ func (filter *NumberNotInAdvancedFilter_STATUS) AssignProperties_To_NumberNotInA
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	if filter.Values != nil {
@@ -7299,7 +7479,7 @@ type StringBeginsWithAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringBeginsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *StringBeginsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -7321,7 +7501,9 @@ func (filter *StringBeginsWithAdvancedFilter) ConvertToARM(resolved genruntime.C
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7349,7 +7531,7 @@ func (filter *StringBeginsWithAdvancedFilter) PopulateFromARM(owner genruntime.A
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7368,9 +7550,10 @@ func (filter *StringBeginsWithAdvancedFilter) AssignProperties_From_StringBegins
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringBeginsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringBeginsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7389,8 +7572,12 @@ func (filter *StringBeginsWithAdvancedFilter) AssignProperties_To_StringBeginsWi
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7411,7 +7598,7 @@ type StringBeginsWithAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringBeginsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *StringBeginsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -7438,7 +7625,7 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) PopulateFromARM(owner genru
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7457,9 +7644,10 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) AssignProperties_From_Strin
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringBeginsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringBeginsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7478,8 +7666,12 @@ func (filter *StringBeginsWithAdvancedFilter_STATUS) AssignProperties_To_StringB
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7501,7 +7693,7 @@ type StringContainsAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringContainsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *StringContainsAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -7523,7 +7715,9 @@ func (filter *StringContainsAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7551,7 +7745,7 @@ func (filter *StringContainsAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7570,9 +7764,10 @@ func (filter *StringContainsAdvancedFilter) AssignProperties_From_StringContains
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringContainsAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringContainsAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7591,8 +7786,12 @@ func (filter *StringContainsAdvancedFilter) AssignProperties_To_StringContainsAd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7613,7 +7812,7 @@ type StringContainsAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringContainsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *StringContainsAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -7640,7 +7839,7 @@ func (filter *StringContainsAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7659,9 +7858,10 @@ func (filter *StringContainsAdvancedFilter_STATUS) AssignProperties_From_StringC
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringContainsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringContainsAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7680,8 +7880,12 @@ func (filter *StringContainsAdvancedFilter_STATUS) AssignProperties_To_StringCon
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7703,7 +7907,7 @@ type StringEndsWithAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringEndsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *StringEndsWithAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -7725,7 +7929,9 @@ func (filter *StringEndsWithAdvancedFilter) ConvertToARM(resolved genruntime.Con
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7753,7 +7959,7 @@ func (filter *StringEndsWithAdvancedFilter) PopulateFromARM(owner genruntime.Arb
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7772,9 +7978,10 @@ func (filter *StringEndsWithAdvancedFilter) AssignProperties_From_StringEndsWith
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringEndsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringEndsWithAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7793,8 +8000,12 @@ func (filter *StringEndsWithAdvancedFilter) AssignProperties_To_StringEndsWithAd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7815,7 +8026,7 @@ type StringEndsWithAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringEndsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *StringEndsWithAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -7842,7 +8053,7 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) PopulateFromARM(owner genrunt
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7861,9 +8072,10 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) AssignProperties_From_StringE
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringEndsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringEndsWithAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7882,8 +8094,12 @@ func (filter *StringEndsWithAdvancedFilter_STATUS) AssignProperties_To_StringEnd
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -7905,7 +8121,7 @@ type StringInAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *StringInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -7927,7 +8143,9 @@ func (filter *StringInAdvancedFilter) ConvertToARM(resolved genruntime.ConvertTo
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -7955,7 +8173,7 @@ func (filter *StringInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitrary
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -7974,9 +8192,10 @@ func (filter *StringInAdvancedFilter) AssignProperties_From_StringInAdvancedFilt
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -7995,8 +8214,12 @@ func (filter *StringInAdvancedFilter) AssignProperties_To_StringInAdvancedFilter
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -8017,7 +8240,7 @@ type StringInAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *StringInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -8044,7 +8267,7 @@ func (filter *StringInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime.Ar
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -8063,9 +8286,10 @@ func (filter *StringInAdvancedFilter_STATUS) AssignProperties_From_StringInAdvan
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -8084,8 +8308,12 @@ func (filter *StringInAdvancedFilter_STATUS) AssignProperties_To_StringInAdvance
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -8107,7 +8335,7 @@ type StringNotInAdvancedFilter struct {
 
 	// +kubebuilder:validation:Required
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
+	OperatorType *StringNotInAdvancedFilter_OperatorType `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -8129,7 +8357,9 @@ func (filter *StringNotInAdvancedFilter) ConvertToARM(resolved genruntime.Conver
 	}
 
 	// Set property ‘OperatorType’:
-	result.OperatorType = filter.OperatorType
+	if filter.OperatorType != nil {
+		result.OperatorType = *filter.OperatorType
+	}
 
 	// Set property ‘Values’:
 	for _, item := range filter.Values {
@@ -8157,7 +8387,7 @@ func (filter *StringNotInAdvancedFilter) PopulateFromARM(owner genruntime.Arbitr
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -8176,9 +8406,10 @@ func (filter *StringNotInAdvancedFilter) AssignProperties_From_StringNotInAdvanc
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		operatorType := StringNotInAdvancedFilter_OperatorType(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -8197,8 +8428,12 @@ func (filter *StringNotInAdvancedFilter) AssignProperties_To_StringNotInAdvanced
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)
@@ -8219,7 +8454,7 @@ type StringNotInAdvancedFilter_STATUS struct {
 	Key *string `json:"key,omitempty"`
 
 	// OperatorType: The operator type used for filtering, e.g., NumberIn, StringContains, BoolEquals and others.
-	OperatorType StringNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
+	OperatorType *StringNotInAdvancedFilter_OperatorType_STATUS `json:"operatorType,omitempty"`
 
 	// Values: The set of filter values.
 	Values []string `json:"values,omitempty"`
@@ -8246,7 +8481,7 @@ func (filter *StringNotInAdvancedFilter_STATUS) PopulateFromARM(owner genruntime
 	}
 
 	// Set property ‘OperatorType’:
-	filter.OperatorType = typedInput.OperatorType
+	filter.OperatorType = &typedInput.OperatorType
 
 	// Set property ‘Values’:
 	for _, item := range typedInput.Values {
@@ -8265,9 +8500,10 @@ func (filter *StringNotInAdvancedFilter_STATUS) AssignProperties_From_StringNotI
 
 	// OperatorType
 	if source.OperatorType != nil {
-		filter.OperatorType = StringNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		operatorType := StringNotInAdvancedFilter_OperatorType_STATUS(*source.OperatorType)
+		filter.OperatorType = &operatorType
 	} else {
-		filter.OperatorType = ""
+		filter.OperatorType = nil
 	}
 
 	// Values
@@ -8286,8 +8522,12 @@ func (filter *StringNotInAdvancedFilter_STATUS) AssignProperties_To_StringNotInA
 	destination.Key = genruntime.ClonePointerToString(filter.Key)
 
 	// OperatorType
-	operatorType := string(filter.OperatorType)
-	destination.OperatorType = &operatorType
+	if filter.OperatorType != nil {
+		operatorType := string(*filter.OperatorType)
+		destination.OperatorType = &operatorType
+	} else {
+		destination.OperatorType = nil
+	}
 
 	// Values
 	destination.Values = genruntime.CloneSliceOfString(filter.Values)

--- a/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen_test.go
+++ b/v2/api/eventgrid/v1beta20200601/event_subscription_types_gen_test.go
@@ -1735,7 +1735,7 @@ func AzureFunctionEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_AzureFunction)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_AzureFunction))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 }
@@ -1840,7 +1840,7 @@ func AzureFunctionEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAzureFunctionEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_STATUS_AzureFunction)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(AzureFunctionEventSubscriptionDestination_EndpointType_STATUS_AzureFunction))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
@@ -1946,7 +1946,7 @@ func EventHubEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_EventHub)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_EventHub))
 }
 
 func Test_EventHubEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2049,7 +2049,7 @@ func EventHubEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForEventHubEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_STATUS_EventHub)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(EventHubEventSubscriptionDestination_EndpointType_STATUS_EventHub))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2153,7 +2153,7 @@ func HybridConnectionEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_HybridConnection)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_HybridConnection))
 }
 
 func Test_HybridConnectionEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2256,7 +2256,7 @@ func HybridConnectionEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForHybridConnectionEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_STATUS_HybridConnection)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(HybridConnectionEventSubscriptionDestination_EndpointType_STATUS_HybridConnection))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2360,7 +2360,7 @@ func ServiceBusQueueEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_ServiceBusQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_ServiceBusQueue))
 }
 
 func Test_ServiceBusQueueEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2463,7 +2463,7 @@ func ServiceBusQueueEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusQueueEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS_ServiceBusQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusQueueEventSubscriptionDestination_EndpointType_STATUS_ServiceBusQueue))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2567,7 +2567,7 @@ func ServiceBusTopicEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_ServiceBusTopic)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_ServiceBusTopic))
 }
 
 func Test_ServiceBusTopicEventSubscriptionDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2670,7 +2670,7 @@ func ServiceBusTopicEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForServiceBusTopicEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS_ServiceBusTopic)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(ServiceBusTopicEventSubscriptionDestination_EndpointType_STATUS_ServiceBusTopic))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2775,7 +2775,7 @@ func StorageBlobDeadLetterDestinationGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination(gens map[string]gopter.Gen) {
 	gens["BlobContainerName"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_StorageBlob)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_StorageBlob))
 }
 
 func Test_StorageBlobDeadLetterDestination_STATUS_WhenPropertiesConverted_RoundTripsWithoutLoss(t *testing.T) {
@@ -2879,7 +2879,7 @@ func StorageBlobDeadLetterDestination_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageBlobDeadLetterDestination_STATUS(gens map[string]gopter.Gen) {
 	gens["BlobContainerName"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_STATUS_StorageBlob)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageBlobDeadLetterDestination_EndpointType_STATUS_StorageBlob))
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -2983,7 +2983,7 @@ func StorageQueueEventSubscriptionDestinationGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_StorageQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_StorageQueue))
 	gens["QueueName"] = gen.PtrOf(gen.AlphaString())
 }
 
@@ -3087,7 +3087,7 @@ func StorageQueueEventSubscriptionDestination_STATUSGenerator() gopter.Gen {
 
 // AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStorageQueueEventSubscriptionDestination_STATUS(gens map[string]gopter.Gen) {
-	gens["EndpointType"] = gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_STATUS_StorageQueue)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(StorageQueueEventSubscriptionDestination_EndpointType_STATUS_StorageQueue))
 	gens["QueueName"] = gen.PtrOf(gen.AlphaString())
 	gens["ResourceId"] = gen.PtrOf(gen.AlphaString())
 }
@@ -3194,7 +3194,7 @@ func WebHookEventSubscriptionDestinationGenerator() gopter.Gen {
 func AddIndependentPropertyGeneratorsForWebHookEventSubscriptionDestination(gens map[string]gopter.Gen) {
 	gens["AzureActiveDirectoryApplicationIdOrUri"] = gen.PtrOf(gen.AlphaString())
 	gens["AzureActiveDirectoryTenantId"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_WebHook)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_WebHook))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 }
@@ -3302,7 +3302,7 @@ func AddIndependentPropertyGeneratorsForWebHookEventSubscriptionDestination_STAT
 	gens["AzureActiveDirectoryApplicationIdOrUri"] = gen.PtrOf(gen.AlphaString())
 	gens["AzureActiveDirectoryTenantId"] = gen.PtrOf(gen.AlphaString())
 	gens["EndpointBaseUrl"] = gen.PtrOf(gen.AlphaString())
-	gens["EndpointType"] = gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_STATUS_WebHook)
+	gens["EndpointType"] = gen.PtrOf(gen.OneConstOf(WebHookEventSubscriptionDestination_EndpointType_STATUS_WebHook))
 	gens["MaxEventsPerBatch"] = gen.PtrOf(gen.Int())
 	gens["PreferredBatchSizeInKilobytes"] = gen.PtrOf(gen.Int())
 }
@@ -3408,7 +3408,7 @@ func BoolEqualsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_BoolEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_BoolEquals))
 	gens["Value"] = gen.PtrOf(gen.Bool())
 }
 
@@ -3513,7 +3513,7 @@ func BoolEqualsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForBoolEqualsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_STATUS_BoolEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(BoolEqualsAdvancedFilter_OperatorType_STATUS_BoolEquals))
 	gens["Value"] = gen.PtrOf(gen.Bool())
 }
 
@@ -3618,7 +3618,7 @@ func NumberGreaterThanAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_NumberGreaterThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_NumberGreaterThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -3723,7 +3723,7 @@ func NumberGreaterThanAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_STATUS_NumberGreaterThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanAdvancedFilter_OperatorType_STATUS_NumberGreaterThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -3828,7 +3828,7 @@ func NumberGreaterThanOrEqualsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_NumberGreaterThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_NumberGreaterThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -3933,7 +3933,7 @@ func NumberGreaterThanOrEqualsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberGreaterThanOrEqualsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberGreaterThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberGreaterThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberGreaterThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4038,7 +4038,7 @@ func NumberInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberInAdvancedFilter_OperatorType_NumberIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberInAdvancedFilter_OperatorType_NumberIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4143,7 +4143,7 @@ func NumberInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberInAdvancedFilter_OperatorType_STATUS_NumberIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberInAdvancedFilter_OperatorType_STATUS_NumberIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4248,7 +4248,7 @@ func NumberLessThanAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_NumberLessThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_NumberLessThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4353,7 +4353,7 @@ func NumberLessThanAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_STATUS_NumberLessThan)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanAdvancedFilter_OperatorType_STATUS_NumberLessThan))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4458,7 +4458,7 @@ func NumberLessThanOrEqualsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_NumberLessThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_NumberLessThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4563,7 +4563,7 @@ func NumberLessThanOrEqualsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberLessThanOrEqualsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberLessThanOrEquals)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberLessThanOrEqualsAdvancedFilter_OperatorType_STATUS_NumberLessThanOrEquals))
 	gens["Value"] = gen.PtrOf(gen.Float64())
 }
 
@@ -4668,7 +4668,7 @@ func NumberNotInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_NumberNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_NumberNotIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4773,7 +4773,7 @@ func NumberNotInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForNumberNotInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_STATUS_NumberNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(NumberNotInAdvancedFilter_OperatorType_STATUS_NumberNotIn))
 	gens["Values"] = gen.SliceOf(gen.Float64())
 }
 
@@ -4878,7 +4878,7 @@ func StringBeginsWithAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_StringBeginsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_StringBeginsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -4983,7 +4983,7 @@ func StringBeginsWithAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringBeginsWithAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_STATUS_StringBeginsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringBeginsWithAdvancedFilter_OperatorType_STATUS_StringBeginsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5088,7 +5088,7 @@ func StringContainsAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_StringContains)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_StringContains))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5193,7 +5193,7 @@ func StringContainsAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringContainsAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_STATUS_StringContains)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringContainsAdvancedFilter_OperatorType_STATUS_StringContains))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5298,7 +5298,7 @@ func StringEndsWithAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_StringEndsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_StringEndsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5403,7 +5403,7 @@ func StringEndsWithAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringEndsWithAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_STATUS_StringEndsWith)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringEndsWithAdvancedFilter_OperatorType_STATUS_StringEndsWith))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5508,7 +5508,7 @@ func StringInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringInAdvancedFilter_OperatorType_StringIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringInAdvancedFilter_OperatorType_StringIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5613,7 +5613,7 @@ func StringInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringInAdvancedFilter_OperatorType_STATUS_StringIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringInAdvancedFilter_OperatorType_STATUS_StringIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5718,7 +5718,7 @@ func StringNotInAdvancedFilterGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_StringNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_StringNotIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }
 
@@ -5823,6 +5823,6 @@ func StringNotInAdvancedFilter_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForStringNotInAdvancedFilter_STATUS(gens map[string]gopter.Gen) {
 	gens["Key"] = gen.PtrOf(gen.AlphaString())
-	gens["OperatorType"] = gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_STATUS_StringNotIn)
+	gens["OperatorType"] = gen.PtrOf(gen.OneConstOf(StringNotInAdvancedFilter_OperatorType_STATUS_StringNotIn))
 	gens["Values"] = gen.SliceOf(gen.AlphaString())
 }

--- a/v2/api/eventgrid/v1beta20200601/structure.txt
+++ b/v2/api/eventgrid/v1beta20200601/structure.txt
@@ -25,7 +25,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │   │   │       │   └── SourceField: *string
 │   │   │       ├── Id: *Object (1 property)
 │   │   │       │   └── SourceField: *string
-│   │   │       ├── InputSchemaMappingType: Enum (1 value)
+│   │   │       ├── InputSchemaMappingType: *Enum (1 value)
 │   │   │       │   └── "Json"
 │   │   │       ├── Subject: *Object (2 properties)
 │   │   │       │   ├── DefaultValue: *string
@@ -62,7 +62,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │       │       │   └── SourceField: *string
 │       │       ├── Id: *Object (1 property)
 │       │       │   └── SourceField: *string
-│       │       ├── InputSchemaMappingType: Enum (1 value)
+│       │       ├── InputSchemaMappingType: *Enum (1 value)
 │       │       │   └── "Json"
 │       │       ├── Subject: *Object (2 properties)
 │       │       │   ├── DefaultValue: *string
@@ -268,41 +268,41 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │   │   ├── DeadLetterDestination: *Object (1 property)
 │   │   │   └── StorageBlob: *Object (3 properties)
 │   │   │       ├── BlobContainerName: *string
-│   │   │       ├── EndpointType: Enum (1 value)
+│   │   │       ├── EndpointType: *Enum (1 value)
 │   │   │       │   └── "StorageBlob"
 │   │   │       └── ResourceReference: *genruntime.ResourceReference
 │   │   ├── Destination: *Object (7 properties)
 │   │   │   ├── AzureFunction: *Object (4 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "AzureFunction"
 │   │   │   │   ├── MaxEventsPerBatch: *int
 │   │   │   │   ├── PreferredBatchSizeInKilobytes: *int
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── EventHub: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "EventHub"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── HybridConnection: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "HybridConnection"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── ServiceBusQueue: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "ServiceBusQueue"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── ServiceBusTopic: *Object (2 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "ServiceBusTopic"
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── StorageQueue: *Object (3 properties)
-│   │   │   │   ├── EndpointType: Enum (1 value)
+│   │   │   │   ├── EndpointType: *Enum (1 value)
 │   │   │   │   │   └── "StorageQueue"
 │   │   │   │   ├── QueueName: *string
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   └── WebHook: *Object (6 properties)
 │   │   │       ├── AzureActiveDirectoryApplicationIdOrUri: *string
 │   │   │       ├── AzureActiveDirectoryTenantId: *string
-│   │   │       ├── EndpointType: Enum (1 value)
+│   │   │       ├── EndpointType: *Enum (1 value)
 │   │   │       │   └── "WebHook"
 │   │   │       ├── EndpointUrl: *genruntime.SecretReference
 │   │   │       ├── MaxEventsPerBatch: *int
@@ -316,62 +316,62 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │   │   │   ├── AdvancedFilters: Object (12 properties)[]
 │   │   │   │   ├── BoolEquals: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "BoolEquals"
 │   │   │   │   │   └── Value: *bool
 │   │   │   │   ├── NumberGreaterThan: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberGreaterThan"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberGreaterThanOrEquals: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberGreaterThanOrEquals"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberIn: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberIn"
 │   │   │   │   │   └── Values: float64[]
 │   │   │   │   ├── NumberLessThan: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberLessThan"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberLessThanOrEquals: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberLessThanOrEquals"
 │   │   │   │   │   └── Value: *float64
 │   │   │   │   ├── NumberNotIn: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "NumberNotIn"
 │   │   │   │   │   └── Values: float64[]
 │   │   │   │   ├── StringBeginsWith: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringBeginsWith"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   ├── StringContains: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringContains"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   ├── StringEndsWith: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringEndsWith"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   ├── StringIn: *Object (3 properties)
 │   │   │   │   │   ├── Key: *string
-│   │   │   │   │   ├── OperatorType: Enum (1 value)
+│   │   │   │   │   ├── OperatorType: *Enum (1 value)
 │   │   │   │   │   │   └── "StringIn"
 │   │   │   │   │   └── Values: string[]
 │   │   │   │   └── StringNotIn: *Object (3 properties)
 │   │   │   │       ├── Key: *string
-│   │   │   │       ├── OperatorType: Enum (1 value)
+│   │   │   │       ├── OperatorType: *Enum (1 value)
 │   │   │   │       │   └── "StringNotIn"
 │   │   │   │       └── Values: string[]
 │   │   │   ├── IncludedEventTypes: string[]
@@ -388,34 +388,34 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │       ├── DeadLetterDestination: *Object (1 property)
 │       │   └── StorageBlob: *Object (3 properties)
 │       │       ├── BlobContainerName: *string
-│       │       ├── EndpointType: Enum (1 value)
+│       │       ├── EndpointType: *Enum (1 value)
 │       │       │   └── "StorageBlob"
 │       │       └── ResourceId: *string
 │       ├── Destination: *Object (7 properties)
 │       │   ├── AzureFunction: *Object (4 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "AzureFunction"
 │       │   │   ├── MaxEventsPerBatch: *int
 │       │   │   ├── PreferredBatchSizeInKilobytes: *int
 │       │   │   └── ResourceId: *string
 │       │   ├── EventHub: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "EventHub"
 │       │   │   └── ResourceId: *string
 │       │   ├── HybridConnection: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "HybridConnection"
 │       │   │   └── ResourceId: *string
 │       │   ├── ServiceBusQueue: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "ServiceBusQueue"
 │       │   │   └── ResourceId: *string
 │       │   ├── ServiceBusTopic: *Object (2 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "ServiceBusTopic"
 │       │   │   └── ResourceId: *string
 │       │   ├── StorageQueue: *Object (3 properties)
-│       │   │   ├── EndpointType: Enum (1 value)
+│       │   │   ├── EndpointType: *Enum (1 value)
 │       │   │   │   └── "StorageQueue"
 │       │   │   ├── QueueName: *string
 │       │   │   └── ResourceId: *string
@@ -423,7 +423,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │       │       ├── AzureActiveDirectoryApplicationIdOrUri: *string
 │       │       ├── AzureActiveDirectoryTenantId: *string
 │       │       ├── EndpointBaseUrl: *string
-│       │       ├── EndpointType: Enum (1 value)
+│       │       ├── EndpointType: *Enum (1 value)
 │       │       │   └── "WebHook"
 │       │       ├── MaxEventsPerBatch: *int
 │       │       └── PreferredBatchSizeInKilobytes: *int
@@ -436,62 +436,62 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │       │   ├── AdvancedFilters: Object (12 properties)[]
 │       │   │   ├── BoolEquals: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "BoolEquals"
 │       │   │   │   └── Value: *bool
 │       │   │   ├── NumberGreaterThan: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberGreaterThan"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberGreaterThanOrEquals: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberGreaterThanOrEquals"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberIn: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberIn"
 │       │   │   │   └── Values: float64[]
 │       │   │   ├── NumberLessThan: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberLessThan"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberLessThanOrEquals: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberLessThanOrEquals"
 │       │   │   │   └── Value: *float64
 │       │   │   ├── NumberNotIn: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "NumberNotIn"
 │       │   │   │   └── Values: float64[]
 │       │   │   ├── StringBeginsWith: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringBeginsWith"
 │       │   │   │   └── Values: string[]
 │       │   │   ├── StringContains: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringContains"
 │       │   │   │   └── Values: string[]
 │       │   │   ├── StringEndsWith: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringEndsWith"
 │       │   │   │   └── Values: string[]
 │       │   │   ├── StringIn: *Object (3 properties)
 │       │   │   │   ├── Key: *string
-│       │   │   │   ├── OperatorType: Enum (1 value)
+│       │   │   │   ├── OperatorType: *Enum (1 value)
 │       │   │   │   │   └── "StringIn"
 │       │   │   │   └── Values: string[]
 │       │   │   └── StringNotIn: *Object (3 properties)
 │       │   │       ├── Key: *string
-│       │   │       ├── OperatorType: Enum (1 value)
+│       │   │       ├── OperatorType: *Enum (1 value)
 │       │   │       │   └── "StringNotIn"
 │       │   │       └── Values: string[]
 │       │   ├── IncludedEventTypes: string[]
@@ -835,7 +835,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │   │   │       │   └── SourceField: *string
 │   │   │       ├── Id: *Object (1 property)
 │   │   │       │   └── SourceField: *string
-│   │   │       ├── InputSchemaMappingType: Enum (1 value)
+│   │   │       ├── InputSchemaMappingType: *Enum (1 value)
 │   │   │       │   └── "Json"
 │   │   │       ├── Subject: *Object (2 properties)
 │   │   │       │   ├── DefaultValue: *string
@@ -872,7 +872,7 @@ github.com/Azure/azure-service-operator/v2/api/eventgrid/v1beta20200601
 │       │       │   └── SourceField: *string
 │       │       ├── Id: *Object (1 property)
 │       │       │   └── SourceField: *string
-│       │       ├── InputSchemaMappingType: Enum (1 value)
+│       │       ├── InputSchemaMappingType: *Enum (1 value)
 │       │       │   └── "Json"
 │       │       ├── Subject: *Object (2 properties)
 │       │       │   ├── DefaultValue: *string

--- a/v2/api/machinelearningservices/v1beta20210701/structure.txt
+++ b/v2/api/machinelearningservices/v1beta20210701/structure.txt
@@ -357,7 +357,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   ├── Properties: *Object (10 properties)
 │   │   │   ├── AKS: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "AKS"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -395,7 +395,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── AmlCompute: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "AmlCompute"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -428,7 +428,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── ComputeInstance: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "ComputeInstance"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -465,14 +465,14 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── DataFactory: *Object (5 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "DataFactory"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── DataLakeAnalytics: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "DataLakeAnalytics"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -481,7 +481,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── Databricks: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "Databricks"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -491,7 +491,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── HDInsight: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "HDInsight"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -506,7 +506,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── Kubernetes: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "Kubernetes"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -526,7 +526,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   ├── SynapseSpark: *Object (6 properties)
 │   │   │   │   ├── ComputeLocation: *string
-│   │   │   │   ├── ComputeType: Enum (1 value)
+│   │   │   │   ├── ComputeType: *Enum (1 value)
 │   │   │   │   │   └── "SynapseSpark"
 │   │   │   │   ├── Description: *string
 │   │   │   │   ├── DisableLocalAuth: *bool
@@ -549,7 +549,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │   │   │   │   └── ResourceReference: *genruntime.ResourceReference
 │   │   │   └── VirtualMachine: *Object (6 properties)
 │   │   │       ├── ComputeLocation: *string
-│   │   │       ├── ComputeType: Enum (1 value)
+│   │   │       ├── ComputeType: *Enum (1 value)
 │   │   │       │   └── "VirtualMachine"
 │   │   │       ├── Description: *string
 │   │   │       ├── DisableLocalAuth: *bool
@@ -603,7 +603,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       ├── Properties: *Object (10 properties)
 │       │   ├── AKS: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "AKS"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -667,7 +667,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── AmlCompute: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "AmlCompute"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -754,7 +754,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── ComputeInstance: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "ComputeInstance"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -878,7 +878,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── DataFactory: *Object (10 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "DataFactory"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -911,7 +911,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── DataLakeAnalytics: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "DataLakeAnalytics"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -946,7 +946,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── Databricks: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "Databricks"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -982,7 +982,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── HDInsight: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "HDInsight"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -1023,7 +1023,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── Kubernetes: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "Kubernetes"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -1067,7 +1067,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   ├── SynapseSpark: *Object (11 properties)
 │       │   │   ├── ComputeLocation: *string
-│       │   │   ├── ComputeType: Enum (1 value)
+│       │   │   ├── ComputeType: *Enum (1 value)
 │       │   │   │   └── "SynapseSpark"
 │       │   │   ├── CreatedOn: *string
 │       │   │   ├── Description: *string
@@ -1116,7 +1116,7 @@ github.com/Azure/azure-service-operator/v2/api/machinelearningservices/v1beta202
 │       │   │   └── ResourceId: *string
 │       │   └── VirtualMachine: *Object (11 properties)
 │       │       ├── ComputeLocation: *string
-│       │       ├── ComputeType: Enum (1 value)
+│       │       ├── ComputeType: *Enum (1 value)
 │       │       │   └── "VirtualMachine"
 │       │       ├── CreatedOn: *string
 │       │       ├── Description: *string

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen.go
@@ -2009,7 +2009,7 @@ type AKS struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType AKS_ComputeType `json:"computeType,omitempty"`
+	ComputeType *AKS_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -2041,7 +2041,9 @@ func (aks *AKS) ConvertToARM(resolved genruntime.ConvertToARMResolvedDetails) (i
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = aks.ComputeType
+	if aks.ComputeType != nil {
+		result.ComputeType = *aks.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if aks.Description != nil {
@@ -2096,7 +2098,7 @@ func (aks *AKS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference, armInp
 	}
 
 	// Set property ‘ComputeType’:
-	aks.ComputeType = typedInput.ComputeType
+	aks.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -2135,9 +2137,10 @@ func (aks *AKS) AssignProperties_From_AKS(source *v20210701s.AKS) error {
 
 	// ComputeType
 	if source.ComputeType != nil {
-		aks.ComputeType = AKS_ComputeType(*source.ComputeType)
+		computeType := AKS_ComputeType(*source.ComputeType)
+		aks.ComputeType = &computeType
 	} else {
-		aks.ComputeType = ""
+		aks.ComputeType = nil
 	}
 
 	// Description
@@ -2184,8 +2187,12 @@ func (aks *AKS) AssignProperties_To_AKS(destination *v20210701s.AKS) error {
 	destination.ComputeLocation = genruntime.ClonePointerToString(aks.ComputeLocation)
 
 	// ComputeType
-	computeType := string(aks.ComputeType)
-	destination.ComputeType = &computeType
+	if aks.ComputeType != nil {
+		computeType := string(*aks.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(aks.Description)
@@ -2234,7 +2241,7 @@ type AKS_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType AKS_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *AKS_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -2288,7 +2295,7 @@ func (aks *AKS_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwnerReference,
 	}
 
 	// Set property ‘ComputeType’:
-	aks.ComputeType = typedInput.ComputeType
+	aks.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -2365,9 +2372,10 @@ func (aks *AKS_STATUS) AssignProperties_From_AKS_STATUS(source *v20210701s.AKS_S
 
 	// ComputeType
 	if source.ComputeType != nil {
-		aks.ComputeType = AKS_ComputeType_STATUS(*source.ComputeType)
+		computeType := AKS_ComputeType_STATUS(*source.ComputeType)
+		aks.ComputeType = &computeType
 	} else {
-		aks.ComputeType = ""
+		aks.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -2449,8 +2457,12 @@ func (aks *AKS_STATUS) AssignProperties_To_AKS_STATUS(destination *v20210701s.AK
 	destination.ComputeLocation = genruntime.ClonePointerToString(aks.ComputeLocation)
 
 	// ComputeType
-	computeType := string(aks.ComputeType)
-	destination.ComputeType = &computeType
+	if aks.ComputeType != nil {
+		computeType := string(*aks.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(aks.CreatedOn)
@@ -2535,7 +2547,7 @@ type AmlCompute struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType AmlCompute_ComputeType `json:"computeType,omitempty"`
+	ComputeType *AmlCompute_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -2567,7 +2579,9 @@ func (compute *AmlCompute) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = compute.ComputeType
+	if compute.ComputeType != nil {
+		result.ComputeType = *compute.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if compute.Description != nil {
@@ -2622,7 +2636,7 @@ func (compute *AmlCompute) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 	}
 
 	// Set property ‘ComputeType’:
-	compute.ComputeType = typedInput.ComputeType
+	compute.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -2661,9 +2675,10 @@ func (compute *AmlCompute) AssignProperties_From_AmlCompute(source *v20210701s.A
 
 	// ComputeType
 	if source.ComputeType != nil {
-		compute.ComputeType = AmlCompute_ComputeType(*source.ComputeType)
+		computeType := AmlCompute_ComputeType(*source.ComputeType)
+		compute.ComputeType = &computeType
 	} else {
-		compute.ComputeType = ""
+		compute.ComputeType = nil
 	}
 
 	// Description
@@ -2710,8 +2725,12 @@ func (compute *AmlCompute) AssignProperties_To_AmlCompute(destination *v20210701
 	destination.ComputeLocation = genruntime.ClonePointerToString(compute.ComputeLocation)
 
 	// ComputeType
-	computeType := string(compute.ComputeType)
-	destination.ComputeType = &computeType
+	if compute.ComputeType != nil {
+		computeType := string(*compute.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(compute.Description)
@@ -2760,7 +2779,7 @@ type AmlCompute_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType AmlCompute_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *AmlCompute_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -2814,7 +2833,7 @@ func (compute *AmlCompute_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 	}
 
 	// Set property ‘ComputeType’:
-	compute.ComputeType = typedInput.ComputeType
+	compute.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -2891,9 +2910,10 @@ func (compute *AmlCompute_STATUS) AssignProperties_From_AmlCompute_STATUS(source
 
 	// ComputeType
 	if source.ComputeType != nil {
-		compute.ComputeType = AmlCompute_ComputeType_STATUS(*source.ComputeType)
+		computeType := AmlCompute_ComputeType_STATUS(*source.ComputeType)
+		compute.ComputeType = &computeType
 	} else {
-		compute.ComputeType = ""
+		compute.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -2975,8 +2995,12 @@ func (compute *AmlCompute_STATUS) AssignProperties_To_AmlCompute_STATUS(destinat
 	destination.ComputeLocation = genruntime.ClonePointerToString(compute.ComputeLocation)
 
 	// ComputeType
-	computeType := string(compute.ComputeType)
-	destination.ComputeType = &computeType
+	if compute.ComputeType != nil {
+		computeType := string(*compute.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(compute.CreatedOn)
@@ -3061,7 +3085,7 @@ type ComputeInstance struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType ComputeInstance_ComputeType `json:"computeType,omitempty"`
+	ComputeType *ComputeInstance_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -3093,7 +3117,9 @@ func (instance *ComputeInstance) ConvertToARM(resolved genruntime.ConvertToARMRe
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = instance.ComputeType
+	if instance.ComputeType != nil {
+		result.ComputeType = *instance.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if instance.Description != nil {
@@ -3148,7 +3174,7 @@ func (instance *ComputeInstance) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘ComputeType’:
-	instance.ComputeType = typedInput.ComputeType
+	instance.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -3187,9 +3213,10 @@ func (instance *ComputeInstance) AssignProperties_From_ComputeInstance(source *v
 
 	// ComputeType
 	if source.ComputeType != nil {
-		instance.ComputeType = ComputeInstance_ComputeType(*source.ComputeType)
+		computeType := ComputeInstance_ComputeType(*source.ComputeType)
+		instance.ComputeType = &computeType
 	} else {
-		instance.ComputeType = ""
+		instance.ComputeType = nil
 	}
 
 	// Description
@@ -3236,8 +3263,12 @@ func (instance *ComputeInstance) AssignProperties_To_ComputeInstance(destination
 	destination.ComputeLocation = genruntime.ClonePointerToString(instance.ComputeLocation)
 
 	// ComputeType
-	computeType := string(instance.ComputeType)
-	destination.ComputeType = &computeType
+	if instance.ComputeType != nil {
+		computeType := string(*instance.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(instance.Description)
@@ -3286,7 +3317,7 @@ type ComputeInstance_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType ComputeInstance_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *ComputeInstance_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -3340,7 +3371,7 @@ func (instance *ComputeInstance_STATUS) PopulateFromARM(owner genruntime.Arbitra
 	}
 
 	// Set property ‘ComputeType’:
-	instance.ComputeType = typedInput.ComputeType
+	instance.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -3417,9 +3448,10 @@ func (instance *ComputeInstance_STATUS) AssignProperties_From_ComputeInstance_ST
 
 	// ComputeType
 	if source.ComputeType != nil {
-		instance.ComputeType = ComputeInstance_ComputeType_STATUS(*source.ComputeType)
+		computeType := ComputeInstance_ComputeType_STATUS(*source.ComputeType)
+		instance.ComputeType = &computeType
 	} else {
-		instance.ComputeType = ""
+		instance.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -3501,8 +3533,12 @@ func (instance *ComputeInstance_STATUS) AssignProperties_To_ComputeInstance_STAT
 	destination.ComputeLocation = genruntime.ClonePointerToString(instance.ComputeLocation)
 
 	// ComputeType
-	computeType := string(instance.ComputeType)
-	destination.ComputeType = &computeType
+	if instance.ComputeType != nil {
+		computeType := string(*instance.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(instance.CreatedOn)
@@ -3587,7 +3623,7 @@ type Databricks struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType Databricks_ComputeType `json:"computeType,omitempty"`
+	ComputeType *Databricks_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -3617,7 +3653,9 @@ func (databricks *Databricks) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = databricks.ComputeType
+	if databricks.ComputeType != nil {
+		result.ComputeType = *databricks.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if databricks.Description != nil {
@@ -3672,7 +3710,7 @@ func (databricks *Databricks) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 	}
 
 	// Set property ‘ComputeType’:
-	databricks.ComputeType = typedInput.ComputeType
+	databricks.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -3711,9 +3749,10 @@ func (databricks *Databricks) AssignProperties_From_Databricks(source *v20210701
 
 	// ComputeType
 	if source.ComputeType != nil {
-		databricks.ComputeType = Databricks_ComputeType(*source.ComputeType)
+		computeType := Databricks_ComputeType(*source.ComputeType)
+		databricks.ComputeType = &computeType
 	} else {
-		databricks.ComputeType = ""
+		databricks.ComputeType = nil
 	}
 
 	// Description
@@ -3760,8 +3799,12 @@ func (databricks *Databricks) AssignProperties_To_Databricks(destination *v20210
 	destination.ComputeLocation = genruntime.ClonePointerToString(databricks.ComputeLocation)
 
 	// ComputeType
-	computeType := string(databricks.ComputeType)
-	destination.ComputeType = &computeType
+	if databricks.ComputeType != nil {
+		computeType := string(*databricks.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(databricks.Description)
@@ -3810,7 +3853,7 @@ type Databricks_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType Databricks_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *Databricks_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -3862,7 +3905,7 @@ func (databricks *Databricks_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 	}
 
 	// Set property ‘ComputeType’:
-	databricks.ComputeType = typedInput.ComputeType
+	databricks.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -3939,9 +3982,10 @@ func (databricks *Databricks_STATUS) AssignProperties_From_Databricks_STATUS(sou
 
 	// ComputeType
 	if source.ComputeType != nil {
-		databricks.ComputeType = Databricks_ComputeType_STATUS(*source.ComputeType)
+		computeType := Databricks_ComputeType_STATUS(*source.ComputeType)
+		databricks.ComputeType = &computeType
 	} else {
-		databricks.ComputeType = ""
+		databricks.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -4023,8 +4067,12 @@ func (databricks *Databricks_STATUS) AssignProperties_To_Databricks_STATUS(desti
 	destination.ComputeLocation = genruntime.ClonePointerToString(databricks.ComputeLocation)
 
 	// ComputeType
-	computeType := string(databricks.ComputeType)
-	destination.ComputeType = &computeType
+	if databricks.ComputeType != nil {
+		computeType := string(*databricks.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(databricks.CreatedOn)
@@ -4109,7 +4157,7 @@ type DataFactory struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType DataFactory_ComputeType `json:"computeType,omitempty"`
+	ComputeType *DataFactory_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -4138,7 +4186,9 @@ func (factory *DataFactory) ConvertToARM(resolved genruntime.ConvertToARMResolve
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = factory.ComputeType
+	if factory.ComputeType != nil {
+		result.ComputeType = *factory.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if factory.Description != nil {
@@ -4183,7 +4233,7 @@ func (factory *DataFactory) PopulateFromARM(owner genruntime.ArbitraryOwnerRefer
 	}
 
 	// Set property ‘ComputeType’:
-	factory.ComputeType = typedInput.ComputeType
+	factory.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -4211,9 +4261,10 @@ func (factory *DataFactory) AssignProperties_From_DataFactory(source *v20210701s
 
 	// ComputeType
 	if source.ComputeType != nil {
-		factory.ComputeType = DataFactory_ComputeType(*source.ComputeType)
+		computeType := DataFactory_ComputeType(*source.ComputeType)
+		factory.ComputeType = &computeType
 	} else {
-		factory.ComputeType = ""
+		factory.ComputeType = nil
 	}
 
 	// Description
@@ -4248,8 +4299,12 @@ func (factory *DataFactory) AssignProperties_To_DataFactory(destination *v202107
 	destination.ComputeLocation = genruntime.ClonePointerToString(factory.ComputeLocation)
 
 	// ComputeType
-	computeType := string(factory.ComputeType)
-	destination.ComputeType = &computeType
+	if factory.ComputeType != nil {
+		computeType := string(*factory.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(factory.Description)
@@ -4286,7 +4341,7 @@ type DataFactory_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType DataFactory_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *DataFactory_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -4337,7 +4392,7 @@ func (factory *DataFactory_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwn
 	}
 
 	// Set property ‘ComputeType’:
-	factory.ComputeType = typedInput.ComputeType
+	factory.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -4403,9 +4458,10 @@ func (factory *DataFactory_STATUS) AssignProperties_From_DataFactory_STATUS(sour
 
 	// ComputeType
 	if source.ComputeType != nil {
-		factory.ComputeType = DataFactory_ComputeType_STATUS(*source.ComputeType)
+		computeType := DataFactory_ComputeType_STATUS(*source.ComputeType)
+		factory.ComputeType = &computeType
 	} else {
-		factory.ComputeType = ""
+		factory.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -4475,8 +4531,12 @@ func (factory *DataFactory_STATUS) AssignProperties_To_DataFactory_STATUS(destin
 	destination.ComputeLocation = genruntime.ClonePointerToString(factory.ComputeLocation)
 
 	// ComputeType
-	computeType := string(factory.ComputeType)
-	destination.ComputeType = &computeType
+	if factory.ComputeType != nil {
+		computeType := string(*factory.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(factory.CreatedOn)
@@ -4549,7 +4609,7 @@ type DataLakeAnalytics struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType DataLakeAnalytics_ComputeType `json:"computeType,omitempty"`
+	ComputeType *DataLakeAnalytics_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -4579,7 +4639,9 @@ func (analytics *DataLakeAnalytics) ConvertToARM(resolved genruntime.ConvertToAR
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = analytics.ComputeType
+	if analytics.ComputeType != nil {
+		result.ComputeType = *analytics.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if analytics.Description != nil {
@@ -4634,7 +4696,7 @@ func (analytics *DataLakeAnalytics) PopulateFromARM(owner genruntime.ArbitraryOw
 	}
 
 	// Set property ‘ComputeType’:
-	analytics.ComputeType = typedInput.ComputeType
+	analytics.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -4673,9 +4735,10 @@ func (analytics *DataLakeAnalytics) AssignProperties_From_DataLakeAnalytics(sour
 
 	// ComputeType
 	if source.ComputeType != nil {
-		analytics.ComputeType = DataLakeAnalytics_ComputeType(*source.ComputeType)
+		computeType := DataLakeAnalytics_ComputeType(*source.ComputeType)
+		analytics.ComputeType = &computeType
 	} else {
-		analytics.ComputeType = ""
+		analytics.ComputeType = nil
 	}
 
 	// Description
@@ -4722,8 +4785,12 @@ func (analytics *DataLakeAnalytics) AssignProperties_To_DataLakeAnalytics(destin
 	destination.ComputeLocation = genruntime.ClonePointerToString(analytics.ComputeLocation)
 
 	// ComputeType
-	computeType := string(analytics.ComputeType)
-	destination.ComputeType = &computeType
+	if analytics.ComputeType != nil {
+		computeType := string(*analytics.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(analytics.Description)
@@ -4772,7 +4839,7 @@ type DataLakeAnalytics_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType DataLakeAnalytics_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *DataLakeAnalytics_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -4824,7 +4891,7 @@ func (analytics *DataLakeAnalytics_STATUS) PopulateFromARM(owner genruntime.Arbi
 	}
 
 	// Set property ‘ComputeType’:
-	analytics.ComputeType = typedInput.ComputeType
+	analytics.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -4901,9 +4968,10 @@ func (analytics *DataLakeAnalytics_STATUS) AssignProperties_From_DataLakeAnalyti
 
 	// ComputeType
 	if source.ComputeType != nil {
-		analytics.ComputeType = DataLakeAnalytics_ComputeType_STATUS(*source.ComputeType)
+		computeType := DataLakeAnalytics_ComputeType_STATUS(*source.ComputeType)
+		analytics.ComputeType = &computeType
 	} else {
-		analytics.ComputeType = ""
+		analytics.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -4985,8 +5053,12 @@ func (analytics *DataLakeAnalytics_STATUS) AssignProperties_To_DataLakeAnalytics
 	destination.ComputeLocation = genruntime.ClonePointerToString(analytics.ComputeLocation)
 
 	// ComputeType
-	computeType := string(analytics.ComputeType)
-	destination.ComputeType = &computeType
+	if analytics.ComputeType != nil {
+		computeType := string(*analytics.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(analytics.CreatedOn)
@@ -5071,7 +5143,7 @@ type HDInsight struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType HDInsight_ComputeType `json:"computeType,omitempty"`
+	ComputeType *HDInsight_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -5101,7 +5173,9 @@ func (insight *HDInsight) ConvertToARM(resolved genruntime.ConvertToARMResolvedD
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = insight.ComputeType
+	if insight.ComputeType != nil {
+		result.ComputeType = *insight.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if insight.Description != nil {
@@ -5156,7 +5230,7 @@ func (insight *HDInsight) PopulateFromARM(owner genruntime.ArbitraryOwnerReferen
 	}
 
 	// Set property ‘ComputeType’:
-	insight.ComputeType = typedInput.ComputeType
+	insight.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -5195,9 +5269,10 @@ func (insight *HDInsight) AssignProperties_From_HDInsight(source *v20210701s.HDI
 
 	// ComputeType
 	if source.ComputeType != nil {
-		insight.ComputeType = HDInsight_ComputeType(*source.ComputeType)
+		computeType := HDInsight_ComputeType(*source.ComputeType)
+		insight.ComputeType = &computeType
 	} else {
-		insight.ComputeType = ""
+		insight.ComputeType = nil
 	}
 
 	// Description
@@ -5244,8 +5319,12 @@ func (insight *HDInsight) AssignProperties_To_HDInsight(destination *v20210701s.
 	destination.ComputeLocation = genruntime.ClonePointerToString(insight.ComputeLocation)
 
 	// ComputeType
-	computeType := string(insight.ComputeType)
-	destination.ComputeType = &computeType
+	if insight.ComputeType != nil {
+		computeType := string(*insight.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(insight.Description)
@@ -5294,7 +5373,7 @@ type HDInsight_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType HDInsight_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *HDInsight_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -5346,7 +5425,7 @@ func (insight *HDInsight_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwner
 	}
 
 	// Set property ‘ComputeType’:
-	insight.ComputeType = typedInput.ComputeType
+	insight.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -5423,9 +5502,10 @@ func (insight *HDInsight_STATUS) AssignProperties_From_HDInsight_STATUS(source *
 
 	// ComputeType
 	if source.ComputeType != nil {
-		insight.ComputeType = HDInsight_ComputeType_STATUS(*source.ComputeType)
+		computeType := HDInsight_ComputeType_STATUS(*source.ComputeType)
+		insight.ComputeType = &computeType
 	} else {
-		insight.ComputeType = ""
+		insight.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -5507,8 +5587,12 @@ func (insight *HDInsight_STATUS) AssignProperties_To_HDInsight_STATUS(destinatio
 	destination.ComputeLocation = genruntime.ClonePointerToString(insight.ComputeLocation)
 
 	// ComputeType
-	computeType := string(insight.ComputeType)
-	destination.ComputeType = &computeType
+	if insight.ComputeType != nil {
+		computeType := string(*insight.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(insight.CreatedOn)
@@ -5593,7 +5677,7 @@ type Kubernetes struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType Kubernetes_ComputeType `json:"computeType,omitempty"`
+	ComputeType *Kubernetes_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -5625,7 +5709,9 @@ func (kubernetes *Kubernetes) ConvertToARM(resolved genruntime.ConvertToARMResol
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = kubernetes.ComputeType
+	if kubernetes.ComputeType != nil {
+		result.ComputeType = *kubernetes.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if kubernetes.Description != nil {
@@ -5680,7 +5766,7 @@ func (kubernetes *Kubernetes) PopulateFromARM(owner genruntime.ArbitraryOwnerRef
 	}
 
 	// Set property ‘ComputeType’:
-	kubernetes.ComputeType = typedInput.ComputeType
+	kubernetes.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -5719,9 +5805,10 @@ func (kubernetes *Kubernetes) AssignProperties_From_Kubernetes(source *v20210701
 
 	// ComputeType
 	if source.ComputeType != nil {
-		kubernetes.ComputeType = Kubernetes_ComputeType(*source.ComputeType)
+		computeType := Kubernetes_ComputeType(*source.ComputeType)
+		kubernetes.ComputeType = &computeType
 	} else {
-		kubernetes.ComputeType = ""
+		kubernetes.ComputeType = nil
 	}
 
 	// Description
@@ -5768,8 +5855,12 @@ func (kubernetes *Kubernetes) AssignProperties_To_Kubernetes(destination *v20210
 	destination.ComputeLocation = genruntime.ClonePointerToString(kubernetes.ComputeLocation)
 
 	// ComputeType
-	computeType := string(kubernetes.ComputeType)
-	destination.ComputeType = &computeType
+	if kubernetes.ComputeType != nil {
+		computeType := string(*kubernetes.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(kubernetes.Description)
@@ -5818,7 +5909,7 @@ type Kubernetes_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType Kubernetes_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *Kubernetes_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -5872,7 +5963,7 @@ func (kubernetes *Kubernetes_STATUS) PopulateFromARM(owner genruntime.ArbitraryO
 	}
 
 	// Set property ‘ComputeType’:
-	kubernetes.ComputeType = typedInput.ComputeType
+	kubernetes.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -5949,9 +6040,10 @@ func (kubernetes *Kubernetes_STATUS) AssignProperties_From_Kubernetes_STATUS(sou
 
 	// ComputeType
 	if source.ComputeType != nil {
-		kubernetes.ComputeType = Kubernetes_ComputeType_STATUS(*source.ComputeType)
+		computeType := Kubernetes_ComputeType_STATUS(*source.ComputeType)
+		kubernetes.ComputeType = &computeType
 	} else {
-		kubernetes.ComputeType = ""
+		kubernetes.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -6033,8 +6125,12 @@ func (kubernetes *Kubernetes_STATUS) AssignProperties_To_Kubernetes_STATUS(desti
 	destination.ComputeLocation = genruntime.ClonePointerToString(kubernetes.ComputeLocation)
 
 	// ComputeType
-	computeType := string(kubernetes.ComputeType)
-	destination.ComputeType = &computeType
+	if kubernetes.ComputeType != nil {
+		computeType := string(*kubernetes.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(kubernetes.CreatedOn)
@@ -6119,7 +6215,7 @@ type SynapseSpark struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType SynapseSpark_ComputeType `json:"computeType,omitempty"`
+	ComputeType *SynapseSpark_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -6149,7 +6245,9 @@ func (spark *SynapseSpark) ConvertToARM(resolved genruntime.ConvertToARMResolved
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = spark.ComputeType
+	if spark.ComputeType != nil {
+		result.ComputeType = *spark.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if spark.Description != nil {
@@ -6204,7 +6302,7 @@ func (spark *SynapseSpark) PopulateFromARM(owner genruntime.ArbitraryOwnerRefere
 	}
 
 	// Set property ‘ComputeType’:
-	spark.ComputeType = typedInput.ComputeType
+	spark.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -6243,9 +6341,10 @@ func (spark *SynapseSpark) AssignProperties_From_SynapseSpark(source *v20210701s
 
 	// ComputeType
 	if source.ComputeType != nil {
-		spark.ComputeType = SynapseSpark_ComputeType(*source.ComputeType)
+		computeType := SynapseSpark_ComputeType(*source.ComputeType)
+		spark.ComputeType = &computeType
 	} else {
-		spark.ComputeType = ""
+		spark.ComputeType = nil
 	}
 
 	// Description
@@ -6292,8 +6391,12 @@ func (spark *SynapseSpark) AssignProperties_To_SynapseSpark(destination *v202107
 	destination.ComputeLocation = genruntime.ClonePointerToString(spark.ComputeLocation)
 
 	// ComputeType
-	computeType := string(spark.ComputeType)
-	destination.ComputeType = &computeType
+	if spark.ComputeType != nil {
+		computeType := string(*spark.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(spark.Description)
@@ -6342,7 +6445,7 @@ type SynapseSpark_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType SynapseSpark_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *SynapseSpark_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -6394,7 +6497,7 @@ func (spark *SynapseSpark_STATUS) PopulateFromARM(owner genruntime.ArbitraryOwne
 	}
 
 	// Set property ‘ComputeType’:
-	spark.ComputeType = typedInput.ComputeType
+	spark.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -6471,9 +6574,10 @@ func (spark *SynapseSpark_STATUS) AssignProperties_From_SynapseSpark_STATUS(sour
 
 	// ComputeType
 	if source.ComputeType != nil {
-		spark.ComputeType = SynapseSpark_ComputeType_STATUS(*source.ComputeType)
+		computeType := SynapseSpark_ComputeType_STATUS(*source.ComputeType)
+		spark.ComputeType = &computeType
 	} else {
-		spark.ComputeType = ""
+		spark.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -6555,8 +6659,12 @@ func (spark *SynapseSpark_STATUS) AssignProperties_To_SynapseSpark_STATUS(destin
 	destination.ComputeLocation = genruntime.ClonePointerToString(spark.ComputeLocation)
 
 	// ComputeType
-	computeType := string(spark.ComputeType)
-	destination.ComputeType = &computeType
+	if spark.ComputeType != nil {
+		computeType := string(*spark.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(spark.CreatedOn)
@@ -6641,7 +6749,7 @@ type VirtualMachine struct {
 
 	// +kubebuilder:validation:Required
 	// ComputeType: The type of compute
-	ComputeType VirtualMachine_ComputeType `json:"computeType,omitempty"`
+	ComputeType *VirtualMachine_ComputeType `json:"computeType,omitempty"`
 
 	// Description: The description of the Machine Learning compute.
 	Description *string `json:"description,omitempty"`
@@ -6671,7 +6779,9 @@ func (machine *VirtualMachine) ConvertToARM(resolved genruntime.ConvertToARMReso
 	}
 
 	// Set property ‘ComputeType’:
-	result.ComputeType = machine.ComputeType
+	if machine.ComputeType != nil {
+		result.ComputeType = *machine.ComputeType
+	}
 
 	// Set property ‘Description’:
 	if machine.Description != nil {
@@ -6726,7 +6836,7 @@ func (machine *VirtualMachine) PopulateFromARM(owner genruntime.ArbitraryOwnerRe
 	}
 
 	// Set property ‘ComputeType’:
-	machine.ComputeType = typedInput.ComputeType
+	machine.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘Description’:
 	if typedInput.Description != nil {
@@ -6765,9 +6875,10 @@ func (machine *VirtualMachine) AssignProperties_From_VirtualMachine(source *v202
 
 	// ComputeType
 	if source.ComputeType != nil {
-		machine.ComputeType = VirtualMachine_ComputeType(*source.ComputeType)
+		computeType := VirtualMachine_ComputeType(*source.ComputeType)
+		machine.ComputeType = &computeType
 	} else {
-		machine.ComputeType = ""
+		machine.ComputeType = nil
 	}
 
 	// Description
@@ -6814,8 +6925,12 @@ func (machine *VirtualMachine) AssignProperties_To_VirtualMachine(destination *v
 	destination.ComputeLocation = genruntime.ClonePointerToString(machine.ComputeLocation)
 
 	// ComputeType
-	computeType := string(machine.ComputeType)
-	destination.ComputeType = &computeType
+	if machine.ComputeType != nil {
+		computeType := string(*machine.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// Description
 	destination.Description = genruntime.ClonePointerToString(machine.Description)
@@ -6864,7 +6979,7 @@ type VirtualMachine_STATUS struct {
 	ComputeLocation *string `json:"computeLocation,omitempty"`
 
 	// ComputeType: The type of compute
-	ComputeType VirtualMachine_ComputeType_STATUS `json:"computeType,omitempty"`
+	ComputeType *VirtualMachine_ComputeType_STATUS `json:"computeType,omitempty"`
 
 	// CreatedOn: The time at which the compute was created.
 	CreatedOn *string `json:"createdOn,omitempty"`
@@ -6916,7 +7031,7 @@ func (machine *VirtualMachine_STATUS) PopulateFromARM(owner genruntime.Arbitrary
 	}
 
 	// Set property ‘ComputeType’:
-	machine.ComputeType = typedInput.ComputeType
+	machine.ComputeType = &typedInput.ComputeType
 
 	// Set property ‘CreatedOn’:
 	if typedInput.CreatedOn != nil {
@@ -6993,9 +7108,10 @@ func (machine *VirtualMachine_STATUS) AssignProperties_From_VirtualMachine_STATU
 
 	// ComputeType
 	if source.ComputeType != nil {
-		machine.ComputeType = VirtualMachine_ComputeType_STATUS(*source.ComputeType)
+		computeType := VirtualMachine_ComputeType_STATUS(*source.ComputeType)
+		machine.ComputeType = &computeType
 	} else {
-		machine.ComputeType = ""
+		machine.ComputeType = nil
 	}
 
 	// CreatedOn
@@ -7077,8 +7193,12 @@ func (machine *VirtualMachine_STATUS) AssignProperties_To_VirtualMachine_STATUS(
 	destination.ComputeLocation = genruntime.ClonePointerToString(machine.ComputeLocation)
 
 	// ComputeType
-	computeType := string(machine.ComputeType)
-	destination.ComputeType = &computeType
+	if machine.ComputeType != nil {
+		computeType := string(*machine.ComputeType)
+		destination.ComputeType = &computeType
+	} else {
+		destination.ComputeType = nil
+	}
 
 	// CreatedOn
 	destination.CreatedOn = genruntime.ClonePointerToString(machine.CreatedOn)

--- a/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen_test.go
+++ b/v2/api/machinelearningservices/v1beta20210701/workspaces_compute_types_gen_test.go
@@ -793,7 +793,7 @@ func AKSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForAKS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAKS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(AKS_ComputeType_AKS)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(AKS_ComputeType_AKS))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -912,7 +912,7 @@ func AKS_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForAKS_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAKS_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(AKS_ComputeType_STATUS_AKS)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(AKS_ComputeType_STATUS_AKS))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -1044,7 +1044,7 @@ func AmlComputeGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForAmlCompute is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAmlCompute(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(AmlCompute_ComputeType_AmlCompute)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(AmlCompute_ComputeType_AmlCompute))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -1163,7 +1163,7 @@ func AmlCompute_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForAmlCompute_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForAmlCompute_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(AmlCompute_ComputeType_STATUS_AmlCompute)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(AmlCompute_ComputeType_STATUS_AmlCompute))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -1295,7 +1295,7 @@ func ComputeInstanceGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForComputeInstance is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForComputeInstance(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(ComputeInstance_ComputeType_ComputeInstance)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(ComputeInstance_ComputeType_ComputeInstance))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -1415,7 +1415,7 @@ func ComputeInstance_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForComputeInstance_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForComputeInstance_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(ComputeInstance_ComputeType_STATUS_ComputeInstance)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(ComputeInstance_ComputeType_STATUS_ComputeInstance))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -1547,7 +1547,7 @@ func DatabricksGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForDatabricks is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDatabricks(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(Databricks_ComputeType_Databricks)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(Databricks_ComputeType_Databricks))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -1666,7 +1666,7 @@ func Databricks_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForDatabricks_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDatabricks_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(Databricks_ComputeType_STATUS_Databricks)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(Databricks_ComputeType_STATUS_Databricks))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -1789,7 +1789,7 @@ func DataFactoryGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForDataFactory is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDataFactory(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(DataFactory_ComputeType_DataFactory)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(DataFactory_ComputeType_DataFactory))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -1903,7 +1903,7 @@ func DataFactory_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForDataFactory_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDataFactory_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(DataFactory_ComputeType_STATUS_DataFactory)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(DataFactory_ComputeType_STATUS_DataFactory))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -2034,7 +2034,7 @@ func DataLakeAnalyticsGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForDataLakeAnalytics is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDataLakeAnalytics(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(DataLakeAnalytics_ComputeType_DataLakeAnalytics)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(DataLakeAnalytics_ComputeType_DataLakeAnalytics))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -2154,7 +2154,7 @@ func DataLakeAnalytics_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForDataLakeAnalytics_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForDataLakeAnalytics_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(DataLakeAnalytics_ComputeType_STATUS_DataLakeAnalytics)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(DataLakeAnalytics_ComputeType_STATUS_DataLakeAnalytics))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -2286,7 +2286,7 @@ func HDInsightGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForHDInsight is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForHDInsight(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(HDInsight_ComputeType_HDInsight)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(HDInsight_ComputeType_HDInsight))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -2405,7 +2405,7 @@ func HDInsight_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForHDInsight_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForHDInsight_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(HDInsight_ComputeType_STATUS_HDInsight)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(HDInsight_ComputeType_STATUS_HDInsight))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -2537,7 +2537,7 @@ func KubernetesGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForKubernetes is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForKubernetes(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(Kubernetes_ComputeType_Kubernetes)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(Kubernetes_ComputeType_Kubernetes))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -2656,7 +2656,7 @@ func Kubernetes_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForKubernetes_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForKubernetes_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(Kubernetes_ComputeType_STATUS_Kubernetes)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(Kubernetes_ComputeType_STATUS_Kubernetes))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -2788,7 +2788,7 @@ func SynapseSparkGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForSynapseSpark is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSynapseSpark(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(SynapseSpark_ComputeType_SynapseSpark)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(SynapseSpark_ComputeType_SynapseSpark))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -2908,7 +2908,7 @@ func SynapseSpark_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForSynapseSpark_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForSynapseSpark_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(SynapseSpark_ComputeType_STATUS_SynapseSpark)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(SynapseSpark_ComputeType_STATUS_SynapseSpark))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
@@ -3040,7 +3040,7 @@ func VirtualMachineGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForVirtualMachine is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachine(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(VirtualMachine_ComputeType_VirtualMachine)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(VirtualMachine_ComputeType_VirtualMachine))
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())
 }
@@ -3160,7 +3160,7 @@ func VirtualMachine_STATUSGenerator() gopter.Gen {
 // AddIndependentPropertyGeneratorsForVirtualMachine_STATUS is a factory method for creating gopter generators
 func AddIndependentPropertyGeneratorsForVirtualMachine_STATUS(gens map[string]gopter.Gen) {
 	gens["ComputeLocation"] = gen.PtrOf(gen.AlphaString())
-	gens["ComputeType"] = gen.OneConstOf(VirtualMachine_ComputeType_STATUS_VirtualMachine)
+	gens["ComputeType"] = gen.PtrOf(gen.OneConstOf(VirtualMachine_ComputeType_STATUS_VirtualMachine))
 	gens["CreatedOn"] = gen.PtrOf(gen.AlphaString())
 	gens["Description"] = gen.PtrOf(gen.AlphaString())
 	gens["DisableLocalAuth"] = gen.PtrOf(gen.Bool())

--- a/v2/internal/controllers/crd_eventgrid_domain_test.go
+++ b/v2/internal/controllers/crd_eventgrid_domain_test.go
@@ -118,7 +118,7 @@ func DomainTopicAndSubscription_CRUD(tc *testcommon.KubePerTestContext, queue *s
 			Owner: tc.AsExtensionOwner(topic),
 			Destination: &eventgrid.EventSubscriptionDestination{
 				StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
-					EndpointType: endpointType, // TODO[donotmerge]: This should be a ptr but isn't, see https://github.com/Azure/azure-service-operator/issues/2619
+					EndpointType: &endpointType,
 					// TODO[donotmerge]: These properties used to be in a "Properties" property but are flattened
 					// TODO[donotmerge]: in the Swagger branch
 					//Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{
@@ -144,7 +144,7 @@ func DomainSubscription_CRUD(tc *testcommon.KubePerTestContext, queue *storage.S
 			Owner: tc.AsExtensionOwner(domain),
 			Destination: &eventgrid.EventSubscriptionDestination{
 				StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
-					EndpointType: endpointType, // TODO[donotmerge]: This should be a ptr but isn't, see https://github.com/Azure/azure-service-operator/issues/2619
+					EndpointType: &endpointType,
 					// TODO[donotmerge]: These properties used to be in a "Properties" property but are flattened
 					// TODO[donotmerge]: in the Swagger branch
 					//Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{

--- a/v2/internal/controllers/crd_eventgrid_topic_test.go
+++ b/v2/internal/controllers/crd_eventgrid_topic_test.go
@@ -107,7 +107,7 @@ func Topic_Subscription_CRUD(tc *testcommon.KubePerTestContext, rg *resources.Re
 			Owner: tc.AsExtensionOwner(topic),
 			Destination: &eventgrid.EventSubscriptionDestination{
 				StorageQueue: &eventgrid.StorageQueueEventSubscriptionDestination{
-					EndpointType: endpointType, // TODO[donotmerge]: This should be a ptr but isn't, see https://github.com/Azure/azure-service-operator/issues/2619
+					EndpointType: &endpointType,
 					// TODO[donotmerge]: These properties used to be in a "Properties" property but are flattened
 					// TODO[donotmerge]: in the Swagger branch
 					//Properties: &eventgrid.StorageQueueEventSubscriptionDestinationProperties{

--- a/v2/internal/controllers/crd_machinelearningservices_test.go
+++ b/v2/internal/controllers/crd_machinelearningservices_test.go
@@ -177,7 +177,7 @@ func newWorkspacesCompute(tc *testcommon.KubePerTestContext, owner *genruntime.K
 			Properties: &machinelearningservices.Compute{
 				VirtualMachine: &machinelearningservices.VirtualMachine{
 					ComputeLocation:   tc.AzureRegion,
-					ComputeType:       computeType,
+					ComputeType:       &computeType,
 					DisableLocalAuth:  to.BoolPtr(true),
 					ResourceReference: tc.MakeReferenceFromResource(vm),
 					Properties: &machinelearningservices.VirtualMachine_Properties{

--- a/v2/internal/controllers/crd_mariadb_server_test.go
+++ b/v2/internal/controllers/crd_mariadb_server_test.go
@@ -42,7 +42,7 @@ func Test_MariaDB_Server_CRUD(t *testing.T) {
 				Default: &mariadb.ServerPropertiesForDefaultCreate{
 					AdministratorLogin:         to.StringPtr(adminUser),
 					AdministratorLoginPassword: adminPasswordRef,
-					CreateMode:                 createMode, // TODO[donotmerge]: This should take a ptr, see https://github.com/Azure/azure-service-operator/issues/2619
+					CreateMode:                 &createMode,
 					PublicNetworkAccess:        &networkAccess,
 					StorageProfile: &mariadb.StorageProfile{
 						StorageAutogrow: &autogrow,

--- a/v2/tools/generator/internal/codegen/pipeline/assemble_oneof.go
+++ b/v2/tools/generator/internal/codegen/pipeline/assemble_oneof.go
@@ -313,12 +313,14 @@ func (oa *oneOfAssembler) addDiscriminatorProperty(name astmodel.TypeName, rootN
 			valueName := oa.idFactory.CreateIdentifier(discriminatorValue, astmodel.Exported)
 
 			// Create the discriminator property as a single valued enum
+			enumType := astmodel.NewEnumType(
+				astmodel.StringType,
+				astmodel.MakeEnumValue(valueName, fmt.Sprintf("%q", discriminatorValue)))
+
 			property := astmodel.NewPropertyDefinition(
 				propertyName,
 				propertyJson,
-				astmodel.NewEnumType(
-					astmodel.StringType,
-					astmodel.MakeEnumValue(valueName, fmt.Sprintf("%q", discriminatorValue))))
+				astmodel.NewOptionalType(enumType))
 
 			if discriminatorValue == "" {
 				klog.Warning("Weirdness")

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Alpha.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Alpha.golden
@@ -5,5 +5,5 @@ github.com/Azure/azure-service-operator/testing/person/v20200101
         ├── Object (1 property)
         │   └── FullName: string
         └── Object (1 property)
-            └── Discriminator: Enum (1 value)
+            └── Discriminator: *Enum (1 value)
                 └── "Alpha"

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Beta.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Beta.golden
@@ -5,5 +5,5 @@ github.com/Azure/azure-service-operator/testing/person/v20200101
         ├── Object (1 property)
         │   └── FullName: string
         └── Object (1 property)
-            └── Discriminator: Enum (1 value)
+            └── Discriminator: *Enum (1 value)
                 └── "Beta"

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Delta.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Delta.golden
@@ -7,5 +7,5 @@ github.com/Azure/azure-service-operator/testing/person/v20200101
         ├── Object (1 property)
         │   └── FullName: string
         └── Object (1 property)
-            └── Discriminator: Enum (1 value)
+            └── Discriminator: *Enum (1 value)
                 └── "Delta"

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Epsilon.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Epsilon.golden
@@ -9,5 +9,5 @@ github.com/Azure/azure-service-operator/testing/person/v20200101
         ├── Object (1 property)
         │   └── FullName: string
         └── Object (1 property)
-            └── Discriminator: Enum (1 value)
+            └── Discriminator: *Enum (1 value)
                 └── "Epsilon"

--- a/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Gamma.golden
+++ b/v2/tools/generator/internal/codegen/pipeline/testdata/Test_OneOfAssembler_AssembleOneOfs_ReturnsExpectedResult/Gamma.golden
@@ -5,5 +5,5 @@ github.com/Azure/azure-service-operator/testing/person/v20200101
         ├── Object (1 property)
         │   └── FullName: string
         └── Object (1 property)
-            └── Discriminator: Enum (1 value)
+            └── Discriminator: *Enum (1 value)
                 └── "Gamma"


### PR DESCRIPTION
**What this PR does / why we need it**:

Discriminator enums were incorrectly being generated as non-optional, when they should have been optional.

Closes #2619 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/zFck2kp7QlZBu/giphy.gif)
