### PR TITLE
bump initialDelaySeconds for readiness and liveness probe

### DIFF
--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -49,12 +49,12 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 20
+          initialDelaySeconds: 60
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: 5
+          initialDelaySeconds: 60
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator pod was running into timeouts on my arm64 mac machine due to readiness probe timeout. This PR bumps the `initialDelaySeconds` for readiness and liveness probes so that operator gets more time to load and apply CRDs.
