### PR TITLE
Support Workload Identity KIND clusters

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -208,6 +208,13 @@ if should-install "$TOOL_DEST/cmctl"; then
     curl -L "https://github.com/jetstack/cert-manager/releases/latest/download/cmctl-${os}-${arch}.tar.gz" | tar -xz -C "$TOOL_DEST"
 fi
 
+# Install azwi
+write-verbose "Checking for $TOOL_DEST/azwi"
+if should-install "$TOOL_DEST/azwi"; then
+    write-info "Installing azwi…"
+    curl -sL "https://github.com/Azure/azure-workload-identity/releases/download/v1.0.0/azwi-v1.0.0-${os}-${arch}.tar.gz" | tar xz -C "$TOOL_DEST" azwi
+fi
+
 # Ensure tooling for Hugo is available
 write-verbose "Checking for /usr/bin/postcss"
 if should-install "/usr/bin/postcss"; then 

--- a/.github/workflows/live-validation.yml
+++ b/.github/workflows/live-validation.yml
@@ -28,7 +28,7 @@ jobs:
           echo "container_id=$container_id" >> $GITHUB_ENV
 
       - name: Run CI tasks against live resources
-        run: docker exec -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT  -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "${{env.container_id }}" task ci-live
+        run: docker exec --env HOSTROOT=$GITHUB_WORKSPACE -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT  -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "${{env.container_id }}" task ci-live
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Run integration tests
         run: |
           container_id=${{ env.container_id }}
-          docker exec -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "$container_id" task controller:ci-integration-tests --concurrency 1 # limit concurrency because build machines are small
+          docker exec --env HOSTROOT=$GITHUB_WORKSPACE -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "$container_id" task controller:ci-integration-tests --concurrency 1 # limit concurrency because build machines are small
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Run integration tests
         run: |
           container_id=${{ env.container_id }}
-          docker exec -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "$container_id" task controller:ci-integration-tests
+          docker exec --env HOSTROOT=$GITHUB_WORKSPACE -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "$container_id" task controller:ci-integration-tests
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -471,16 +471,12 @@ tasks:
   controller:test-integration-kind-ci:
     desc: Run live integration tests in kind and deletes the kind cluster afterwards.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:kind-create-helm-podidentity]
+    deps: [controller:kind-create-helm-workload-identity]
     cmds:
       # This timeout is purposefully low - if we find that this job is taking a long time we may need to think of other ways
       # to keep CI fast
-      # TODO: Below pattern was taken from https://github.com/go-task/task/pull/474 to ensure cleanup runs after the test.
-      - |
-        (go test -timeout 40m -run '{{default ".*" .TEST_FILTER}}' ./test); # Run the tests in a subshell
-        TEST_EXIT=$?;
-        kind delete cluster --name=asov2
-        exit $TEST_EXIT
+      - defer: { task: controller:kind-delete }
+      - go test -timeout 40m -run '{{default ".*" .TEST_FILTER}}' ./test
 
   # Note that this target isn't used in CI and is intended for use when running locally on a kind cluster
   # that you don't want to delete (in contrast to test-integration-kind-ci which will delete the kind cluster
@@ -488,7 +484,7 @@ tasks:
   controller:test-integration-kind:
     desc: Run live integration tests in kind.
     dir: "{{.CONTROLLER_ROOT}}"
-    deps: [controller:kind-create-helm-podidentity]
+    deps: [controller:kind-create-helm-workload-identity]
     cmds:
       # This timeout is purposefully low - if we find that this job is taking a long time we may need to think of other ways
       # to keep CI fast
@@ -502,14 +498,8 @@ tasks:
       # This timeout is purposefully low - if we find that this job is
       # taking a long time we may need to think of other ways to keep
       # CI fast
-      # TODO: Below pattern was taken from
-      # https://github.com/go-task/task/pull/474 to ensure cleanup
-      # runs after the test.
-      - |
-        (go test -timeout 15m -v -run '{{default ".*" .TEST_FILTER}}' ./test/multitenant); # Run the tests in a subshell.
-        TEST_EXIT=$?;
-        kind delete cluster --name=asov2
-        exit $TEST_EXIT
+      - defer: { task: controller:kind-delete }
+      - go test -timeout 15m -v -run '{{default ".*" .TEST_FILTER}}' ./test/multitenant
 
   # Note that this target isn't used in CI and is intended for use
   # when running locally on a kind cluster that you don't want to
