### PR TITLE
Update cert manager version to use latest(1.12.1)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -732,7 +732,7 @@ tasks:
     cmds:
       - "kubectl create namespace cert-manager"
       - "kubectl label namespace cert-manager cert-manager.io/disable-validation=true"
-      - "kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml"
+      - "kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.12.1/cert-manager.yaml"
     status:
       - "kubectl get namespace cert-manager"
 

--- a/docs/operator-bundle/testing-and-releasing.md
+++ b/docs/operator-bundle/testing-and-releasing.md
@@ -27,7 +27,7 @@ This is the latest released operator bundle, which might not correspond to the l
     ```
 3. Install cert-manager:
     ```sh
-    k apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.yaml
+    k apply -f https://github.com/jetstack/cert-manager/releases/download/v1.12.1/cert-manager.yaml
     ```
 4. Install the `opm` tool to build the index image:
     * Follow [these instructions](https://docs.openshift.com/container-platform/4.5/operators/admin/olm-managing-custom-catalogs.html#olm-installing-opm_olm-managing-custom-catalogs) to get the `opm` binary.

--- a/v2/README.md
+++ b/v2/README.md
@@ -32,7 +32,7 @@ ASO supports more than 150 different Azure resources, with more added every rele
 1. Install [cert-manager](https://cert-manager.io/docs/installation/kubernetes/) on the cluster using the following command.
 
     ```bash
-    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.12.1/cert-manager.yaml
     ```
    Check that the cert-manager pods have started successfully before continuing.
 
@@ -190,7 +190,7 @@ As for deleting controller components, just `kubectl delete -f` the release mani
 to get started. For example, creating and deleting cert-manager.
 ```bash
 # remove the cert-manager components
-kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.12.1/cert-manager.yaml
 ```
 
 ## How to contribute


### PR DESCRIPTION


**What this PR does / why we need it**:

We were using 1.8.x version for cert-manager in our CI. Updating it to 1.12.1 in this PR

