### PR TITLE
Fix DevContainer Builds

### DIFF
--- a/.github/workflows/build-devcontainer-image.yml
+++ b/.github/workflows/build-devcontainer-image.yml
@@ -25,8 +25,8 @@ jobs:
       contents: read
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v2
@@ -38,8 +38,7 @@ jobs:
       - name: Build & push Devcontainer image 
         uses: docker/build-push-action@v4
         with:
-          # This context means the action does its own checkout of the repo
-          context: "{{defaultContext}}:.devcontainer"
+          context: .devcontainer
           push: true
           # Build an image usable as cache-from, per: https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
           build-args: BUILDKIT_INLINE_CACHE=1

--- a/docs/hugo/.htmltest.yml
+++ b/docs/hugo/.htmltest.yml
@@ -9,8 +9,8 @@ IgnoreURLs:
   - /favicons/
   - /scss/
   - /js/
-  - example.com
   - index.xml
+  - example.com
   - "https://armwiki.azurewebsites.net/api_contracts/guidelines/templatedeployment.html" # Returns 404 even though valid
   - "https://marketplace.visualstudio.com/items" # Marketplace links return 401 even if valid
   - "https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/async-api-reference.md" # Manually checked, not a 404


### PR DESCRIPTION
**What this PR does / why we need it**:

Previous attempt to upgrade from deprecated versions of the docker actions failed, so trying again.

**Special notes for your reviewer**:

It appears the _required_ use of `docker/setup-buildx-action@v2` ... isn't.

Manually tested by pushing the branch and triggering the workflow.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/2NABZ6SkKNTGjD6D2D/giphy.gif)
