### PR TITLE
Fix redis samples

### DIFF
--- a/v2/samples/cache/v1api/refs/v1api20201201_redis.yaml
+++ b/v2/samples/cache/v1api/refs/v1api20201201_redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: linked-sampleredis
   namespace: default
 spec:
-  location: eastus2
+  location: westcentralus
   owner:
     name: aso-sample-rg
   sku:

--- a/v2/samples/cache/v1api/refs/v1api20201201_redis.yaml
+++ b/v2/samples/cache/v1api/refs/v1api20201201_redis.yaml
@@ -1,7 +1,7 @@
 apiVersion: cache.azure.com/v1api20201201
 kind: Redis
 metadata:
-  name: linked-sampleredis
+  name: linked-sample-redis
   namespace: default
 spec:
   location: westcentralus

--- a/v2/samples/cache/v1api/v1api20201201_redislinkedserver.yaml
+++ b/v2/samples/cache/v1api/v1api20201201_redislinkedserver.yaml
@@ -11,5 +11,5 @@ spec:
   linkedRedisCacheReference:
     group: cache.azure.com
     kind: Redis
-    name: linked-sampleredis
+    name: linked-sample-redis
   serverRole: Secondary

--- a/v2/samples/cache/v1api/v1api20201201_redislinkedserver.yaml
+++ b/v2/samples/cache/v1api/v1api20201201_redislinkedserver.yaml
@@ -2,7 +2,7 @@ apiVersion: cache.azure.com/v1api20201201
 kind: RedisLinkedServer
 metadata:
   # This name needs to be the same as the secondary redis server.
-  name: linked-sampleredis
+  name: linked-sample-redis
   namespace: default
 spec:
   owner:

--- a/v2/samples/cache/v1api/v1api20201201_redislinkedserver.yaml
+++ b/v2/samples/cache/v1api/v1api20201201_redislinkedserver.yaml
@@ -2,15 +2,14 @@ apiVersion: cache.azure.com/v1api20201201
 kind: RedisLinkedServer
 metadata:
   # This name needs to be the same as the secondary redis server.
-  name: sampleredis2-alpha
+  name: linked-sampleredis
   namespace: default
 spec:
-  location: westcentralus
   owner:
     name: sampleredis1
   linkedRedisCacheLocation: westcentralus
   linkedRedisCacheReference:
     group: cache.azure.com
     kind: Redis
-    name: sampleredis2-alpha
+    name: linked-sampleredis
   serverRole: Secondary

--- a/v2/samples/cache/v1beta/v1beta20201201_redislinkedserver.yaml
+++ b/v2/samples/cache/v1beta/v1beta20201201_redislinkedserver.yaml
@@ -5,7 +5,6 @@ metadata:
   name: sampleredis2-beta
   namespace: default
 spec:
-  location: westcentralus
   owner:
     name: sampleredis1
   linkedRedisCacheLocation: westcentralus


### PR DESCRIPTION


**What this PR does / why we need it**:

Found out while scenario testing, `RedisLinkedServer` has `location` property on it which should not be there.
