### PR TITLE
Configuration of FederatedIdentityCredential 

### DIFF
--- a/v2/api/managedidentity/v1api20220131preview/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1api20220131preview/federated_identity_credential_types_gen.go
@@ -225,7 +225,7 @@ func (credential *FederatedIdentityCredential) ValidateUpdate(old runtime.Object
 
 // createValidations validates the creation of the resource
 func (credential *FederatedIdentityCredential) createValidations() []func() error {
-	return []func() error{credential.validateResourceReferences}
+	return []func() error{credential.validateResourceReferences, credential.validateOptionalConfigMapReferences}
 }
 
 // deleteValidations validates the deletion of the resource
@@ -239,7 +239,20 @@ func (credential *FederatedIdentityCredential) updateValidations() []func(old ru
 		func(old runtime.Object) error {
 			return credential.validateResourceReferences()
 		},
-		credential.validateWriteOnceProperties}
+		credential.validateWriteOnceProperties,
+		func(old runtime.Object) error {
+			return credential.validateOptionalConfigMapReferences()
+		},
+	}
+}
+
+// validateOptionalConfigMapReferences validates all optional configmap reference pairs to ensure that at most 1 is set
+func (credential *FederatedIdentityCredential) validateOptionalConfigMapReferences() error {
+	refs, err := reflecthelpers.FindOptionalConfigMapReferences(&credential.Spec)
+	if err != nil {
+		return err
+	}
+	return genruntime.ValidateOptionalConfigMapReferences(refs)
 }
 
 // validateResourceReferences validates all resource references
@@ -346,9 +359,11 @@ type UserAssignedIdentities_FederatedIdentityCredential_Spec struct {
 	// doesn't have to be.
 	AzureName string `json:"azureName,omitempty"`
 
-	// +kubebuilder:validation:Required
 	// Issuer: The URL of the issuer to be trusted.
-	Issuer *string `json:"issuer,omitempty"`
+	Issuer *string `json:"issuer,omitempty" optionalConfigMapPair:"Issuer"`
+
+	// IssuerFromConfig: The URL of the issuer to be trusted.
+	IssuerFromConfig *genruntime.ConfigMapReference `json:"issuerFromConfig,omitempty" optionalConfigMapPair:"Issuer"`
 
 	// +kubebuilder:validation:Required
 	// Owner: The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also
@@ -356,9 +371,11 @@ type UserAssignedIdentities_FederatedIdentityCredential_Spec struct {
 	// reference to a managedidentity.azure.com/UserAssignedIdentity resource
 	Owner *genruntime.KnownResourceReference `group:"managedidentity.azure.com" json:"owner,omitempty" kind:"UserAssignedIdentity"`
 
-	// +kubebuilder:validation:Required
 	// Subject: The identifier of the external identity.
-	Subject *string `json:"subject,omitempty"`
+	Subject *string `json:"subject,omitempty" optionalConfigMapPair:"Subject"`
+
+	// SubjectFromConfig: The identifier of the external identity.
+	SubjectFromConfig *genruntime.ConfigMapReference `json:"subjectFromConfig,omitempty" optionalConfigMapPair:"Subject"`
 }
 
 var _ genruntime.ARMTransformer = &UserAssignedIdentities_FederatedIdentityCredential_Spec{}
@@ -376,7 +393,9 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Conve
 	// Set property ‘Properties’:
 	if credential.Audiences != nil ||
 		credential.Issuer != nil ||
-		credential.Subject != nil {
+		credential.IssuerFromConfig != nil ||
+		credential.Subject != nil ||
+		credential.SubjectFromConfig != nil {
 		result.Properties = &FederatedIdentityCredentialProperties_ARM{}
 	}
 	for _, item := range credential.Audiences {
@@ -386,8 +405,24 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Conve
 		issuer := *credential.Issuer
 		result.Properties.Issuer = &issuer
 	}
+	if credential.IssuerFromConfig != nil {
+		issuerValue, err := resolved.ResolvedConfigMaps.Lookup(*credential.IssuerFromConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "looking up configmap for property Issuer")
+		}
+		issuer := issuerValue
+		result.Properties.Issuer = &issuer
+	}
 	if credential.Subject != nil {
 		subject := *credential.Subject
+		result.Properties.Subject = &subject
+	}
+	if credential.SubjectFromConfig != nil {
+		subjectValue, err := resolved.ResolvedConfigMaps.Lookup(*credential.SubjectFromConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "looking up configmap for property Subject")
+		}
+		subject := subjectValue
 		result.Properties.Subject = &subject
 	}
 	return result, nil
