### PR TITLE
Bump version for helm chart repo push action

### DIFF
--- a/.github/workflows/helm-chart-repo.yaml
+++ b/.github/workflows/helm-chart-repo.yaml
@@ -85,7 +85,7 @@ jobs:
           docker exec "$container_id" task controller:gen-helm-manifest
 
       - name: Commit and push changes
-        uses: devops-infra/action-commit-push@v0.9.0
+        uses: devops-infra/action-commit-push@v0.9.2
         with:
           github_token: ${{ secrets.GH_PAT }}
           commit_message: Add Helm Chart


### PR DESCRIPTION


**What this PR does / why we need it**:

Action is failing with a weird [error](https://github.com/Azure/azure-service-operator/actions/runs/3701280108/jobs/6270646847). 

Bumping the version for test if it fixes.

