### PR TITLE
Fix bug where an update to the resource being reconciled could cause reconciliation to fail to requeue quickly like it should.

### DIFF
--- a/v2/internal/reconcilers/annotations.go
+++ b/v2/internal/reconcilers/annotations.go
@@ -6,12 +6,16 @@ Licensed under the MIT license.
 package reconcilers
 
 import (
+	"reflect"
+
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/Azure/azure-service-operator/v2/internal/util/annotations"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 )
+
+const PerResourceSecretAnnotation = "serviceoperator.azure.com/credential-from"
 
 // ARMReconcilerAnnotationChangedPredicate creates a predicate that emits events when annotations
 // interesting to the generic ARM reconciler are changed
@@ -20,6 +24,16 @@ func ARMReconcilerAnnotationChangedPredicate(log logr.Logger) predicate.Predicat
 		log,
 		map[string]annotations.HasAnnotationChanged{
 			ReconcilePolicyAnnotation: HasReconcilePolicyAnnotationChanged,
+		})
+}
+
+// ARMPerResourceSecretAnnotationChangedPredicate creates a predicate that emits events when annotations
+// interesting to the generic ARM reconciler are changed
+func ARMPerResourceSecretAnnotationChangedPredicate(log logr.Logger) predicate.Predicate {
+	return annotations.MakeSelectAnnotationChangedPredicate(
+		log,
+		map[string]annotations.HasAnnotationChanged{
+			PerResourceSecretAnnotation: HasAnnotationChanged,
 		})
 }
 
@@ -36,4 +50,9 @@ func GetReconcilePolicy(obj genruntime.MetaObject, log logr.Logger) ReconcilePol
 	}
 
 	return policy
+}
+
+// HasAnnotationChanged returns true if the annotation has changed
+func HasAnnotationChanged(old *string, new *string) bool {
+	return !reflect.DeepEqual(old, new)
 }

--- a/v2/internal/reconcilers/arm/arm_client_cache.go
+++ b/v2/internal/reconcilers/arm/arm_client_cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/config"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	"github.com/Azure/azure-service-operator/v2/internal/metrics"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
@@ -34,9 +35,8 @@ const (
 	// #nosec
 	globalCredentialSecretName = "aso-controller-settings"
 	// #nosec
-	NamespacedSecretName        = "aso-credential"
-	PerResourceSecretAnnotation = "serviceoperator.azure.com/credential-from"
-	namespacedNameSeparator     = "/"
+	NamespacedSecretName    = "aso-credential"
+	namespacedNameSeparator = "/"
 )
 
 // ARMClientCache is a cache for armClients to hold multiple credential clients and global credential client.
@@ -115,7 +115,7 @@ func (c *ARMClientCache) GetClient(ctx context.Context, obj genruntime.ARMMetaOb
 }
 
 func (c *ARMClientCache) getPerResourceCredential(ctx context.Context, obj genruntime.ARMMetaObject) (*armClient, error) {
-	return c.getCredentialFromAnnotation(ctx, obj, PerResourceSecretAnnotation)
+	return c.getCredentialFromAnnotation(ctx, obj, reconcilers.PerResourceSecretAnnotation)
 }
 
 func (c *ARMClientCache) getNamespacedCredential(ctx context.Context, namespace string) (*armClient, error) {

--- a/v2/internal/reconcilers/arm/arm_client_cache_test.go
+++ b/v2/internal/reconcilers/arm/arm_client_cache_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/config"
 	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
 	"github.com/Azure/azure-service-operator/v2/internal/metrics"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 	"github.com/Azure/azure-service-operator/v2/internal/resolver"
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"
 )
