### PR TITLE
Use 1ES Pool for long-running CI jobs

### DIFF
--- a/.github/workflows/pr-validation-fork.yml
+++ b/.github/workflows/pr-validation-fork.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   integration-tests-fork:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=aso-1es-pool]
     if:
       github.event_name == 'repository_dispatch' &&
       github.event.client_payload.slash_command.args.named.sha != '' &&
@@ -101,7 +101,7 @@ jobs:
       - name: Run integration tests
         run: |
           container_id=${{ env.container_id }}
-          docker exec --env HOSTROOT=$GITHUB_WORKSPACE -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "$container_id" task controller:ci-integration-tests --concurrency 1 # limit concurrency because build machines are small
+          docker exec --env HOSTROOT=$GITHUB_WORKSPACE -e AZURE_TENANT_ID -e AZURE_CLIENT_ID -e AZURE_CLIENT_SECRET -e AZURE_SUBSCRIPTION_ID -e AZURE_CLIENT_SECRET_MULTITENANT -e AZURE_CLIENT_ID_MULTITENANT -e AZURE_CLIENT_ID_CERT_AUTH -e AZURE_CLIENT_SECRET_CERT_AUTH "$container_id" task controller:ci-integration-tests
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -44,7 +44,7 @@ jobs:
           go get "$repo/v2@$sha"
 
   test-generator:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=aso-1es-pool]
     permissions:
       packages: read
 
@@ -102,7 +102,7 @@ jobs:
           container_id=${{ env.container_id }}
 
           set +e # don't exit instantly on failure, we need to produce Markdown summary
-          docker exec "$container_id" task ci --concurrency 1 # limit concurrency because build machines are small
+          docker exec "$container_id" task ci
 
           EXIT_CODE=$?
           set -e
@@ -122,8 +122,8 @@ jobs:
       - name: Build docker image & build configuration YAML
         run: |
           container_id=${{ env.container_id }}
-          docker exec "$container_id" task controller:docker-build-and-save --concurrency 1 # limit concurrency because build machines are small
-          docker exec "$container_id" task controller:run-kustomize-for-envtest --concurrency 1 # limit concurrency because build machines are small
+          docker exec "$container_id" task controller:docker-build-and-save
+          docker exec "$container_id" task controller:run-kustomize-for-envtest
         if: steps.check-changes.outputs.code-changed == 'true'
 
       - name: Archive outputs
@@ -140,7 +140,7 @@ jobs:
 
   # TODO: Changing this name requires changing the github API calls in pr-validation-fork.yml
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=aso-1es-pool]
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       packages: read

--- a/.github/workflows/pre-release-tests.yaml
+++ b/.github/workflows/pre-release-tests.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=aso-1es-pool]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -256,6 +256,7 @@ tasks:
       - task: cleanup-old-live-azure-resources
       - task: controller:test-integration-kind-ci
       - task: controller:test-multitenant-integration-kind-ci
+      - task: cleanup-old-live-azure-resources  # Run this on both sides of the test pass to do our best to avoid leaking something
 
   controller:ci-live:
     cmds:
@@ -519,8 +520,7 @@ tasks:
     dir: "{{.CONTROLLER_ROOT}}"
     deps:
       - controller:test-integration-envtest-live
-      - controller:test-integration-kind-ci
-      - cleanup-old-live-azure-resources
+      - controller:ci-integration-tests
 
   controller:generate-types:
     desc: Run {{.GENERATOR_APP}} to generate input files for controller-gen for {{.CONTROLLER_APP}}.

