### PR TITLE
Include asoctl binaries in release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,15 +29,10 @@ jobs:
           docker start "$container_id"
           echo "id=$container_id" >> $GITHUB_OUTPUT
         
-      - name: Run Kustomize 
+      - name: Build required release files
         run: |
           container_id=${{steps.devcontainer.outputs.id}}
-          docker exec "$container_id" task controller:run-kustomize
-
-      - name: Make multitenant files
-        run: |
-          container_id=${{steps.devcontainer.outputs.id}}
-          docker exec "$container_id" task controller:make-multitenant-files
+          docker exec "$container_id" task make-release-artifacts
 
       - name: Build & tag Docker image
         run: |
@@ -47,11 +42,11 @@ jobs:
           DOCKER_PUSH_TARGET: ${{ secrets.REGISTRY_PUBLIC }}
 
       - name: Upload release assets
-        uses: svenstaro/upload-release-action@2f88c7710e85b1f8b5f6c3a2fcadaa7f865af713 # this is v2, but pinned
+        uses: svenstaro/upload-release-action@7319e4733ec7a184d739a6f412c40ffc339b69c7 # this is v2.5.0, but pinned
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
-          file: "v2/bin/{azureserviceoperator,multitenant-cluster,multitenant-tenant}_*.yaml"
+          file: "v2/out/release/*"
           file_glob: true
 
       - name: Login to registry

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -112,6 +112,28 @@ tasks:
   basic-checks:
     deps: [header-check, specifier-check]
 
+  make-release-artifacts:
+    desc: Produce files required for an ASOv2 release
+    dir: "{{.CONTROLLER_ROOT}}"
+    deps:
+      - controller:run-kustomize
+      - controller:make-multitenant-files
+      - task: asoctl:build
+        vars: {GOOS: "linux", GOARCH: "amd64"}
+      - task: asoctl:build
+        vars: {GOOS: "linux", GOARCH: "arm64"}
+      - task: asoctl:build
+        vars: {GOOS: "darwin", GOARCH: "amd64"}
+      - task: asoctl:build
+        vars: {GOOS: "darwin", GOARCH: "arm64"}
+      - task: asoctl:build
+        vars: {GOOS: "windows", GOARCH: "amd64"}
+    cmds:
+      - rm -rf out/release
+      - mkdir -p out/release
+      - cp ./bin/{azureserviceoperator,multitenant-cluster,multitenant-tenant}_*.yaml out/release
+      - cp ./bin/asoctl* out/release
+
   ############### Asoctl targets ###############
 
   asoctl:quick-checks:
@@ -155,9 +177,16 @@ tasks:
   asoctl:build:
     desc: Generate the {{.ASOCTL_APP}} binary.
     dir: '{{.ASOCTL_ROOT}}'
+    label: asoctl:build-{{.GOOS}}-{{.GOARCH}}
     deps: [controller:generate-crds]
+    generates:
+      - ../../bin/{{.ASOCTL_APP}}-{{.GOOS}}-{{.GOARCH}}
     cmds:
-      - go build {{.VERSION_FLAGS}} -o ../../bin/{{.ASOCTL_APP}} .
+      - GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build {{.VERSION_FLAGS}} -o ../../bin/{{.ASOCTL_APP}}-{{.GOOS}}-{{.GOARCH}}{{.EXT}} .
+    vars:
+      EXT: '{{if eq .GOOS "windows"}}.exe{{else}}{{end}}'
+      GOOS: '{{default OS .GOOS}}'
+      GOARCH: '{{default ARCH .GOARCH}}'
 
   ############### Generator targets ###############
 


### PR DESCRIPTION
Fixes #2825.

Builds binaries for Linux ARM and AMD64, Darwin (mac) ARM and AMD64, and Windows AMD64.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/13GIgrGdslD9oQ/giphy.gif)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
