### PR TITLE
Improve pod securityContext parameters

### DIFF
--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -64,4 +64,7 @@ spec:
           requests:
             cpu: 200m
             memory: 256Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 10

--- a/v2/config/manager/manager_auth_proxy_patch.yaml
+++ b/v2/config/manager/manager_auth_proxy_patch.yaml
@@ -19,3 +19,6 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
Specify readOnlyRootFilesystem: true and allowPrivilegeEscalation: false for extra security goodness.

Resolves #3056.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
