### PR TITLE
Refactor cross resource reference config overrides

### DIFF
--- a/v2/tools/generator/internal/codegen/code_generator.go
+++ b/v2/tools/generator/internal/codegen/code_generator.go
@@ -149,6 +149,7 @@ func createAllPipelineStages(idFactory astmodel.IdentifierFactory, configuration
 
 		pipeline.FixOptionalCollectionAliases(),
 
+		pipeline.ApplyCrossResourceReferencesFromConfig(configuration).UsedFor(pipeline.ARMTarget),
 		pipeline.TransformCrossResourceReferences(configuration, idFactory).UsedFor(pipeline.ARMTarget),
 		pipeline.TransformCrossResourceReferencesToString().UsedFor(pipeline.CrossplaneTarget),
 		pipeline.AddSecrets(configuration).UsedFor(pipeline.ARMTarget),

--- a/v2/tools/generator/internal/codegen/golden_files_test.go
+++ b/v2/tools/generator/internal/codegen/golden_files_test.go
@@ -179,6 +179,7 @@ func NewTestCodeGenerator(
 
 			codegen.ReplaceStage(pipeline.StripUnreferencedTypeDefinitionsStageID, stripUnusedTypesPipelineStage())
 		} else {
+			codegen.RemoveStages(pipeline.ApplyCrossResourceReferencesFromConfigStageID)
 			codegen.ReplaceStage(pipeline.TransformCrossResourceReferencesStageID, addCrossResourceReferencesForTest(idFactory))
 		}
 	case config.GenerationPipelineCrossplane:
@@ -339,10 +340,17 @@ func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) *pi
 		"Add cross resource references for test",
 		func(ctx context.Context, state *pipeline.State) (*pipeline.State, error) {
 			defs := make(astmodel.TypeDefinitionSet)
-			isCrossResourceReference := func(_ astmodel.TypeName, prop *astmodel.PropertyDefinition) bool {
-				return pipeline.DoesPropertyLookLikeARMReference(prop)
+			isCrossResourceReference := func(_ astmodel.TypeName, prop *astmodel.PropertyDefinition) pipeline.ARMIDPropertyClassification {
+				ref := pipeline.DoesPropertyLookLikeARMReference(prop)
+				if ref {
+					return pipeline.ARMIDPropertyClassificationSet
+				}
+
+				return pipeline.ARMIDPropertyClassificationUnspecified
 			}
-			visitor := pipeline.MakeCrossResourceReferenceTypeVisitor(idFactory, isCrossResourceReference)
+
+			crossReferenceVisitor := pipeline.MakeARMIDPropertyTypeVisitor(isCrossResourceReference)
+			resourceReferenceVisitor := pipeline.MakeARMIDToResourceReferenceTypeVisitor(idFactory)
 
 			for _, def := range state.Definitions() {
 				// Skip Status types
@@ -352,11 +360,17 @@ func addCrossResourceReferencesForTest(idFactory astmodel.IdentifierFactory) *pi
 					continue
 				}
 
-				t, err := visitor.Visit(def.Type(), def.Name())
+				updatedDef, err := crossReferenceVisitor.VisitDefinition(def, def.Name())
 				if err != nil {
-					return nil, errors.Wrapf(err, "visiting %q", def.Name())
+					return nil, errors.Wrapf(err, "crossReferenceVisitor failed visiting %q", def.Name())
 				}
-				defs.Add(def.WithType(t))
+
+				updatedDef, err = resourceReferenceVisitor.VisitDefinition(updatedDef, def.Name())
+				if err != nil {
+					return nil, errors.Wrapf(err, "resourceReferenceVisitor failed visiting %q", def.Name())
+				}
+
+				defs.Add(updatedDef)
 			}
 
 			return state.WithDefinitions(defs), nil

--- a/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
+++ b/v2/tools/generator/internal/codegen/pipeline/add_cross_resource_references.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog/v2"
 
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
 	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
@@ -30,67 +29,14 @@ func TransformCrossResourceReferences(configuration *config.Configuration, idFac
 		TransformCrossResourceReferencesStageID,
 		"Replace cross-resource references with genruntime.ResourceReference",
 		func(ctx context.Context, state *State) (*State, error) {
-			typesWithARMIDs := make(astmodel.TypeDefinitionSet)
+			updatedDefs := make(astmodel.TypeDefinitionSet)
 
-			var crossResourceReferenceErrs []error
-
-			isCrossResourceReference := func(typeName astmodel.TypeName, prop *astmodel.PropertyDefinition) bool {
-				// First check if we know that this property is an ARMID already
-				isReference, err := configuration.ARMReference(typeName, prop.PropertyName())
-				if primitive, ok := extractPrimitiveType(prop.PropertyType()); ok {
-					if primitive == astmodel.ARMIDType {
-						if err == nil {
-							if !isReference {
-								// We've overridden the ARM spec details
-								return false
-							} else {
-								// Swagger has marked this field as a reference, and we also have it marked in our
-								// config. Record an error saying that the config entry is no longer needed
-								crossResourceReferenceErrs = append(
-									crossResourceReferenceErrs,
-									errors.Errorf("%s.%s marked as ARM reference, but value is not needed because Swagger already says it is an ARM reference",
-										typeName.String(),
-										prop.PropertyName().String()))
-							}
-						}
-
-						return true
-					}
-				}
-
-				if DoesPropertyLookLikeARMReference(prop) && err != nil {
-					if config.IsNotConfiguredError(err) {
-						// This is an error for now to ensure that we don't accidentally miss adding references.
-						// If/when we move to using an upstream marker for cross resource refs, we can remove this and just
-						// trust the Swagger.
-						crossResourceReferenceErrs = append(
-							crossResourceReferenceErrs,
-							// Don't wrap the existing error here because it adds a lot of extra boilerplate text we don't want
-							errors.Errorf(
-								"%s.%s looks like a resource reference but was not labelled as one; You may need to add it to the 'objectModelConfiguration' section of the config file",
-								typeName,
-								prop.PropertyName()))
-					} else {
-						// Something else went wrong checking our configuration
-						crossResourceReferenceErrs = append(
-							crossResourceReferenceErrs,
-							errors.Wrapf(
-								err,
-								"%s.%s looks like a resource reference but something went wrong checking for configuration",
-								typeName,
-								prop.PropertyName()))
-					}
-				}
-
-				return isReference
-			}
-
-			visitor := MakeCrossResourceReferenceTypeVisitor(idFactory, isCrossResourceReference)
+			visitor := MakeARMIDToResourceReferenceTypeVisitor(idFactory)
 			for _, def := range state.Definitions() {
 				// Skip Status types
 				// TODO: we need flags
 				if def.Name().IsStatus() {
-					typesWithARMIDs.Add(def)
+					updatedDefs.Add(def)
 					continue
 				}
 
@@ -99,99 +45,16 @@ func TransformCrossResourceReferences(configuration *config.Configuration, idFac
 					return nil, errors.Wrapf(err, "visiting %q", def.Name())
 				}
 
-				typesWithARMIDs.Add(def.WithType(t))
-
-				// TODO: Remove types that have only a single field ID and pull things up a level? Will need to wait for George's
-				// TODO: Properties collapsing work for this.
+				updatedDefs.Add(def.WithType(t))
 			}
 
-			var err error = kerrors.NewAggregate(crossResourceReferenceErrs)
-			if err != nil {
-				return nil, err
-			}
-
-			updatedDefs, err := stripARMIDPrimitiveTypes(typesWithARMIDs)
+			resultDefs, err := stripARMIDPrimitiveTypes(updatedDefs)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to strip ARM ID primitive types")
 			}
 
-			err = configuration.VerifyARMReferencesConsumed()
-			if err != nil {
-				klog.Error(err)
-
-				return nil, errors.Wrap(
-					err,
-					"Found unused $armReference configurations; these need to be fixed or removed.")
-			}
-
-			return state.WithDefinitions(updatedDefs), nil
+			return state.WithDefinitions(resultDefs), nil
 		})
