### PR TITLE
Filter against upgrading non-ASO resources

### DIFF
--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -8,7 +8,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-service-operator/v2/api"
 	"math/rand"
 	"os"
 	"regexp"
@@ -35,13 +34,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	. "github.com/Azure/azure-service-operator/v2/internal/logging"
+	asometrics "github.com/Azure/azure-service-operator/v2/internal/metrics"
+	armreconciler "github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm"
+
+	"github.com/Azure/azure-service-operator/v2/api"
 	"github.com/Azure/azure-service-operator/v2/internal/config"
 	"github.com/Azure/azure-service-operator/v2/internal/controllers"
 	"github.com/Azure/azure-service-operator/v2/internal/crdmanagement"
 	"github.com/Azure/azure-service-operator/v2/internal/identity"
-	. "github.com/Azure/azure-service-operator/v2/internal/logging"
-	asometrics "github.com/Azure/azure-service-operator/v2/internal/metrics"
-	armreconciler "github.com/Azure/azure-service-operator/v2/internal/reconcilers/arm"
 	"github.com/Azure/azure-service-operator/v2/internal/reconcilers/generic"
 	"github.com/Azure/azure-service-operator/v2/internal/util/interval"
 	"github.com/Azure/azure-service-operator/v2/internal/util/kubeclient"

--- a/v2/cmd/controller/app/setup.go
+++ b/v2/cmd/controller/app/setup.go
@@ -8,6 +8,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-service-operator/v2/api"
 	"math/rand"
 	"os"
 	"regexp"
@@ -66,11 +67,17 @@ func SetupPreUpgradeCheck(ctx context.Context) error {
 		return errors.Wrap(err, "failed to list CRDs")
 	}
 
+	scheme := api.CreateScheme()
 	crdRegexp := regexp.MustCompile(`.*\.azure\.com`)
 	var errs []error
 	for _, crd := range list.Items {
 		crd := crd
 		if !crdRegexp.MatchString(crd.Name) {
+			continue
+		}
+
+		if !scheme.Recognizes(crd.GroupVersionKind()) {
+			// Not one of our resources
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As reported in #3127, ASO upgrade fails when there are non-ASO CRDs present that use the `azure.com` suffix. We filter out for GVKs that we don't recognize.

Closes #3127

**How does this PR make you feel**:
![gif](https://media.giphy.com/media/12ELmx0C4EFKcE/giphy.gif)
