### PR TITLE
Fix bug preventing operator from installing CRDs into a different namespace

### DIFF
--- a/v2/internal/crdmanagement/manager.go
+++ b/v2/internal/crdmanagement/manager.go
@@ -390,11 +390,11 @@ func fixCRDNamespace(crd apiextensions.CustomResourceDefinition, namespace strin
 	}
 
 	// Set cert-manager.io/inject-ca-from
-	if len(result.Labels) > 0 {
-		if injectCAFrom, ok := result.Labels[certMgrInjectCAFromAnnotation]; ok {
+	if len(result.Annotations) > 0 {
+		if injectCAFrom, ok := result.Annotations[certMgrInjectCAFromAnnotation]; ok {
 			split := strings.Split(injectCAFrom, "/")
 			if len(split) == 2 {
-				result.Labels[certMgrInjectCAFromAnnotation] = fmt.Sprintf("%s/%s", namespace, split[1])
+				result.Annotations[certMgrInjectCAFromAnnotation] = fmt.Sprintf("%s/%s", namespace, split[1])
 			}
 		}
 	}


### PR DESCRIPTION
We were fixing up the cert-manager label when really it's an annotation that should have been fixed.

- Adds a unit test.
- Fixes #3057.

**If applicable**:
- [ ] this PR contains documentation
- [x] this PR contains tests