@@ -425,6 +460,8 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 		}
 	}
 
+	// no assignment for property ‘IssuerFromConfig’
+
 	// Set property ‘Owner’:
 	credential.Owner = &genruntime.KnownResourceReference{Name: owner.Name}
 
@@ -436,6 +473,8 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Popul
 			credential.Subject = &subject
 		}
 	}
+
+	// no assignment for property ‘SubjectFromConfig’
 
 	// No error
 	return nil
@@ -503,6 +542,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 	// Issuer
 	credential.Issuer = genruntime.ClonePointerToString(source.Issuer)
 
+	// IssuerFromConfig
+	if source.IssuerFromConfig != nil {
+		issuerFromConfig := source.IssuerFromConfig.Copy()
+		credential.IssuerFromConfig = &issuerFromConfig
+	} else {
+		credential.IssuerFromConfig = nil
+	}
+
 	// Owner
 	if source.Owner != nil {
 		owner := source.Owner.Copy()
@@ -513,6 +560,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 
 	// Subject
 	credential.Subject = genruntime.ClonePointerToString(source.Subject)
+
+	// SubjectFromConfig
+	if source.SubjectFromConfig != nil {
+		subjectFromConfig := source.SubjectFromConfig.Copy()
+		credential.SubjectFromConfig = &subjectFromConfig
+	} else {
+		credential.SubjectFromConfig = nil
+	}
 
 	// No error
 	return nil
@@ -532,6 +587,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 	// Issuer
 	destination.Issuer = genruntime.ClonePointerToString(credential.Issuer)
 
+	// IssuerFromConfig
+	if credential.IssuerFromConfig != nil {
+		issuerFromConfig := credential.IssuerFromConfig.Copy()
+		destination.IssuerFromConfig = &issuerFromConfig
+	} else {
+		destination.IssuerFromConfig = nil
+	}
+
 	// OriginalVersion
 	destination.OriginalVersion = credential.OriginalVersion()
 
@@ -545,6 +608,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 
 	// Subject
 	destination.Subject = genruntime.ClonePointerToString(credential.Subject)
+
+	// SubjectFromConfig
+	if credential.SubjectFromConfig != nil {
+		subjectFromConfig := credential.SubjectFromConfig.Copy()
+		destination.SubjectFromConfig = &subjectFromConfig
+	} else {
+		destination.SubjectFromConfig = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/managedidentity/v1api20220131preview/structure.txt
+++ b/v2/api/managedidentity/v1api20220131preview/structure.txt
@@ -4,12 +4,14 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20220131prev
 │   └── "2022-01-31-preview"
 ├── FederatedIdentityCredential: Resource
 │   ├── Owner: UserAssignedIdentity
-│   ├── Spec: Object (5 properties)
+│   ├── Spec: Object (7 properties)
 │   │   ├── Audiences: string[]
 │   │   ├── AzureName: string
 │   │   ├── Issuer: *string
+│   │   ├── IssuerFromConfig: *genruntime.ConfigMapReference
 │   │   ├── Owner: *genruntime.KnownResourceReference
-│   │   └── Subject: *string
+│   │   ├── Subject: *string
+│   │   └── SubjectFromConfig: *genruntime.ConfigMapReference
 │   └── Status: Object (7 properties)
 │       ├── Audiences: string[]
 │       ├── Conditions: conditions.Condition[]

--- a/v2/api/managedidentity/v1api20220131preview/user_assigned_identities_federated_identity_credential_spec_arm_types_gen.go
+++ b/v2/api/managedidentity/v1api20220131preview/user_assigned_identities_federated_identity_credential_spec_arm_types_gen.go
@@ -35,8 +35,8 @@ type FederatedIdentityCredentialProperties_ARM struct {
 	Audiences []string `json:"audiences,omitempty"`
 
 	// Issuer: The URL of the issuer to be trusted.
-	Issuer *string `json:"issuer,omitempty"`
+	Issuer *string `json:"issuer,omitempty" optionalConfigMapPair:"Issuer"`
 
 	// Subject: The identifier of the external identity.
-	Subject *string `json:"subject,omitempty"`
+	Subject *string `json:"subject,omitempty" optionalConfigMapPair:"Subject"`
 }

--- a/v2/api/managedidentity/v1api20220131preview/zz_generated.deepcopy.go
+++ b/v2/api/managedidentity/v1api20220131preview/zz_generated.deepcopy.go
@@ -235,6 +235,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 		*out = new(string)
 		**out = **in
 	}
+	if in.IssuerFromConfig != nil {
+		in, out := &in.IssuerFromConfig, &out.IssuerFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.Owner != nil {
 		in, out := &in.Owner, &out.Owner
 		*out = new(genruntime.KnownResourceReference)
@@ -243,6 +248,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 	if in.Subject != nil {
 		in, out := &in.Subject, &out.Subject
 		*out = new(string)
+		**out = **in
+	}
+	if in.SubjectFromConfig != nil {
+		in, out := &in.SubjectFromConfig, &out.SubjectFromConfig
+		*out = new(genruntime.ConfigMapReference)
 		**out = **in
 	}
 }

--- a/v2/api/managedidentity/v1api20220131previewstorage/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1api20220131previewstorage/federated_identity_credential_types_gen.go
@@ -145,17 +145,19 @@ type UserAssignedIdentities_FederatedIdentityCredential_Spec struct {
 
 	// AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it
 	// doesn't have to be.
-	AzureName       string  `json:"azureName,omitempty"`
-	Issuer          *string `json:"issuer,omitempty"`
-	OriginalVersion string  `json:"originalVersion,omitempty"`
+	AzureName        string                         `json:"azureName,omitempty"`
+	Issuer           *string                        `json:"issuer,omitempty" optionalConfigMapPair:"Issuer"`
+	IssuerFromConfig *genruntime.ConfigMapReference `json:"issuerFromConfig,omitempty" optionalConfigMapPair:"Issuer"`
+	OriginalVersion  string                         `json:"originalVersion,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Owner: The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also
 	// controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a
 	// reference to a managedidentity.azure.com/UserAssignedIdentity resource
-	Owner       *genruntime.KnownResourceReference `group:"managedidentity.azure.com" json:"owner,omitempty" kind:"UserAssignedIdentity"`
-	PropertyBag genruntime.PropertyBag             `json:"$propertyBag,omitempty"`
-	Subject     *string                            `json:"subject,omitempty"`
+	Owner             *genruntime.KnownResourceReference `group:"managedidentity.azure.com" json:"owner,omitempty" kind:"UserAssignedIdentity"`
+	PropertyBag       genruntime.PropertyBag             `json:"$propertyBag,omitempty"`
+	Subject           *string                            `json:"subject,omitempty" optionalConfigMapPair:"Subject"`
+	SubjectFromConfig *genruntime.ConfigMapReference     `json:"subjectFromConfig,omitempty" optionalConfigMapPair:"Subject"`
 }
 
 var _ genruntime.ConvertibleSpec = &UserAssignedIdentities_FederatedIdentityCredential_Spec{}

--- a/v2/api/managedidentity/v1api20220131previewstorage/structure.txt
+++ b/v2/api/managedidentity/v1api20220131previewstorage/structure.txt
@@ -4,14 +4,16 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20220131prev
 │   └── "2022-01-31-preview"
 └── FederatedIdentityCredential: Resource
     ├── Owner: github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20220131preview.UserAssignedIdentity
-    ├── Spec: Object (7 properties)
+    ├── Spec: Object (9 properties)
     │   ├── Audiences: string[]
     │   ├── AzureName: string
     │   ├── Issuer: *string
+    │   ├── IssuerFromConfig: *genruntime.ConfigMapReference
     │   ├── OriginalVersion: string
     │   ├── Owner: *genruntime.KnownResourceReference
     │   ├── PropertyBag: genruntime.PropertyBag
-    │   └── Subject: *string
+    │   ├── Subject: *string
+    │   └── SubjectFromConfig: *genruntime.ConfigMapReference
     └── Status: Object (8 properties)
         ├── Audiences: string[]
         ├── Conditions: conditions.Condition[]

--- a/v2/api/managedidentity/v1api20220131previewstorage/zz_generated.deepcopy.go
+++ b/v2/api/managedidentity/v1api20220131previewstorage/zz_generated.deepcopy.go
@@ -147,6 +147,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 		*out = new(string)
 		**out = **in
 	}
+	if in.IssuerFromConfig != nil {
+		in, out := &in.IssuerFromConfig, &out.IssuerFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.Owner != nil {
 		in, out := &in.Owner, &out.Owner
 		*out = new(genruntime.KnownResourceReference)
@@ -162,6 +167,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 	if in.Subject != nil {
 		in, out := &in.Subject, &out.Subject
 		*out = new(string)
+		**out = **in
+	}
+	if in.SubjectFromConfig != nil {
+		in, out := &in.SubjectFromConfig, &out.SubjectFromConfig
+		*out = new(genruntime.ConfigMapReference)
 		**out = **in
 	}
 }

--- a/v2/api/managedidentity/v1beta20220131preview/structure.txt
+++ b/v2/api/managedidentity/v1beta20220131preview/structure.txt
@@ -4,12 +4,14 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1beta20220131pre
 │   └── "2022-01-31-preview"
 ├── FederatedIdentityCredential: Resource
 │   ├── Owner: github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20220131preview.UserAssignedIdentity
-│   ├── Spec: Object (5 properties)
+│   ├── Spec: Object (7 properties)
 │   │   ├── Audiences: string[]
 │   │   ├── AzureName: string
 │   │   ├── Issuer: *string
+│   │   ├── IssuerFromConfig: *genruntime.ConfigMapReference
 │   │   ├── Owner: *genruntime.KnownResourceReference
-│   │   └── Subject: *string
+│   │   ├── Subject: *string
+│   │   └── SubjectFromConfig: *genruntime.ConfigMapReference
 │   └── Status: Object (7 properties)
 │       ├── Audiences: string[]
 │       ├── Conditions: conditions.Condition[]

--- a/v2/api/managedidentity/v1beta20220131preview/user_assigned_identities_federated_identity_credential_spec_arm_types_gen.go
+++ b/v2/api/managedidentity/v1beta20220131preview/user_assigned_identities_federated_identity_credential_spec_arm_types_gen.go
@@ -31,6 +31,6 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec_ARM) G
 // Deprecated version of FederatedIdentityCredentialProperties. Use v1api20220131preview.FederatedIdentityCredentialProperties instead
 type FederatedIdentityCredentialProperties_ARM struct {
 	Audiences []string `json:"audiences,omitempty"`
-	Issuer    *string  `json:"issuer,omitempty"`
-	Subject   *string  `json:"subject,omitempty"`
+	Issuer    *string  `json:"issuer,omitempty" optionalConfigMapPair:"Issuer"`
+	Subject   *string  `json:"subject,omitempty" optionalConfigMapPair:"Subject"`
 }

--- a/v2/api/managedidentity/v1beta20220131preview/zz_generated.deepcopy.go
+++ b/v2/api/managedidentity/v1beta20220131preview/zz_generated.deepcopy.go
@@ -235,6 +235,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 		*out = new(string)
 		**out = **in
 	}
+	if in.IssuerFromConfig != nil {
+		in, out := &in.IssuerFromConfig, &out.IssuerFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.Owner != nil {
 		in, out := &in.Owner, &out.Owner
 		*out = new(genruntime.KnownResourceReference)
@@ -243,6 +248,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 	if in.Subject != nil {
 		in, out := &in.Subject, &out.Subject
 		*out = new(string)
+		**out = **in
+	}
+	if in.SubjectFromConfig != nil {
+		in, out := &in.SubjectFromConfig, &out.SubjectFromConfig
+		*out = new(genruntime.ConfigMapReference)
 		**out = **in
 	}
 }

--- a/v2/api/managedidentity/v1beta20220131previewstorage/federated_identity_credential_types_gen.go
+++ b/v2/api/managedidentity/v1beta20220131previewstorage/federated_identity_credential_types_gen.go
@@ -235,17 +235,19 @@ type UserAssignedIdentities_FederatedIdentityCredential_Spec struct {
 
 	// AzureName: The name of the resource in Azure. This is often the same as the name of the resource in Kubernetes but it
 	// doesn't have to be.
-	AzureName       string  `json:"azureName,omitempty"`
-	Issuer          *string `json:"issuer,omitempty"`
-	OriginalVersion string  `json:"originalVersion,omitempty"`
+	AzureName        string                         `json:"azureName,omitempty"`
+	Issuer           *string                        `json:"issuer,omitempty" optionalConfigMapPair:"Issuer"`
+	IssuerFromConfig *genruntime.ConfigMapReference `json:"issuerFromConfig,omitempty" optionalConfigMapPair:"Issuer"`
+	OriginalVersion  string                         `json:"originalVersion,omitempty"`
 
 	// +kubebuilder:validation:Required
 	// Owner: The owner of the resource. The owner controls where the resource goes when it is deployed. The owner also
 	// controls the resources lifecycle. When the owner is deleted the resource will also be deleted. Owner is expected to be a
 	// reference to a managedidentity.azure.com/UserAssignedIdentity resource
-	Owner       *genruntime.KnownResourceReference `group:"managedidentity.azure.com" json:"owner,omitempty" kind:"UserAssignedIdentity"`
-	PropertyBag genruntime.PropertyBag             `json:"$propertyBag,omitempty"`
-	Subject     *string                            `json:"subject,omitempty"`
+	Owner             *genruntime.KnownResourceReference `group:"managedidentity.azure.com" json:"owner,omitempty" kind:"UserAssignedIdentity"`
+	PropertyBag       genruntime.PropertyBag             `json:"$propertyBag,omitempty"`
+	Subject           *string                            `json:"subject,omitempty" optionalConfigMapPair:"Subject"`
+	SubjectFromConfig *genruntime.ConfigMapReference     `json:"subjectFromConfig,omitempty" optionalConfigMapPair:"Subject"`
 }
 
 var _ genruntime.ConvertibleSpec = &UserAssignedIdentities_FederatedIdentityCredential_Spec{}
@@ -312,6 +314,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 	// Issuer
 	credential.Issuer = genruntime.ClonePointerToString(source.Issuer)
 
+	// IssuerFromConfig
+	if source.IssuerFromConfig != nil {
+		issuerFromConfig := source.IssuerFromConfig.Copy()
+		credential.IssuerFromConfig = &issuerFromConfig
+	} else {
+		credential.IssuerFromConfig = nil
+	}
+
 	// OriginalVersion
 	credential.OriginalVersion = source.OriginalVersion
 
@@ -325,6 +335,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 
 	// Subject
 	credential.Subject = genruntime.ClonePointerToString(source.Subject)
+
+	// SubjectFromConfig
+	if source.SubjectFromConfig != nil {
+		subjectFromConfig := source.SubjectFromConfig.Copy()
+		credential.SubjectFromConfig = &subjectFromConfig
+	} else {
+		credential.SubjectFromConfig = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {
@@ -360,6 +378,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 	// Issuer
 	destination.Issuer = genruntime.ClonePointerToString(credential.Issuer)
 
+	// IssuerFromConfig
+	if credential.IssuerFromConfig != nil {
+		issuerFromConfig := credential.IssuerFromConfig.Copy()
+		destination.IssuerFromConfig = &issuerFromConfig
+	} else {
+		destination.IssuerFromConfig = nil
+	}
+
 	// OriginalVersion
 	destination.OriginalVersion = credential.OriginalVersion
 
@@ -373,6 +399,14 @@ func (credential *UserAssignedIdentities_FederatedIdentityCredential_Spec) Assig
 
 	// Subject
 	destination.Subject = genruntime.ClonePointerToString(credential.Subject)
+
+	// SubjectFromConfig
+	if credential.SubjectFromConfig != nil {
+		subjectFromConfig := credential.SubjectFromConfig.Copy()
+		destination.SubjectFromConfig = &subjectFromConfig
+	} else {
+		destination.SubjectFromConfig = nil
+	}
 
 	// Update the property bag
 	if len(propertyBag) > 0 {

--- a/v2/api/managedidentity/v1beta20220131previewstorage/structure.txt
+++ b/v2/api/managedidentity/v1beta20220131previewstorage/structure.txt
@@ -4,14 +4,16 @@ github.com/Azure/azure-service-operator/v2/api/managedidentity/v1beta20220131pre
 │   └── "2022-01-31-preview"
 ├── FederatedIdentityCredential: Resource
 │   ├── Owner: github.com/Azure/azure-service-operator/v2/api/managedidentity/v1api20220131preview.UserAssignedIdentity
-│   ├── Spec: Object (7 properties)
+│   ├── Spec: Object (9 properties)
 │   │   ├── Audiences: string[]
 │   │   ├── AzureName: string
 │   │   ├── Issuer: *string
+│   │   ├── IssuerFromConfig: *genruntime.ConfigMapReference
 │   │   ├── OriginalVersion: string
 │   │   ├── Owner: *genruntime.KnownResourceReference
 │   │   ├── PropertyBag: genruntime.PropertyBag
-│   │   └── Subject: *string
+│   │   ├── Subject: *string
+│   │   └── SubjectFromConfig: *genruntime.ConfigMapReference
 │   └── Status: Object (8 properties)
 │       ├── Audiences: string[]
 │       ├── Conditions: conditions.Condition[]

--- a/v2/api/managedidentity/v1beta20220131previewstorage/zz_generated.deepcopy.go
+++ b/v2/api/managedidentity/v1beta20220131previewstorage/zz_generated.deepcopy.go
@@ -147,6 +147,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 		*out = new(string)
 		**out = **in
 	}
+	if in.IssuerFromConfig != nil {
+		in, out := &in.IssuerFromConfig, &out.IssuerFromConfig
+		*out = new(genruntime.ConfigMapReference)
+		**out = **in
+	}
 	if in.Owner != nil {
 		in, out := &in.Owner, &out.Owner
 		*out = new(genruntime.KnownResourceReference)
@@ -162,6 +167,11 @@ func (in *UserAssignedIdentities_FederatedIdentityCredential_Spec) DeepCopyInto(
 	if in.Subject != nil {
 		in, out := &in.Subject, &out.Subject
 		*out = new(string)
+		**out = **in
+	}
+	if in.SubjectFromConfig != nil {
+		in, out := &in.SubjectFromConfig, &out.SubjectFromConfig
+		*out = new(genruntime.ConfigMapReference)
 		**out = **in
 	}
 }

--- a/v2/azure-arm.yaml
+++ b/v2/azure-arm.yaml
@@ -575,7 +575,7 @@ status:
 #
 # $generatedConfigs: <map of string -> string>
 #     The key of the map is the name of the property to export, the value of the map is a json-path like expression
-#     to the property to export. Currently only $.<prop>.<prop> snytax is supported.
+#     to the property to export. Currently only $.<prop>.<prop> syntax is supported.
 #     Only valid for resources.
 #     Example:
 #         $generatedConfigs:
@@ -1288,6 +1288,12 @@ objectModelConfiguration:
       UserAssignedIdentities_FederatedIdentityCredential:
         $exportAs: FederatedIdentityCredential
         $supportedFrom: v2.0.0-beta.3
+      FederatedIdentityCredentialProperties:
+        Issuer:
+          $importConfigMapMode: optional
+        Subject:
+          $importConfigMapMode: optional
+
   machinelearningservices:
     2021-07-01:
       AksNetworkingConfiguration:

--- a/v2/internal/controllers/controller_resources_gen.go
+++ b/v2/internal/controllers/controller_resources_gen.go
@@ -541,7 +541,25 @@ func getKnownStorageTypes() []*registration.StorageType {
 	})
 	result = append(result, &registration.StorageType{Obj: new(machinelearningservices_v1api20210701s.WorkspacesConnection)})
 	result = append(result, &registration.StorageType{Obj: new(managedidentity_v1api20181130s.UserAssignedIdentity)})
-	result = append(result, &registration.StorageType{Obj: new(managedidentity_v1api20220131ps.FederatedIdentityCredential)})
+	result = append(result, &registration.StorageType{
+		Obj: new(managedidentity_v1api20220131ps.FederatedIdentityCredential),
+		Indexes: []registration.Index{
+			{
+				Key:  ".spec.issuerFromConfig",
+				Func: indexManagedidentityFederatedIdentityCredentialIssuerFromConfig,
+			},
+			{
+				Key:  ".spec.subjectFromConfig",
+				Func: indexManagedidentityFederatedIdentityCredentialSubjectFromConfig,
+			},
+		},
+		Watches: []registration.Watch{
+			{
+				Src:              &source.Kind{Type: &v1.ConfigMap{}},
+				MakeEventHandler: watchConfigMapsFactory([]string{".spec.issuerFromConfig", ".spec.subjectFromConfig"}, &managedidentity_v1api20220131ps.FederatedIdentityCredentialList{}),
+			},
+		},
+	})
 	result = append(result, &registration.StorageType{Obj: new(network_v1api20180501s.DnsZone)})
 	result = append(result, &registration.StorageType{Obj: new(network_v1api20180501s.DnsZonesAAAARecord)})
 	result = append(result, &registration.StorageType{Obj: new(network_v1api20180501s.DnsZonesARecord)})
@@ -2352,6 +2370,30 @@ func indexMachinelearningservicesWorkspacesComputeVirtualMachinePassword(rawObj 
 		return nil
 	}
 	return obj.Spec.Properties.VirtualMachine.Properties.AdministratorAccount.Password.Index()
+}
+
+// indexManagedidentityFederatedIdentityCredentialIssuerFromConfig an index function for managedidentity_v1api20220131ps.FederatedIdentityCredential .spec.issuerFromConfig
+func indexManagedidentityFederatedIdentityCredentialIssuerFromConfig(rawObj client.Object) []string {
+	obj, ok := rawObj.(*managedidentity_v1api20220131ps.FederatedIdentityCredential)
+	if !ok {
+		return nil
+	}
+	if obj.Spec.IssuerFromConfig == nil {
+		return nil
+	}
+	return obj.Spec.IssuerFromConfig.Index()
+}
+
+// indexManagedidentityFederatedIdentityCredentialSubjectFromConfig an index function for managedidentity_v1api20220131ps.FederatedIdentityCredential .spec.subjectFromConfig
+func indexManagedidentityFederatedIdentityCredentialSubjectFromConfig(rawObj client.Object) []string {
+	obj, ok := rawObj.(*managedidentity_v1api20220131ps.FederatedIdentityCredential)
+	if !ok {
+		return nil
+	}
+	if obj.Spec.SubjectFromConfig == nil {
+		return nil
+	}
+	return obj.Spec.SubjectFromConfig.Index()
 }
 
 // indexNetworkDnsForwardingRuleSetsForwardingRuleIpAddressFromConfig an index function for network_v1api20220701s.DnsForwardingRuleSetsForwardingRule .spec.targetDnsServers.ipAddressFromConfig


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows the `issuer` and `subject` properties of FederatedIdentityCredential to be set from configMaps.

Closes #3030 

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/ZBKeYnWR23pDBp6yRE/giphy.gif)
