### PR TITLE
Fix bug where some resources could be missing an owner

### DIFF
--- a/v2/tools/generator/internal/codegen/pipeline/load_types.go
+++ b/v2/tools/generator/internal/codegen/pipeline/load_types.go
@@ -533,6 +533,8 @@ func applyRenames(renames map[astmodel.TypeName]astmodel.TypeName, typesFromFile
 			SpecType:   newSpecType,
 			StatusType: newStatusType,
 			SourceFile: rt.SourceFile,
+			ARMURI:     rt.ARMURI,
+			ARMType:    rt.ARMType,
 		}
 	}
 


### PR DESCRIPTION
This could happen if there was a name collision as the ARM URL was lost.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
