### PR TITLE
Replace `--attributes-only` and `--preserve` with `-p` in kustomize-build.sh

### DIFF
--- a/scripts/kustomize-build.sh
+++ b/scripts/kustomize-build.sh
@@ -44,7 +44,7 @@ if [[ -n "$DESTINATION" ]]; then
   # envsubst on all the files
   for file in $(find "$DESTINATION" -type f); do
     tmp=$(mktemp)
-    cp --attributes-only --preserve $file $tmp
+    cp -p $file $tmp
     cat $file | envsubst $ENVSUBST_VARS > $tmp
     mv $tmp $file
   done


### PR DESCRIPTION

**What this PR does / why we need it**:

`--attributes-only` and `--preserve` flags for `cp` does not work on mac. Have replaced them with `-p` as a fix. 


**Special notes for your reviewer**:

We don't need `--attributes-only` so dropping it totally. 

