### PR TITLE
Allow injecting custom documentation into our supported resources page

### DIFF
--- a/docs/hugo/content/reference/_index.md
+++ b/docs/hugo/content/reference/_index.md
@@ -10,7 +10,7 @@ cascade:
 - type: docs
 - render: always
 ---
-These are the resources with Azure Service Operator support committed to our **main** branch
+These are the resources with Azure Service Operator support committed to our **main** branch,
 grouped by the originating ARM service.
 (Newly supported resources will appear in this list prior to inclusion in any ASO release.)
 
@@ -108,6 +108,10 @@ grouped by the originating ARM service.
 | [Server](https://azure.github.io/azure-service-operator/reference/dbformariadb/v1beta20180601/#dbformariadb.azure.com/v1beta20180601.Server)               | 2018-06-01  | v1beta20180601 | v2.0.0-beta.1  | [View](https://github.com/Azure/azure-service-operator/tree/main/v2/samples/dbformariadb/v1beta/v1beta20180601_server.yaml)        |
 
 ## Dbformysql
+
+Azure Database for MySQL - Single Server is on the retirement path and is [scheduled for retirement by September 16, 2024](https://learn.microsoft.com/en-us/azure/mysql/single-server/whats-happening-to-mysql-single-server). We will not be supporting it in ASO v2.
+
+Existing instances of *Single Server* can be migrated to *Azure Database for MySQL - Flexible Server* using the [Azure Database migration Service](https://azure.microsoft.com/en-us/products/database-migration).
 
 | Resource                                                                                                                                                                                     | ARM Version | CRD Version         | Supported From | Sample                                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|---------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/v2/azure/supported-resources/README
+++ b/docs/v2/azure/supported-resources/README
@@ -1,0 +1,3 @@
+This folder contains documentation fragments for injection into the report listing the versions of supported resources.
+
+Each file should be named for the *group* of the resources, and will be injected after the heading for the group, and before the list of resources.

--- a/docs/v2/azure/supported-resources/dbformysql.md
+++ b/docs/v2/azure/supported-resources/dbformysql.md
@@ -1,0 +1,3 @@
+Azure Database for MySQL - Single Server is on the retirement path and is [scheduled for retirement by September 16, 2024](https://learn.microsoft.com/en-us/azure/mysql/single-server/whats-happening-to-mysql-single-server). We will not be supporting it in ASO v2.
+
+Existing instances of *Single Server* can be migrated to *Azure Database for MySQL - Flexible Server* using the [Azure Database migration Service](https://azure.microsoft.com/en-us/products/database-migration).

--- a/docs/v2/azure/supported-resources/header.md
+++ b/docs/v2/azure/supported-resources/header.md
@@ -1,0 +1,3 @@
+These are the resources with Azure Service Operator support committed to our **main** branch,
+grouped by the originating ARM service.
+(Newly supported resources will appear in this list prior to inclusion in any ASO release.)

--- a/docs/v2/crossplane/supported-resources/README
+++ b/docs/v2/crossplane/supported-resources/README
@@ -1,0 +1,3 @@
+This folder contains documentation fragments for injection into the report listing the versions of supported resources.
+
+Each file should be named for the *group* of the resources, and will be injected after the heading for the group, and before the list of resources.

--- a/docs/v2/crossplane/supported-resources/header.md
+++ b/docs/v2/crossplane/supported-resources/header.md
@@ -1,0 +1,2 @@
+These are the Crossplane resources committed to our **main** branch, grouped by the originating ARM service.
+(Newly supported resources will appear in this list prior to inclusion in any ASO release.)

--- a/hack/crossplane/azure-crossplane.yaml
+++ b/hack/crossplane/azure-crossplane.yaml
@@ -6,9 +6,8 @@ typesOutputPath: apis
 supportedResourcesReport:
   # Path is relative to the module path, above
   outputPath: apis/resources.md
-  introduction: |
-    These are the Crossplane resources committed to our **main** branch, grouped by the originating ARM service.
-    (Newly supported resources will appear in this list prior to inclusion in any ASO release.)
+  # Path to documentation fragments to inject into the report
+  fragmentPath: ../../docs/v2/crossplane/supported-resources
 
 pipeline: crossplane
 typeFilters:

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -23,10 +23,8 @@ pipeline: azure
 supportedResourcesReport:
   # Path is relative to the module path, above
   outputPath: ../docs/hugo/content/reference/_index.md
-  introduction: |
-    These are the resources with Azure Service Operator support committed to our **main** branch
-    grouped by the originating ARM service.
-    (Newly supported resources will appear in this list prior to inclusion in any ASO release.)
+  # Path to documentation fragments to inject into the report
+  fragmentPath: ../docs/v2/azure/supported-resources
   # resourceUrlTemplate is the template for generating URLs to the API docs for our resources
   # the placeholders {group} {version} and {kind} are supported.
   resourceUrlTemplate: "https://azure.github.io/azure-service-operator/reference/{group}/{version}/#{group}.azure.com/{version}.{kind}"

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions.go
@@ -36,9 +36,12 @@ func ReportResourceVersions(configuration *config.Configuration) *Stage {
 		ReportResourceVersionsStageID,
 		"Generate a report listing all the resources generated",
 		func(ctx context.Context, state *State) (*State, error) {
-			report := NewResourceVersionsReport(state.Definitions(), configuration)
+			report, err := NewResourceVersionsReport(state.Definitions(), configuration)
+			if err != nil {
+				return nil, err
+			}
 
-			err := report.WriteTo(configuration.SupportedResourcesReport.FullOutputPath())
+			err = report.WriteTo(configuration.SupportedResourcesReport.FullOutputPath())
 			if err != nil {
 				return nil, err
 			}
@@ -53,29 +56,71 @@ type ResourceVersionsReport struct {
 	objectModelConfiguration *config.ObjectModelConfiguration
 	rootUrl                  string
 	samplesPath              string
-	groups                   set.Set[string]                       // A set of all our groups
-	kinds                    map[string]astmodel.TypeDefinitionSet // For each group, the set of all available resources
-	frontMatter              string                                // Front matter to be inserted at the top of the report
-	// A separate list of resources for each package
-	lists map[astmodel.PackageReference][]astmodel.TypeDefinition
+	frontMatter              string                                                  // Front matter to be inserted at the top of the report
+	availableFragments       map[string]string                                       // A collection of the fragments to use in the report
+	groups                   set.Set[string]                                         // A set of all our groups
+	kinds                    map[string]astmodel.TypeDefinitionSet                   // For each group, the set of all available resources
+	lists                    map[astmodel.PackageReference][]astmodel.TypeDefinition // A separate list of resources for each package
+	typoAdvisor              *config.TypoAdvisor                                     // Advisor used to troubleshoot unused fragments
 }
 
 func NewResourceVersionsReport(
 	definitions astmodel.TypeDefinitionSet,
 	cfg *config.Configuration,
-) *ResourceVersionsReport {
+) (*ResourceVersionsReport, error) {
 	result := &ResourceVersionsReport{
 		reportConfiguration:      cfg.SupportedResourcesReport,
 		objectModelConfiguration: cfg.ObjectModelConfiguration,
 		rootUrl:                  cfg.RootURL,
 		samplesPath:              cfg.SamplesPath,
+		availableFragments:       make(map[string]string),
 		groups:                   set.Make[string](),
 		kinds:                    make(map[string]astmodel.TypeDefinitionSet),
 		lists:                    make(map[astmodel.PackageReference][]astmodel.TypeDefinition),
+		typoAdvisor:              config.NewTypoAdvisor(),
+	}
+
+	err := result.loadFragments()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to load report fragments")
 	}
 
 	result.summarize(definitions)
-	return result
+	return result, nil
+}
+
+// loadFragments scans the files in the fragments directory and loads them into the availableFragments map
+func (report *ResourceVersionsReport) loadFragments() error {
+	fragmentsPath := report.reportConfiguration.FullFragmentPath()
+
+	files, err := ioutil.ReadDir(fragmentsPath)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to read fragments from directory %q", fragmentsPath)
+	}
+
+	for _, file := range files {
+		// Skip subdirectories
+		if file.IsDir() {
+			continue
+		}
+
+		// Load the file contents
+		fileName := file.Name()
+		content, err := ioutil.ReadFile(filepath.Join(fragmentsPath, fileName))
+		if err != nil {
+			return errors.Wrapf(err, "Unable to read fragment file %q", fileName)
+		}
+
+		// Strip the extension from the filename
+		name := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+
+		report.availableFragments[name] = string(content)
+	}
+
+	// We don't want our README to trigger an error
+	report.typoAdvisor.AddTerm("README")
+
+	return nil
 }
 
 // summarize collates a list of all resources, grouped by package
@@ -134,8 +179,11 @@ func (report *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder) err
 		buffer.WriteString(report.defaultFrontMatter())
 	}
 
-	buffer.WriteString(report.reportConfiguration.Introduction)
-	buffer.WriteString("\n\n")
+	// Include file header if found
+	if fragment, ok := report.findFragment("header"); ok {
+		buffer.WriteString(fragment)
+		buffer.WriteString("\n\n")
+	}
 
 	// Sort groups into alphabetical order
 	groups := set.AsSortedSlice(report.groups)
@@ -143,6 +191,13 @@ func (report *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder) err
 	var errs []error
 	for _, svc := range groups {
 		buffer.WriteString(fmt.Sprintf("## %s\n\n", strings.Title(svc)))
+
+		// Include a fragment for this group if we have one
+		if fragment, ok := report.findFragment(svc); ok {
+			buffer.WriteString(fragment)
+			buffer.WriteString("\n\n")
+		}
+
 		table, err := report.createTable(report.kinds[svc])
 		if err != nil {
 			errs = append(errs, err)
@@ -151,6 +206,16 @@ func (report *ResourceVersionsReport) WriteToBuffer(buffer *strings.Builder) err
 
 		table.WriteTo(buffer)
 		buffer.WriteString("\n")
+	}
+
+	// Check to see whether all fragments were used
+	for name := range report.availableFragments {
+		if report.typoAdvisor.HasTerm(name) {
+			continue
+		}
+
+		err := report.typoAdvisor.Errorf(name, "Fragment %q was not used", name)
+		errs = append(errs, err)
 	}
 
 	return kerrors.NewAggregate(errs)
@@ -346,4 +411,12 @@ func (report *ResourceVersionsReport) defaultFrontMatter() string {
 	buffer.WriteString("title: Supported Resources\n")
 	buffer.WriteString("---\n\n")
 	return buffer.String()
+}
+
+// findFragment will find the named fragment and return it if it exists.
+func (report *ResourceVersionsReport) findFragment(name string) (string, bool) {
+	report.typoAdvisor.AddTerm(name)
+
+	fragment, ok := report.availableFragments[name]
+	return fragment, ok
 }

--- a/v2/tools/generator/internal/codegen/pipeline/report_resource_versions_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/report_resource_versions_test.go
@@ -87,7 +87,8 @@ func TestGolden_ReportResourceVersions(t *testing.T) {
 	srr := cfg.SupportedResourcesReport
 	srr.Introduction = "These are the resources with Azure Service Operator support."
 
-	report := NewResourceVersionsReport(defs, cfg)
+	report, err := NewResourceVersionsReport(defs, cfg)
+	g.Expect(err).ToNot(HaveOccurred())
 
 	var buffer strings.Builder
 	g.Expect(report.WriteToBuffer(

--- a/v2/tools/generator/internal/config/supported_resources_report.go
+++ b/v2/tools/generator/internal/config/supported_resources_report.go
@@ -12,9 +12,10 @@ import (
 // SupportedResourcesReport is configuration for the report that lists all the supported resources.
 type SupportedResourcesReport struct {
 	cfg *Configuration // Back reference to global configuration
-
-	OutputPath   string `yaml:"outputPath,omitempty"`   // Destination filepath for the report, relative to DestinationGoModuleFile
-	Introduction string `yaml:"introduction,omitempty"` // Introduction to the report
+	// OutputPath is the destination filepath for the report, relative to DestinationGoModuleFile
+	OutputPath string `yaml:"outputPath,omitempty"`
+	// FragmentPath is a folder path for markdown fragments to inject into the file
+	FragmentPath string `yaml:"fragmentPath,omitempty"`
 	// ResourceUrlTemplate is a template for URL to the API docs for a resource
 	// It may use the placeholders {group} {version} and {kind}
 	ResourceUrlTemplate string `yaml:"resourceUrlTemplate"`
@@ -35,4 +36,11 @@ func (srr *SupportedResourcesReport) FullOutputPath() string {
 	return filepath.Join(
 		filepath.Dir(srr.cfg.DestinationGoModuleFile),
 		srr.OutputPath)
+}
+
+// FullFragmentFolderPath returns the fully qualified path to our fragment folder
+func (srr *SupportedResourcesReport) FullFragmentPath() string {
+	return filepath.Join(
+		filepath.Dir(srr.cfg.DestinationGoModuleFile),
+		srr.FragmentPath)
 }

--- a/v2/tools/generator/internal/config/typo_advisor.go
+++ b/v2/tools/generator/internal/config/typo_advisor.go
@@ -40,6 +40,13 @@ func (advisor *TypoAdvisor) HasTerms() bool {
 	return len(advisor.terms) > 0
 }
 
+// HasTerm returns true if the specified term is known to the advisor
+func (advisor *TypoAdvisor) HasTerm(term string) bool {
+	advisor.lock.RLock()
+	defer advisor.lock.RUnlock()
+	return advisor.terms.Contains(term)
+}
+
 // ClearTerms removes all the terms from ths advisor
 func (advisor *TypoAdvisor) ClearTerms() {
 	advisor.terms.Clear()


### PR DESCRIPTION
Closes #2655

**What this PR does / why we need it**:

We've found a need to inject hand-written documentation into our supported resources report; this PR provides this capability by importing fragments found in a nominated folder. 

If any fragment isn't used, we get an error, along with a suggestion about the right name to use:

```
Error during code generation:
failed during pipeline stage 66/67 [reportResourceVersions]: Generate a report listing all the resources generated: writing versions report to ..\docs\hugo\content\reference\_index.md:
Fragment "mysql" was not used (did you mean dbformysql?)
```

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/yy6hXyy2DsM5W/giphy.gif)

**If applicable**:
- [x] this PR contains documentation
