### PR TITLE
Update AzureDevops Docker file to Go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.20 as builder
 
 # need jq for running the Makefile
 RUN curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x /usr/local/bin/jq


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed the Docker file in our root (which I believe is used by Azure DevOps) was still set to use Go 1.18.