@@ -642,6 +632,22 @@ tasks:
       aso2 -n {{.ASO_NAMESPACE}} --create-namespace ./charts/azure-service-operator/"
     - task: controller:wait-for-operator-ready
 
+  controller:install-helm-wi:
+    desc: Generate and install helm chart on cluster using workload identity
+    dir: "{{.CONTROLLER_ROOT}}"
+    cmds:
+      - "helm upgrade --install --set azureSubscriptionID=$AZURE_SUBSCRIPTION_ID \
+      --set azureTenantID=$AZURE_TENANT_ID \
+      --set azureClientID={{.AZURE_MI_CLIENT_ID}} \
+      --set useWorkloadIdentityAuth=true \
+      --set image.repository={{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}} \
+      aso2 -n {{.ASO_NAMESPACE}} --create-namespace ./charts/azure-service-operator/"
+      - task: controller:wait-for-operator-ready
+    vars:
+      # Override the AZURE_CLIENT_ID env variable here
+      AZURE_MI_CLIENT_ID:
+        sh: "cat v2/out/workload-identity/azure/miclientid.txt"
+
   controller:delete-helm:
     desc: Delete helm release
     cmds:
@@ -652,6 +658,8 @@ tasks:
     run: always
     cmds:
       - "kind delete cluster --name=asov2"
+      - "{{.SCRIPTS_ROOT}}/delete-kind-wi-storage.sh -d v2/out/workload-identity"
+      - "kind delete cluster --name=asov2-wi"
 
   controller:kind-create:
     desc: Creates a kind cluster and local Docker registry. Images in the local registry can be pulled in the kind cluster
@@ -660,6 +668,38 @@ tasks:
       - "export KIND_CLUSTER_NAME=asov2 && {{.SCRIPTS_ROOT}}/kind-with-registry.sh"
     status:
       - "kind get clusters | grep \"^asov2$\""
+
+  controller:kind-create-wi:
+    desc: Creates a kind cluster and local Docker registry with OIDC + workload identity enabled. Images in the local registry can be pulled in the kind cluster.
+    run: always
+    dir: "v2/"
+    deps: [az-login]
+    cmds:
+      - "rm -rf out/workload-identity"
+      - "mkdir -p out/workload-identity"
+      - "{{.SCRIPTS_ROOT}}/create-kind-wi-storage.sh -d out/workload-identity -p {{.TEST_LIVE_RESOURCE_PREFIX}}"
+      - "export KIND_CLUSTER_NAME=asov2-wi && \
+            export SERVICE_ACCOUNT_ISSUER=$(cat out/workload-identity/azure/saissuer.txt) && \
+            {{.SCRIPTS_ROOT}}/kind-with-registry.sh"
+    status:
+      - "kind get clusters | grep \"^asov2-wi$\""
+    env:
+      SERVICE_ACCOUNT_KEY_FILE:
+        sh: "echo ${HOSTROOT:-$PWD}/v2/out/workload-identity/sa.pub" # Have to use HOSTROOT here for mounting files when in docker-in-docker as paths are relative to host
+      SERVICE_ACCOUNT_SIGNING_KEY_FILE:
+        sh: "echo ${HOSTROOT:-$PWD}/v2/out/workload-identity/sa.key"
+
+  controller:create-mi-for-workload-identity:
+    desc: Creates a managed identity and federated identity credential for user in a kind cluster
+    dir: "v2/"
+    deps: [az-login]
+    cmds:
+      - "{{.SCRIPTS_ROOT}}/make-mi-fic.sh -g {{.RESOURCE_GROUP}} -i {{.ISSUER}} -d ./out/workload-identity"
+    vars:
+      RESOURCE_GROUP:
+        sh: "cat ./out/workload-identity/azure/rg.txt"
+      ISSUER:
+        sh: "cat ./out/workload-identity/azure/saissuer.txt"
 
   controller:scan-image:
     desc: Builds a local image and scans the image using trivy
@@ -699,27 +739,19 @@ tasks:
     status:
       - "kubectl get namespace cert-manager"
 