--- a/scripts/v2/cipool/deploy.bicep
+++ b/scripts/v2/cipool/deploy.bicep
@@ -1,0 +1,78 @@
+param location string = resourceGroup().location
+
+var poolName = 'aso-1es-pool'
+var sku = 'Standard_D8ds_v4'
+
+// Base 1ES Image Resource IDs
+var ubuntu2204GalleryVersionResourceId = '/subscriptions/723b64f0-884d-4994-b6de-8960d049cb7e/resourceGroups/CloudTestImages/providers/Microsoft.Compute/galleries/CloudTestGallery/images/MMSUbuntu22.04-Secure/versions/latest'
+
+
+var poolSettings = {
+  maxPoolSize: 4 // We run 2 jobs per CI run on this pool, so a max of 4 means we can run 2 CI builds in parallel
+  resourcePredictions: [
+    {
+      '21:00': 2  // 9 AM Monday NZT
+    }
+    {
+      '05:00': 0  // 5 PM Monday NZT
+      '16:00': 2  // 9 AM Monday PST
+    }
+    {
+      '05:00': 0  // 5 PM Tuesday NZT
+      '16:00': 2  // 9 AM Tuesday PST
+    }
+    {
+      '05:00': 0  // 5 PM Wednesday NZT
+      '16:00': 2  // 9 AM Wednesday PST
+    }
+    {
+      '05:00': 0  // 5 PM Thursday NZT
+      '16:00': 2  // 9 AM Thursday PST
+    }
+    {
+      '05:00': 0  // 5 PM Friday NZT
+      '16:00': 2  // 9 AM Friday PST
+    }
+    {
+      '00:00': 0 // 5 PM Friday PST
+    }
+  ]
+}
+
+resource agentImage 'Microsoft.CloudTest/images@2020-05-07' = {
+  name: '1es-ubuntu-22.04'
+  location: location
+  properties: {
+    imageType: 'SharedImageGallery'
+    resourceId: ubuntu2204GalleryVersionResourceId
+  }
+}
+
+
+resource hostedPool 'Microsoft.CloudTest/hostedpools@2020-05-07' = {
+  name: poolName
+  location: location
+  properties: {
+    organizationProfile: {
+      type: 'GitHub'
+      organizationName: 'Azure'
+      url: 'https://github.com/Azure/azure-service-operator'
+    }
+    sku: {
+      name: sku
+      tier: 'Standard' // Supports premium but we don't need it as work is done on temp disk anyway. See https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-hosted-azure-devops-pools/demands.
+    }
+    images: [
+      {
+        subscriptionId: subscription().subscriptionId
+        imageName: agentImage.name
+        poolBufferPercentage: '100'
+      }
+    ]
+    maxPoolSize: poolSettings.maxPoolSize
+    agentProfile: {
+      type: 'Stateless'
+      resourcePredictions: poolSettings.resourcePredictions
+    }
+  }
+}

--- a/scripts/v2/cipool/deploy.sh
+++ b/scripts/v2/cipool/deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # fail on...failures
+set -x # log commands as they run
+
+# Note: You must run az login before executing this script
+
+[[ -z "${AZURE_SUBSCRIPTION_ID}" ]] && echo "AZURE_SUBSCRIPTION_ID is not set" && exit 1
+
+ROOT=$(dirname "${BASH_SOURCE[0]}")
+
+
+RESOURCE_GROUP="1es-pool"
+REGION="westus3"
+TIMESTAMP="$(date -Iseconds | tr -d :+-)"
+
+# This group should already exist but create it just in case
+az group create -l "${REGION}" -n "${RESOURCE_GROUP}"
+az deployment group create -n "deployment-pool-${TIMESTAMP}" -g "${RESOURCE_GROUP}" -f "${ROOT}/deploy.bicep"

--- a/v2/internal/testcommon/kube_test_context_envtest.go
+++ b/v2/internal/testcommon/kube_test_context_envtest.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -430,9 +432,12 @@ func createEnvtestContext() (BaseTestContextFactory, context.CancelFunc) {
 		clients: make(map[string]*perNamespace),
 	}
 
+	cpus := runtime.NumCPU()
+	concurrencyLimit := math.Max(float64(cpus/4), 1)
+
 	envTests := sharedEnvTests{
 		envtestLock:               sync.Mutex{},
-		concurrencyLimitSemaphore: semaphore.NewWeighted(1),
+		concurrencyLimitSemaphore: semaphore.NewWeighted(int64(concurrencyLimit)),
 		envtests:                  make(map[string]*runningEnvTest),
 		namespaceResources:        perNamespaceResources,
 	}


### PR DESCRIPTION
**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
