### PR TITLE
Fix `ok to test` workflow.

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -19,5 +19,4 @@ jobs:
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: ok-to-test
-          named-args: true
           permission: write

--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     if:
       github.event_name == 'repository_dispatch' &&
-      github.event.client_payload.slash_command.sha != '' &&
-      contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.sha)
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha)
     permissions:
       checks: write
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `ok-to-test` workflow and the PR workflow it triggers for updates to the `peter-evans/slash-command-dispatch` action. In the [**v2.0.0**](https://github.com/peter-evans/slash-command-dispatch/releases/tag/v2.0.0) release, the payload was altered to prevent named arguments overwriting other values.

**Special notes for your reviewer**:

Can't test this without merging, unfortunately. 
Please check the linked docs on the breaking change and review my changes in that context.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/cDHmMMxYnRiGsrbrWS/giphy.gif)