-}
-
-type crossResourceReferenceChecker func(typeName astmodel.TypeName, prop *astmodel.PropertyDefinition) bool
-
-type CrossResourceReferenceTypeVisitor struct {
-	astmodel.TypeVisitor
-	// referenceChecker is a function describing what a cross resource reference looks like. It is overridable so that
-	// we can use a more simplistic criteria for tests.
-	isPropertyAnARMReference crossResourceReferenceChecker
-}
-
-func MakeCrossResourceReferenceTypeVisitor(idFactory astmodel.IdentifierFactory, referenceChecker crossResourceReferenceChecker) CrossResourceReferenceTypeVisitor {
-	visitor := CrossResourceReferenceTypeVisitor{
-		isPropertyAnARMReference: referenceChecker,
-	}
-
-	transformResourceReferenceProperties := func(_ *astmodel.TypeVisitor, it *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
-		typeName := ctx.(astmodel.TypeName)
-
-		var newProps []*astmodel.PropertyDefinition
-		it.Properties().ForEach(func(prop *astmodel.PropertyDefinition) {
-			if visitor.isPropertyAnARMReference(typeName, prop) {
-				klog.V(4).Infof("Transforming \"%s.%s\" field into genruntime.ResourceReference", typeName, prop.PropertyName())
-				originalName := string(prop.PropertyName())
-				prop = makeResourceReferenceProperty(typeName, idFactory, prop)
-
-				// TODO: We could pass this information forward some other way?
-				// Add tag so that we remember what this field was before
-				prop = prop.WithTag(astmodel.ARMReferenceTag, originalName)
-			}
-
-			newProps = append(newProps, prop)
-		})
-
-		it = it.WithoutProperties()
-		result := it.WithProperties(newProps...)
-		return result, nil
-	}
-
-	visitor.TypeVisitor = astmodel.TypeVisitorBuilder{
-		VisitObjectType: transformResourceReferenceProperties,
-	}.Build()
-
-	return visitor
-}
-
-// DoesPropertyLookLikeARMReference uses a simple heuristic to determine if a property looks like it might be an ARM reference.
-// This can be used for logging/reporting purposes to discover references which we missed.
-func DoesPropertyLookLikeARMReference(prop *astmodel.PropertyDefinition) bool {
-	// The property must be a string, optional string, list of strings, or map[string]string
-	isString := astmodel.TypeEquals(prop.PropertyType(), astmodel.StringType)
-	isOptionalString := astmodel.TypeEquals(prop.PropertyType(), astmodel.OptionalStringType)
-	isStringSlice := astmodel.TypeEquals(prop.PropertyType(), astmodel.NewArrayType(astmodel.StringType))
-	isStringMap := astmodel.TypeEquals(prop.PropertyType(), astmodel.NewMapType(astmodel.StringType, astmodel.StringType))
-
-	if !isString && !isOptionalString && !isStringSlice && !isStringMap {
-		return false
-	}
-
-	hasMatchingDescription := armIDDescriptionRegex.MatchString(prop.Description())
-	namedID := prop.HasName("Id")
-	if hasMatchingDescription || namedID {
-		return true
-	}
-
-	return false
 }
 
 func makeReferencePropertyName(existing *astmodel.PropertyDefinition, isSlice bool, isMap bool) string {
@@ -243,6 +106,104 @@ func makeLegacyReferencePropertyName(existing *astmodel.PropertyDefinition, isSl
 	return referencePropertyName
 }
 
+type ARMIDToGenruntimeReferenceTypeVisitor struct {
+	astmodel.TypeVisitor
+	idFactory astmodel.IdentifierFactory
+}
+
+func (v *ARMIDToGenruntimeReferenceTypeVisitor) transformARMIDToGenruntimeResourceReference(
+	_ *astmodel.TypeVisitor,
+	it *astmodel.PrimitiveType,
+	_ interface{},
+) (astmodel.Type, error) {
+	if it == astmodel.ARMIDType {
+		return astmodel.ResourceReferenceType, nil
+	}
+
+	return it, nil
+}
+
+func (v *ARMIDToGenruntimeReferenceTypeVisitor) renamePropertiesWithARMIDReferences(
+	this *astmodel.TypeVisitor,
+	it *astmodel.ObjectType,
+	ctx interface{},
+) (astmodel.Type, error) {
+	// First, we visit this type like normal
+	result, err := astmodel.IdentityVisitOfObjectType(this, it, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	typeName := ctx.(astmodel.TypeName)
+	ot, ok := result.(*astmodel.ObjectType)
+	if !ok {
+		return nil, errors.Errorf("result for visitObjectType of %s was not expected ObjectType, instead %T", typeName, result)
+	}
+
+	// Now, check if any properties have been updated and if they have change their names to match
+	var newProps []*astmodel.PropertyDefinition
+	var errs []error
+	ot.Properties().ForEach(func(prop *astmodel.PropertyDefinition) {
+		origProp, ok := it.Property(prop.PropertyName())
+		if !ok {
+			errs = append(errs, errors.Errorf("expected to find property %q on %s", prop.PropertyName(), typeName))
+			return
+		}
+
+		if origProp.Equals(prop, astmodel.EqualityOverrides{}) {
+			newProps = append(newProps, prop)
+			return
+		}
+
+		newProp := makeResourceReferenceProperty(typeName, v.idFactory, prop)
+		newProps = append(newProps, newProp)
+	})
+
+	err = kerrors.NewAggregate(errs)
+	if err != nil {
+		return nil, err
+	}
+
+	ot = ot.WithoutProperties()
+	ot = ot.WithProperties(newProps...)
+	return ot, nil
+}
+
+func (v *ARMIDToGenruntimeReferenceTypeVisitor) stripValidationForResourceReferences(
+	this *astmodel.TypeVisitor,
+	it *astmodel.ValidatedType,
+	ctx interface{},
+) (astmodel.Type, error) {
+	result, err := astmodel.IdentityVisitOfValidatedType(this, it, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if astmodel.TypeEquals(it, result) {
+		return result, nil
+	}
+
+	// If they aren't equal, just return the element
+	validated, ok := result.(*astmodel.ValidatedType)
+	if !ok {
+		return nil, errors.Errorf("expected IdentityVisitOfValidatedType to return a ValidatedType, but it instead returned %T", result)
+	}
+	return validated.ElementType(), nil
+}
+
+func MakeARMIDToResourceReferenceTypeVisitor(idFactory astmodel.IdentifierFactory) ARMIDToGenruntimeReferenceTypeVisitor {
+	result := ARMIDToGenruntimeReferenceTypeVisitor{
+		idFactory: idFactory,
+	}
+	result.TypeVisitor = astmodel.TypeVisitorBuilder{
+		VisitPrimitive:     result.transformARMIDToGenruntimeResourceReference,
+		VisitObjectType:    result.renamePropertiesWithARMIDReferences,
+		VisitValidatedType: result.stripValidationForResourceReferences,
+	}.Build()
+
+	return result
+}
+
 func makeResourceReferenceProperty(
 	typeName astmodel.TypeName,
 	idFactory astmodel.IdentifierFactory,
@@ -258,20 +219,15 @@ func makeResourceReferenceProperty(
 		referencePropertyName = makeReferencePropertyName(existing, isSlice, isMap)
 	}
 
-	var newPropType astmodel.Type
-
-	if isSlice {
-		newPropType = astmodel.NewArrayType(astmodel.ResourceReferenceType)
-	} else if isMap {
-		newPropType = astmodel.NewMapType(astmodel.StringType, astmodel.ResourceReferenceType)
-	} else {
-		newPropType = astmodel.NewOptionalType(astmodel.ResourceReferenceType)
-	}
+	originalName := string(existing.PropertyName())
 
 	newProp := astmodel.NewPropertyDefinition(
 		idFactory.CreatePropertyName(referencePropertyName, astmodel.Exported),
 		idFactory.CreateStringIdentifier(referencePropertyName, astmodel.NotExported),
-		newPropType)
+		existing.PropertyType())
+	// TODO: We could pass this information forward some other way?
+	// Add tag so that we remember what this field was before
+	newProp = newProp.WithTag(astmodel.ARMReferenceTag, originalName)
 
 	newProp = newProp.WithDescription(existing.Description())
 	if existing.IsRequired() {
@@ -305,22 +261,4 @@ func stripARMIDPrimitiveTypes(types astmodel.TypeDefinitionSet) (astmodel.TypeDe
 	}
 
 	return result, nil
-}
-
-// ExtractPrimitiveType extracts a PrimitiveType from the specified type if possible. This includes unwrapping
-// MetaType's like ValidatedType as well as checking the element type of types such as ArrayType and MapType.
-func extractPrimitiveType(aType astmodel.Type) (*astmodel.PrimitiveType, bool) {
-	if primitiveType, ok := astmodel.AsPrimitiveType(aType); ok {
-		return primitiveType, ok
-	}
-
-	if arrayType, ok := astmodel.AsArrayType(aType); ok {
-		return extractPrimitiveType(arrayType.Element())
-	}
-
-	if mapType, ok := astmodel.AsMapType(aType); ok {
-		return extractPrimitiveType(mapType.ValueType())
-	}
-
-	return nil, false
 }

--- a/v2/tools/generator/internal/codegen/pipeline/apply_cross_resource_references_from_config.go
+++ b/v2/tools/generator/internal/codegen/pipeline/apply_cross_resource_references_from_config.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package pipeline
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/astmodel"
+	"github.com/Azure/azure-service-operator/v2/tools/generator/internal/config"
+)
+
+type ARMIDPropertyClassification string
+
+const (
+	ARMIDPropertyClassificationUnset       = ARMIDPropertyClassification("unset")
+	ARMIDPropertyClassificationSet         = ARMIDPropertyClassification("set")
+	ARMIDPropertyClassificationUnspecified = ARMIDPropertyClassification("unspecified")
+)
+
+// ApplyCrossResourceReferencesFromConfigStageID is the unique identifier for this pipeline stage
+const ApplyCrossResourceReferencesFromConfigStageID = "applyCrossResourceReferencesFromConfig"
+
+// ApplyCrossResourceReferencesFromConfig replaces cross resource references from the configuration with astmodel.ARMID.
+func ApplyCrossResourceReferencesFromConfig(configuration *config.Configuration) *Stage {
+	return NewStage(
+		ApplyCrossResourceReferencesFromConfigStageID,
+		"Replace cross-resource references in the config with astmodel.ARMID",
+		func(ctx context.Context, state *State) (*State, error) {
+			typesWithARMIDs := make(astmodel.TypeDefinitionSet)
+
+			var crossResourceReferenceErrs []error
+
+			isCrossResourceReference := func(typeName astmodel.TypeName, prop *astmodel.PropertyDefinition) ARMIDPropertyClassification {
+				// First check if we know that this property is an ARMID already
+				isReference, err := configuration.ARMReference(typeName, prop.PropertyName())
+				isSwaggerARMID := isTypeARMID(prop.PropertyType())
+
+				// If we've got a Swagger ARM ID entry AND an entry in our config, that might be a problem
+				if isSwaggerARMID && err == nil {
+					if !isReference {
+						// We allow overriding the ARM ID status of a property to false in our config
+						return ARMIDPropertyClassificationUnset
+					} else {
+						// Swagger has marked this field as a reference, and we also have it marked in our
+						// config. Record an error saying that the config entry is no longer needed
+						crossResourceReferenceErrs = append(
+							crossResourceReferenceErrs,
+							errors.Errorf("%s.%s marked as ARM reference, but value is not needed because Swagger already says it is an ARM reference",
+								typeName.String(),
+								prop.PropertyName().String()))
+					}
+				}
+
+				if DoesPropertyLookLikeARMReference(prop) && err != nil {
+					if config.IsNotConfiguredError(err) {
+						// This is an error for now to ensure that we don't accidentally miss adding references.
+						// If/when we move to using an upstream marker for cross resource refs, we can remove this and just
+						// trust the Swagger.
+						crossResourceReferenceErrs = append(
+							crossResourceReferenceErrs,
+							errors.Wrapf(
+								err,
+								"%s.%s looks like a resource reference but was not labelled as one; You may need to add it to the 'objectModelConfiguration' section of the config file",
+								typeName,
+								prop.PropertyName()))
+					} else {
+						// Something else went wrong checking our configuration
+						crossResourceReferenceErrs = append(
+							crossResourceReferenceErrs,
+							errors.Wrapf(
+								err,
+								"%s.%s looks like a resource reference but something went wrong checking for configuration",
+								typeName,
+								prop.PropertyName()))
+					}
+				}
+
+				if isReference {
+					return ARMIDPropertyClassificationSet
+				}
+				return ARMIDPropertyClassificationUnspecified
+			}
+
+			visitor := MakeARMIDPropertyTypeVisitor(isCrossResourceReference)
+			for _, def := range state.Definitions() {
+				// Skip Status types
+				// TODO: we need flags
+				if def.Name().IsStatus() {
+					typesWithARMIDs.Add(def)
+					continue
+				}
+
+				t, err := visitor.Visit(def.Type(), def.Name())
+				if err != nil {
+					return nil, errors.Wrapf(err, "visiting %q", def.Name())
+				}
+
+				typesWithARMIDs.Add(def.WithType(t))
+
+				// TODO: Remove types that have only a single field ID and pull things up a level? Will need to wait for George's
+				// TODO: Properties collapsing work for this.
+			}
+
+			var err error = kerrors.NewAggregate(crossResourceReferenceErrs)
+			if err != nil {
+				return nil, err
+			}
+
+			err = configuration.VerifyARMReferencesConsumed()
+			if err != nil {
+				klog.Error(err)
+
+				return nil, errors.Wrap(
+					err,
+					"Found unused $armReference configurations; these need to be fixed or removed.")
+			}
+
+			return state.WithDefinitions(typesWithARMIDs), nil
+		})
+}
+
+type crossResourceReferenceChecker func(typeName astmodel.TypeName, prop *astmodel.PropertyDefinition) ARMIDPropertyClassification
+
+type ARMIDPropertyTypeVisitor struct {
+	astmodel.TypeVisitor
+	// isPropertyAnARMReference is a function describing what a cross resource reference looks like. It is overridable so that
+	// we can use a more simplistic criteria for tests.
+	isPropertyAnARMReference crossResourceReferenceChecker
+}
+
+func MakeARMIDPropertyTypeVisitor(referenceChecker crossResourceReferenceChecker) ARMIDPropertyTypeVisitor {
+	visitor := ARMIDPropertyTypeVisitor{
+		isPropertyAnARMReference: referenceChecker,
+	}
+
+	transformResourceReferenceProperties := func(_ *astmodel.TypeVisitor, it *astmodel.ObjectType, ctx interface{}) (astmodel.Type, error) {
+		typeName := ctx.(astmodel.TypeName)
+
+		var newProps []*astmodel.PropertyDefinition
+		it.Properties().ForEach(func(prop *astmodel.PropertyDefinition) {
+			classification := visitor.isPropertyAnARMReference(typeName, prop)
+			if classification == ARMIDPropertyClassificationSet {
+				klog.V(4).Infof("Transforming \"%s.%s\" field into astmodel.ARMID", typeName, prop.PropertyName())
+				prop = makeARMIDProperty(prop)
+			} else if classification == ARMIDPropertyClassificationUnset {
+				klog.V(4).Infof("Transforming \"%s.%s\" field into string from astmodel.ARMID", typeName, prop.PropertyName())
+				prop = unsetARMIDProperty(prop)
+			}
+
+			newProps = append(newProps, prop)
+		})
+
+		it = it.WithoutProperties()
+		result := it.WithProperties(newProps...)
+		return result, nil
+	}
+
+	visitor.TypeVisitor = astmodel.TypeVisitorBuilder{
+		VisitObjectType: transformResourceReferenceProperties,
+	}.Build()
+
+	return visitor
+}
+
+// DoesPropertyLookLikeARMReference uses a simple heuristic to determine if a property looks like it might be an ARM reference.
+// This can be used for logging/reporting purposes to discover references which we missed.
+func DoesPropertyLookLikeARMReference(prop *astmodel.PropertyDefinition) bool {
+	// The property must be a string, optional string, list of strings, or map[string]string
+	isString := astmodel.TypeEquals(prop.PropertyType(), astmodel.StringType)
+	isOptionalString := astmodel.TypeEquals(prop.PropertyType(), astmodel.OptionalStringType)
+	isStringSlice := astmodel.TypeEquals(prop.PropertyType(), astmodel.NewArrayType(astmodel.StringType))
+	isStringMap := astmodel.TypeEquals(prop.PropertyType(), astmodel.NewMapType(astmodel.StringType, astmodel.StringType))
+
+	if !isString && !isOptionalString && !isStringSlice && !isStringMap {
+		return false
+	}
+
+	hasMatchingDescription := armIDDescriptionRegex.MatchString(prop.Description())
+	namedID := prop.HasName("Id")
+	if hasMatchingDescription || namedID {
+		return true
+	}
+
+	return false
+}
+
+func makeARMIDProperty(existing *astmodel.PropertyDefinition) *astmodel.PropertyDefinition {
+	return makeARMIDPropertyImpl(existing, astmodel.ARMIDType)
+}
+
+func makeARMIDPropertyImpl(existing *astmodel.PropertyDefinition, newType astmodel.Type) *astmodel.PropertyDefinition {
+	_, isSlice := astmodel.AsArrayType(existing.PropertyType())
+	_, isMap := astmodel.AsMapType(existing.PropertyType())
+
+	var newPropType astmodel.Type
+
+	if isSlice {
+		newPropType = astmodel.NewArrayType(newType)
+	} else if isMap {
+		newPropType = astmodel.NewMapType(astmodel.StringType, newType)
+	} else {
+		newPropType = astmodel.NewOptionalType(newType)
+	}
+
+	newProp := existing.WithType(newPropType)
+
+	return newProp
+}
+
+func unsetARMIDProperty(existing *astmodel.PropertyDefinition) *astmodel.PropertyDefinition {
+	return makeARMIDPropertyImpl(existing, astmodel.StringType)
+}
+
+// isTypeARMID determines if the type has an ARM ID somewhere inside of it
+func isTypeARMID(aType astmodel.Type) bool {
+	if primitiveType, ok := astmodel.AsPrimitiveType(aType); ok {
+		return primitiveType == astmodel.ARMIDType
+	}
+
+	if arrayType, ok := astmodel.AsArrayType(aType); ok {
+		return isTypeARMID(arrayType.Element())
+	}
+
+	if mapType, ok := astmodel.AsMapType(aType); ok {
+		return isTypeARMID(mapType.KeyType()) || isTypeARMID(mapType.ValueType())
+	}
+
+	return false
+}

--- a/v2/tools/generator/internal/codegen/pipeline/create_arm_types_test.go
+++ b/v2/tools/generator/internal/codegen/pipeline/create_arm_types_test.go
@@ -97,6 +97,7 @@ func TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions(t *tes
 	configuration := config.NewConfiguration()
 	configuration.ObjectModelConfiguration = omc
 
+	configToARMIDs := ApplyCrossResourceReferencesFromConfig(configuration)
 	crossResourceRefs := TransformCrossResourceReferences(configuration, idFactory)
 	createARMTypes := CreateARMTypes(idFactory)
 	applyARMConversionInterface := ApplyARMConversionInterface(idFactory)
@@ -106,6 +107,7 @@ func TestCreateFlattenedARMTypeWithResourceRef_CreatesExpectedConversions(t *tes
 
 	state, err := RunTestPipeline(
 		NewState().WithDefinitions(defs),
+		configToARMIDs,
 		crossResourceRefs,
 		createARMTypes,
 		applyARMConversionInterface,

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewARMCodeGeneratorFromConfigCreatesRightPipeline.golden
@@ -30,6 +30,7 @@ stripUnreferenced                                            Strip unreferenced 
 replaceAnyTypeWithJSON                                       Replace properties using interface{} with arbitrary JSON
 improvePropertyDescriptions                                  Improve property descriptions by copying from the corresponding type
 fixOptionalCollectionAliases                                 Replace types which are optional aliases to collections with just the collection alias
+applyCrossResourceReferencesFromConfig            azure      Replace cross-resource references in the config with astmodel.ARMID
 transformCrossResourceReferences                  azure      Replace cross-resource references with genruntime.ResourceReference
 addSecrets                                        azure      Replace properties flagged as secret with genruntime.SecretReference
 addConfigMaps                                     azure      Replace properties flagged as a configMap with genruntime.ConfigMapReference. For properties flagged as an optional configMap, add a new <property>FromConfig property.

--- a/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
+++ b/v2/tools/generator/internal/codegen/testdata/TestGolden_NewTestCodeGeneratorCreatesRightPipeline.golden
@@ -1,60 +1,61 @@
 Expected Pipeline Stages for Test Code Generation
 -------------------------------------------------
-loadTestSchema                                       Load and walk schema (test)
-assembleOneOfTypes                                   Assemble OneOf types from OpenAPI Fragments
-allof-anyof-objects                                  Convert allOf and oneOf to object types
-flattenResources                                     Flatten nested resource types
-stripUnused                                          Strip unused types for test
-removeAliases                                        Remove type aliases
-nameTypes                                            Name inner types for CRD
-propertyRewrites                                     Modify property types using configured transforms
-applyIsResourceOverrides                             Apply $isResource overrides to objects
-fixIdFields                                          Remove ARM ID annotations from status, and Id from Spec types
-unrollRecursiveTypes                                 Unroll directly recursive types since they are not supported by controller-gen
-removeStatusPropertyValidation                       Remove validation from all status properties
-determineResourceOwnership                           Determine ARM resource relationships
-removeAliases                                        Remove type aliases
-stripUnused                                          Strip unused types for test
-assertTypesStructureValid                            Verify that all local TypeNames refer to a type
-add-api-version-enums                                Add enums for API Versions in each package
-removeAliases                                        Remove type aliases
-makeStatusPropertiesOptional                         Force all status properties to be optional
-transformValidatedFloats                             Transform validated 'spec' float type values to validated integer types for compatibility with controller-gen
-addLocatableInterface                                Add the Locatable interface for Location based resources such as ResourceGroup
-removeEmptyObjects                                   Remove empty Objects
-verifyNoErroredTypes                                 Verify there are no ErroredType's containing errors
-stripUnused                                          Strip unused types for test
-replaceAnyTypeWithJSON                               Replace properties using interface{} with arbitrary JSON
-improvePropertyDescriptions                          Improve property descriptions by copying from the corresponding type
-fixOptionalCollectionAliases                         Replace types which are optional aliases to collections with just the collection alias
-addSecrets                                azure      Replace properties flagged as secret with genruntime.SecretReference
-addConfigMaps                             azure      Replace properties flagged as a configMap with genruntime.ConfigMapReference. For properties flagged as an optional configMap, add a new <property>FromConfig property.
-makeOneOfDiscriminantRequired             azure      Fix one of types to a discriminator which is not omitempty/optional
-applyKubernetesResourceInterface          azure      Add the KubernetesResource interface to every resource
-flattenProperties                                    Apply flattening to properties marked for flattening
-stripUnused                                          Strip unused types for test
-addStatusConditions                       azure      Add the property 'Conditions' to all status types and implements genruntime.Conditioner on all resources
-addOperatorSpec                           azure      Adds the property 'OperatorSpec' to all Spec types that require it
-addKubernetesExporter                     azure      Adds the KubernetesExporter interface to resources that need it
-applyDefaulterAndValidatorInterfaces      azure      Add the admission.Defaulter and admission.Validator interfaces to each resource that requires them
-injectOriginalVersionFunction             azure      Inject the function OriginalVersion() into each Spec type
-createStorageTypes                        azure      Create storage versions of CRD types
-createConversionGraph                     azure      Create the graph of conversions between versions of each resource group
-injectOriginalVersionProperty             azure      Inject the property OriginalVersion into each Storage Spec type
-injectPropertyAssignmentFunctions         azure      Inject property assignment functions AssignFrom() and AssignTo() into resources and objects
-implementConvertibleSpecInterface         azure      Inject ConvertSpecTo() and ConvertSpecFrom() to implement genruntime.ConvertibleSpec on each Spec type
-implementConvertibleStatusInterface       azure      Inject ConvertStatusTo() and ConvertStatusFrom() to implement genruntime.ConvertibleStatus on each Status type
-injectOriginalGVKFunction                 azure      Inject the function OriginalGVK() into each Resource type
-injectSpecInitializationFunctions         azure      Inject spec initialization functions Initialize_From_*() into resources and objects
-implementImportableResourceInterface      azure      Implement the ImportableResource interface for resources that support import via asoctl
-markLatestStorageVariantAsHubVersion      azure      Mark the latest GA storage variant of each resource as the hub version
-injectHubFunction                         azure      Inject the function Hub() into each hub resource
-implementConvertibleInterface             azure      Implement the Convertible interface on each non-hub Resource type
-injectJSONTestCases                       azure      Add test cases to verify JSON serialization
-injectPropertyAssignmentTestCases         azure      Add test cases to verify PropertyAssignment functions
-injectResourceConversionTestCases         azure      Add test cases to verify Resource implementations of conversion.Convertible (funcs ConvertTo & ConvertFrom) behave as expected
-simplifyDefinitions                                  Flatten definitions by removing wrapper types
-ensureArmTypeExistsForEveryType           azure      Check that an ARM type exists for both Spec and Status of each resource
-detectSkippingProperties                  azure      Detect properties that skip resource or object versions
-exportTestPackages                                   Export packages for test
-exportControllerResourceRegistrations     azure      Export resource registrations to ""
+loadTestSchema                                        Load and walk schema (test)
+assembleOneOfTypes                                    Assemble OneOf types from OpenAPI Fragments
+allof-anyof-objects                                   Convert allOf and oneOf to object types
+flattenResources                                      Flatten nested resource types
+stripUnused                                           Strip unused types for test
+removeAliases                                         Remove type aliases
+nameTypes                                             Name inner types for CRD
+propertyRewrites                                      Modify property types using configured transforms
+applyIsResourceOverrides                              Apply $isResource overrides to objects
+fixIdFields                                           Remove ARM ID annotations from status, and Id from Spec types
+unrollRecursiveTypes                                  Unroll directly recursive types since they are not supported by controller-gen
+removeStatusPropertyValidation                        Remove validation from all status properties
+determineResourceOwnership                            Determine ARM resource relationships
+removeAliases                                         Remove type aliases
+stripUnused                                           Strip unused types for test
+assertTypesStructureValid                             Verify that all local TypeNames refer to a type
+add-api-version-enums                                 Add enums for API Versions in each package
+removeAliases                                         Remove type aliases
+makeStatusPropertiesOptional                          Force all status properties to be optional
+transformValidatedFloats                              Transform validated 'spec' float type values to validated integer types for compatibility with controller-gen
+addLocatableInterface                                 Add the Locatable interface for Location based resources such as ResourceGroup
+removeEmptyObjects                                    Remove empty Objects
+verifyNoErroredTypes                                  Verify there are no ErroredType's containing errors
+stripUnused                                           Strip unused types for test
+replaceAnyTypeWithJSON                                Replace properties using interface{} with arbitrary JSON
+improvePropertyDescriptions                           Improve property descriptions by copying from the corresponding type
+fixOptionalCollectionAliases                          Replace types which are optional aliases to collections with just the collection alias
+applyCrossResourceReferencesFromConfig     azure      Replace cross-resource references in the config with astmodel.ARMID
+addSecrets                                 azure      Replace properties flagged as secret with genruntime.SecretReference
+addConfigMaps                              azure      Replace properties flagged as a configMap with genruntime.ConfigMapReference. For properties flagged as an optional configMap, add a new <property>FromConfig property.
+makeOneOfDiscriminantRequired              azure      Fix one of types to a discriminator which is not omitempty/optional
+applyKubernetesResourceInterface           azure      Add the KubernetesResource interface to every resource
+flattenProperties                                     Apply flattening to properties marked for flattening
+stripUnused                                           Strip unused types for test
+addStatusConditions                        azure      Add the property 'Conditions' to all status types and implements genruntime.Conditioner on all resources
+addOperatorSpec                            azure      Adds the property 'OperatorSpec' to all Spec types that require it
+addKubernetesExporter                      azure      Adds the KubernetesExporter interface to resources that need it
+applyDefaulterAndValidatorInterfaces       azure      Add the admission.Defaulter and admission.Validator interfaces to each resource that requires them
+injectOriginalVersionFunction              azure      Inject the function OriginalVersion() into each Spec type
+createStorageTypes                         azure      Create storage versions of CRD types
+createConversionGraph                      azure      Create the graph of conversions between versions of each resource group
+injectOriginalVersionProperty              azure      Inject the property OriginalVersion into each Storage Spec type
+injectPropertyAssignmentFunctions          azure      Inject property assignment functions AssignFrom() and AssignTo() into resources and objects
+implementConvertibleSpecInterface          azure      Inject ConvertSpecTo() and ConvertSpecFrom() to implement genruntime.ConvertibleSpec on each Spec type
+implementConvertibleStatusInterface        azure      Inject ConvertStatusTo() and ConvertStatusFrom() to implement genruntime.ConvertibleStatus on each Status type
+injectOriginalGVKFunction                  azure      Inject the function OriginalGVK() into each Resource type
+injectSpecInitializationFunctions          azure      Inject spec initialization functions Initialize_From_*() into resources and objects
+implementImportableResourceInterface       azure      Implement the ImportableResource interface for resources that support import via asoctl
+markLatestStorageVariantAsHubVersion       azure      Mark the latest GA storage variant of each resource as the hub version
+injectHubFunction                          azure      Inject the function Hub() into each hub resource
+implementConvertibleInterface              azure      Implement the Convertible interface on each non-hub Resource type
+injectJSONTestCases                        azure      Add test cases to verify JSON serialization
+injectPropertyAssignmentTestCases          azure      Add test cases to verify PropertyAssignment functions
+injectResourceConversionTestCases          azure      Add test cases to verify Resource implementations of conversion.Convertible (funcs ConvertTo & ConvertFrom) behave as expected
+simplifyDefinitions                                   Flatten definitions by removing wrapper types
+ensureArmTypeExistsForEveryType            azure      Check that an ARM type exists for both Spec and Status of each resource
+detectSkippingProperties                   azure      Detect properties that skip resource or object versions
+exportTestPackages                                    Export packages for test
+exportControllerResourceRegistrations      azure      Export resource registrations to ""


### PR DESCRIPTION
The original cross resource reference config override handler classified properties as references (or not). This works OK for properties of type *string or string but doesn't work for collections like []string or map[string]Something, because in those cases it's not the property that is the reference it's the type (or a part of the type).

The Swagger "format": "arm-id" importer already used the astmodel.ARMID type. Now the config based overrides also use the same type and work for collections.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