-  controller:install-aad-pod-identity-local:
-    desc: Installs 'aad-pod-identity' in managed mode
-    cmds:
-      - "kubectl apply -f https://raw.githubusercontent.com/Azure/aad-pod-identity/master/deploy/infra/managed-mode-deployment.yaml"
-      - "kubectl wait --for=condition=Ready --timeout=2m pods --all --namespace kube-system"
-      # Also wait for the CRDs to be established, because we have seen situations where for some reason creating resources of that type fails
-      # shortly after installation. Error looks like this:
-      # [controller:make-aadpodidentity-secret] unable to recognize "STDIN": no matches for kind "AzureIdentity" in version "aadpodidentity.k8s.io/v1"
-      # [controller:make-aadpodidentity-secret] unable to recognize "STDIN": no matches for kind "AzureIdentityBinding" in version "aadpodidentity.k8s.io/v1"
-      - "kubectl wait --for condition=established --timeout=2m crd/azureidentities.aadpodidentity.k8s.io"
-      - "kubectl wait --for condition=established --timeout=2m crd/azureidentitybindings.aadpodidentity.k8s.io"
-
   controller:make-sp-secret:
     desc: Creates a service principal aso-controller-settings secret for testing purposes
     cmds:
       - "{{.SCRIPTS_ROOT}}/deploy_testing_secret.sh sp"
 
-  controller:make-aadpodidentity-secret:
-    desc: Creates an aad-pod-identity secret for testing purposes
+  controller:make-workload-identity-secret:
+    desc: Creates a workload identity secret for testing purposes
     cmds:
-      - "{{.SCRIPTS_ROOT}}/deploy_testing_secret.sh aadpodidentity"
+      - "{{.SCRIPTS_ROOT}}/deploy_testing_secret.sh workloadidentity"
+    env:
+      # Override the AZURE_CLIENT_ID env variable here
+      AZURE_MI_CLIENT_ID:  # TODO: Ideally would override AZURE_CLIENT_ID here but we can't because of https://github.com/go-task/task/issues/1038
+        sh: "cat v2/out/workload-identity/azure/miclientid.txt"
 
   controller:wait-for-operator-ready:
     desc: Waits for the operator and associated CRDs to be ready
@@ -739,17 +771,17 @@ tasks:
       - task: controller:make-sp-secret
       - task: controller:wait-for-operator-ready
 
-  controller:kind-create-with-podidentity:
-    desc: Creates a local kind cluster with 'AAD Pod Identity' installed alongside ASO.
+  controller:kind-create-with-workload-identity:
+    desc: Creates a local kind cluster in workload identity mode with ASO using a managed identity.
     cmds:
-      - task: controller:kind-create
+      - task: controller:kind-create-wi
+      - task: controller:create-mi-for-workload-identity
       - task: controller:install-cert-manager
       - task: controller:docker-push-local
       # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
       - "cmctl check api --wait=2m"
       - task: controller:install
-      - task: controller:install-aad-pod-identity-local
-      - task: controller:make-aadpodidentity-secret
+      - task: controller:make-workload-identity-secret
       - task: controller:wait-for-operator-ready
 
   controller:kind-create-multitenant-cluster:
@@ -817,13 +849,17 @@ tasks:
       - "cmctl check api --wait=2m"
       - task: controller:install-helm
 
-  controller:kind-create-helm-podidentity:
-    desc: Creates a local kind cluster with 'AAD Pod Identity' installed alongside ASO helm chart.
-    deps: [controller:kind-create-helm]
+  controller:kind-create-helm-workload-identity:
+    desc: Creates a local kind cluster with Workload identity installed alongside ASO helm chart using UMI auth.
     cmds:
-      - task: controller:install-aad-pod-identity-local
-      - task: controller:make-aadpodidentity-secret
-      - task: controller:wait-for-operator-ready
+      - task: controller:kind-create-wi
+      - task: controller:create-mi-for-workload-identity
+      - task: controller:install-cert-manager
+      - task: controller:docker-push-local
+      - task: controller:gen-helm-manifest
+      # We need the below to wait until cert-manager is up, otherwise the subsequent installation of webhooks fails. See https://cert-manager.io/next-docs/installation/verify/
+      - "cmctl check api --wait=2m"
+      - task: controller:install-helm-wi
 
   controller:gen-crd-docs:
     desc: Generates API docs for CRDs
@@ -908,7 +944,7 @@ tasks:
   az-login:
     desc: Runs AZ login
     cmds:
