### PR TITLE
Allow users to configure a subset of CRDs to install

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -335,7 +335,8 @@ tasks:
       --set azureSubscriptionID=$AZURE_SUBSCRIPTION_ID \
       --set azureTenantID=$AZURE_TENANT_ID \
       --set azureClientID=$AZURE_CLIENT_ID \
-      --set azureClientSecret=$AZURE_CLIENT_SECRET"
+      --set azureClientSecret=$AZURE_CLIENT_SECRET \
+      --set crdPattern=*"
     - "kubectl create namespace pre-release"
     # TODO: Can remove the -c parameter once we GA. -c means skip waiting for CRDs to reach established state.
     # TODO: this needs to be skipped because the CRD label for filtering doesn't exist in the old beta charts.
@@ -629,6 +630,7 @@ tasks:
       --set azureClientID=$AZURE_CLIENT_ID \
       --set azureClientSecret=$AZURE_CLIENT_SECRET \
       --set image.repository={{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}} \
+      --set crdPattern=* \
       aso2 -n {{.ASO_NAMESPACE}} --create-namespace ./charts/azure-service-operator/"
     - task: controller:wait-for-operator-ready
 
@@ -641,6 +643,7 @@ tasks:
       --set azureClientID={{.AZURE_MI_CLIENT_ID}} \
       --set useWorkloadIdentityAuth=true \
       --set image.repository={{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}} \
+      --set crdPattern=* \
       aso2 -n {{.ASO_NAMESPACE}} --create-namespace ./charts/azure-service-operator/"
       - task: controller:wait-for-operator-ready
     vars:
@@ -714,6 +717,7 @@ tasks:
     dir: "{{.CONTROLLER_ROOT}}"
     cmds:
       - "{{.SCRIPTS_ROOT}}/kustomize-build.sh -k operator -v {{.VERSION}} > out/operator.yaml"
+      - "sed -i 's/--crd-pattern=.*/--crd-pattern=*/g' out/operator.yaml"
       - "kubectl apply --server-side=true -f out/operator.yaml" # TODO: may need | sed "s_${CONFIG_REGISTRY}_${REGISTRY}/${IMG}_" at some point
 
   controller:bundle-crds:
@@ -820,6 +824,7 @@ tasks:
       # Install cluster scope chart (mode == webhooks)
       - "helm upgrade --install --set multitenant.enable=true --set azureOperatorMode=webhooks \
            --set image.repository={{.LOCAL_REGISTRY_CONTROLLER_DOCKER_IMAGE}} \
+           --set crdPattern=* \
            aso2 -n {{.ASO_NAMESPACE}} --create-namespace ./charts/azure-service-operator/"
       - task: controller:wait-for-operator-ready
       # Install tenant chart

--- a/scripts/v2/generate-helm-manifest.sh
+++ b/scripts/v2/generate-helm-manifest.sh
@@ -61,6 +61,7 @@ find "$GEN_FILES_DIR" -type f -exec sed -i 's/azureserviceoperator-system/{{ .Re
 # Apply CRD guards
 sed -i "1 s/^/$IF_CRDS\n/;$ a {{- end }}" "$GEN_FILES_DIR"/*crd-manager-role*
 flow_control "--crd-pattern" "--crd-pattern" "$IF_CRDS" "$GEN_FILES_DIR"/*_deployment_*
+sed -i 's/--crd-pattern=.*/--crd-pattern={{ .Values.crdPattern }}/g' "$GEN_FILES_DIR"/*_deployment_*
 
 # Perform file level changes for cluster and tenant
 for file in $(find "$GEN_FILES_DIR" -type f)

--- a/v2/charts/azure-service-operator/values.yaml
+++ b/v2/charts/azure-service-operator/values.yaml
@@ -92,6 +92,25 @@ metrics:
 # the operator will only reconcile that subset if those are the only CRDs it finds when the pod starts.
 installCRDs: true
 
+# crdPattern is a semicolon delimited string containing the CRD patterns for the operator to install.
+# Setting this has no effect if installCRDs is false.
+# This defines what new CRDs will be installed by ASO. Will always upgrade any existing CRDs even if no
+# crdPattern is defined. Leaving this field unspecified for a fresh install of ASO will result in the operator pod
+# exiting with an error saying no CRDs are configured. Leaving this field unspecified during an upgrade of ASO preserves
+# the existing set of CRDs already in the cluster. The existing CRDs will be upgraded to the latest version but no
+# new CRDs will be installed.
+# Values can be globs utilizing * or ?. The pattern is compared against the "{group}/{kind}" string of each CRD.
+# Patterns are case-insensitive.
+# Example: "resources.azure.com/*" would match the "resources.azure.com/ResourceGroup" resource.
+# Example: "compute.azure.com/*" would match all compute CRDs
+# Example: "resources.azure.com/*;compute.azure.com/*" would match all resources.azure.com resources as well as all
+# compute resources.
+# We strongly recommend including entire groups such as "dbformysql.azure.com/*". Individual CRDs such as
+# "dbformysql.azure.com/FlexibleServer" can be listed, but there are often other resources in the group which pair
+# together to enable other scenarios, such as dbformysql.azure.com/FlexibleServersFirewallRules, and it's generally
+# easier to just include the whole group.
+crdPattern: ''
+
 # podAnnotations contain the pod annotations for Azure Service Operator
 podAnnotations: {}
 

