### PR TITLE
Fix broken image links

### DIFF
--- a/docs/hugo/content/contributing/generator-overview.md
+++ b/docs/hugo/content/contributing/generator-overview.md
@@ -23,7 +23,7 @@ Key packages used to structure the code of the generator are as follows:
 
 In this diagram is shown the full directory structure of the ASO code generator, including all the packages named above.
 
-![Overview](images/aso-codegen-structure.svg)
+![Overview](../images/aso-codegen-structure.svg)
 
 The size of each dot reflects the size of the file; the legend in the corner shows the meaning of colour.
 

--- a/docs/hugo/content/design/ADR-2022-08-Evil-Discriminator.md
+++ b/docs/hugo/content/design/ADR-2022-08-Evil-Discriminator.md
@@ -147,11 +147,11 @@ Complicating the situation, definitions can form a hierarchy, with multiple leve
 
 We can depict these relationships visually:
 
-![Media Codecs](images/adr-2022-08-swagger-heirarchy.png)
+![Media Codecs](../images/adr-2022-08-swagger-heirarchy.png)
 
 In order for the rest of the ASO code generator to operate normally, we need to transform this structure into one that matches the form available in the original JSON Schema:
 
-![Transformed Codecs](images/adr-2022-08-post-transform.png)
+![Transformed Codecs](../images/adr-2022-08-post-transform.png)
 
 The changes here are:
 
@@ -194,7 +194,7 @@ We handle this by synthesizing a discriminator property for each derived type th
 
 Not every "ancestor" of a OneOf will necessarily itself be a OneOf; they may also be a regular object type or an AllOf type. 
 
-TODO: IMAGE HERE
+![AllOf as Ancestor](../images/adr-2022-08-allof-ancestors.png)
 
 When we walk the parents of a leaf OneOf to find all the potential properties, we need to walk these references as well.
 

--- a/docs/hugo/content/design/ADR-2022-11-Resource-Import.md
+++ b/docs/hugo/content/design/ADR-2022-11-Resource-Import.md
@@ -82,7 +82,7 @@ $ asoctl export resource http://management.azure.com/subscriptions/00000000-0000
 
 The process of generating the YAML for a given resource can be simplified to the following flow:
 
-![Data Flow](images/adr-2022-11-import-flow.png)
+![Data Flow](../images/adr-2022-11-import-flow.png)
 
 1. The user specified URL is used to ***GET*** the resource from Azure in its native ARM format.
 2. We apply a ***conversion*** to obtain a Status object for the relevant custom resource.

--- a/docs/hugo/link-checker.json
+++ b/docs/hugo/link-checker.json
@@ -1,7 +1,7 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "^(?!http|images|\\./images).*"
+      "pattern": "^(?!http).*"
     },
     {
       "pattern": "https://github.com/Azure/azure-resource-manager-rpc.*",


### PR DESCRIPTION
**What this PR does / why we need it**:

Our markdown link checker gets images wrong, because our markdown is rendered by Hugo.

The link-checker assumes that each `markdown.md` file gets rendered as `http://www.example.com/markdown.html`, for which an image in the same folder would be referenced as `image.png`.

However, with Hugo, each `markdown.md` file gets rendered as a directory containing an `index.html` file. The URL looks like `http://www.example.com/markdown/` so an image referenced as `image.png` would be loaded from `http://www.example.com/markdown/image.png` which doesn't work.

Our image links therefore need to be of the form `../image.pn` at the start so the fully resolved URL actually references the image file as `http://www.example.com/image.png`.

**Special notes for your reviewer**:

I've also fixed the image link in the ADR for Evil Discriminator.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/J3T9b6JFfxFT2/giphy.gif)

**If applicable**:
- [x] this PR contains documentation

