### PR TITLE
Fix broken image reference

### DIFF
--- a/docs/hugo/content/design/ADR-2022-11-Resource-Import.md
+++ b/docs/hugo/content/design/ADR-2022-11-Resource-Import.md
@@ -82,7 +82,7 @@ $ asoctl export resource http://management.azure.com/subscriptions/00000000-0000
 
 The process of generating the YAML for a given resource can be simplified to the following flow:
 
-![Data Flow](./images/adr-2022-11-import-flow.png)
+![Data Flow](../images/adr-2022-11-import-flow.png)
 
 1. The user specified URL is used to ***GET*** the resource from Azure in its native ARM format.
 2. We apply a ***conversion*** to obtain a Status object for the relevant custom resource.


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed by @matthchr, the image reference is broken for one of our ADRs.

<img width="776" alt="image" src="https://user-images.githubusercontent.com/1272094/226753554-e800625b-02a6-4cc9-ad97-ea32d7b85343.png">

Tweaking the image URL makes it work:

<img width="794" alt="image" src="https://user-images.githubusercontent.com/1272094/226753417-9222ffbb-fa4b-4d58-a961-f539dfb21180.png">

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/yed7zEzk5pJZ8I9LlF/giphy.gif)

**If applicable**:
- [x] this PR contains documentation
