### PR TITLE
Add helper method to export controllers.CreateScheme

### DIFF
--- a/v2/api/scheme.go
+++ b/v2/api/scheme.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/controllers"
 )
 
-// CreateScheme is a helper method to export 'internal/controllers/controller_resources.go/CreateScheme()' method outside internal package.
+// CreateScheme is a helper method to export 'internal/controllers/controller_resources.go/CreateScheme()' method outside internal package for external use.
 func CreateScheme() *runtime.Scheme {
 	return controllers.CreateScheme()
 }

--- a/v2/api/scheme.go
+++ b/v2/api/scheme.go
@@ -1,0 +1,17 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/Azure/azure-service-operator/v2/internal/controllers"
+)
+
+// CreateScheme is a helper method to export 'internal/controllers/controller_resources.go/CreateScheme()' method outside internal package.
+func CreateScheme() *runtime.Scheme {
+	return controllers.CreateScheme()
+}

--- a/v2/api/scheme.go
+++ b/v2/api/scheme.go
@@ -11,7 +11,8 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/controllers"
 )
 
-// CreateScheme is a helper method to export 'internal/controllers/controller_resources.go/CreateScheme()' method outside internal package for external use.
+// CreateScheme creates a runtime.Scheme containing ASO resource definitions
 func CreateScheme() *runtime.Scheme {
+	// CreateScheme is a helper method to export 'internal/controllers/controller_resources.go/CreateScheme()' method outside internal package for external use.
 	return controllers.CreateScheme()
 }


### PR DESCRIPTION


**What this PR does / why we need it**:

This PR includes `v2/api/scheme.go` to expose `internal/controllers.CreateScheme()` method externally
