### PR TITLE
Add NamespacesTopicsSubscription extension to handle cloudError

### DIFF
--- a/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
+++ b/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
@@ -32,7 +32,7 @@ func (e *NamespacesTopicsSubscriptionExtension) ClassifyError(
 		return core.CloudErrorDetails{}, err
 	}
 
-	// Override is to treat MessagingGatewayBadRequest as retryable for NamespacesTopicsSubscriptionExtension
+	// Override is to treat MessagingGatewayBadRequest as retryable for NamespacesTopicsSubscription
 	if isRetryableMessagingGatewayBadRequest(cloudError) {
 		details.Classification = core.ErrorRetryable
 	}

--- a/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
+++ b/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
@@ -16,7 +16,7 @@ import (
 var _ extensions.ErrorClassifier = &NamespacesTopicsSubscriptionExtension{}
 
 // ClassifyError evaluates the provided error, returning whether it is fatal or can be retried.
-// A MessagingGatewayBadRequest error (400) is normally fatal, but NamespacesTopicsSubscriptionExtension resource may return 400 whilst a dependency is being created,
+// A MessagingGatewayBadRequest error (400) is normally fatal, but NamespacesTopicsSubscription resource may return MessagingGatewayBadRequest whilst a dependency is being created,
 // so we override for that case.
 // cloudError is the error returned from ARM.
 // apiVersion is the ARM API version used for the request.

--- a/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
+++ b/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package customizations
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/Azure/azure-service-operator/v2/internal/genericarmclient"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/core"
+	"github.com/Azure/azure-service-operator/v2/pkg/genruntime/extensions"
+)
+
+var _ extensions.ErrorClassifier = &NamespacesTopicsSubscriptionExtension{}
+
+// ClassifyError evaluates the provided error, returning whether it is fatal or can be retried.
+// A conflict error (409) is normally fatal, but Redis resources may return 409 whilst a dependency is being created,
+// so we override for that case.
+// cloudError is the error returned from ARM.
+// apiVersion is the ARM API version used for the request.
+// log is a logger than can be used for telemetry.
+// next is the next implementation to call.
+func (e *NamespacesTopicsSubscriptionExtension) ClassifyError(
+	cloudError *genericarmclient.CloudError,
+	apiVersion string,
+	log logr.Logger,
+	next extensions.ErrorClassifierFunc) (core.CloudErrorDetails, error) {
+	details, err := next(cloudError)
+	if err != nil {
+		return core.CloudErrorDetails{}, err
+	}
+
+	// Override is to treat Conflict as retryable for Redis, if the message contains "try again later"
+	if isRetryableConflict(cloudError) {
+		details.Classification = core.ErrorRetryable
+	}
+
+	return details, nil
+}
+
+// isRetryableConflict checks the passed error to see if it is a retryable conflict, returning true if it is.
+func isRetryableConflict(err *genericarmclient.CloudError) bool {
+	if err == nil {
+		return false
+	}
+
+	return err.Code() == "MessagingGatewayBadRequest"
+}

--- a/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
+++ b/v2/api/servicebus/customizations/namespaces_topic_subscription_extension.go
@@ -16,7 +16,7 @@ import (
 var _ extensions.ErrorClassifier = &NamespacesTopicsSubscriptionExtension{}
 
 // ClassifyError evaluates the provided error, returning whether it is fatal or can be retried.
-// A conflict error (409) is normally fatal, but Redis resources may return 409 whilst a dependency is being created,
+// A MessagingGatewayBadRequest error (400) is normally fatal, but NamespacesTopicsSubscriptionExtension resource may return 400 whilst a dependency is being created,
 // so we override for that case.
 // cloudError is the error returned from ARM.
 // apiVersion is the ARM API version used for the request.
@@ -32,16 +32,16 @@ func (e *NamespacesTopicsSubscriptionExtension) ClassifyError(
 		return core.CloudErrorDetails{}, err
 	}
 
-	// Override is to treat Conflict as retryable for Redis, if the message contains "try again later"
-	if isRetryableConflict(cloudError) {
+	// Override is to treat MessagingGatewayBadRequest as retryable for NamespacesTopicsSubscriptionExtension
+	if isRetryableMessagingGatewayBadRequest(cloudError) {
 		details.Classification = core.ErrorRetryable
 	}
 
 	return details, nil
 }
 
-// isRetryableConflict checks the passed error to see if it is a retryable conflict, returning true if it is.
-func isRetryableConflict(err *genericarmclient.CloudError) bool {
+// isRetryableMessagingGatewayBadRequest checks the passed error to see if it is a retryable MessagingGatewayBadRequest, returning true if it is.
+func isRetryableMessagingGatewayBadRequest(err *genericarmclient.CloudError) bool {
 	if err == nil {
 		return false
 	}


### PR DESCRIPTION


Closes #2736 

**What this PR does / why we need it**:

With this extension, we handle `MessagingGatewayBadRequest` as retriable and non-fatal. So that we can wait for the `forwardTo` resource to exist.
