### PR TITLE
Force usage of Kustomize v4 for ASOv1 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -431,8 +431,9 @@ jobs:
         img="$IMAGE_NAME:$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION"
         echo $img
         sed -i -e 's@controller:latest@'${img}'@g' ./config/default/manager_image_patch.yaml
-        which kustomize
-        kustomize build config/default > $(Build.ArtifactStagingDirectory)/setup.yaml
+        which $GOPATH/bin/kustomize
+        $GOPATH/bin/kustomize verison
+        $GOPATH/bin/kustomize build config/default > $(Build.ArtifactStagingDirectory)/setup.yaml
         set -x
         echo $img > $(Build.ArtifactStagingDirectory)/azure-service-operator.txt
         mkdir $(Build.ArtifactStagingDirectory)/scripts


### PR DESCRIPTION
ubuntu-latest now has Kustomize v5 by default which is what we were using before (even though we purposefully selected Kustomize v4 in our installation scripts we weren't actually using it).

This ensures that we use the pinned version of Kustomize.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