-      - az login --service-principal -u {{.AZURE_CLIENT_ID}} -p {{.AZURE_CLIENT_SECRET}} --tenant {{.AZURE_TENANT_ID}}
+      - az login --service-principal -u {{.AZURE_CLIENT_ID}} -p {{.AZURE_CLIENT_SECRET}} --tenant {{.AZURE_TENANT_ID}} > /dev/null
       - az account set --subscription {{.AZURE_SUBSCRIPTION_ID}}
 
   header-check:

--- a/docs/hugo/content/contributing/_index.md
+++ b/docs/hugo/content/contributing/_index.md
@@ -50,7 +50,7 @@ $ docker build $(git rev-parse --show-toplevel)/.devcontainer -t asodev:latest
 … image will be created …
 
 $ # After that you can start a terminal in the development container with:
-$ docker run --env-file ~/work/envs.env -v $(git rev-parse --show-toplevel):/go/src -w /go/src -u $(id -u ${USER}):$(id -g ${USER}) --group-add $(stat -c '%g' /var/run/docker.sock) -v /var/run/docker.sock:/var/run/docker.sock --network=host  -it asodev:latest /bin/bash
+$ docker run --env-file ~/work/envs.env --env HOSTROOT=$(git rev-parse --show-toplevel) -v $(git rev-parse --show-toplevel):/go/src -w /go/src -u $(id -u ${USER}):$(id -g ${USER}) --group-add $(stat -c '%g' /var/run/docker.sock) -v /var/run/docker.sock:/var/run/docker.sock --network=host  -it asodev:latest /bin/bash
 ```
 
 It is not recommended to mount the source like this on Windows (WSL2) as the cross-VM file operations are very slow.

--- a/scripts/create-kind-wi-storage.sh
+++ b/scripts/create-kind-wi-storage.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+print_usage() {
+  echo "Usage: create-kind-wi-storage.sh -d <DIRECTORY> -p <PREFIX>"
+}
+
+while getopts 'd:p:' flag; do
+  case "${flag}" in
+    d) DIR="${OPTARG}" ;;
+    p) PREFIX="${OPTARG}" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+if [[ -z "$DIR" ]] || [[ -z "$PREFIX" ]]; then
+  print_usage
+  exit 1
+fi
+
+# Generate names and save in files
+mkdir -p "${DIR}/azure"
+RESOURCE_GROUP="${PREFIX}-rg-wi$(openssl rand -hex 6)"
+AZURE_STORAGE_ACCOUNT="asowi$(openssl rand -hex 6)"
+AZURE_STORAGE_CONTAINER="oidc-test"
+
+# If somehow the files already exist then the resource also already exists and we shouldn't do anything
+if [ -f "$DIR/azure/rg.txt" ]; then
+  # Nothing to do, no existing rg
+  echo "Using existing RG $(cat ${DIR}/azure/rg.txt)"
+  exit 0
+fi
+
+echo ${RESOURCE_GROUP} > "${DIR}/azure/rg.txt"
+echo "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_STORAGE_CONTAINER}/" > "${DIR}/azure/saissuer.txt"
+
+# Generate the OIDC keys
+openssl genrsa -out "$DIR/sa.key" 2048
+openssl rsa -in "$DIR/sa.key" -pubout -out "$DIR/sa.pub"
+
+az group create -l westus -n "${RESOURCE_GROUP}" --tags "CreatedAt=$(date --utc +"%Y-%m-%dT%H:%M:%SZ")"
+az storage account create --resource-group "${RESOURCE_GROUP}" --name "${AZURE_STORAGE_ACCOUNT}"
+az storage container create --account-name "${AZURE_STORAGE_ACCOUNT}" --name "${AZURE_STORAGE_CONTAINER}" --public-access container
+
+cat <<EOF > "${DIR}/openid-configuration.json"
+{
+  "issuer": "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_STORAGE_CONTAINER}/",
+  "jwks_uri": "https://${AZURE_STORAGE_ACCOUNT}.blob.core.windows.net/${AZURE_STORAGE_CONTAINER}/openid/v1/jwks",
+  "response_types_supported": [
+    "id_token"
+  ],
+  "subject_types_supported": [
+    "public"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "RS256"
+  ]
+}
+EOF
+
+az storage blob upload \
+  --account-name "${AZURE_STORAGE_ACCOUNT}" \
+  --container-name "${AZURE_STORAGE_CONTAINER}" \
+  --file "${DIR}/openid-configuration.json" \
+  --name .well-known/openid-configuration
+
+azwi jwks --public-keys "${DIR}/sa.pub" --output-file "${DIR}/jwks.json"
+
+az storage blob upload \
+  --account-name "${AZURE_STORAGE_ACCOUNT}" \
+  --container-name "${AZURE_STORAGE_CONTAINER}" \
+  --file "${DIR}/jwks.json" \
+  --name openid/v1/jwks

--- a/scripts/delete-kind-wi-storage.sh
+++ b/scripts/delete-kind-wi-storage.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+print_usage() {
+  echo "Usage: delete-kind-wi-storage.sh -d <DIRECTORY>"
+}
+
+while getopts 'd:' flag; do
+  case "${flag}" in
+    d) DIR="${OPTARG}" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+
+if [[ -z "$DIR" ]]; then
+  print_usage
+  exit 1
+fi
+
+EXISTS=$(kind get clusters -q | grep "^asov2-wi$" || true)
+
+if [ -f "$DIR/azure/rg.txt" ]; then
+  RESOURCE_GROUP=$(cat $DIR/azure/rg.txt)
+else
+  # Nothing to do, no existing rg
+  exit 0
+fi
+
+if [[ -z "$EXISTS" ]]; then
+  # Nothing to do, no match
+  exit 0
+fi
+
+if [ $(az group exists --name ${RESOURCE_GROUP}) = true ]; then
+  echo "Deleting resourceGroup: ${RESOURCE_GROUP}"
+  az group delete --name ${RESOURCE_GROUP} -y
+  echo "Done deleting resourceGroup: ${RESOURCE_GROUP}"
+
+  rm -rf "${DIR}/azure"
+fi
+

--- a/scripts/make-mi-fic.sh
+++ b/scripts/make-mi-fic.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function create_role_assignment() {
+  az role assignment create --assignee "${USER_ASSIGNED_OBJECT_ID}" \
+      --role "Owner" \
+      --subscription "${AZURE_SUBSCRIPTION_ID}"
+}
+
+function retry_create_role_assignment() {
+  until create_role_assignment; do
+    sleep 5
+  done
+
+}
+
+print_usage() {
+  echo "Usage: make-mi-fic-kind-wi-storage.sh -g <RESOURCE_GROUP> -i <ISSUER> -d <DIR>"
+}
+
+while getopts 'g:i:d:' flag; do
+  case "${flag}" in
+    g) RESOURCE_GROUP="${OPTARG}" ;;
+    i) ISSUER="${OPTARG}" ;;
+    d) DIR="${OPTARG}" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+
+if [[ -z "$RESOURCE_GROUP" ]] || [[ -z "$ISSUER" ]] || [[ -z "$DIR" ]]; then
+  print_usage
+  exit 1
+fi
+
+IDENTITIES=$(az identity list --resource-group ${RESOURCE_GROUP} -o table)
+
+if [[ ! -z "$IDENTITIES" ]]; then
+  echo "An identity already exists, not creating another one"
+  exit 0
+fi
+
+IDENTITY_NAME="mi$(openssl rand -hex 6)"
+SUBJECT="system:serviceaccount:azureserviceoperator-system:azureserviceoperator-default"
+
+az identity create --name ${IDENTITY_NAME} --resource-group ${RESOURCE_GROUP}
+az identity federated-credential create \
+  --identity-name ${IDENTITY_NAME} \
+  --name fic \
+  --resource-group ${RESOURCE_GROUP} \
+  --issuer ${ISSUER} \
+  --subject ${SUBJECT} \
+  --audiences "api://AzureADTokenExchange"
+
+export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${IDENTITY_NAME}" --query 'clientId' -otsv)"
+export USER_ASSIGNED_OBJECT_ID="$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${IDENTITY_NAME}" --query 'principalId' -otsv)"
+
+export -f create_role_assignment
+export -f retry_create_role_assignment
+timeout 1m bash -c retry_create_role_assignment
+
+echo ${USER_ASSIGNED_CLIENT_ID} > "${DIR}/azure/miclientid.txt"


### PR DESCRIPTION
Useful for testing AAD required features.

Also moves our default ci tests to use workload identity w/ a managed identity rather than aad pod identity (which is deprecated) with a service principal.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
