### PR TITLE
Fix metrics issues

### DIFF
--- a/v2/cmd/controller/main.go
+++ b/v2/cmd/controller/main.go
@@ -58,7 +58,6 @@ func main() {
 
 	armMetrics := asometrics.NewARMClientMetrics()
 	asometrics.RegisterMetrics(armMetrics)
-
 	scheme := controllers.CreateScheme()
 
 	ctrl.SetLogger(klogr.New())
@@ -101,7 +100,7 @@ func main() {
 	}
 
 	kubeClient := kubeclient.NewClient(mgr.GetClient())
-	armClientCache := armreconciler.NewARMClientCache(globalARMClient, cfg.PodNamespace, kubeClient, cfg.Cloud(), nil)
+	armClientCache := armreconciler.NewARMClientCache(globalARMClient, cfg.PodNamespace, kubeClient, cfg.Cloud(), nil, armMetrics)
 
 	var clientFactory armreconciler.ARMClientFactory = func(ctx context.Context, obj genruntime.ARMMetaObject) (*genericarmclient.GenericClient, string, error) {
 		return armClientCache.GetClient(ctx, obj)

--- a/v2/internal/genericarmclient/generic_client.go
+++ b/v2/internal/genericarmclient/generic_client.go
@@ -37,18 +37,18 @@ type GenericClient struct {
 	subscriptionID string
 	creds          azcore.TokenCredential
 	opts           *arm.ClientOptions
-	metrics        metrics.ARMClientMetrics
+	metrics        *metrics.ARMClientMetrics
 }
 
 // TODO: Need to do retryAfter detection in each call?
 
 // NewGenericClient creates a new instance of GenericClient
-func NewGenericClient(cloudCfg cloud.Configuration, creds azcore.TokenCredential, subscriptionID string, metrics metrics.ARMClientMetrics) (*GenericClient, error) {
+func NewGenericClient(cloudCfg cloud.Configuration, creds azcore.TokenCredential, subscriptionID string, metrics *metrics.ARMClientMetrics) (*GenericClient, error) {
 	return NewGenericClientFromHTTPClient(cloudCfg, creds, nil, subscriptionID, metrics)
 }
 
 // NewGenericClientFromHTTPClient creates a new instance of GenericClient from the provided connection.
-func NewGenericClientFromHTTPClient(cloudCfg cloud.Configuration, creds azcore.TokenCredential, httpClient *http.Client, subscriptionID string, metrics metrics.ARMClientMetrics) (*GenericClient, error) {
+func NewGenericClientFromHTTPClient(cloudCfg cloud.Configuration, creds azcore.TokenCredential, httpClient *http.Client, subscriptionID string, metrics *metrics.ARMClientMetrics) (*GenericClient, error) {
 	rmConfig, ok := cloudCfg.Services[cloud.ResourceManager]
 	if !ok {
 		return nil, errors.Errorf("provided cloud missing %q entry", cloud.ResourceManager)

--- a/v2/internal/metrics/arm_client_metrics.go
+++ b/v2/internal/metrics/arm_client_metrics.go
@@ -23,14 +23,14 @@ const (
 )
 
 type ARMClientMetrics struct {
-	azureRequestsTotal       *prometheus.CounterVec
-	azureFailedRequestsTotal *prometheus.CounterVec
-	azureRequestsTime        *prometheus.HistogramVec
+	azureSuccessfulRequestsTotal *prometheus.CounterVec
+	azureFailedRequestsTotal     *prometheus.CounterVec
+	azureRequestsTime            *prometheus.HistogramVec
 }
 
 var _ Metrics = &ARMClientMetrics{}
 
-func NewARMClientMetrics() ARMClientMetrics {
+func NewARMClientMetrics() *ARMClientMetrics {
 
 	azureSuccessfulRequestsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "azure_successful_requests_total",
@@ -47,25 +47,25 @@ func NewARMClientMetrics() ARMClientMetrics {
 		Help: "Length of time per ARM request",
 	}, []string{"resource", "requestType"})
 
-	return ARMClientMetrics{
-		azureRequestsTotal:       azureSuccessfulRequestsTotal,
-		azureFailedRequestsTotal: azureFailedRequestsTotal,
-		azureRequestsTime:        azureRequestsTime,
+	return &ARMClientMetrics{
+		azureSuccessfulRequestsTotal: azureSuccessfulRequestsTotal,
+		azureFailedRequestsTotal:     azureFailedRequestsTotal,
+		azureRequestsTime:            azureRequestsTime,
 	}
 }
 
 // RegisterMetrics registers the collectors with prometheus server.
-func (a ARMClientMetrics) RegisterMetrics() {
-	metrics.Registry.MustRegister(a.azureRequestsTime, a.azureRequestsTotal, a.azureFailedRequestsTotal)
+func (a *ARMClientMetrics) RegisterMetrics() {
+	metrics.Registry.MustRegister(a.azureRequestsTime, a.azureSuccessfulRequestsTotal, a.azureFailedRequestsTotal)
 }
 
 // RecordAzureSuccessRequestsTotal records the total successful number requests to ARM by increasing the counter.
-func (a ARMClientMetrics) RecordAzureSuccessRequestsTotal(resourceName string, statusCode int, method HTTPMethod) {
-	a.azureRequestsTotal.WithLabelValues(resourceName, string(method), strconv.Itoa(statusCode)).Inc()
+func (a *ARMClientMetrics) RecordAzureSuccessRequestsTotal(resourceName string, statusCode int, method HTTPMethod) {
+	a.azureSuccessfulRequestsTotal.WithLabelValues(resourceName, string(method), strconv.Itoa(statusCode)).Inc()
 }
 
 // RecordAzureFailedRequestsTotal records the number of failed requests to ARM.
-func (a ARMClientMetrics) RecordAzureFailedRequestsTotal(resourceName string, method HTTPMethod) {
+func (a *ARMClientMetrics) RecordAzureFailedRequestsTotal(resourceName string, method HTTPMethod) {
 	a.azureFailedRequestsTotal.WithLabelValues(resourceName, string(method)).Inc()
 }
 

--- a/v2/internal/metrics/metrics.go
+++ b/v2/internal/metrics/metrics.go
@@ -7,8 +7,9 @@ package metrics
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-service-operator/v2/internal/logging"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/Azure/azure-service-operator/v2/internal/logging"
 )
 
 type Metrics interface {

--- a/v2/internal/reconcilers/arm/arm_client_cache.go
+++ b/v2/internal/reconcilers/arm/arm_client_cache.go
@@ -47,6 +47,7 @@ type ARMClientCache struct {
 	globalClient *armClient
 	kubeClient   kubeclient.Client
 	httpClient   *http.Client
+	armMetrics   *metrics.ARMClientMetrics
 }
 
 func NewARMClientCache(
@@ -54,7 +55,8 @@ func NewARMClientCache(
 	podNamespace string,
 	kubeClient kubeclient.Client,
 	configuration cloud.Configuration,
-	httpClient *http.Client) *ARMClientCache {
+	httpClient *http.Client,
+	armMetrics *metrics.ARMClientMetrics) *ARMClientCache {
 
 	globalClient := &armClient{
 		genericClient:  client,
@@ -68,6 +70,7 @@ func NewARMClientCache(
 		kubeClient:   kubeClient,
 		globalClient: globalClient,
 		httpClient:   httpClient,
+		armMetrics:   armMetrics,
 	}
 }
 
@@ -179,7 +182,7 @@ func (c *ARMClientCache) getARMClientFromSecret(secret *v1.Secret) (*armClient, 
 		return nil, err
 	}
 
-	newClient, err := genericarmclient.NewGenericClientFromHTTPClient(c.cloudConfig, credential, c.httpClient, subscriptionID, metrics.NewARMClientMetrics())
+	newClient, err := genericarmclient.NewGenericClientFromHTTPClient(c.cloudConfig, credential, c.httpClient, subscriptionID, c.armMetrics)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


Closes #2647 

**What this PR does / why we need it**:

ASO metrics were not getting recorded, so found out the problem of not passing in the reference. Also, updated armClientCache to hold armMetrics so that all the `GenericClients` share the same metrics instance. 

