### PR TITLE
Improve resource path canonicalization

### DIFF
--- a/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
+++ b/v2/tools/generator/internal/jsonast/swagger_type_extractor.go
@@ -129,7 +129,7 @@ func (extractor *SwaggerTypeExtractor) ExtractResourceTypes(ctx context.Context,
 		fullPutParameters := append(op.Parameters, op.Put.Parameters...)
 
 		nameParameterType := extractor.getNameParameterType(ctx, rawOperationPath, scanner, fullPutParameters)
-		operationPaths := extractor.expandEnumsInPath(ctx, rawOperationPath, scanner, fullPutParameters)
+		operationPaths := extractor.expandAndCanonicalizePath(ctx, rawOperationPath, scanner, fullPutParameters)
 
 		for _, operationPath := range operationPaths {
 			err := extractor.extractOneResourceType(
@@ -541,8 +541,34 @@ func (extractor *SwaggerTypeExtractor) getNameParameterType(
 	return paramType
 }
 
-// expandEnumsInPath expands simple enums with a single value in the path
-func (extractor *SwaggerTypeExtractor) expandEnumsInPath(
+// expandAndCanonicalizePath expands enums in the path. There are a number of cases here which make enum expansion and
+// subsequent resource name extraction tricky:
+//  1. Not every "resource" follows the standard ARM ID pattern of "/resourceType/{resourceName}/childResourceType/{childResourceName}".
+//     For example see https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2014-04-01/cosmos-db.json#L3195.
+//     This API has a PUT "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}/apis/gremlin/databases/{databaseName}"
+//     where /apis/gremlin looks like it should be the name of a resource called "apis", but in fact it has a different
+//     body payload than apis/sql.
+//     There are other examples of this as well, such as Web.Sites config: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/web/resource-manager/Microsoft.Web/stable/2020-12-01/WebApps.json#L1797
+//  2. While most enums are for "names", some enums are for "types", see for example PrivateDNSZone RecordSets:
+//     https://github.com/Azure/azure-rest-api-specs/blob/main/specification/privatedns/resource-manager/Microsoft.Network/stable/2020-06-01/privatedns.json#L744.
+//     This is the primary reason why this method must return a collection of paths, as a single URL may actually refer to
+//     multiple resources. We want to make sure to expand these enums.
+//  3. Many services have enums for resource names with a single value "default". In some cases, some paths for this
+//     resource may use a parameter of type enum with a single value "default", while other usages in the same Swagger
+//     put default directly into the path. This makes it important to expand these values, to ensure that resource
+//     ownership ends up working later.
+//     Ref: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/storage/resource-manager/Microsoft.Storage/stable/2021-04-01/blob.json#L58
+//  4. There are many other instances of single-value enums used for names that aren't "default". It just so happens that
+//     service teams that use this pattern seem to consistently use either a hardcoded name or a parameter. They don't seem
+//     to mix/match like the storage example in #3 above.
+//     Ref: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/sql/resource-manager/Microsoft.Sql/stable/2021-11-01/ServerAzureADAdministrators.json#L61
+//
+// The above realities result in the following algorithm:
+//   - Expand all enums that are in the resourceType section of the path (case 2 above)
+//   - Expand all enums with a single value "default", to protect against hardcoding of "default" in other URL paths (case 3 above)
+//   - Don't expand any other enums, which protects us from considering those parameters as part of the resource type and
+//     including them in the resource name later
+func (extractor *SwaggerTypeExtractor) expandAndCanonicalizePath(
 	ctx context.Context,
 	operationPath string,
 	scanner *SchemaScanner,
@@ -552,8 +578,43 @@ func (extractor *SwaggerTypeExtractor) expandEnumsInPath(
 		operationPath,
 	}
 
+	_, subpath, err := extractor.extractResourceSubpath(operationPath)
+	if err != nil {
+		// This error is safe to ignore in this case as it means that we can't parse the path as a resource.
+		// Just return the raw path so we do further processing and log a message
+		klog.Errorf("Error expanding enums in path (%s): %s", extractor.swaggerPath, err.Error())
+		return results
+	}
+
+	paramMap := make(map[string]spec.Parameter)
 	for _, param := range parameters {
 		_, resolved := extractor.fullyResolveParameter(param)
+
+		paramMap[resolved.Name] = resolved
+	}
+
+	split := strings.Split(subpath, "/")
+	// Loop over split to ensure we're processing the url paths left to right, which is important
+	// for counting which parameters correspond to a "name" and which correspond to a "type"
+	for i, urlPart := range split {
+		if len(urlPart) == 0 {
+			// skip empty parts
+			continue
+		}
+
+		if urlPart[0] != '{' {
+			// Not a parameter, so by definition doesn't need to be expanded
+			continue
+		}
+
+		paramName := strings.Trim(urlPart, "{}")
+		// Note that Swagger requires a case-sensitive match, so we don't need to worry about case insensitivity here
+		param, ok := paramMap[paramName]
+		if !ok {
+			// This shouldn't happen, but if it does the best bet is to just continue as without the actual
+			// parameter there's no way to perform substitution
+			continue
+		}
 
 		var err error
 		var paramType astmodel.Type
@@ -569,19 +630,47 @@ func (extractor *SwaggerTypeExtractor) expandEnumsInPath(
 		}
 
 		enum, isEnum := paramType.(*astmodel.EnumType)
-		if isEnum {
-			toReplace := fmt.Sprintf("{%s}", resolved.Name)
-			var expanded []string
-
-			for _, path := range results {
-				for _, opt := range enum.Options() {
-					theOption := strings.Trim(opt.Value, "\"")
-					expanded = append(expanded, strings.ReplaceAll(path, toReplace, theOption))
-				}
-			}
-
-			results = expanded
+		if !isEnum {
+			// We only expand enums, skip everything else
+			continue
 		}
+
+		if len(enum.Options()) == 0 {
+			// This shouldn't happen but guard against it anyway
+			continue
+		}
+
+		if !astmodel.TypeEquals(enum.BaseType(), astmodel.StringType) {
+			// We only expand string enums
+			continue
+		}
+
+		// resource types come on the even indices after the group.
+		// Example: Microsoft.Group/resourceType/{resourceName}/{childResourceTypeParameter}/{childName},
+		// has "resourceType" at index=0, "{childResourceTypeParameter}" at index=2
+		isResourceTypeParameter := i%2 == 0
+		isDefaultEnum := false
+		if len(enum.Options()) == 1 {
+			opt := enum.Options()[0]
+			theOption := strings.Trim(opt.Value, "\"")
+			isDefaultEnum = strings.EqualFold(theOption, "default")
+		}
+
+		if !isResourceTypeParameter && !isDefaultEnum {
+			continue
+		}
+
+		toReplace := fmt.Sprintf("{%s}", param.Name)
+		var expanded []string
+
+		for _, path := range results {
+			for _, opt := range enum.Options() {
+				theOption := strings.Trim(opt.Value, "\"")
+				expanded = append(expanded, strings.ReplaceAll(path, toReplace, theOption))
+			}
+		}
+
+		results = expanded
 	}
 
 	return results
@@ -594,6 +683,25 @@ func (extractor *SwaggerTypeExtractor) resourceNameFromOperationPath(operationPa
 	}
 
 	return group + "/" + resource, astmodel.MakeTypeName(extractor.outputPackage, name), nil
+}
+
+// extractResourceSubpath gets the subpath focused on the actual resource.
+// For example: “…/Microsoft.GroupName/resourceType/{parameterId}/differentType/{otherId}/something/{moreId}”
+// would return "Microsoft.GroupName", "resourceType/{parameterId}/differentType/{otherId}/something/{moreId}"
+func (extractor *SwaggerTypeExtractor) extractResourceSubpath(operationPath string) (string, string, error) {
+	urlParts := strings.Split(operationPath, "/")
+	for i, urlPart := range urlParts {
+		if len(urlPart) == 0 {
+			// skip empty parts
+			continue
+		}
+
+		if SwaggerGroupRegex.MatchString(urlPart) {
+			return urlPart, strings.Join(urlParts[i+1:], "/"), nil
+		}
+	}
+
+	return "", "", errors.Errorf("no group name (‘Microsoft…’) found in %s", operationPath)
 }
 
 // inferNameFromURLPath attempts to extract a name from a Swagger operation path
@@ -609,8 +717,12 @@ func (extractor *SwaggerTypeExtractor) inferNameFromURLPath(operationPath string
 		return "Microsoft.Resources", "resourceGroups", "ResourceGroup", nil
 	}
 
-	urlParts := strings.Split(operationPath, "/")
-	reading := false
+	group, subpath, err := extractor.extractResourceSubpath(operationPath)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	urlParts := strings.Split(subpath, "/")
 	skippedLast := false
 	for _, urlPart := range urlParts {
 		if len(urlPart) == 0 {
@@ -618,32 +730,25 @@ func (extractor *SwaggerTypeExtractor) inferNameFromURLPath(operationPath string
 			continue
 		}
 
-		if reading {
-			if urlPart == "default" {
-				// skip; shouldn’t be part of name
-				// TODO: I haven’t yet found where this is done in autorest/autorest.armresource to document this
-			} else if urlPart[0] == '{' {
-				// this is a url parameter
-
-				if skippedLast {
-					// this means two {parameters} in a row
-					return "", "", "", errors.Errorf("multiple parameters in path")
-				}
-
-				skippedLast = true
-			} else {
-				// normal part of path, uppercase first character
-				nameParts = append(nameParts, urlPart)
-				skippedLast = false
+		// If default was defined as an enum in the Swagger, this check is not needed as it wouldn't have been expanded by
+		// the expandEnumsInPath method, but some services hardcode default into their URLs like : blobService/default/containers/{containerName}
+		// and we don't want the "default" name to be part of the resource type name for those cases so we ignore it here.
+		if strings.EqualFold(urlPart, "default") {
+			// skip; shouldn’t be part of name
+			// TODO: I haven’t yet found where this is done in autorest/autorest.armresource to document this
+		} else if urlPart[0] == '{' {
+			// this is a url parameter
+			if skippedLast {
+				// this means two {parameters} in a row
+				return "", "", "", errors.Errorf("multiple parameters in path")
 			}
-		} else if SwaggerGroupRegex.MatchString(urlPart) {
-			group = urlPart
-			reading = true
-		}
-	}
 
-	if !reading {
-		return "", "", "", errors.Errorf("no group name (‘Microsoft…’ = %q) found", group)
+			skippedLast = true
+		} else {
+			// normal part of path, uppercase first character
+			nameParts = append(nameParts, urlPart)
+			skippedLast = false
+		}
 	}
 
 	if len(nameParts) == 0 {

--- a/v2/tools/generator/internal/jsonast/swagger_type_extractor_test.go
+++ b/v2/tools/generator/internal/jsonast/swagger_type_extractor_test.go
@@ -6,33 +6,48 @@
 package jsonast
 
 import (
-	"fmt"
+	"context"
 	"testing"
 
 	"github.com/go-openapi/spec"
 	. "github.com/onsi/gomega"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
 )
 
-func Example_inferNameFromURLPath() {
+func Test_InferNameFromURLPath_ParentResource(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
 	extractor := &SwaggerTypeExtractor{
 		idFactory: astmodel.NewIdentifierFactory(),
 	}
 
-	group, resource, name, _ := extractor.inferNameFromURLPath("/Microsoft.GroupName/resourceName/{resourceId}")
-	fmt.Printf("%s/%s: %s", group, resource, name)
+	group, resource, name, err := extractor.inferNameFromURLPath("/Microsoft.GroupName/resourceName/{resourceId}")
+	t.Logf("%s/%s: %s", group, resource, name)
 	// Output: Microsoft.GroupName/resourceName: ResourceName
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(group).To(Equal("Microsoft.GroupName"))
+	g.Expect(resource).To(Equal("resourceName"))
+	g.Expect(name).To(Equal("ResourceName"))
 }
 
-func Example_inferNameFromURLPath_ChildResources() {
+func Test_InferNameFromURLPath_ChildResources(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
 	extractor := &SwaggerTypeExtractor{
 		idFactory: astmodel.NewIdentifierFactory(),
 	}
 
-	group, resource, name, _ := extractor.inferNameFromURLPath("/Microsoft.GroupName/resourceName/{resourceId}/someChild/{childId}")
-	fmt.Printf("%s/%s: %s", group, resource, name)
+	group, resource, name, err := extractor.inferNameFromURLPath("/Microsoft.GroupName/resourceName/{resourceId}/someChild/{childId}")
+	t.Logf("%s/%s: %s", group, resource, name)
 	// Output: Microsoft.GroupName/resourceName/someChild: ResourceName_SomeChild
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(group).To(Equal("Microsoft.GroupName"))
+	g.Expect(resource).To(Equal("resourceName/someChild"))
+	g.Expect(name).To(Equal("ResourceName_SomeChild"))
 }
 
 func Test_InferNameFromURLPath_FailsWithMultipleParametersInARow(t *testing.T) {
@@ -73,6 +88,21 @@ func Test_InferNameFromURLPath_SkipsDefault(t *testing.T) {
 	g.Expect(group).To(Equal("Microsoft.Storage"))
 	g.Expect(resource).To(Equal("storageAccounts/blobServices/containers"))
 	g.Expect(name).To(Equal("StorageAccounts_BlobServices_Container"))
+}
+
+func Test_InferNameFromURLPath_ExtensionResource(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	extractor := &SwaggerTypeExtractor{
+		idFactory: astmodel.NewIdentifierFactory(),
+	}
+
+	group, resource, name, err := extractor.inferNameFromURLPath("/{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}")
+	g.Expect(err).To(BeNil())
+	g.Expect(group).To(Equal("Microsoft.Authorization"))
+	g.Expect(resource).To(Equal("roleAssignments"))
+	g.Expect(name).To(Equal("RoleAssignment"))
 }
 
 func Test_extractLastPathParam_ExtractsParameter(t *testing.T) {
@@ -168,4 +198,197 @@ func Test_extractLastPathParam_StaticParameterName(t *testing.T) {
 
 	g.Expect(ok).To(BeTrue())
 	g.Expect(lastParam).To(Equal(param))
+}
+
+func Test_ExtractResourceSubpath(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	extractor := &SwaggerTypeExtractor{
+		idFactory: astmodel.NewIdentifierFactory(),
+	}
+
+	group, subpath, err := extractor.extractResourceSubpath("whatever/{whateverParam}/stuff/Microsoft.GroupName/resourceName/{resourceId}/{anotherParameter}")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(group).To(Equal("Microsoft.GroupName"))
+	g.Expect(subpath).To(Equal("resourceName/{resourceId}/{anotherParameter}"))
+}
+
+func Test_ExpandAndCanonicalizePath_DoesNotExpandSimplePath(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ctx := context.Background()
+	extractor := &SwaggerTypeExtractor{
+		idFactory: astmodel.NewIdentifierFactory(),
+	}
+	scanner := NewSchemaScanner(astmodel.NewIdentifierFactory(), config.NewConfiguration())
+
+	parameters := []spec.Parameter{
+		makeSubscriptionIDParameter(),
+		makeResourceGroupParameter(),
+		{
+			ParamProps: spec.ParamProps{
+				Name: "typeName",
+				Schema: &spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"string"},
+					},
+				},
+			},
+		},
+	}
+
+	paths := extractor.expandAndCanonicalizePath(
+		ctx,
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}",
+		scanner,
+		parameters)
+
+	g.Expect(paths).To(HaveLen(1))
+	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}"))
+}
+
+func Test_ExpandAndCanonicalizePath_ExpandsSingleValueEnumInNameLocationWithDefault(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ctx := context.Background()
+	extractor := &SwaggerTypeExtractor{
+		idFactory: astmodel.NewIdentifierFactory(),
+	}
+	scanner := NewSchemaScanner(astmodel.NewIdentifierFactory(), config.NewConfiguration())
+
+	parameters := []spec.Parameter{
+		makeSubscriptionIDParameter(),
+		makeResourceGroupParameter(),
+		{
+			ParamProps: spec.ParamProps{
+				Name: "typeName",
+				Schema: &spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"string"},
+						Enum: []interface{}{
+							"default",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	paths := extractor.expandAndCanonicalizePath(
+		ctx,
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}",
+		scanner,
+		parameters)
+
+	g.Expect(paths).To(HaveLen(1))
+	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/default"))
+}
+
+func Test_ExpandAndCanonicalizePath_DoesNotExpandSingleValueEnumWithoutDefault(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ctx := context.Background()
+	extractor := &SwaggerTypeExtractor{
+		idFactory: astmodel.NewIdentifierFactory(),
+	}
+	scanner := NewSchemaScanner(astmodel.NewIdentifierFactory(), config.NewConfiguration())
+
+	parameters := []spec.Parameter{
+		makeSubscriptionIDParameter(),
+		makeResourceGroupParameter(),
+		{
+			ParamProps: spec.ParamProps{
+				Name: "typeName",
+				Schema: &spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"string"},
+						Enum: []interface{}{
+							"current",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	paths := extractor.expandAndCanonicalizePath(
+		ctx,
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}",
+		scanner,
+		parameters)
+
+	g.Expect(paths).To(HaveLen(1))
+	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/type/{typeName}"))
+}
+
+func Test_ExpandAndCanonicalizePath_ExpandsEnumInResourceTypePath(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	ctx := context.Background()
+	extractor := &SwaggerTypeExtractor{
+		idFactory: astmodel.NewIdentifierFactory(),
+	}
+	scanner := NewSchemaScanner(astmodel.NewIdentifierFactory(), config.NewConfiguration())
+
+	parameters := []spec.Parameter{
+		makeSubscriptionIDParameter(),
+		makeResourceGroupParameter(),
+		{
+			ParamProps: spec.ParamProps{
+				Name: "type",
+				Schema: &spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"string"},
+						Enum: []interface{}{
+							"a",
+							"b",
+							"c",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	paths := extractor.expandAndCanonicalizePath(
+		ctx,
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/{type}/{typeName}",
+		scanner,
+		parameters)
+
+	g.Expect(paths).To(HaveLen(3))
+	g.Expect(paths[0]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/a/{typeName}"))
+	g.Expect(paths[1]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/b/{typeName}"))
+	g.Expect(paths[2]).To(Equal("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Group/c/{typeName}"))
+}
+
+func makeSubscriptionIDParameter() spec.Parameter {
+	return spec.Parameter{
+		ParamProps: spec.ParamProps{
+			Name: "subscriptionId",
+			Schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: spec.StringOrArray{"string"},
+				},
+			},
+		},
+	}
+}
+
+func makeResourceGroupParameter() spec.Parameter {
+	return spec.Parameter{
+		ParamProps: spec.ParamProps{
+			Name: "resourceGroup",
+			Schema: &spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type: spec.StringOrArray{"string"},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Fix issue where infer name would include parameters which were the resource "name" such as "current", when really we only want to include parameters which define resource type.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