--- a/v2/cmd/controller/main.go
+++ b/v2/cmd/controller/main.go
@@ -26,6 +26,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.Info("Launching with flags", "flags", flgs.String())
+
 	if flgs.PreUpgradeCheck {
 		err = app.SetupPreUpgradeCheck(ctx)
 		if err != nil {

--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         - --health-addr=:8081
         - --enable-leader-election
         - --v=2
-        - --crd-pattern=*
+        - --crd-pattern=
         ports:
           - containerPort: 8081
             name: health-port

--- a/v2/internal/crdmanagement/crd_installation_instruction.go
+++ b/v2/internal/crdmanagement/crd_installation_instruction.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+package crdmanagement
+
+import (
+	"fmt"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+type DiffResult string
+
+const (
+	NoDifference     = DiffResult("NoDifference")
+	SpecDifferent    = DiffResult("SpecDifferent")
+	VersionDifferent = DiffResult("VersionDifferent")
+)
+
+func (i DiffResult) DiffReason(crd apiextensions.CustomResourceDefinition) string {
+	switch i {
+	case NoDifference:
+		return fmt.Sprintf("No difference between existing and goal CRD %q", makeMatchString(crd))
+	case SpecDifferent:
+		return fmt.Sprintf("The spec was different between existing and goal CRD %q", makeMatchString(crd))
+	case VersionDifferent:
+		return fmt.Sprintf("The version was different between existing and goal CRD %q", makeMatchString(crd))
+	default:
+		return fmt.Sprintf("Unknown DiffResult %q", i)
+	}
+}
+
+type FilterResult string
+
+const (
+	MatchedExistingCRD = FilterResult("MatchedExistingCRD")
+	MatchedPattern     = FilterResult("MatchedPattern")
+	Excluded           = FilterResult("Excluded")
+)
+
+type CRDInstallationInstruction struct {
+	CRD apiextensions.CustomResourceDefinition
+
+	// FilterResult contains the result of if the CRD was considered for installation or not
+	FilterResult FilterResult
+	// FilterReason contains a user-facing reason for why the CRD was or was not considered for installation
+	FilterReason string
+
+	// DiffResult contains the result of the diff between the existing CRD (if any) and the goal CRD. This may
+	// be NoDifference if the CRD was filtered from consideration before the diff phase.
+	DiffResult DiffResult
+}
+
+func (i *CRDInstallationInstruction) ShouldApply() (bool, string) {
+	excluded := i.FilterResult == Excluded
+	if excluded {
+		return false, i.FilterReason
+	}
+
+	isSame := i.DiffResult == NoDifference
+	if isSame {
+		return false, i.DiffResult.DiffReason(i.CRD)
+	}
+
+	return true, i.DiffResult.DiffReason(i.CRD)
+}
+
+func IncludedCRDs(instructions []*CRDInstallationInstruction) []*CRDInstallationInstruction {
+	// Prealloc false positive: https://github.com/alexkohler/prealloc/issues/16
+	//nolint:prealloc
+	var result []*CRDInstallationInstruction
+	for _, instruction := range instructions {
+		if instruction.FilterResult == Excluded {
+			continue
+		}
+		result = append(result, instruction)
+	}
+
+	return result
+}

--- a/v2/internal/crdmanagement/manager_test.go
+++ b/v2/internal/crdmanagement/manager_test.go
@@ -25,54 +25,9 @@ import (
 	"github.com/Azure/azure-service-operator/v2/internal/util/to"
 )
 
-func newFakeKubeClient(s *runtime.Scheme) kubeclient.Client {
-	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
-	return kubeclient.NewClient(fakeClient)
-}
-
-func newTestScheme() *runtime.Scheme {
-	s := runtime.NewScheme()
-	_ = apiextensions.AddToScheme(s)
-
-	return s
-}
-
-func makeBasicCRD(name string) apiextensions.CustomResourceDefinition {
-	return apiextensions.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apiextensions.k8s.io/v1",
-			Kind:       "CustomResourceDefinition",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s.testrp.azure.com", name),
-		},
-		Spec: apiextensions.CustomResourceDefinitionSpec{
-			Group: "testrp.azure.com",
-			Scope: apiextensions.NamespaceScoped,
-			Versions: []apiextensions.CustomResourceDefinitionVersion{
-				{
-					Name:    "v1alpha1api20181130",
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensions.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
-							Properties: map[string]apiextensions.JSONSchemaProps{
-								"apiVersion": {
-									Type:        "string",
-									Description: "APIVersion description",
-								},
-								"kind": {
-									Type:        "string",
-									Description: "Kind description",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
+/*
+ * LoadCRDs tests
+ */
 
 func Test_LoadCRDs(t *testing.T) {
 	t.Parallel()
@@ -96,6 +51,10 @@ func Test_LoadCRDs(t *testing.T) {
 	g.Expect(loadedCRDs).To(HaveLen(1))
 	g.Expect(loadedCRDs[0]).To(Equal(crd))
 }
+
+/*
+ * FindMatchingCRDs tests
+ */
 
 func Test_FindMatchingCRDs_EqualCRDsCompareAsEqual(t *testing.T) {
 	t.Parallel()
@@ -179,6 +138,10 @@ func Test_FindMatchingCRDs_CRDsWithDifferentConversionsCompareAsEqual(t *testing
 	g.Expect(existing[0].Spec.Conversion.Webhook.ClientConfig.CABundle).ToNot(BeEmpty())
 }
 
+/*
+ * FindNonMatchingCRDs tests
+ */
+
 func Test_FindNonMatchingCRDs_EqualCRDsCompareAsEqual(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -195,6 +158,7 @@ func Test_FindNonMatchingCRDs_EqualCRDsCompareAsEqual(t *testing.T) {
 
 	g.Expect(nonMatching).To(BeEmpty())
 }
+
 func Test_FindNonMatchingCRDs_MissingCRD(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -260,6 +224,133 @@ func Test_FindNonMatchingCRDs_CRDsWithDifferentConversionsCompareAsEqual(t *test
 	g.Expect(existing[0].Spec.Conversion.Webhook.ClientConfig.CABundle).ToNot(BeEmpty())
 }
 
+/*
+ * DetermineCRDsToInstallOrUpgrade tests
+ */
+
+func Test_DetermineCRDsToInstallOrUpgrade(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		goal     []apiextensions.CustomResourceDefinition
+		existing []apiextensions.CustomResourceDefinition
+		patterns string
+		validate func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction)
+	}{
+		{
+			name:     "Skips CRDs if no pattern or installed",
+			goal:     []apiextensions.CustomResourceDefinition{makeBasicCRD("test")},
+			existing: nil,
+			patterns: "",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].FilterResult).To(Equal(crdmanagement.Excluded))
+				g.Expect(instructions[0].FilterReason).To(ContainSubstring("was not matched by CRD pattern and did not already exist in cluster"))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeFalse())
+			},
+		},
+		{
+			name:     "Matches CRDs if pattern matches",
+			goal:     []apiextensions.CustomResourceDefinition{makeBasicCRD("test")},
+			existing: nil,
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].FilterResult).To(Equal(crdmanagement.MatchedPattern))
+				g.Expect(instructions[0].FilterReason).To(Equal("CRD named \"testrp.azure.com/test\" matched pattern \"testrp.azure.com/*\""))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.SpecDifferent))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeTrue())
+			},
+		},
+		{
+			name:     "Matches if CRD already installed",
+			goal:     []apiextensions.CustomResourceDefinition{makeBasicCRD("test")},
+			existing: []apiextensions.CustomResourceDefinition{makeBasicCRDWithVersion("test", "1.1")},
+			patterns: "",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].FilterResult).To(Equal(crdmanagement.MatchedExistingCRD))
+				g.Expect(instructions[0].FilterReason).To(Equal("A CRD named \"testrp.azure.com/test\" was already installed, considering that existing CRD for update"))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.VersionDifferent))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeTrue())
+			},
+		},
+		{
+			name:     "Matches if CRD already installed and pattern matches, pattern matches wins",
+			goal:     []apiextensions.CustomResourceDefinition{makeBasicCRD("test")},
+			existing: []apiextensions.CustomResourceDefinition{makeBasicCRDWithVersion("test", "1.1")},
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].FilterResult).To(Equal(crdmanagement.MatchedPattern))
+				g.Expect(instructions[0].FilterReason).To(Equal("CRD named \"testrp.azure.com/test\" matched pattern \"testrp.azure.com/*\""))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.VersionDifferent))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeTrue())
+			},
+		},
+		{
+			name:     "Pattern matches but CRD already installed, nothing to do",
+			goal:     []apiextensions.CustomResourceDefinition{makeBasicCRD("test")},
+			existing: []apiextensions.CustomResourceDefinition{makeBasicCRD("test")},
+			patterns: "testrp.azure.com/*",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(1))
+				g.Expect(instructions[0].FilterResult).To(Equal(crdmanagement.MatchedPattern))
+				g.Expect(instructions[0].FilterReason).To(Equal("CRD named \"testrp.azure.com/test\" matched pattern \"testrp.azure.com/*\""))
+				g.Expect(instructions[0].DiffResult).To(Equal(crdmanagement.NoDifference))
+				apply, _ := instructions[0].ShouldApply()
+				g.Expect(apply).To(BeFalse())
+			},
+		},
+		{
+			name:     "Pattern matches subset of CRDs from group, only that subset is installed",
+			goal:     []apiextensions.CustomResourceDefinition{makeBasicCRD("test1"), makeBasicCRD("test2")},
+			existing: nil,
+			patterns: "testrp.azure.com/test1",
+			validate: func(g *WithT, instructions []*crdmanagement.CRDInstallationInstruction) {
+				g.Expect(instructions).To(HaveLen(2))
+
+				// use loop here rather than index as installation instruction order may not match CRD order
+				for _, instruction := range instructions {
+					if instruction.CRD.Name == "test1.testrp.azure.com" {
+						g.Expect(instruction.FilterResult).To(Equal(crdmanagement.MatchedPattern))
+						g.Expect(instruction.FilterReason).To(Equal("CRD named \"testrp.azure.com/test1\" matched pattern \"testrp.azure.com/test1\""))
+						g.Expect(instruction.DiffResult).To(Equal(crdmanagement.SpecDifferent))
+						apply, _ := instruction.ShouldApply()
+						g.Expect(apply).To(BeTrue())
+					} else {
+						g.Expect(instruction.FilterResult).To(Equal(crdmanagement.Excluded))
+						g.Expect(instruction.FilterReason).To(ContainSubstring("was not matched by CRD pattern and did not already exist in cluster"))
+						apply, _ := instruction.ShouldApply()
+						g.Expect(apply).To(BeFalse())
+					}
+				}
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			g := NewGomegaWithT(t)
+			logger := testcommon.NewTestLogger(t)
+			crdManager := crdmanagement.NewManager(logger, nil)
+
+			instructions, err := crdManager.DetermineCRDsToInstallOrUpgrade(c.goal, c.existing, c.patterns)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			c.validate(g, instructions)
+		})
+	}
+}
+
 func Test_ListCRDs_ListsOnlyCRDsMatchingLabel(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)
