### PR TITLE
chore: use time.Since instead of time.Now().Sub

### DIFF
--- a/pkg/helpers/retry_test.go
+++ b/pkg/helpers/retry_test.go
@@ -14,7 +14,7 @@ func TestRetryTimeout(t *testing.T) {
 	_ = Retry(5*time.Second, 1*time.Second, func() error {
 		return fmt.Errorf("test")
 	})
-	stop := time.Now().Sub(start)
+	stop := time.Since(start)
 	if stop < 5*time.Second {
 		t.Errorf("retry ended too soon: %s", stop)
 	}
@@ -24,7 +24,7 @@ func TestRetryStopErr(t *testing.T) {
 	_ = Retry(5*time.Second, 1*time.Second, func() error {
 		return NewStop(fmt.Errorf("test"))
 	})
-	stop := time.Now().Sub(start)
+	stop := time.Since(start)
 	if stop > 1*time.Second {
 		t.Errorf("retry with stop should not take so long: %s", stop)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

Closes #[issue number]

**What this PR does / why we need it**:
use time.Since instead of time.Now().Sub
**Special notes for your reviewer**:

**How does this PR make you feel**:
![gif](https://giphy.com/)

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains tests
