### PR TITLE
Document v2.1.0 breaking changes

### DIFF
--- a/docs/hugo/content/guide/breaking-changes/_index.md
+++ b/docs/hugo/content/guide/breaking-changes/_index.md
@@ -15,6 +15,18 @@ You can easily swap from a `v1beta` version to a `v1api` version by just replaci
 
 ## Released Breaking Changes
 
+### v2.1.0
+
+Breaking changes are:
+
+* The operator no longer installs CRDs by default.
+* `serviceoperator.azure.com/credential-from` no longer supports secret references that are outside the namespace the resource is in
+* Upgrades from releases prior to `v2.0.0-beta.5` are still disallowed (same as v2.0.0)
+
+<!-- The replacementPatterns in link-checker.json are 97% correct, but don't work for _index.md files. Link manually checked by @matthchr -->
+<!-- markdown-link-check-disable-next-line -->
+For more information see [v2.1.0 Breaking Changes](breaking-changes-v2.1.0).
+
 ### v2.0.0
 
 Breaking changes are:

--- a/docs/hugo/content/guide/breaking-changes/breaking-changes-v2.1.0.md
+++ b/docs/hugo/content/guide/breaking-changes/breaking-changes-v2.1.0.md
@@ -1,0 +1,32 @@
+---
+title: "v2.1.0 Breaking Changes"
+linkTitle: "v2.1.0"
+weight: 80
+---
+
+## The operator no longer installs CRDs by default
+
+**Action required:** When installing ASO for the first time, you must now specify `crdPattern` (for Helm) or `--crd-patterns` 
+(in operator pod cmdline for raw YAML) to select the subset of CRDs you would like to install.
+
+When upgrading ASO, existing CRDs will be automatically updated to the new version but new CRDs added in that release 
+will not automatically be installed. 
+This means that when upgrading the operator, if you don't want to use any CRDs newly added in that release you don't 
+need to do anything.
+
+**Action required:** When upgrading ASO, if you want to install new CRDs (for example CRDs just added in the version of 
+ASO you are upgrading to) you must specify `crdPattern` (Helm) or `--crd-patterns` (YAML) to install the CRDs. 
+For example: if you do want to use a newly added CRD (such as `network.azure.com/bastionHosts` mentioned
+below), you would need to specify `crdPatterns=network.azure.com/*` when performing the upgrade.
+
+See [CRD management in ASO](https://azure.github.io/azure-service-operator/guide/crd-management/) for more details 
+about this change and why it was made.
+
+## `serviceoperator.azure.com/credential-from` no longer supports cross namespace secret references
+
+This was never documented as supported but worked unintentionally. The feature now works as it was always documented: 
+allowing references to secrets only if the secret is in the same namespace as the resource itself.
+
+This was a security issue which we had to close.
+
+See [#2919](https://github.com/Azure/azure-service-operator/pull/2919)

--- a/scripts/v2/check-changes.sh
+++ b/scripts/v2/check-changes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-IGNORE_FILTERS=("docs/" "README.md" "scripts/v2/check-changes.sh")
+IGNORE_FILTERS=("docs/" "README.md" "v2/README.md" "scripts/v2/check-changes.sh")
 CHANGED_FILES=$(git diff HEAD HEAD~ --name-only)
 IGNORED_COUNT=0
 NON_IGNORED_COUNT=0

--- a/v2/README.md
+++ b/v2/README.md
@@ -98,7 +98,7 @@ See the list of supported resources [here](https://azure.github.io/azure-service
    > [limits of the Kubernetes you are running](https://github.com/Azure/azure-service-operator/issues/2920). `*` is **not**
    > recommended on AKS Free-tier clusters.
    > 
-   > See [CRD management](./guide/crd-management) for more details.
+   > See [CRD management](https://azure.github.io/azure-service-operator/guide/crd-management/) for more details.
 
    Alternatively you can install from the [release YAML directly](https://azure.github.io/azure-service-operator/guide/installing-from-yaml).
 


### PR DESCRIPTION
Also fixes a relative link to make it absolute so it works in both the README and hugo site context.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains tests
