### PR TITLE
Fix postcss always reinstalling

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -219,7 +219,7 @@ fi
 
 # Ensure tooling for Hugo is available
 write-verbose "Checking for /usr/bin/postcss"
-if should-install "/usr/bin/postcss"; then 
+if ! which postcss; then 
     write-info "Installing postcss"
     npm install --global postcss postcss-cli autoprefixer
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently `postcss` will always install when `dev.sh` is run, regardless of whether it's already installed or not.

Turns out it installs into different locations inside/outside the devcontainer; switching to using `which` means it should work in both cases.

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/ZSvAC5c9RkW4g/giphy.gif)
