### PR TITLE
Fix asoctl when importing resources with fixed names

### DIFF
--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
@@ -484,11 +484,16 @@ func (i *importableARMResource) SetName(
 
 	importable.SetName(n)
 
-	// AzureName needs to be exactly as specified in the ARM URL
-	// Need to use reflection to set it
+	// AzureName needs to be exactly as specified in the ARM URL.
+	// Use reflection to set it as we don't have convenient access.
+	// Not all resources have the AzureName property - some resources
+	// have hard coded names that ASO handles directly
+	// (e.g. Microsoft.Storage/storageAccounts/tableServices always has the name 'default')
 	specField := reflect.ValueOf(importable.GetSpec()).Elem()
 	azureNameField := specField.FieldByName("AzureName")
+	if azureNameField.IsValid() {
 	azureNameField.SetString(name)
+	}
 }
 
 func (i *importableARMResource) SetOwner(

--- a/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
+++ b/v2/cmd/asoctl/internal/importing/importable_arm_resource.go
@@ -492,7 +492,7 @@ func (i *importableARMResource) SetName(
 	specField := reflect.ValueOf(importable.GetSpec()).Elem()
 	azureNameField := specField.FieldByName("AzureName")
 	if azureNameField.IsValid() {
-	azureNameField.SetString(name)
+		azureNameField.SetString(name)
 	}
 }
 

--- a/v2/cmd/asoctl/internal/importing/resource_importer_report.go
+++ b/v2/cmd/asoctl/internal/importing/resource_importer_report.go
@@ -6,6 +6,7 @@
 package importing
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -124,11 +125,28 @@ func (k *resourceImportReportKey) lessThan(other resourceImportReportKey) bool {
 }
 
 func (k *resourceImportReportKey) WriteToLog(log logr.Logger, count int) {
-	log.Info(
-		"Summary",
-		"Group", k.group,
-		"Kind", k.kind,
-		"Status", k.status,
-		"Count", count,
-		"Reason", k.reason)
+	switch k.status {
+	case Imported:
+		log.Info(
+			"Successful imports",
+			"Group", k.group,
+			"Kind", k.kind,
+
+			"Count", count,
+			"Reason", k.reason)
+	case Skipped:
+		log.V(1).Info(
+			"Skipped imports",
+			"Group", k.group,
+			"Kind", k.kind,
+			"Count", count,
+			"Reason", k.reason)
+	case Failed:
+		log.Error(
+			errors.New(k.reason),
+			"Failed imports",
+			"Group", k.group,
+			"Kind", k.kind,
+			"Count", count)
+	}
 }

--- a/v2/cmd/asoctl/internal/importing/resource_importer_report.go
+++ b/v2/cmd/asoctl/internal/importing/resource_importer_report.go
@@ -131,9 +131,7 @@ func (k *resourceImportReportKey) WriteToLog(log logr.Logger, count int) {
 			"Successful imports",
 			"Group", k.group,
 			"Kind", k.kind,
-
-			"Count", count,
-			"Reason", k.reason)
+			"Count", count)
 	case Skipped:
 		log.V(1).Info(
 			"Skipped imports",


### PR DESCRIPTION
**What this PR does / why we need it**:

If a resource being imported has a fixed name, it doesn't have an AzureName property and `asoctl` was encountering a panic.

Fixes #3098 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/FiBzv5FRE85PO/giphy.gif)
