### PR TITLE
Create PreReconciliation Extension Point

### DIFF
--- a/v2/internal/controllers/generic_controller.go
+++ b/v2/internal/controllers/generic_controller.go
@@ -332,7 +332,7 @@ func (gr *GenericReconciler) createOrUpdate(ctx context.Context, log logr.Logger
 		return ctrl.Result{}, err
 	}
 
-	// Check the reconcile policy to ensure we're allowed to issue a CreateOrUpdate
+	// Check the reconcile-policy to ensure we're allowed to issue a CreateOrUpdate
 	reconcilePolicy := reconcilers.GetReconcilePolicy(metaObj, log)
 	if !reconcilePolicy.AllowsModify() {
 		return ctrl.Result{}, gr.handleSkipReconcile(ctx, log, metaObj)

--- a/v2/internal/genericarmclient/generic_client.go
+++ b/v2/internal/genericarmclient/generic_client.go
@@ -349,7 +349,7 @@ func (client *GenericClient) HeadByID(ctx context.Context, resourceID string, ap
 func IsNotFoundError(err error) bool {
 	var typedError *azcore.ResponseError
 	if errors.As(err, &typedError) {
-		if typedError.StatusCode == 404 {
+		if typedError.StatusCode == http.StatusNotFound {
 			return true
 		}
 	}

--- a/v2/internal/reconcilers/annotations.go
+++ b/v2/internal/reconcilers/annotations.go
@@ -23,7 +23,7 @@ func ARMReconcilerAnnotationChangedPredicate(log logr.Logger) predicate.Predicat
 		})
 }
 
-// GetReconcilePolicy gets the reconcile policy from the ReconcilePolicyAnnotation
+// GetReconcilePolicy gets the reconcile-policy from the ReconcilePolicyAnnotation
 func GetReconcilePolicy(obj genruntime.MetaObject, log logr.Logger) ReconcilePolicy {
 	policyStr := obj.GetAnnotations()[ReconcilePolicyAnnotation]
 	policy, err := ParseReconcilePolicy(policyStr)

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler.go
@@ -92,7 +92,12 @@ func (r *AzureDeploymentReconciler) asARMObj(obj genruntime.MetaObject) (genrunt
 	return typedObj, nil
 }
 
-func (r *AzureDeploymentReconciler) makeInstance(ctx context.Context, log logr.Logger, eventRecorder record.EventRecorder, obj genruntime.MetaObject) (*azureDeploymentReconcilerInstance, error) {
+func (r *AzureDeploymentReconciler) makeInstance(
+	ctx context.Context,
+	log logr.Logger,
+	eventRecorder record.EventRecorder,
+	obj genruntime.MetaObject,
+) (*azureDeploymentReconcilerInstance, error) {
 	typedObj, err := r.asARMObj(obj)
 	if err != nil {
 		return nil, err
@@ -111,7 +116,12 @@ func (r *AzureDeploymentReconciler) makeInstance(ctx context.Context, log logr.L
 	return newAzureDeploymentReconcilerInstance(typedObj, log, eventRecorder, armClient, *r), nil
 }
 
-func (r *AzureDeploymentReconciler) CreateOrUpdate(ctx context.Context, log logr.Logger, eventRecorder record.EventRecorder, obj genruntime.MetaObject) (ctrl.Result, error) {
+func (r *AzureDeploymentReconciler) CreateOrUpdate(
+	ctx context.Context,
+	log logr.Logger,
+	eventRecorder record.EventRecorder,
+	obj genruntime.MetaObject,
+) (ctrl.Result, error) {
 	instance, err := r.makeInstance(ctx, log, eventRecorder, obj)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -119,7 +129,12 @@ func (r *AzureDeploymentReconciler) CreateOrUpdate(ctx context.Context, log logr
 	return instance.CreateOrUpdate(ctx)
 }
 
-func (r *AzureDeploymentReconciler) Delete(ctx context.Context, log logr.Logger, eventRecorder record.EventRecorder, obj genruntime.MetaObject) (ctrl.Result, error) {
+func (r *AzureDeploymentReconciler) Delete(
+	ctx context.Context,
+	log logr.Logger,
+	eventRecorder record.EventRecorder,
+	obj genruntime.MetaObject,
+) (ctrl.Result, error) {
 	instance, err := r.makeInstance(ctx, log, eventRecorder, obj)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -127,7 +142,12 @@ func (r *AzureDeploymentReconciler) Delete(ctx context.Context, log logr.Logger,
 	return instance.Delete(ctx)
 }
 
-func (r *AzureDeploymentReconciler) Claim(ctx context.Context, log logr.Logger, eventRecorder record.EventRecorder, obj genruntime.MetaObject) error {
+func (r *AzureDeploymentReconciler) Claim(
+	ctx context.Context,
+	log logr.Logger,
+	eventRecorder record.EventRecorder,
+	obj genruntime.MetaObject,
+) error {
 	typedObj, err := r.asARMObj(obj)
 	if err != nil {
 		return err
@@ -152,7 +172,12 @@ func (r *AzureDeploymentReconciler) Claim(ctx context.Context, log logr.Logger, 
 	return nil
 }
 
-func (r *AzureDeploymentReconciler) UpdateStatus(ctx context.Context, log logr.Logger, eventRecorder record.EventRecorder, obj genruntime.MetaObject) error {
+func (r *AzureDeploymentReconciler) UpdateStatus(
+	ctx context.Context,
+	log logr.Logger,
+	eventRecorder record.EventRecorder,
+	obj genruntime.MetaObject,
+) error {
 	instance, err := r.makeInstance(ctx, log, eventRecorder, obj)
 	if err != nil {
 		return err

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -277,12 +277,14 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 
 	// If the check says we're postponing reconcile, we're done for now as there's nothing to do.
 	if check.PostponeReconciliation() {
+		r.Log.V(Status).Info("Extension recommended postponing reconciliation")
 		return ctrl.Result{}, nil
 	}
 
 	// If the check says we're blocking reconcile, we return ReadyConditionImpactingError here to update the Ready
 	// condition is updated so the user can see why we're not reconciling right now, and to trigger a retry in a bit.
 	if check.BlockReconciliation() {
+		r.Log.V(Status).Info("Extension recommended blocking reconciliation", "message", check.Message())
 		return ctrl.Result{}, check.CreateConditionError()
 	}
 

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -275,10 +275,14 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 		return ctrl.Result{}, impactingError
 	}
 
-	// If the check says we don't need to reconcile, we're done
-	// We use a ReadyConditionImpactingError here to ensure the Ready condition is updated so the user can see why
-	// we're not reconciling right now. We'll try again later.
-	if !check.ShouldReconcile() {
+	// If the check says we're postponing reconcile, we're done for now as there's nothing to do.
+	if check.PostponeReconciliation() {
+		return ctrl.Result{}, nil
+	}
+
+	// If the check says we're blocking reconcile, we return ReadyConditionImpactingError here to update the Ready
+	// condition is updated so the user can see why we're not reconciling right now, and to trigger a retry in a bit.
+	if check.BlockReconciliation() {
 		return ctrl.Result{}, check.CreateConditionError()
 	}
 

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"time"
+
+	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/go-logr/logr"
@@ -193,7 +194,10 @@ func (r *azureDeploymentReconcilerInstance) DetermineCreateOrUpdateAction(
 	checker, refreshRequired := extensions.CreatePreReconciliationChecker(r.Extension, r.alwaysReconcile)
 	if refreshRequired {
 		r.Log.V(Verbose).Info("Refreshing Status of resource")
-		r.updateStatus(ctx)
+		err := r.updateStatus(ctx)
+		if err != nil {
+			return CreateOrUpdateActionNoAction, NoAction, errors.Wrapf(err, "error refreshing status of resource for pre-reconciliation check")
+		}
 	}
 
 	check, err := checker(ctx, r.Obj, r.KubeClient, r.ARMClient, r.Log)

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -284,7 +284,7 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 
 	resourceID := genruntime.GetResourceIDOrDefault(r.Obj)
 	if resourceID != "" {
-		err := checkSubscription(resourceID, r.ARMClient.SubscriptionID())
+		err = checkSubscription(resourceID, r.ARMClient.SubscriptionID())
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -199,7 +199,7 @@ func NoAction(_ context.Context) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-// StartDeleteOfResource will begin the delete of a resource by telling Azure to start deleting it. The resource will be
+// StartDeleteOfResource will begin deletion of a resource by telling Azure to start deleting it. The resource will be
 // marked with the provisioning state of "Deleting".
 func (r *azureDeploymentReconcilerInstance) StartDeleteOfResource(ctx context.Context) (ctrl.Result, error) {
 	msg := "Starting delete of resource"
@@ -261,7 +261,7 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 
 	check, err := r.prereconciliationCheck(ctx)
 	if err != nil {
-		// Something went wrong running the check. We assume it's not fatal, and we'll try again later
+		// Failed to do the prereconciliation check, this is a serious but non-fatal error
 		// Make sure we return a ReadyConditionImpactingError so that the Ready condition is updated for the user
 		// Ideally any implementation of the checker should return a ReadyConditionImpactingError, but we can't
 		// guarantee that, so we wrap as required
@@ -317,7 +317,7 @@ func (r *azureDeploymentReconcilerInstance) BeginCreateOrUpdateResource(
 	r.Recorder.Eventf(r.Obj, v1.EventTypeNormal, string(CreateOrUpdateActionBeginCreation), "Successfully sent resource to Azure with ID %q", armResource.GetID())
 
 	// If we are done here it means the deployment succeeded immediately. It can't have failed because if it did
-	// we would have taken the err path above.
+	// we would have taken the error path above.
 	if pollerResp.Poller.Done() {
 		return r.handleCreatePollerSuccess(ctx)
 	}
@@ -782,7 +782,7 @@ func deleteResource(
 	log.V(Info).Info("Successfully issued DELETE to Azure")
 
 	// If we are done here it means delete succeeded immediately. It can't have failed because if it did
-	// we would have taken the err path above.
+	// we would have taken the error path, above.
 	if pollerResp.Poller.Done() {
 		return ctrl.Result{}, nil
 	}

--- a/v2/pkg/genruntime/conditions/ready_condition_builder.go
+++ b/v2/pkg/genruntime/conditions/ready_condition_builder.go
@@ -36,6 +36,7 @@ var ReasonAdditionalKubernetesObjWriteFailure = Reason{Name: "FailedWritingAddit
 var ReasonReconciling = Reason{Name: "Reconciling", RetryClassification: RetryFast}
 var ReasonDeleting = Reason{Name: "Deleting", RetryClassification: RetryFast}
 var ReasonReconciliationFailedPermanently = Reason{Name: "ReconciliationFailedPermanently", RetryClassification: RetryNone}
+var ReasonAzureResourceNotReady = Reason{Name: "AzureResourceNotReady", RetryClassification: RetrySlow}
 
 // ReasonFailed is a catch-all error code for when we don't have a more specific error classification
 var ReasonFailed = Reason{Name: "Failed", RetryClassification: RetrySlow}

--- a/v2/pkg/genruntime/conditions/ready_condition_builder.go
+++ b/v2/pkg/genruntime/conditions/ready_condition_builder.go
@@ -36,7 +36,8 @@ var ReasonAdditionalKubernetesObjWriteFailure = Reason{Name: "FailedWritingAddit
 var ReasonReconciling = Reason{Name: "Reconciling", RetryClassification: RetryFast}
 var ReasonDeleting = Reason{Name: "Deleting", RetryClassification: RetryFast}
 var ReasonReconciliationFailedPermanently = Reason{Name: "ReconciliationFailedPermanently", RetryClassification: RetryNone}
-var ReasonAzureResourceNotReady = Reason{Name: "AzureResourceNotReady", RetryClassification: RetrySlow}
+var ReasonReconcileBlocked = Reason{Name: "ReconciliationBlocked", RetryClassification: RetrySlow}
+var ReasonReconcilePostponed = Reason{Name: "ReconciliationPostponed", RetryClassification: RetrySlow}
 
 // ReasonFailed is a catch-all error code for when we don't have a more specific error classification
 var ReasonFailed = Reason{Name: "Failed", RetryClassification: RetrySlow}

--- a/v2/pkg/genruntime/extensions/error_classifier.go
+++ b/v2/pkg/genruntime/extensions/error_classifier.go
@@ -35,7 +35,8 @@ func CreateErrorClassifier(
 	host genruntime.ResourceExtension,
 	classifier ErrorClassifierFunc,
 	apiVersion string,
-	log logr.Logger) ErrorClassifierFunc {
+	log logr.Logger,
+) ErrorClassifierFunc {
 	impl, ok := host.(ErrorClassifier)
 	if !ok {
 		return classifier

--- a/v2/pkg/genruntime/extensions/prereconciliation_checker.go
+++ b/v2/pkg/genruntime/extensions/prereconciliation_checker.go
@@ -78,19 +78,20 @@ func BlockReconcile(reason string) PreReconcileCheckResult {
 
 // PostponeReconcile indicates reconciliation of a resource is not currently required by returning a
 // PreReconcileCheckResult with action `Postpone`.
-// reason is an explanatory reason to show to the user via an info condition on the resource.
-func PostponeReconcile(reason string) PreReconcileCheckResult {
+func PostponeReconcile() PreReconcileCheckResult {
 	return PreReconcileCheckResult{
 		action:   preReconcileCheckResultTypePostpone,
 		severity: conditions.ConditionSeverityInfo,
 		reason:   conditions.ReasonReconcilePostponed,
-		message:  reason,
 	}
 }
 
-// ShouldReconcile returns true if the provided PreReconcileCheckResult indicates that the resource should be reconciled.
-func (r PreReconcileCheckResult) ShouldReconcile() bool {
-	return r.action == preReconcileCheckResultTypeProceed
+func (r PreReconcileCheckResult) PostponeReconciliation() bool {
+	return r.action == preReconcileCheckResultTypePostpone
+}
+
+func (r PreReconcileCheckResult) BlockReconciliation() bool {
+	return r.action == preReconcileCheckResultTypeBlock
 }
 
 // CreateConditionError returns an error that can be used to set a condition on the resource.

--- a/v2/pkg/genruntime/extensions/prereconciliation_checker.go
+++ b/v2/pkg/genruntime/extensions/prereconciliation_checker.go
@@ -30,6 +30,7 @@ type PreReconciliationChecker interface {
 	PreReconcileCheck(
 		ctx context.Context,
 		obj genruntime.MetaObject,
+		owner genruntime.MetaObject,
 		kubeClient kubeclient.Client,
 		armClient *genericarmclient.GenericClient,
 		log logr.Logger,
@@ -40,6 +41,7 @@ type PreReconciliationChecker interface {
 type PreReconcileCheckFunc func(
 	ctx context.Context,
 	obj genruntime.MetaObject,
+	owner genruntime.MetaObject,
 	kubeClient kubeclient.Client,
 	armClient *genericarmclient.GenericClient,
 	log logr.Logger,
@@ -88,6 +90,8 @@ const (
 // If the resource in question has not implemented the PreReconciliationChecker interface, the provided default checker
 // is returned directly.
 // We also return a bool indicating whether the resource extension implements the PreReconciliationChecker interface.
+// host is a resource extension that may implement the PreReconciliationChecker interface.
+// checker is the nested checker to use if the resource extension does not implement the PreReconciliationChecker interface.
 func CreatePreReconciliationChecker(
 	host genruntime.ResourceExtension,
 	checker PreReconcileCheckFunc,
@@ -100,13 +104,14 @@ func CreatePreReconciliationChecker(
 	return func(
 		ctx context.Context,
 		obj genruntime.MetaObject,
+		owner genruntime.MetaObject,
 		kubeClient kubeclient.Client,
 		armClient *genericarmclient.GenericClient,
 		log logr.Logger,
 	) (PreReconcileCheckResult, error) {
 		log.V(Status).Info("Extension pre-reconcile check running")
 
-		result, err := impl.PreReconcileCheck(ctx, obj, kubeClient, armClient, log, checker)
+		result, err := impl.PreReconcileCheck(ctx, obj, owner, kubeClient, armClient, log, checker)
 		if err != nil {
 			log.V(Status).Info(
 				"Extension pre-reconcile check failed",

--- a/v2/pkg/genruntime/extensions/prereconciliation_checker.go
+++ b/v2/pkg/genruntime/extensions/prereconciliation_checker.go
@@ -94,6 +94,10 @@ func (r PreReconcileCheckResult) BlockReconciliation() bool {
 	return r.action == preReconcileCheckResultTypeBlock
 }
 
+func (r PreReconcileCheckResult) Message() string {
+	return r.message
+}
+
 // CreateConditionError returns an error that can be used to set a condition on the resource.
 func (r PreReconcileCheckResult) CreateConditionError() error {
 	return conditions.NewReadyConditionImpactingError(

--- a/v2/pkg/genruntime/extensions/prereconciliation_checker.go
+++ b/v2/pkg/genruntime/extensions/prereconciliation_checker.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package extensions
+
+import (
+	"context"
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
+	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
+	"github.com/go-logr/logr"
+)
+
+// PreReconciliationChecker is implemented by resources that want to do extra checks before proceeding with
+// a full ARM reconcile.
+type PreReconciliationChecker interface {
+	// PreReconcileCheck does a pre-reconcile check to see if the resource is in a state that can be reconciled.
+	// ARM resources should implement this to avoid reconciliation attempts that cannot possibly succeed.
+	// Returns ProceedWithReconcile if the reconciliation should go ahead.
+	// Returns SkipReconcile and a human-readable reason if the reconciliation should be skipped.
+	// ctx is the current operation context.
+	// obj is the resource about to be reconciled. The resource's State will be freshly updated.
+	// kubeClient allows access to the cluster for any required queries.
+	// armClient allows access to ARM for any required queries.
+	// log is the logger for the current operation.
+	// next is the next (nested) implementation to call.
+	PreReconcileCheck(
+		ctx context.Context,
+		obj genruntime.MetaObject,
+		kubeClient kubeclient.Client,
+		armClient *genericarmclient.GenericClient,
+		log logr.Logger,
+		next PreReconcileCheckFunc,
+	) (PreReconcileCheckResult, error)
+}
+
+type PreReconcileCheckFunc func(
+	ctx context.Context,
+	obj genruntime.MetaObject,
+	kubeClient kubeclient.Client,
+	armClient *genericarmclient.GenericClient,
+	log logr.Logger,
+) (PreReconcileCheckResult, error)
+
+type PreReconcileCheckResult struct {
+	action preReconcileCheckResultType
+	reason string
+}
+
+// ProceedWithReconcile returns a PreReconcileCheckResult indicating that the resource is ready for reconciliation.
+func ProceedWithReconcile() PreReconcileCheckResult {
+	return PreReconcileCheckResult{
+		action: preReconcileCheckResultTypeProceed,
+	}
+}
+
+// SkipReconcile returns a PreReconcileCheckResult indicating that the resource is not ready for reconciliation.
+// An explanatory reason is included.
+func SkipReconcile(reason string) PreReconcileCheckResult {
+	return PreReconcileCheckResult{
+		action: preReconcileCheckResultTypeSkip,
+		reason: reason,
+	}
+}
+
+// ShouldReconcile returns true if the provided PreReconcileCheckResult indicates that the resource should be reconciled.
+func (r PreReconcileCheckResult) ShouldReconcile() bool {
+	return r.action == preReconcileCheckResultTypeProceed
+}
+
+// Reason returns the reason for the PreReconcileCheckResult.
+func (r PreReconcileCheckResult) Reason() string {
+	return r.reason
+}
+
+// PreReconcileCheckResultType is the type of result returned by PreReconcileCheck.
+type preReconcileCheckResultType string
+
+const (
+	preReconcileCheckResultTypeProceed preReconcileCheckResultType = "Proceed"
+	preReconcileCheckResultTypeSkip    preReconcileCheckResultType = "Skip"
+)
+
+// CreatePreReconciliationChecker creates a checker that can be used to check if a resource is ready for reconciliation.
+// If the resource in question has not implemented the PreReconciliationChecker interface, the provided default checker
+// is returned directly.
+// We also return a bool indicating whether the resource extension implements the PreReconciliationChecker interface.
+func CreatePreReconciliationChecker(
+	host genruntime.ResourceExtension,
+	checker PreReconcileCheckFunc,
+) (PreReconcileCheckFunc, bool) {
+	impl, ok := host.(PreReconciliationChecker)
+	if !ok {
+		return checker, false
+	}
+
+	return func(
+		ctx context.Context,
+		obj genruntime.MetaObject,
+		kubeClient kubeclient.Client,
+		armClient *genericarmclient.GenericClient,
+		log logr.Logger,
+	) (PreReconcileCheckResult, error) {
+		log.V(Status).Info("Extension pre-reconcile check running")
+
+		result, err := impl.PreReconcileCheck(ctx, obj, kubeClient, armClient, log, checker)
+		if err != nil {
+			log.V(Status).Info(
+				"Extension pre-reconcile check failed",
+				"Error", err.Error())
+
+			// We choose to skip here so that things are definitely broken and the user will notice
+			// If we defaulted to always reconciling, the user might not notice that something is wrong
+			return SkipReconcile("Extension PreReconcileCheck failed"), err
+		}
+
+		log.V(Status).Info(
+			"Extension pre-reconcile check succeeded",
+			"Result", result)
+
+		return result, nil
+	}, true
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates an extension point allowing resources to customize ASO to avoid sending PUT requests that can't possibly succeed.

Implements #2649
Closes #2644

**Special notes for your reviewer**:

Follow-up PRs will implement this extension point for selected resources.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/astlErJSYq1cA/giphy.gif)
