### PR TITLE
Update initialization instruction

### DIFF
--- a/docs/hugo/content/contributing/_index.md
+++ b/docs/hugo/content/contributing/_index.md
@@ -35,7 +35,7 @@ If you want to use this:
     2. Search for "`Azure/azure-service-operator`".
     3. Choose either of the following options about where to create the volume.
     4. The window will reload and run the `Dockerfile` setup. The first time, this will take some minutes to complete as it installs all dependencies.
-    5. Run `git fetch --unshallow` if the repository you clone is a shallow clone.
+    5. Run `git fetch --unshallow` if the repository you clone is a shallow clone. If you miss this step, you may see errors like `"./scripts/build-version.py v2" failed: exit status 1` when running `task`.
     6. Run `git submodule init` and `git submodule update`
 
 3. To validate everything is working correctly, you can open a terminal in VS Code and run `task -l`. This will show a list of all `task` commands. Running `task` by itself (or `task default`) will run quick local pre-checkin tests and validation.


### PR DESCRIPTION
Closes #[issue number]

**What this PR does / why we need it**:
When using VS Code devcontainer plugin to setup ASOv2 dev environment, I am running into following error when `task defult`: `task: Command "./scripts/build-version.py v2" failed: exit status 1`
This is because the repository was cloned with a depth setting, which create a shallow copy.
The fix is to convert the shallow clone to regular one by: `git fetch --unshallow`

**How does this PR make you feel**:
![gif](https://giphy.com/gifs/yJFeycRK2DB4c)

**If applicable**:
- this PR contains documentation
