### PR TITLE
Fix KUBEBUILDER_ASSETS set from dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -14,7 +14,8 @@ if ! ENVTEST=$("$TOOL_DEST/setup-envtest" use --print env 1.23.5) ; then
     echo "Failed to setup envtest"
     exit 1
 fi
-$ENVTEST
+
+echo "$ENVTEST" > source
 
 export PATH="$KUBEBUILDER_ASSETS:$TOOL_DEST:$PATH"
 


### PR DESCRIPTION
Without this fix, the env variable set has single quotes which means it doesn't actually work.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