@@ -311,6 +402,71 @@ func Test_BundledCRDs_HaveExactlyTwoInstancesOfNamespace(t *testing.T) {
 	g.Expect(count).To(Equal(2))
 }
 
+/*
+ * Helper functions
+ */
+
 func makeFakeCABundle() []byte {
 	return []byte{17, 14, 12, 21, 33, 61, 25, 99, 111}
+}
+
+func newFakeKubeClient(s *runtime.Scheme) kubeclient.Client {
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	return kubeclient.NewClient(fakeClient)
+}
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = apiextensions.AddToScheme(s)
+
+	return s
+}
+
+func makeBasicCRD(name string) apiextensions.CustomResourceDefinition {
+	return apiextensions.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.testrp.azure.com", name),
+		},
+		Spec: apiextensions.CustomResourceDefinitionSpec{
+			Group: "testrp.azure.com",
+			Names: apiextensions.CustomResourceDefinitionNames{
+				Kind: name,
+			},
+			Scope: apiextensions.NamespaceScoped,
+			Versions: []apiextensions.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1api20181130",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensions.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+							Properties: map[string]apiextensions.JSONSchemaProps{
+								"apiVersion": {
+									Type:        "string",
+									Description: "APIVersion description",
+								},
+								"kind": {
+									Type:        "string",
+									Description: "Kind description",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeBasicCRDWithVersion(name string, version string) apiextensions.CustomResourceDefinition {
+	crd := makeBasicCRD(name)
+	crd.Labels = map[string]string{
+		crdmanagement.ServiceOperatorVersionLabel: version,
+	}
+
+	return crd
 }

--- a/v2/internal/util/flags/string_slice_flags.go
+++ b/v2/internal/util/flags/string_slice_flags.go
@@ -19,6 +19,10 @@ func (i *SliceFlags) String() string {
 }
 
 func (i *SliceFlags) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+
 	if strings.Contains(value, ",") {
 		// split
 		split := strings.Split(value, ",")


### PR DESCRIPTION
Fixes #1433.
Fixes #2920.

* By default, no CRDs are installed.
* If no CRDs are installed, the operator pod will exit with an error stating that there are no CRDs.
* Operator pod --crd-pattern command-line argument will now accept more than '*'.
* --crd-pattern means NEW CRDs to install. Existing CRDs in the cluster will always be upgraded. This means that upgrading an existing ASO installation without specifying any new CRDs will upgrade all of the existing CRDs and install no new CRDs.

Documentation updates will come in a separate PR.

**If applicable**:
- [x] this PR contains documentation
- [x] this PR contains tests
