### PR TITLE
Modify CRD Documentation to skip non-code folders

### DIFF
--- a/scripts/v2/gen-api-docs.sh
+++ b/scripts/v2/gen-api-docs.sh
@@ -24,6 +24,12 @@ find "$OUTPUTDIR" -type f -name '[a-z]*.md'  -delete
 # Iterate through the directories
 for package in $(find "$APIROOT" -type d); 
 do
+    # Skip this directory if there are no .go files
+    if ! ls "$package"/*.go &> /dev/null
+    then
+        continue
+    fi
+
     PACKAGE_VERSION=$(basename "$package")
     GROUPNAME=$(basename $(dirname $package))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently our CRD Documentation pass will abort if we try to generate documentation for a folder that contains no Go code. This can happen when we have orphan `structure.txt` files left in the project. 

I've added a check into the script to skip these folders.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/F9hQLAVhWnL56/giphy.gif)
