### PR TITLE
Ensure the correct resource version is used for KubernetesExporter checks

### DIFF
--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	. "github.com/Azure/azure-service-operator/v2/internal/logging"
@@ -511,7 +512,7 @@ func (r *azureDeploymentReconcilerInstance) saveAssociatedKubernetesResources(ct
 	}
 
 	// Also check if the resource itself implements KubernetesExporter
-	exporter, ok := r.Obj.(genruntime.KubernetesExporter)
+	exporter, ok := r.ObjAsKubernetesExporter()
 	if ok {
 		var additionalResources []client.Object
 		additionalResources, err = exporter.ExportKubernetesResources(ctx, r.Obj, r.ARMClient, r.Log)
@@ -551,6 +552,39 @@ func (r *azureDeploymentReconcilerInstance) saveAssociatedKubernetesResources(ct
 	}
 
 	return nil
+}
+
+// ObjAsKubernetesExporter returns r.Obj as a genruntime.KubernetesExporter if it supports that interface, respecting
+// the original API version used to create the resource.
+func (r *azureDeploymentReconcilerInstance) ObjAsKubernetesExporter() (genruntime.KubernetesExporter, bool) {
+	resource := r.Obj
+	resourceGVK := resource.GetObjectKind().GroupVersionKind()
+
+	desiredGVK := genruntime.GetOriginalGVK(resource)
+	if resourceGVK != desiredGVK {
+		// Need to convert the hub resource we have to the original version used
+		scheme := r.ResourceResolver.Scheme()
+		versionedResource, err := genruntime.NewEmptyVersionedResourceFromGVK(scheme, desiredGVK)
+		if err != nil {
+			r.Log.V(Status).Info("Unable to create expected version of %s", desiredGVK)
+			return nil, false
+		}
+
+		if convertible, ok := versionedResource.(conversion.Convertible); ok {
+			hub := resource.(conversion.Hub)
+			err := convertible.ConvertFrom(hub)
+			if err != nil {
+				r.Log.V(Status).Info("Unable to convert resource to %s", desiredGVK)
+				return nil, false
+			}
+		}
+
+		resource = versionedResource
+	}
+
+	// Now test whether we support the interface
+	result, ok := resource.(genruntime.KubernetesExporter)
+	return result, ok
 }
 
 // ConvertResourceToARMResource converts a genruntime.ARMMetaObject (a Kubernetes representation of a resource) into

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -566,7 +566,10 @@ func (r *azureDeploymentReconcilerInstance) ObjAsKubernetesExporter() (genruntim
 		scheme := r.ResourceResolver.Scheme()
 		versionedResource, err := genruntime.NewEmptyVersionedResourceFromGVK(scheme, desiredGVK)
 		if err != nil {
-			r.Log.V(Status).Info("Unable to create expected version of %s", desiredGVK)
+			r.Log.V(Status).Info(
+				"Unable to create expected resource version",
+				"have", resourceGVK,
+				"desired", desiredGVK)
 			return nil, false
 		}
 
@@ -574,7 +577,10 @@ func (r *azureDeploymentReconcilerInstance) ObjAsKubernetesExporter() (genruntim
 			hub := resource.(conversion.Hub)
 			err := convertible.ConvertFrom(hub)
 			if err != nil {
-				r.Log.V(Status).Info("Unable to convert resource to %s", desiredGVK)
+				r.Log.V(Status).Info(
+					"Unable to convert resource to expected version",
+					"original", resourceGVK,
+					"destination", desiredGVK)
 				return nil, false
 			}
 		}

--- a/v2/internal/testcommon/kube_per_test_context.go
+++ b/v2/internal/testcommon/kube_per_test_context.go
@@ -455,6 +455,7 @@ func (tc *KubePerTestContext) PatchResourceAndWait(old client.Object, new client
 
 // GetResource retrieves the current state of the resource from K8s (not from Azure).
 func (tc *KubePerTestContext) GetResource(key types.NamespacedName, obj client.Object) {
+	tc.T.Helper()
 	tc.G.Expect(tc.kubeClient.Get(tc.Ctx, key, obj)).To(gomega.Succeed())
 }
 


### PR DESCRIPTION
Closes #2650 

**What this PR does / why we need it**:

When checking for a code-generated implementation of `genruntime.KubernetesExporter`, we need to make sure we're looking at the correct version of the resource. 

Unlike extensions, where a single extension handles all versions of a resource, our code generated implementation can (and does!) differ between resource versions.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/kLoQuefagoQ5W/giphy.gif)