@@ -113,7 +114,7 @@ func Test_ARMClientCache_ReturnsPerResourceScopedClientOverNamespacedClient(t *t
 	g.Expect(err).ToNot(HaveOccurred())
 
 	rg := newResourceGroup("")
-	rg.Annotations = map[string]string{PerResourceSecretAnnotation: perResourceCredentialName.String()}
+	rg.Annotations = map[string]string{reconcilers.PerResourceSecretAnnotation: perResourceCredentialName.String()}
 	err = res.kubeClient.Create(ctx, rg)
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -141,7 +142,7 @@ func Test_ARMClientCache_ReturnsError_IfSecretNotFound(t *testing.T) {
 	}
 
 	rg := newResourceGroup("")
-	rg.Annotations = map[string]string{PerResourceSecretAnnotation: credentialNamespacedName.String()}
+	rg.Annotations = map[string]string{reconcilers.PerResourceSecretAnnotation: credentialNamespacedName.String()}
 	err = res.kubeClient.Create(ctx, rg)
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -172,7 +173,7 @@ func Test_ARMClientCache_ReturnsPerResourceScopedClient(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	rg := newResourceGroup("")
-	rg.Annotations = map[string]string{PerResourceSecretAnnotation: credentialNamespacedName.String()}
+	rg.Annotations = map[string]string{reconcilers.PerResourceSecretAnnotation: credentialNamespacedName.String()}
 	err = res.kubeClient.Create(ctx, rg)
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
+++ b/v2/internal/reconcilers/arm/azure_generic_arm_reconciler_instance.go
@@ -380,7 +380,7 @@ func checkSubscription(resourceID string, clientSubID string) error {
 }
 
 func (r *azureDeploymentReconcilerInstance) handleCreatePollerFailed(err error) error {
-	r.Log.V(Status).Info(
+	r.Log.V(Debug).Info(
 		"Resource creation failure",
 		"resourceID", genruntime.GetResourceIDOrDefault(r.Obj),
 		"error", err.Error())
@@ -392,7 +392,7 @@ func (r *azureDeploymentReconcilerInstance) handleCreatePollerFailed(err error) 
 }
 
 func (r *azureDeploymentReconcilerInstance) handleDeletePollerFailed(err error) error {
-	r.Log.V(Status).Info(
+	r.Log.V(Debug).Info(
 		"Resource deletion failure",
 		"resourceID", genruntime.GetResourceIDOrDefault(r.Obj),
 		"error", err.Error())

--- a/v2/internal/reconcilers/generic/register.go
+++ b/v2/internal/reconcilers/generic/register.go
@@ -132,9 +132,11 @@ func register(
 
 	// Note: These predicates prevent status updates from triggering a reconcile.
 	// to learn more look at https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/predicate#GenerationChangedPredicate
+	predicateLog := options.LogConstructor(nil).WithName(info.Name)
 	filter := predicate.Or(
 		predicate.GenerationChangedPredicate{},
-		reconcilers.ARMReconcilerAnnotationChangedPredicate(options.LogConstructor(nil).WithName(info.Name)))
+		reconcilers.ARMReconcilerAnnotationChangedPredicate(predicateLog),
+		reconcilers.ARMPerResourceSecretAnnotationChangedPredicate(predicateLog))
 
 	builder := ctrl.NewControllerManagedBy(mgr).
 		// Note: These predicates prevent status updates from triggering a reconcile.

--- a/v2/internal/util/kubeclient/utilities.go
+++ b/v2/internal/util/kubeclient/utilities.go
@@ -7,7 +7,12 @@ package kubeclient
 
 import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func IgnoreNotFound(err error) error {
+	return client.IgnoreNotFound(err)
+}
 
 func IgnoreNotFoundAndConflict(err error) error {
 	if IsNotFoundOrConflict(err) {

--- a/v2/pkg/genruntime/conditions/errors.go
+++ b/v2/pkg/genruntime/conditions/errors.go
@@ -47,8 +47,11 @@ func (e *ReadyConditionImpactingError) WithRetryClassification(classification Re
 }
 
 func (e *ReadyConditionImpactingError) Error() string {
-	// Defered to cause
-	return e.cause.Error()
+	return fmt.Sprintf("Reason: %s, Severity: %s, RetryClassification: %s, Cause: %s",
+		e.Reason,
+		e.Severity,
+		e.RetryClassification,
+		e.cause.Error())
 }
 
 func (e *ReadyConditionImpactingError) Is(err error) bool {

--- a/v2/test/single_operator_multitenant_test.go
+++ b/v2/test/single_operator_multitenant_test.go
@@ -20,6 +20,7 @@ import (
 	resources "github.com/Azure/azure-service-operator/v2/api/resources/v1beta20200601"
 	storage "github.com/Azure/azure-service-operator/v2/api/storage/v1beta20210401"
 	"github.com/Azure/azure-service-operator/v2/internal/config"
+	"github.com/Azure/azure-service-operator/v2/internal/reconcilers"
 	"github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm"
 	"github.com/Azure/azure-service-operator/v2/internal/testcommon"
 	"github.com/Azure/azure-service-operator/v2/pkg/genruntime"
@@ -80,14 +81,14 @@ func Test_Multitenant_SingleOperator_PerResourceCredential(t *testing.T) {
 	rg := tc.CreateTestResourceGroupAndWait()
 
 	acct := newStorageAccount(tc, rg)
-	acct.Annotations = map[string]string{arm.PerResourceSecretAnnotation: nsName.String()}
+	acct.Annotations = map[string]string{reconcilers.PerResourceSecretAnnotation: nsName.String()}
 
 	// Creating new storage account in with restricted permissions per resource secret should fail.
 	tc.CreateResourceAndWaitForState(acct, metav1.ConditionFalse, conditions.ConditionSeverityWarning)
 
 	// Deleting the per-resource credential annotation would default to applying the global credential with all permissions
 	old := acct.DeepCopy()
-	delete(acct.Annotations, arm.PerResourceSecretAnnotation)
+	delete(acct.Annotations, reconcilers.PerResourceSecretAnnotation)
 	tc.Patch(old, acct)
 
 	tc.Eventually(acct).Should(tc.Match.BeProvisioned(0))


### PR DESCRIPTION
* Fix a bug where a PUT or PATCH to the resource being reconciled which changed only fields which we were not watching (ignored annotations for example) could cause reconciliation to fail to requeue quickly like it should.

  The root cause of this issue is that we were treating Conflict as an ignorable error, expecting that we could avoid requeing on it because we would get an updated event shortly. This only holds true when the update changes a property of the object we actually care about. If it changes a property we aren't watching we didn't requeue but also didn't get an updated event and so were "stuck" (at least until the periodic reconciliation interval was hit).
* Fix bug were we weren't triggering reconciliation when the credential-from annotation changed.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
