### PR TITLE
Lift concurrency to 3

### DIFF
--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Run integration tests
         run: |
           container_id=${{steps.devcontainer.outputs.id}}
-          docker exec -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT "$container_id" task controller:ci-integration-tests --concurrency 2 # limit concurrency because build machines are small
+          docker exec -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT "$container_id" task controller:ci-integration-tests --concurrency 3 # limit concurrency because build machines are small
+          # Change concurrency to --concurrency 1 once https://github.com/go-task/task/pull/1025 is merged
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -96,7 +96,9 @@ jobs:
           container_id=${{steps.devcontainer.outputs.id}}
 
           set +e # don't exit instantly on failure, we need to produce Markdown summary
-          docker exec "$container_id" task ci --concurrency 2 # limit concurrency because build machines are small
+          docker exec "$container_id" task ci --concurrency 3 # limit concurrency because build machines are small
+          # Change concurrency to --concurrency 1 once https://github.com/go-task/task/pull/1025 is merged
+
           EXIT_CODE=$?
           set -e
 
@@ -114,8 +116,9 @@ jobs:
       - name: Build docker image & build configuration YAML
         run: |
           container_id=${{steps.devcontainer.outputs.id}}
-          docker exec "$container_id" task controller:docker-build-and-save --concurrency 2 # limit concurrency because build machines are small
-          docker exec "$container_id" task controller:run-kustomize-for-envtest --concurrency 2 # limit concurrency because build machines are small
+          docker exec "$container_id" task controller:docker-build-and-save --concurrency 3 # limit concurrency because build machines are small
+          docker exec "$container_id" task controller:run-kustomize-for-envtest --concurrency 3 # limit concurrency because build machines are small
+          # Change concurrency to --concurrency 1 once https://github.com/go-task/task/pull/1025 is merged
 
       - name: Archive outputs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
**What this PR does / why we need it**:

**Task** can experience deadlocks while waiting on executing tasks to complete. 

We were using `--concurrency 2` but this only worked because we were only ever waiting on an outstanding task once. With the recent introduction of the build steps for `asoctl` we can now end up with two concurrent waits on an outstanding tasks at the same time. 

Lifting the concurrent limit should avoid the deadlock until the fix has been merged.

**Special notes for your reviewer**:

Fix for **Task** is here in [PR#1025](https://github.com/go-task/task/pull/1025).

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/Pja8Ied6v7M7Gq5DeK/giphy.gif)
