### PR TITLE
Refactor AddDefaulterInterface

### DIFF
--- a/v2/tools/generator/internal/interfaces/defaulter_interface.go
+++ b/v2/tools/generator/internal/interfaces/defaulter_interface.go
@@ -15,21 +15,20 @@ import (
 func AddDefaulterInterface(
 	resourceDef astmodel.TypeDefinition,
 	idFactory astmodel.IdentifierFactory,
-	definitions astmodel.TypeDefinitionSet) (astmodel.TypeDefinition, error) {
+	defaultFunctions []*functions.ResourceFunction,
+) (astmodel.TypeDefinition, error) {
 
-	resolved, err := definitions.ResolveResourceSpecAndStatus(resourceDef)
-	if err != nil {
-		return astmodel.TypeDefinition{}, errors.Wrapf(err, "unable to resolve resource %s", resourceDef.Name())
+	resourceType, ok := resourceDef.Type().(*astmodel.ResourceType)
+	if !ok {
+		return astmodel.TypeDefinition{}, errors.Errorf("cannot add defaulter interface to non-resource type: %s %T", resourceDef.Name(), resourceDef.Type())
 	}
 
-	defaulterBuilder := functions.NewDefaulterBuilder(resourceDef.Name(), resolved.ResourceType, idFactory)
-
-	// Determine if the resource has a SetName function
-	if resolved.SpecType.HasFunctionWithName(astmodel.SetAzureNameFunc) {
-		defaulterBuilder.AddDefault(functions.NewDefaultAzureNameFunction(resolved.ResourceType, idFactory))
+	defaulterBuilder := functions.NewDefaulterBuilder(resourceDef.Name(), resourceType, idFactory)
+	for _, f := range defaultFunctions {
+		defaulterBuilder.AddDefault(f)
 	}
 
-	resourceType := resolved.ResourceType.WithInterface(defaulterBuilder.ToInterfaceImplementation())
+	resourceType = resourceType.WithInterface(defaulterBuilder.ToInterfaceImplementation())
 
 	return resourceDef.WithType(resourceType), nil
 }


### PR DESCRIPTION
Pass default functions as an argument rather than hardcoding them. This is similar to what we're already doing for validations.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
